### PR TITLE
chore: add repository field to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "optio",
   "version": "0.1.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jonwiggins/optio.git"
+  },
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",


### PR DESCRIPTION
## Summary
- Adds the `repository` field to the root `package.json` pointing to `https://github.com/jonwiggins/optio.git`
- Enables npm and GitHub to properly link the package to its source repository

## Test plan
- [x] Verify `package.json` is valid JSON
- [x] Verify the `repository` field has the correct URL and type

🤖 Generated with [Claude Code](https://claude.com/claude-code)