### PR TITLE
feat: add cost tracking analytics dashboard

### DIFF
--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -1,0 +1,161 @@
+import type { FastifyInstance } from "fastify";
+import { sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+
+export async function analyticsRoutes(app: FastifyInstance) {
+  // Cost analytics — aggregated cost data for the dashboard
+  app.get("/api/analytics/costs", async (req, reply) => {
+    const query = req.query as { days?: string; repoUrl?: string };
+    const days = query.days ? parseInt(query.days, 10) : 30;
+    const repoUrl = query.repoUrl || null;
+
+    const repoFilter = repoUrl ? sql`AND repo_url = ${repoUrl}` : sql``;
+
+    const dateFilter = sql`AND created_at >= NOW() - ${sql.raw(`INTERVAL '${days} days'`)}`;
+
+    // Total cost and task count
+    const [totals] = await db.execute<{
+      total_cost: string;
+      task_count: string;
+      tasks_with_cost: string;
+    }>(sql`
+      SELECT
+        COALESCE(SUM(CAST(cost_usd AS NUMERIC)), 0) AS total_cost,
+        COUNT(*) AS task_count,
+        COUNT(cost_usd) AS tasks_with_cost
+      FROM tasks
+      WHERE cost_usd IS NOT NULL
+        ${dateFilter}
+        ${repoFilter}
+    `);
+
+    // Previous period for trend comparison
+    const [prevTotals] = await db.execute<{
+      total_cost: string;
+    }>(sql`
+      SELECT
+        COALESCE(SUM(CAST(cost_usd AS NUMERIC)), 0) AS total_cost
+      FROM tasks
+      WHERE cost_usd IS NOT NULL
+        AND created_at >= NOW() - ${sql.raw(`INTERVAL '${days * 2} days'`)}
+        AND created_at < NOW() - ${sql.raw(`INTERVAL '${days} days'`)}
+        ${repoFilter}
+    `);
+
+    // Daily cost over time
+    const dailyCosts = await db.execute<{
+      date: string;
+      cost: string;
+      task_count: string;
+    }>(sql`
+      SELECT
+        DATE(created_at) AS date,
+        COALESCE(SUM(CAST(cost_usd AS NUMERIC)), 0) AS cost,
+        COUNT(*) AS task_count
+      FROM tasks
+      WHERE cost_usd IS NOT NULL
+        ${dateFilter}
+        ${repoFilter}
+      GROUP BY DATE(created_at)
+      ORDER BY date ASC
+    `);
+
+    // Cost by repo
+    const costByRepo = await db.execute<{
+      repo_url: string;
+      total_cost: string;
+      task_count: string;
+    }>(sql`
+      SELECT
+        repo_url,
+        COALESCE(SUM(CAST(cost_usd AS NUMERIC)), 0) AS total_cost,
+        COUNT(*) AS task_count
+      FROM tasks
+      WHERE cost_usd IS NOT NULL
+        ${dateFilter}
+        ${repoFilter}
+      GROUP BY repo_url
+      ORDER BY total_cost DESC
+    `);
+
+    // Cost by task type
+    const costByType = await db.execute<{
+      task_type: string;
+      total_cost: string;
+      task_count: string;
+    }>(sql`
+      SELECT
+        task_type,
+        COALESCE(SUM(CAST(cost_usd AS NUMERIC)), 0) AS total_cost,
+        COUNT(*) AS task_count
+      FROM tasks
+      WHERE cost_usd IS NOT NULL
+        ${dateFilter}
+        ${repoFilter}
+      GROUP BY task_type
+      ORDER BY total_cost DESC
+    `);
+
+    // Top most expensive tasks
+    const topTasks = await db.execute<{
+      id: string;
+      title: string;
+      repo_url: string;
+      task_type: string;
+      state: string;
+      cost_usd: string;
+      created_at: string;
+    }>(sql`
+      SELECT id, title, repo_url, task_type, state, cost_usd, created_at
+      FROM tasks
+      WHERE cost_usd IS NOT NULL
+        ${dateFilter}
+        ${repoFilter}
+      ORDER BY CAST(cost_usd AS NUMERIC) DESC
+      LIMIT 10
+    `);
+
+    const totalCost = parseFloat(totals.total_cost) || 0;
+    const prevCost = parseFloat(prevTotals.total_cost) || 0;
+    const taskCount = parseInt(totals.task_count) || 0;
+    const tasksWithCost = parseInt(totals.tasks_with_cost) || 0;
+    const avgCost = tasksWithCost > 0 ? totalCost / tasksWithCost : 0;
+    const costTrend = prevCost > 0 ? ((totalCost - prevCost) / prevCost) * 100 : 0;
+
+    reply.send({
+      summary: {
+        totalCost: totalCost.toFixed(4),
+        taskCount,
+        tasksWithCost,
+        avgCost: avgCost.toFixed(4),
+        costTrend: costTrend.toFixed(1),
+        prevPeriodCost: prevCost.toFixed(4),
+        days,
+      },
+      dailyCosts: dailyCosts.map((r) => ({
+        date: r.date,
+        cost: parseFloat(r.cost) || 0,
+        taskCount: parseInt(r.task_count) || 0,
+      })),
+      costByRepo: costByRepo.map((r) => ({
+        repoUrl: r.repo_url,
+        totalCost: parseFloat(r.total_cost) || 0,
+        taskCount: parseInt(r.task_count) || 0,
+      })),
+      costByType: costByType.map((r) => ({
+        taskType: r.task_type,
+        totalCost: parseFloat(r.total_cost) || 0,
+        taskCount: parseInt(r.task_count) || 0,
+      })),
+      topTasks: topTasks.map((r) => ({
+        id: r.id,
+        title: r.title,
+        repoUrl: r.repo_url,
+        taskType: r.task_type,
+        state: r.state,
+        costUsd: r.cost_usd,
+        createdAt: r.created_at,
+      })),
+    });
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -15,6 +15,7 @@ import { clusterRoutes } from "./routes/cluster.js";
 import { bulkRoutes } from "./routes/bulk.js";
 import { issueRoutes } from "./routes/issues.js";
 import { subtaskRoutes } from "./routes/subtasks.js";
+import { analyticsRoutes } from "./routes/analytics.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 
@@ -55,6 +56,7 @@ export async function buildServer() {
   await app.register(bulkRoutes);
   await app.register(issueRoutes);
   await app.register(subtaskRoutes);
+  await app.register(analyticsRoutes);
 
   // WebSocket routes
   await app.register(logStreamWs);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,25 +12,26 @@
   },
   "dependencies": {
     "@optio/shared": "workspace:*",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "^0.11.0",
+    "@xterm/xterm": "^5.5.0",
+    "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.513.0",
     "next": "^15.3.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@xterm/xterm": "^5.5.0",
-    "@xterm/addon-fit": "^0.10.0",
-    "@xterm/addon-web-links": "^0.11.0",
-    "zustand": "^5.0.5",
+    "recharts": "^3.8.0",
     "sonner": "^2.0.3",
-    "lucide-react": "^0.513.0",
-    "clsx": "^2.1.1",
     "tailwind-merge": "^3.3.0",
-    "date-fns": "^4.1.0"
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.8",
     "@types/node": "^22.15.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
-    "typescript": "^5.7.0",
-    "@tailwindcss/postcss": "^4.1.8",
-    "tailwindcss": "^4.1.8"
+    "tailwindcss": "^4.1.8",
+    "typescript": "^5.7.0"
   }
 }

--- a/apps/web/src/app/costs/page.tsx
+++ b/apps/web/src/app/costs/page.tsx
@@ -1,0 +1,474 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { api } from "@/lib/api-client";
+import { cn, formatRelativeTime, truncate } from "@/lib/utils";
+import Link from "next/link";
+import {
+  DollarSign,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  BarChart3,
+  Activity,
+  Loader2,
+  ArrowUpRight,
+} from "lucide-react";
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  PieChart,
+  Pie,
+} from "recharts";
+
+type CostAnalytics = Awaited<ReturnType<typeof api.getCostAnalytics>>;
+
+const PERIOD_OPTIONS = [
+  { label: "7d", days: 7 },
+  { label: "14d", days: 14 },
+  { label: "30d", days: 30 },
+  { label: "90d", days: 90 },
+];
+
+const REPO_COLORS = [
+  "#6366f1", // indigo
+  "#8b5cf6", // violet
+  "#06b6d4", // cyan
+  "#10b981", // emerald
+  "#f59e0b", // amber
+  "#ef4444", // red
+  "#ec4899", // pink
+  "#14b8a6", // teal
+];
+
+function repoShortName(repoUrl: string): string {
+  const match = repoUrl.match(/([^/]+\/[^/]+?)(?:\.git)?$/);
+  return match ? match[1] : repoUrl;
+}
+
+function formatCost(value: string | number): string {
+  const n = typeof value === "string" ? parseFloat(value) : value;
+  if (isNaN(n) || n === 0) return "$0.00";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+  icon: Icon,
+  trend,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  icon: any;
+  trend?: { value: number; label: string };
+}) {
+  return (
+    <div className="bg-bg-card border border-border rounded-xl p-5">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs text-text-muted font-medium uppercase tracking-wider">
+          {label}
+        </span>
+        <Icon className="w-4 h-4 text-text-muted" />
+      </div>
+      <div className="text-2xl font-semibold text-text">{value}</div>
+      {(sub || trend) && (
+        <div className="mt-1.5 flex items-center gap-2">
+          {trend && (
+            <span
+              className={cn(
+                "flex items-center gap-0.5 text-xs font-medium",
+                trend.value > 0
+                  ? "text-error"
+                  : trend.value < 0
+                    ? "text-success"
+                    : "text-text-muted",
+              )}
+            >
+              {trend.value > 0 ? (
+                <TrendingUp className="w-3 h-3" />
+              ) : trend.value < 0 ? (
+                <TrendingDown className="w-3 h-3" />
+              ) : (
+                <Minus className="w-3 h-3" />
+              )}
+              {trend.value > 0 ? "+" : ""}
+              {trend.value.toFixed(1)}%
+            </span>
+          )}
+          {sub && <span className="text-xs text-text-muted">{sub}</span>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChartTooltipContent({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-bg-card border border-border rounded-lg px-3 py-2 shadow-lg">
+      <p className="text-xs text-text-muted mb-1">{label}</p>
+      {payload.map((p: any, i: number) => (
+        <p key={i} className="text-sm font-medium" style={{ color: p.color }}>
+          {p.name}: {p.name === "Tasks" ? p.value : formatCost(p.value)}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export default function CostsPage() {
+  const [data, setData] = useState<CostAnalytics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [days, setDays] = useState(30);
+  const [repoFilter, setRepoFilter] = useState<string>("");
+  const [repos, setRepos] = useState<Array<{ repoUrl: string }>>([]);
+
+  const loadData = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const params: { days: number; repoUrl?: string } = { days };
+      if (repoFilter) params.repoUrl = repoFilter;
+      const result = await api.getCostAnalytics(params);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load analytics");
+    } finally {
+      setLoading(false);
+    }
+  }, [days, repoFilter]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // Load repos for filter dropdown
+  useEffect(() => {
+    api
+      .listRepos()
+      .then((res) => setRepos(res.repos))
+      .catch(() => {});
+  }, []);
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader2 className="w-6 h-6 animate-spin text-text-muted" />
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <p className="text-text-muted mb-2">{error}</p>
+          <button onClick={loadData} className="text-sm text-primary hover:underline">
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { summary, dailyCosts, costByRepo, costByType, topTasks } = data;
+  const trend = parseFloat(summary.costTrend);
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-text">Cost Analytics</h1>
+          <p className="text-sm text-text-muted mt-0.5">
+            Track and analyze agent spend across your tasks
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {/* Repo filter */}
+          <select
+            value={repoFilter}
+            onChange={(e) => setRepoFilter(e.target.value)}
+            className="bg-bg-card border border-border rounded-lg px-3 py-1.5 text-sm text-text focus:outline-none focus:ring-1 focus:ring-primary"
+          >
+            <option value="">All repos</option>
+            {repos.map((r: any) => (
+              <option key={r.repoUrl} value={r.repoUrl}>
+                {r.fullName || repoShortName(r.repoUrl)}
+              </option>
+            ))}
+          </select>
+          {/* Period selector */}
+          <div className="flex bg-bg-card border border-border rounded-lg overflow-hidden">
+            {PERIOD_OPTIONS.map((opt) => (
+              <button
+                key={opt.days}
+                onClick={() => setDays(opt.days)}
+                className={cn(
+                  "px-3 py-1.5 text-xs font-medium transition-colors",
+                  days === opt.days
+                    ? "bg-primary text-white"
+                    : "text-text-muted hover:text-text hover:bg-bg-hover",
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-4 gap-4">
+        <StatCard
+          label="Total Spend"
+          value={formatCost(summary.totalCost)}
+          icon={DollarSign}
+          trend={{ value: trend, label: "vs prev period" }}
+          sub={`last ${summary.days}d`}
+        />
+        <StatCard
+          label="Average Cost"
+          value={formatCost(summary.avgCost)}
+          icon={BarChart3}
+          sub={`across ${summary.tasksWithCost} tasks`}
+        />
+        <StatCard
+          label="Tasks with Cost"
+          value={String(summary.tasksWithCost)}
+          icon={Activity}
+          sub={`of ${summary.taskCount} total`}
+        />
+        <StatCard
+          label="Prev Period"
+          value={formatCost(summary.prevPeriodCost)}
+          icon={DollarSign}
+          sub={`previous ${summary.days}d`}
+        />
+      </div>
+
+      {/* Cost over time chart */}
+      <div className="bg-bg-card border border-border rounded-xl p-5">
+        <h2 className="text-sm font-medium text-text mb-4">Cost Over Time</h2>
+        {dailyCosts.length === 0 ? (
+          <div className="h-64 flex items-center justify-center text-text-muted text-sm">
+            No cost data for this period
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <AreaChart data={dailyCosts}>
+              <defs>
+                <linearGradient id="costGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#6366f1" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" />
+              <XAxis
+                dataKey="date"
+                tick={{ fill: "#6b7280", fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={(v) => {
+                  const d = new Date(v);
+                  return `${d.getMonth() + 1}/${d.getDate()}`;
+                }}
+              />
+              <YAxis
+                tick={{ fill: "#6b7280", fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={(v) => `$${v}`}
+              />
+              <Tooltip content={<ChartTooltipContent />} />
+              <Area
+                type="monotone"
+                dataKey="cost"
+                name="Cost"
+                stroke="#6366f1"
+                fill="url(#costGradient)"
+                strokeWidth={2}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Two-column layout: Cost by Repo + Cost by Type */}
+      <div className="grid grid-cols-2 gap-4">
+        {/* Cost by repo */}
+        <div className="bg-bg-card border border-border rounded-xl p-5">
+          <h2 className="text-sm font-medium text-text mb-4">Cost by Repository</h2>
+          {costByRepo.length === 0 ? (
+            <div className="h-48 flex items-center justify-center text-text-muted text-sm">
+              No data
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {costByRepo.map((r, i) => {
+                const maxCost = costByRepo[0]?.totalCost || 1;
+                const pct = (r.totalCost / maxCost) * 100;
+                return (
+                  <div key={r.repoUrl}>
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-xs text-text truncate max-w-[60%]">
+                        {repoShortName(r.repoUrl)}
+                      </span>
+                      <span className="text-xs text-text-muted">
+                        {formatCost(r.totalCost)} ({r.taskCount} tasks)
+                      </span>
+                    </div>
+                    <div className="h-2 bg-bg rounded-full overflow-hidden">
+                      <div
+                        className="h-full rounded-full transition-all"
+                        style={{
+                          width: `${pct}%`,
+                          backgroundColor: REPO_COLORS[i % REPO_COLORS.length],
+                        }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Cost by task type */}
+        <div className="bg-bg-card border border-border rounded-xl p-5">
+          <h2 className="text-sm font-medium text-text mb-4">Cost by Task Type</h2>
+          {costByType.length === 0 ? (
+            <div className="h-48 flex items-center justify-center text-text-muted text-sm">
+              No data
+            </div>
+          ) : (
+            <div>
+              <ResponsiveContainer width="100%" height={180}>
+                <PieChart>
+                  <Pie
+                    data={costByType.map((t) => ({
+                      name: t.taskType,
+                      value: t.totalCost,
+                    }))}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={50}
+                    outerRadius={75}
+                    paddingAngle={3}
+                    dataKey="value"
+                  >
+                    {costByType.map((_, i) => (
+                      <Cell key={i} fill={i === 0 ? "#6366f1" : "#8b5cf6"} stroke="none" />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    formatter={(value) => formatCost(Number(value))}
+                    contentStyle={{
+                      backgroundColor: "var(--color-bg-card, #1a1a2e)",
+                      border: "1px solid var(--color-border, #2a2a3e)",
+                      borderRadius: "8px",
+                      fontSize: "12px",
+                    }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+              <div className="flex justify-center gap-6 mt-2">
+                {costByType.map((t, i) => (
+                  <div key={t.taskType} className="flex items-center gap-2">
+                    <div
+                      className="w-2.5 h-2.5 rounded-full"
+                      style={{ backgroundColor: i === 0 ? "#6366f1" : "#8b5cf6" }}
+                    />
+                    <span className="text-xs text-text-muted">
+                      {t.taskType} — {formatCost(t.totalCost)} ({t.taskCount})
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Top most expensive tasks */}
+      <div className="bg-bg-card border border-border rounded-xl p-5">
+        <h2 className="text-sm font-medium text-text mb-4">Most Expensive Tasks</h2>
+        {topTasks.length === 0 ? (
+          <div className="py-8 text-center text-text-muted text-sm">No tasks with cost data</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left py-2 px-3 text-xs font-medium text-text-muted">Task</th>
+                  <th className="text-left py-2 px-3 text-xs font-medium text-text-muted">Repo</th>
+                  <th className="text-left py-2 px-3 text-xs font-medium text-text-muted">Type</th>
+                  <th className="text-left py-2 px-3 text-xs font-medium text-text-muted">State</th>
+                  <th className="text-right py-2 px-3 text-xs font-medium text-text-muted">Cost</th>
+                  <th className="text-right py-2 px-3 text-xs font-medium text-text-muted">When</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topTasks.map((task) => (
+                  <tr
+                    key={task.id}
+                    className="border-b border-border/50 hover:bg-bg-hover transition-colors"
+                  >
+                    <td className="py-2.5 px-3">
+                      <Link
+                        href={`/tasks/${task.id}`}
+                        className="text-text hover:text-primary flex items-center gap-1"
+                      >
+                        {truncate(task.title, 50)}
+                        <ArrowUpRight className="w-3 h-3 text-text-muted" />
+                      </Link>
+                    </td>
+                    <td className="py-2.5 px-3 text-text-muted text-xs">
+                      {repoShortName(task.repoUrl)}
+                    </td>
+                    <td className="py-2.5 px-3">
+                      <span
+                        className={cn(
+                          "text-xs px-2 py-0.5 rounded-full",
+                          task.taskType === "review"
+                            ? "bg-violet-500/10 text-violet-400"
+                            : "bg-indigo-500/10 text-indigo-400",
+                        )}
+                      >
+                        {task.taskType}
+                      </span>
+                    </td>
+                    <td className="py-2.5 px-3">
+                      <span className="text-xs text-text-muted">{task.state}</span>
+                    </td>
+                    <td className="py-2.5 px-3 text-right font-medium text-text">
+                      {formatCost(task.costUsd)}
+                    </td>
+                    <td className="py-2.5 px-3 text-right text-xs text-text-muted">
+                      {formatRelativeTime(task.createdAt)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   KeyRound,
   Settings,
   Zap,
+  DollarSign,
 } from "lucide-react";
 
 const MAIN_NAV = [
@@ -18,6 +19,7 @@ const MAIN_NAV = [
   { href: "/tasks", label: "Tasks", icon: ListTodo },
   { href: "/repos", label: "Repos", icon: FolderGit2 },
   { href: "/cluster", label: "Cluster", icon: Server },
+  { href: "/costs", label: "Costs", icon: DollarSign },
 ];
 
 const SECONDARY_NAV = [

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -306,6 +306,37 @@ export const api = {
       failed: number;
     }>(`/api/tasks/${taskId}/subtasks/status`),
 
+  // Analytics
+  getCostAnalytics: (params?: { days?: number; repoUrl?: string }) => {
+    const qs = new URLSearchParams();
+    if (params?.days) qs.set("days", String(params.days));
+    if (params?.repoUrl) qs.set("repoUrl", params.repoUrl);
+    const query = qs.toString();
+    return request<{
+      summary: {
+        totalCost: string;
+        taskCount: number;
+        tasksWithCost: number;
+        avgCost: string;
+        costTrend: string;
+        prevPeriodCost: string;
+        days: number;
+      };
+      dailyCosts: Array<{ date: string; cost: number; taskCount: number }>;
+      costByRepo: Array<{ repoUrl: string; totalCost: number; taskCount: number }>;
+      costByType: Array<{ taskType: string; totalCost: number; taskCount: number }>;
+      topTasks: Array<{
+        id: string;
+        title: string;
+        repoUrl: string;
+        taskType: string;
+        state: string;
+        costUsd: string;
+        createdAt: string;
+      }>;
+    }>(`/api/analytics/costs${query ? `?${query}` : ""}`);
+  },
+
   assignIssue: (data: {
     issueNumber: number;
     repoId: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
+      recharts:
+        specifier: ^3.8.0
+        version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1)
       sonner:
         specifier: ^2.0.3
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -143,7 +146,7 @@ importers:
         version: 3.5.0
       zustand:
         specifier: ^5.0.5
-        version: 5.0.12(@types/react@19.2.14)(react@19.2.4)
+        version: 5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.8
@@ -1223,6 +1226,17 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
@@ -1347,6 +1361,12 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1475,6 +1495,33 @@ packages:
   '@types/conventional-commits-parser@5.0.2':
     resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1521,6 +1568,9 @@ packages:
 
   '@types/stream-buffers@3.0.8':
     resolution: {integrity: sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
@@ -1903,6 +1953,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   dargs@8.1.0:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
     engines: {node: '>=12'}
@@ -1921,6 +2015,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -2106,6 +2203,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -2353,6 +2453,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2370,6 +2476,10 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
@@ -2854,6 +2964,21 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-is@19.2.4:
+    resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
+
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -2866,6 +2991,14 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  recharts@3.8.0:
+    resolution: {integrity: sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
@@ -2874,6 +3007,14 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2881,6 +3022,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3119,6 +3263,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3211,6 +3358,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -3221,6 +3373,9 @@ packages:
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -4158,6 +4313,18 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -4232,6 +4399,10 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -4333,6 +4504,30 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/docker-modem@3.0.6':
@@ -4386,6 +4581,8 @@ snapshots:
   '@types/stream-buffers@3.0.8':
     dependencies:
       '@types/node': 22.19.15
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4789,6 +4986,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   dargs@8.1.0: {}
 
   date-fns@4.1.0: {}
@@ -4798,6 +5033,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-eql@5.0.2: {}
 
@@ -4899,6 +5136,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.45.1: {}
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -5237,6 +5476,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5249,6 +5492,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@4.1.1: {}
+
+  internmap@2.0.3: {}
 
   ioredis@5.10.1:
     dependencies:
@@ -5726,6 +5971,17 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-is@19.2.4: {}
+
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react@19.2.4: {}
 
   readable-stream@3.6.2:
@@ -5736,15 +5992,43 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  recharts@3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redis-errors@1.2.0: {}
 
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
 
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -6037,6 +6321,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -6115,11 +6401,32 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
 
   uuid@11.1.0: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -6255,7 +6562,9 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zustand@5.0.12(@types/react@19.2.14)(react@19.2.4):
+  zustand@5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:
       '@types/react': 19.2.14
+      immer: 11.1.4
       react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)


### PR DESCRIPTION
## Summary

- Add new `GET /api/analytics/costs` endpoint that aggregates cost data from the tasks table with filtering by date range and repository
- Add new `/costs` page with a comprehensive cost analytics dashboard featuring:
  - Summary cards: total spend, average cost per task, trend vs previous period
  - Cost over time area chart (using recharts)
  - Cost breakdown by repository (horizontal bar indicators)
  - Cost breakdown by task type (donut/pie chart)
  - Top 10 most expensive tasks table with links to task details
  - Filterable by date range (7d/14d/30d/90d) and repository
- Add "Costs" link to sidebar navigation
- Install `recharts` charting library for data visualization

## Test plan

- [ ] Verify `/costs` page loads and displays analytics data
- [ ] Test date range filter (7d, 14d, 30d, 90d) updates data correctly
- [ ] Test repo filter dropdown filters data to selected repo
- [ ] Verify cost-over-time chart renders with real cost data
- [ ] Verify cost-by-repo breakdown shows accurate per-repo totals
- [ ] Verify cost-by-type pie chart distinguishes coding vs review tasks
- [ ] Verify top expensive tasks table links navigate to task details
- [ ] Verify sidebar shows "Costs" link and highlights when active
- [ ] Confirm web production build succeeds (`next build`)
- [ ] Confirm typecheck passes for web and shared packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)