### PR TITLE
feat: improve pod naming and add per-repo task indicators to overview

### DIFF
--- a/.optio/task.md
+++ b/.optio/task.md
@@ -1,27 +1,40 @@
-# Implement OpenAI Codex agent adapter
+# Improve pod naming and add per-repo task indicators to overview
 
-Implement OpenAI Codex agent adapter
+Improve pod naming and add per-repo task indicators to overview
 
 ## Description
 
-The Codex adapter in `packages/agent-adapters/src/claude-code.ts` is currently a stub. `parseResult()` is hardcoded to `success: exitCode === 0` without actually parsing Codex output, and there's no cost tracking, error handling, or PR detection.
+Two related improvements for observability of the pod-per-repo system:
 
-## Current state
+### 1. Improve workspace pod naming
 
-- `buildContainerConfig()` is implemented
-- `parseResult()` is a dummy — doesn't parse Codex output format
-- No cost tracking
-- No PR URL extraction from Codex output
-- No Codex-specific error handling
+Pod names should clearly indicate which repository they belong to. Currently pod names are generic, making it hard to identify which repo is running in which pod when viewing the cluster or `kubectl get pods`.
+
+**Suggested format:** `optio-repo-<owner>-<repo>-<short-hash>` (e.g., `optio-repo-jonwiggins-optio-a3f2`)
+
+Constraints:
+
+- Must be valid K8s resource names (lowercase, alphanumeric + hyphens, max 63 chars)
+- Must be unique (short hash suffix)
+- Should truncate long owner/repo names gracefully
+
+### 2. Add per-repo task indicators to overview panel
+
+The overview page should show at a glance how busy each repo pod is:
+
+- Number of tasks currently **running** in each pod
+- Number of tasks **queued** for that repo
+- Visual indicator of capacity usage (e.g., 2/3 slots used)
+
+This information already exists in the system (`repo_pods.activeTaskCount`, `repos.maxConcurrentTasks`, and queued tasks can be counted from the `tasks` table), it just needs to be surfaced in the UI.
 
 ## Acceptance criteria
 
-- Codex adapter correctly parses agent output
-- PR URLs are detected from Codex logs
-- Cost tracking works (if Codex exposes usage data)
-- Error classification handles Codex-specific failure modes
-- If Codex output format can't be determined, remove Codex from the UI agent selector rather than leaving a broken option
+- Pod names include a human-readable repo identifier
+- Overview panel shows running task count per pod
+- Overview panel shows queued task count per repo
+- Capacity indicator shows usage vs. `maxConcurrentTasks` limit
 
 ---
 
-_Optio Task ID: 7633f5f4-eb11-4891-8a4a-070704352f8f_
+_Optio Task ID: b6c16293-851f-4a3d-bfbd-b3575146bc2f_

--- a/apps/api/src/routes/cluster.ts
+++ b/apps/api/src/routes/cluster.ts
@@ -1,8 +1,8 @@
 import type { FastifyInstance } from "fastify";
 import { KubeConfig, CoreV1Api } from "@kubernetes/client-node";
 import { db } from "../db/client.js";
-import { repoPods, tasks, podHealthEvents } from "../db/schema.js";
-import { eq, desc } from "drizzle-orm";
+import { repoPods, tasks, podHealthEvents, repos } from "../db/schema.js";
+import { eq, desc, and, inArray, sql } from "drizzle-orm";
 
 function getK8sConfig() {
   const kc = new KubeConfig();
@@ -191,12 +191,53 @@ export async function clusterRoutes(app: FastifyInstance) {
       // Get Optio-specific data
       const repoPodRecords = await db.select().from(repoPods);
 
+      // Get per-repo task indicators: queued counts and maxConcurrentTasks
+      const repoUrls = repoPodRecords.map((rp) => rp.repoUrl);
+
+      // Queued task counts per repo
+      const queuedCounts =
+        repoUrls.length > 0
+          ? await db
+              .select({
+                repoUrl: tasks.repoUrl,
+                count: sql<number>`count(*)::int`,
+              })
+              .from(tasks)
+              .where(
+                and(inArray(tasks.repoUrl, repoUrls), inArray(tasks.state, ["queued", "pending"])),
+              )
+              .groupBy(tasks.repoUrl)
+          : [];
+
+      const queuedMap = new Map(queuedCounts.map((r) => [r.repoUrl, r.count]));
+
+      // Max concurrent tasks per repo (from repos config)
+      const repoConfigs =
+        repoUrls.length > 0
+          ? await db
+              .select({
+                repoUrl: repos.repoUrl,
+                maxConcurrentTasks: repos.maxConcurrentTasks,
+              })
+              .from(repos)
+              .where(inArray(repos.repoUrl, repoUrls))
+          : [];
+
+      const maxConcurrentMap = new Map(repoConfigs.map((r) => [r.repoUrl, r.maxConcurrentTasks]));
+
+      // Enrich repo pod records with task indicators
+      const enrichedRepoPods = repoPodRecords.map((rp) => ({
+        ...rp,
+        queuedTaskCount: queuedMap.get(rp.repoUrl) ?? 0,
+        maxConcurrentTasks: maxConcurrentMap.get(rp.repoUrl) ?? 2,
+      }));
+
       reply.send({
         nodes,
         pods,
         services,
         events,
-        repoPods: repoPodRecords,
+        repoPods: enrichedRepoPods,
         summary: {
           totalPods: pods.length,
           runningPods: pods.filter((p) => p.status === "Running").length,

--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -4,7 +4,7 @@ import { db } from "../db/client.js";
 import { repoPods } from "../db/schema.js";
 import { getRuntime } from "./container-service.js";
 import type { ContainerHandle, ContainerSpec, ExecSession, RepoImageConfig } from "@optio/shared";
-import { DEFAULT_AGENT_IMAGE, PRESET_IMAGES } from "@optio/shared";
+import { DEFAULT_AGENT_IMAGE, PRESET_IMAGES, generateRepoPodName } from "@optio/shared";
 import { logger } from "../logger.js";
 
 const IDLE_TIMEOUT_MS = parseInt(process.env.OPTIO_REPO_POD_IDLE_MS ?? "600000", 10); // 10 min default
@@ -139,6 +139,7 @@ spec:
   try {
     // Launch a pod that clones the repo then sleeps forever
     const spec: ContainerSpec = {
+      name: generateRepoPodName(repoUrl),
       image,
       command: ["/opt/optio/repo-init.sh"],
       env: {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -171,7 +171,14 @@ export default function OverviewPage() {
     return sum + (t.costUsd ? parseFloat(t.costUsd) : 0);
   }, 0);
 
-  const { nodes, pods, services, events, summary } = cluster ?? {
+  const {
+    nodes,
+    pods,
+    services,
+    events,
+    summary,
+    repoPods: repoPodRecords,
+  } = cluster ?? {
     nodes: [],
     pods: [],
     services: [],
@@ -184,7 +191,13 @@ export default function OverviewPage() {
       totalNodes: 0,
       readyNodes: 0,
     },
+    repoPods: [],
   };
+
+  // Build a lookup from pod name → repoPod record (for task indicators)
+  const repoPodByName = new Map<string, any>(
+    (repoPodRecords ?? []).map((rp: any) => [rp.podName, rp]),
+  );
 
   return (
     <div className="p-6 max-w-6xl mx-auto space-y-6">
@@ -442,6 +455,7 @@ export default function OverviewPage() {
                 const podTasks = pod.isOptioManaged
                   ? recentTasks.filter((t: any) => t.containerId === pod.name)
                   : [];
+                const repoPod = pod.isOptioManaged ? repoPodByName.get(pod.name) : null;
 
                 return (
                   <div key={pod.name} className="rounded-md border border-border bg-bg-card">
@@ -468,6 +482,7 @@ export default function OverviewPage() {
                             <span className="text-[9px] px-1 py-0.5 rounded bg-primary/10 text-primary">
                               workspace
                             </span>
+                            {repoPod && <CapacityIndicator repoPod={repoPod} />}
                             <ChevronDown
                               className={cn(
                                 "w-3 h-3 text-text-muted ml-auto shrink-0 transition-transform",
@@ -484,6 +499,20 @@ export default function OverviewPage() {
                       </div>
                       <div className="flex items-center gap-2 text-[10px] text-text-muted mt-1 ml-4">
                         <span className={color}>{pod.status}</span>
+                        {repoPod && (
+                          <>
+                            <span className="flex items-center gap-0.5">
+                              <Activity className="w-2.5 h-2.5" />
+                              {repoPod.activeTaskCount ?? 0} running
+                            </span>
+                            {(repoPod.queuedTaskCount ?? 0) > 0 && (
+                              <span className="flex items-center gap-0.5 text-warning">
+                                <Clock className="w-2.5 h-2.5" />
+                                {repoPod.queuedTaskCount} queued
+                              </span>
+                            )}
+                          </>
+                        )}
                         {pod.cpuMillicores != null && (
                           <span className="flex items-center gap-0.5">
                             <Cpu className="w-2.5 h-2.5" />
@@ -658,6 +687,27 @@ function UsageMeter({
         </div>
       )}
     </div>
+  );
+}
+
+function CapacityIndicator({ repoPod }: { repoPod: any }) {
+  const active = repoPod.activeTaskCount ?? 0;
+  const max = repoPod.maxConcurrentTasks ?? 2;
+  const pct = max > 0 ? Math.min((active / max) * 100, 100) : 0;
+  const color = pct >= 100 ? "bg-error" : pct >= 50 ? "bg-warning" : "bg-success";
+
+  return (
+    <span className="flex items-center gap-1.5 text-[9px] text-text-muted tabular-nums">
+      <span className="h-1.5 w-10 rounded-full bg-border/50 overflow-hidden inline-block">
+        <span
+          className={cn("h-full rounded-full block transition-all", color)}
+          style={{ width: `${pct}%` }}
+        />
+      </span>
+      <span>
+        {active}/{max}
+      </span>
+    </span>
   );
 }
 

--- a/packages/container-runtime/src/kubernetes.ts
+++ b/packages/container-runtime/src/kubernetes.ts
@@ -39,8 +39,9 @@ export class KubernetesContainerRuntime implements ContainerRuntime {
   async create(spec: ContainerSpec): Promise<ContainerHandle> {
     await this.ensureNamespace();
 
-    const taskId = spec.labels["taskId"] ?? spec.labels["task-id"] ?? crypto.randomUUID();
-    const podName = `optio-task-${taskId}`;
+    const podName =
+      spec.name ??
+      `optio-task-${spec.labels["taskId"] ?? spec.labels["task-id"] ?? crypto.randomUUID()}`;
 
     const env: V1EnvVar[] = Object.entries(spec.env).map(([name, value]) => {
       const envVar = new V1EnvVar();

--- a/packages/shared/src/constants.test.ts
+++ b/packages/shared/src/constants.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { generateRepoPodName } from "./constants.js";
+
+describe("generateRepoPodName", () => {
+  it("generates a name from an HTTPS GitHub URL", () => {
+    const name = generateRepoPodName("https://github.com/jonwiggins/optio.git");
+    expect(name).toMatch(/^optio-repo-jonwiggins-optio-[0-9a-f]{4}$/);
+  });
+
+  it("generates a name from an SSH GitHub URL", () => {
+    const name = generateRepoPodName("git@github.com:jonwiggins/optio.git");
+    expect(name).toMatch(/^optio-repo-jonwiggins-optio-[0-9a-f]{4}$/);
+  });
+
+  it("handles URLs without .git suffix", () => {
+    const name = generateRepoPodName("https://github.com/myorg/my-repo");
+    expect(name).toMatch(/^optio-repo-myorg-my-repo-[0-9a-f]{4}$/);
+  });
+
+  it("produces valid K8s names (lowercase, alphanumeric, hyphens)", () => {
+    const name = generateRepoPodName("https://github.com/My_Org/My.Repo.Name.git");
+    expect(name).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+    expect(name.length).toBeLessThanOrEqual(63);
+  });
+
+  it("truncates long owner/repo names to fit within 63 chars", () => {
+    const longOwner = "a".repeat(50);
+    const longRepo = "b".repeat(50);
+    const name = generateRepoPodName(`https://github.com/${longOwner}/${longRepo}.git`);
+    expect(name.length).toBeLessThanOrEqual(63);
+    expect(name).toMatch(/^optio-repo-/);
+    expect(name).toMatch(/-[0-9a-f]{4}$/);
+  });
+
+  it("generates unique names (different hash each call)", () => {
+    const name1 = generateRepoPodName("https://github.com/org/repo.git");
+    const name2 = generateRepoPodName("https://github.com/org/repo.git");
+    // Names share prefix but have different hash suffixes (very likely)
+    expect(name1.slice(0, -4)).toBe(name2.slice(0, -4));
+  });
+
+  it("handles fallback for unrecognized URL format", () => {
+    const name = generateRepoPodName("not-a-url");
+    expect(name).toMatch(/^optio-repo-unknown-unknown-[0-9a-f]{4}$/);
+  });
+
+  it("sanitizes special characters in owner/repo", () => {
+    const name = generateRepoPodName("https://github.com/my--org/my__repo.git");
+    expect(name).not.toMatch(/--/); // no double hyphens after sanitization
+    expect(name).toMatch(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+  });
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -5,3 +5,53 @@ export const DEFAULT_AGENT_IMAGE = "optio-agent:latest";
 export const DEFAULT_TICKET_LABEL = "optio";
 export const DEFAULT_MAX_TURNS_CODING = 250;
 export const DEFAULT_MAX_TURNS_REVIEW = 10;
+
+/**
+ * Max length for K8s resource names.
+ */
+const K8S_NAME_MAX = 63;
+
+/**
+ * Generate a human-readable pod name from a repo URL.
+ *
+ * Format: `optio-repo-<owner>-<repo>-<hash>` where hash is a 4-char hex suffix
+ * for uniqueness. Names are valid K8s resource names (lowercase, alphanumeric +
+ * hyphens, max 63 chars). Long owner/repo names are truncated gracefully.
+ */
+export function generateRepoPodName(repoUrl: string): string {
+  // Extract owner/repo from URL patterns like:
+  //   https://github.com/owner/repo.git
+  //   git@github.com:owner/repo.git
+  const match = repoUrl.match(/[/:]([^/]+)\/([^/.]+?)(?:\.git)?$/);
+  const owner = match?.[1] ?? "unknown";
+  const repo = match?.[2] ?? "unknown";
+
+  // Sanitize: lowercase, replace non-alphanumeric with hyphens, collapse multiples
+  const sanitize = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "");
+
+  const prefix = "optio-repo-";
+  // 4-char random hex suffix + 1 hyphen separator
+  const suffixLen = 5;
+  const maxBodyLen = K8S_NAME_MAX - prefix.length - suffixLen;
+
+  let ownerClean = sanitize(owner);
+  let repoClean = sanitize(repo);
+
+  // Ensure we fit within the max body length (owner + hyphen + repo)
+  const totalLen = ownerClean.length + 1 + repoClean.length;
+  if (totalLen > maxBodyLen) {
+    // Split budget: give repo at least half
+    const repoBudget = Math.floor(maxBodyLen / 2);
+    const ownerBudget = maxBodyLen - repoBudget - 1; // -1 for separator
+    ownerClean = ownerClean.slice(0, ownerBudget).replace(/-$/, "");
+    repoClean = repoClean.slice(0, repoBudget).replace(/-$/, "");
+  }
+
+  const hash = Math.random().toString(16).slice(2, 6);
+  return `${prefix}${ownerClean}-${repoClean}-${hash}`;
+}

--- a/packages/shared/src/types/container.ts
+++ b/packages/shared/src/types/container.ts
@@ -9,6 +9,8 @@ export interface ContainerSpec {
   volumes?: VolumeMount[];
   networkMode?: string;
   imagePullPolicy?: "Always" | "Never" | "IfNotPresent";
+  /** Optional pod name override. If not set, the runtime generates one. */
+  name?: string;
 }
 
 export interface VolumeMount {


### PR DESCRIPTION
## Summary

- **Pod naming**: New pods use `optio-repo-<owner>-<repo>-<hash>` format (e.g., `optio-repo-jonwiggins-optio-a3f2`) instead of generic `optio-task-<uuid>`, making it easy to identify repos in `kubectl get pods` and the cluster UI
- **Per-repo task indicators**: Overview page now shows running task count, queued task count, and a visual capacity bar (usage vs `maxConcurrentTasks`) for each workspace pod
- **Tests**: 8 new tests for `generateRepoPodName` covering URL formats, K8s name validity, truncation, and edge cases

## Test plan

- [x] All 66 existing tests pass
- [x] 8 new `generateRepoPodName` tests pass
- [x] TypeScript typechecks pass across all 6 packages
- [x] Prettier formatting passes
- [ ] Verify pod names in a running cluster show repo identifiers
- [ ] Verify overview page shows capacity indicators for workspace pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)