### PR TITLE
chore: bump all package versions to 0.1.0

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optio/api",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optio/web",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "optio",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "turbo dev",

--- a/packages/agent-adapters/package.json
+++ b/packages/agent-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optio/agent-adapters",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/container-runtime/package.json
+++ b/packages/container-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optio/container-runtime",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optio/shared",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ticket-providers/package.json
+++ b/packages/ticket-providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optio/ticket-providers",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Bumps version from `0.0.1` to `0.1.0` across all 7 `package.json` files (root, apps/api, apps/web, and all 4 packages)
- Adds missing `version` field to root `package.json`
- Prepares for initial public release

## Test plan
- [ ] Verify `pnpm install` still resolves workspace dependencies correctly
- [ ] Verify `pnpm turbo typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)