### PR TITLE
fix: replace placeholder org URLs with actual repository URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thanks for your interest in contributing! This guide will help you get started.
 ### Quick Start
 
 ```bash
-git clone https://github.com/your-org/optio.git
+git clone https://github.com/jonwiggins/optio.git
 cd optio
 pnpm install
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Optio manages the full lifecycle: task intake → container provisioning → age
 
 ```bash
 # Clone and install
-git clone https://github.com/your-org/optio.git && cd optio
+git clone https://github.com/jonwiggins/optio.git && cd optio
 pnpm install
 
 # Bootstrap infrastructure (Postgres + Redis in K8s, migrations, .env)


### PR DESCRIPTION
## Summary
- Replaced `https://github.com/your-org/optio.git` with `https://github.com/jonwiggins/optio.git` in `README.md` and `CONTRIBUTING.md`

## Test plan
- [x] Verified no remaining `your-org` placeholder URLs in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)