### PR TITLE
docs: add demo screenshots to README

### DIFF
--- a/.optio/task.md
+++ b/.optio/task.md
@@ -1,36 +1,24 @@
-# Improve test coverage for critical paths
+# Add demo screenshot or GIF to README
 
-Improve test coverage for critical paths
+Add demo screenshot or GIF to README
 
 ## Description
 
-Current test coverage is estimated at 10-15%, focused on shared utilities. The core orchestration paths have zero tests.
+Add visual media (screenshot, GIF, or short video) to the README showing Optio in action. Most popular dev tools repos have visuals near the top that immediately communicate what the tool does.
 
-## What's tested today
+Suggested visuals:
 
-- State machine transitions (`state-machine.test.ts`)
-- Error classifier patterns (`error-classifier.test.ts`)
-- Prompt template rendering (`prompt-template.test.ts`)
-- Agent event parser (`agent-event-parser.test.ts`)
-- PR watcher decision logic (`pr-watcher-worker.test.ts`)
-
-## Critical untested paths (priority order)
-
-1. **Task worker** — the main orchestration loop: concurrency checks, pod provisioning, agent execution, result handling (~200+ lines of complex logic)
-2. **Repo pool service** — pod creation, worktree exec, cleanup (~150+ lines)
-3. **Secret encryption/decryption** — round-trip correctness
-4. **Review agent flow** — subtask creation, prompt rendering, completion callbacks
-5. **Subtask completion checks** — `onSubtaskComplete()` parent advancement logic
-6. **API routes** — at minimum: task CRUD, secrets CRUD, bulk operations
+- The dashboard with a few tasks in various states
+- A task detail view showing streaming logs
+- The repo/cluster management views
 
 ## Acceptance criteria
 
-- Task worker has unit tests covering: concurrency limiting, retry logic, state transitions on success/failure
-- Repo pool service has tests for pod lifecycle
-- Secret encryption has round-trip test
-- Overall coverage meaningfully improved (target: 40%+ of backend logic)
+- At least one screenshot or GIF near the top of README.md
+- Images stored in a `docs/` or `.github/` directory (not a third-party host)
+- Alt text included for accessibility
 
 ---
 
-_Optio Task ID: 52315170-01a9-460e-85fb-c6c57232046d_
-_Source: [github](https://github.com/jonwiggins/optio/issues/11)_
+_Optio Task ID: c519ec95-5d5c-4e95-98da-acfd27d5db77_
+_Source: [github](https://github.com/jonwiggins/optio/issues/6)_

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ AI Agent Workflow Orchestration — run coding agents (Claude Code, OpenAI Codex
 
 Optio manages the full lifecycle: task intake → container provisioning → agent execution → PR creation → CI monitoring → merge. Agents run in isolated Kubernetes pods with git worktrees for efficient multi-task concurrency.
 
+## Demo
+
+<p align="center">
+  <img src="docs/screenshots/dashboard-overview.svg" alt="Optio dashboard showing task overview with running, queued, and completed tasks across repositories" width="100%"/>
+</p>
+<p align="center"><em>Dashboard overview — monitor all tasks at a glance with real-time status updates</em></p>
+
+<p align="center">
+  <img src="docs/screenshots/task-detail-logs.svg" alt="Task detail view with live streaming logs showing agent reading files, writing code, and running type checks" width="100%"/>
+</p>
+<p align="center"><em>Task detail — live-streamed agent logs with tool calls, pipeline progress, and cost tracking</em></p>
+
+<p align="center">
+  <img src="docs/screenshots/repo-management.svg" alt="Repository management view showing configured repos with image presets, review settings, and active pod status" width="100%"/>
+</p>
+<p align="center"><em>Repository management — per-repo agent settings, image presets, and active pod monitoring</em></p>
+
 ## Features
 
 - **Pod-per-repo architecture** — one long-lived pod per repository, tasks run in git worktrees for efficient multi-task concurrency

--- a/docs/screenshots/dashboard-overview.svg
+++ b/docs/screenshots/dashboard-overview.svg
@@ -1,0 +1,149 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 800" font-family="Inter, -apple-system, system-ui, sans-serif">
+  <defs>
+    <style>
+      .mono { font-family: 'JetBrains Mono', 'Fira Code', monospace; }
+    </style>
+    <clipPath id="round-corners">
+      <rect width="1280" height="800" rx="12"/>
+    </clipPath>
+  </defs>
+
+  <g clip-path="url(#round-corners)">
+    <!-- Window chrome -->
+    <rect width="1280" height="800" fill="#0a0a0c"/>
+    <rect width="1280" height="36" fill="#111113"/>
+    <circle cx="20" cy="18" r="6" fill="#ef4444" opacity="0.8"/>
+    <circle cx="40" cy="18" r="6" fill="#f59e0b" opacity="0.8"/>
+    <circle cx="60" cy="18" r="6" fill="#22c55e" opacity="0.8"/>
+    <text x="640" y="23" text-anchor="middle" fill="#a1a1aa" font-size="12" font-weight="500">Optio — Agent Orchestration</text>
+
+    <!-- Sidebar -->
+    <rect x="0" y="36" width="240" height="764" fill="#111113"/>
+    <line x1="240" y1="36" x2="240" y2="800" stroke="#27272a" stroke-width="1"/>
+
+    <!-- Sidebar logo -->
+    <text x="52" y="76" fill="#6d28d9" font-size="14" font-weight="600">&#x26A1;</text>
+    <text x="68" y="76" fill="#fafafa" font-size="16" font-weight="600">Optio</text>
+    <text x="52" y="92" fill="#a1a1aa" font-size="10">Agent Orchestration</text>
+
+    <!-- Sidebar nav - Overview (active) -->
+    <rect x="12" y="112" width="216" height="36" rx="8" fill="rgba(109,40,217,0.1)"/>
+    <rect x="12" y="112" width="2" height="36" rx="1" fill="#6d28d9"/>
+    <text x="44" y="134" fill="#fafafa" font-size="13" font-weight="500">Overview</text>
+
+    <!-- Sidebar nav items -->
+    <text x="44" y="170" fill="#a1a1aa" font-size="13">Tasks</text>
+    <text x="44" y="206" fill="#a1a1aa" font-size="13">Repos</text>
+    <text x="44" y="242" fill="#a1a1aa" font-size="13">Cluster</text>
+    <text x="44" y="278" fill="#a1a1aa" font-size="13">Costs</text>
+
+    <!-- Sidebar secondary nav -->
+    <line x1="24" y1="310" x2="228" y2="310" stroke="#27272a" stroke-width="1"/>
+    <text x="44" y="342" fill="#a1a1aa" font-size="13">Secrets</text>
+    <text x="44" y="378" fill="#a1a1aa" font-size="13">Settings</text>
+
+    <!-- Main content area -->
+    <!-- Header -->
+    <text x="280" y="80" fill="#f4f4f5" font-size="24" font-weight="600" letter-spacing="-0.5">Overview</text>
+    <text x="280" y="100" fill="#a1a1aa" font-size="13">3 active tasks</text>
+
+    <!-- Stat cards row -->
+    <!-- Running -->
+    <rect x="280" y="120" width="175" height="80" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <text x="300" y="150" fill="#a1a1aa" font-size="11" font-weight="500">RUNNING</text>
+    <text x="300" y="180" fill="#6d28d9" font-size="28" font-weight="600">2</text>
+    <circle cx="430" cy="155" r="16" fill="rgba(109,40,217,0.1)"/>
+    <text x="430" y="160" text-anchor="middle" fill="#6d28d9" font-size="14">&#x25B6;</text>
+
+    <!-- Attention -->
+    <rect x="470" y="120" width="175" height="80" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <text x="490" y="150" fill="#a1a1aa" font-size="11" font-weight="500">ATTENTION</text>
+    <text x="490" y="180" fill="#f59e0b" font-size="28" font-weight="600">1</text>
+    <circle cx="620" cy="155" r="16" fill="rgba(245,158,11,0.1)"/>
+    <text x="620" y="160" text-anchor="middle" fill="#f59e0b" font-size="14">&#x26A0;</text>
+
+    <!-- PRs Open -->
+    <rect x="660" y="120" width="175" height="80" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <text x="680" y="150" fill="#a1a1aa" font-size="11" font-weight="500">PRS OPEN</text>
+    <text x="680" y="180" fill="#22c55e" font-size="28" font-weight="600">4</text>
+    <circle cx="810" cy="155" r="16" fill="rgba(34,197,94,0.1)"/>
+    <text x="810" y="160" text-anchor="middle" fill="#22c55e" font-size="13">PR</text>
+
+    <!-- Completed -->
+    <rect x="850" y="120" width="175" height="80" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <text x="870" y="150" fill="#a1a1aa" font-size="11" font-weight="500">COMPLETED</text>
+    <text x="870" y="180" fill="#22c55e" font-size="28" font-weight="600">12</text>
+    <circle cx="1000" cy="155" r="16" fill="rgba(34,197,94,0.1)"/>
+    <text x="1000" y="160" text-anchor="middle" fill="#22c55e" font-size="14">&#x2713;</text>
+
+    <!-- Recent Tasks heading -->
+    <text x="280" y="240" fill="#f4f4f5" font-size="15" font-weight="600">Recent Tasks</text>
+
+    <!-- Task Card 1 - Running -->
+    <rect x="280" y="258" width="760" height="90" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <!-- Title row -->
+    <text x="300" y="286" fill="#fafafa" font-size="14" font-weight="600">feat: add pod scaling controls and worktree lifecycle</text>
+    <!-- State badge - running -->
+    <rect x="940" y="271" width="80" height="22" rx="11" fill="rgba(109,40,217,0.1)"/>
+    <circle cx="955" cy="282" r="3" fill="#6d28d9">
+      <animate attributeName="opacity" values="1;0.3;1" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <text x="965" y="286" fill="#6d28d9" font-size="10" font-weight="600">RUNNING</text>
+    <!-- Metadata -->
+    <text x="300" y="306" fill="#a1a1aa" font-size="11">jonwiggins/optio</text>
+    <text x="430" y="306" fill="#71717a" font-size="11">Claude Code</text>
+    <!-- Footer -->
+    <text x="300" y="334" fill="#71717a" font-size="10">2 min ago</text>
+    <text x="960" y="334" fill="#71717a" font-size="10" class="mono">$0.42</text>
+
+    <!-- Task Card 2 - PR Opened -->
+    <rect x="280" y="360" width="760" height="90" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <text x="300" y="388" fill="#fafafa" font-size="14" font-weight="600">fix: resolve merge conflict in auth middleware</text>
+    <rect x="940" y="373" width="88" height="22" rx="11" fill="rgba(34,197,94,0.1)"/>
+    <circle cx="955" cy="384" r="3" fill="#22c55e"/>
+    <text x="965" y="388" fill="#22c55e" font-size="10" font-weight="600">PR OPENED</text>
+    <text x="300" y="408" fill="#a1a1aa" font-size="11">jonwiggins/optio</text>
+    <text x="430" y="408" fill="#71717a" font-size="11">Claude Code</text>
+    <text x="300" y="436" fill="#71717a" font-size="10">18 min ago</text>
+    <text x="880" y="436" fill="#22c55e" font-size="10">#142 &#x2197;</text>
+    <text x="960" y="436" fill="#71717a" font-size="10" class="mono">$1.83</text>
+
+    <!-- Task Card 3 - Needs Attention -->
+    <rect x="280" y="462" width="760" height="110" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <text x="300" y="490" fill="#fafafa" font-size="14" font-weight="600">refactor: migrate user service to new DB schema</text>
+    <rect x="904" y="475" width="116" height="22" rx="11" fill="rgba(245,158,11,0.1)" stroke="rgba(245,158,11,0.2)" stroke-width="1"/>
+    <circle cx="919" cy="486" r="3" fill="#f59e0b"/>
+    <text x="929" y="490" fill="#f59e0b" font-size="10" font-weight="600">ATTENTION</text>
+    <text x="300" y="510" fill="#a1a1aa" font-size="11">jonwiggins/webapp</text>
+    <text x="430" y="510" fill="#71717a" font-size="11">Claude Code</text>
+    <!-- Error box -->
+    <rect x="300" y="520" width="720" height="36" rx="8" fill="rgba(239,68,68,0.05)" stroke="rgba(239,68,68,0.1)" stroke-width="1"/>
+    <text x="320" y="542" fill="#a1a1aa" font-size="11">CI failed: 2 checks failing — jest tests, type check</text>
+    <rect x="920" y="528" width="80" height="22" rx="6" fill="rgba(109,40,217,0.1)"/>
+    <text x="937" y="543" fill="#6d28d9" font-size="10" font-weight="500">Retry</text>
+
+    <!-- Task Card 4 - Completed -->
+    <rect x="280" y="584" width="760" height="90" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <text x="300" y="612" fill="#fafafa" font-size="14" font-weight="600">test: add unit tests for task-worker and secret-service</text>
+    <rect x="920" y="597" width="100" height="22" rx="11" fill="rgba(34,197,94,0.05)"/>
+    <circle cx="935" cy="608" r="3" fill="#22c55e"/>
+    <text x="945" y="612" fill="#22c55e" font-size="10" font-weight="600">COMPLETED</text>
+    <text x="300" y="632" fill="#a1a1aa" font-size="11">jonwiggins/optio</text>
+    <text x="430" y="632" fill="#71717a" font-size="11">Claude Code</text>
+    <text x="300" y="660" fill="#71717a" font-size="10">1 hour ago</text>
+    <text x="880" y="660" fill="#22c55e" font-size="10">#138 &#x2197;</text>
+    <text x="960" y="660" fill="#71717a" font-size="10" class="mono">$2.17</text>
+
+    <!-- Task Card 5 - Queued -->
+    <rect x="280" y="686" width="760" height="90" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <text x="300" y="714" fill="#fafafa" font-size="14" font-weight="600">docs: update API reference for v2 endpoints</text>
+    <rect x="940" y="699" width="76" height="22" rx="11" fill="rgba(59,130,246,0.1)"/>
+    <circle cx="955" cy="710" r="3" fill="#3b82f6">
+      <animate attributeName="opacity" values="1;0.3;1" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <text x="965" y="714" fill="#3b82f6" font-size="10" font-weight="600">QUEUED</text>
+    <text x="300" y="734" fill="#a1a1aa" font-size="11">jonwiggins/optio</text>
+    <text x="430" y="734" fill="#71717a" font-size="11">Claude Code</text>
+    <text x="300" y="762" fill="#71717a" font-size="10">Just now</text>
+  </g>
+</svg>

--- a/docs/screenshots/repo-management.svg
+++ b/docs/screenshots/repo-management.svg
@@ -1,0 +1,153 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 800" font-family="Inter, -apple-system, system-ui, sans-serif">
+  <defs>
+    <style>
+      .mono { font-family: 'JetBrains Mono', 'Fira Code', monospace; }
+    </style>
+    <clipPath id="round-corners">
+      <rect width="1280" height="800" rx="12"/>
+    </clipPath>
+  </defs>
+
+  <g clip-path="url(#round-corners)">
+    <!-- Window chrome -->
+    <rect width="1280" height="800" fill="#0a0a0c"/>
+    <rect width="1280" height="36" fill="#111113"/>
+    <circle cx="20" cy="18" r="6" fill="#ef4444" opacity="0.8"/>
+    <circle cx="40" cy="18" r="6" fill="#f59e0b" opacity="0.8"/>
+    <circle cx="60" cy="18" r="6" fill="#22c55e" opacity="0.8"/>
+    <text x="640" y="23" text-anchor="middle" fill="#a1a1aa" font-size="12" font-weight="500">Optio — Repositories</text>
+
+    <!-- Sidebar -->
+    <rect x="0" y="36" width="240" height="764" fill="#111113"/>
+    <line x1="240" y1="36" x2="240" y2="800" stroke="#27272a" stroke-width="1"/>
+
+    <!-- Sidebar logo -->
+    <text x="52" y="76" fill="#6d28d9" font-size="14" font-weight="600">&#x26A1;</text>
+    <text x="68" y="76" fill="#fafafa" font-size="16" font-weight="600">Optio</text>
+    <text x="52" y="92" fill="#a1a1aa" font-size="10">Agent Orchestration</text>
+
+    <!-- Sidebar nav - Repos (active) -->
+    <text x="44" y="134" fill="#a1a1aa" font-size="13">Overview</text>
+    <text x="44" y="170" fill="#a1a1aa" font-size="13">Tasks</text>
+    <rect x="12" y="184" width="216" height="36" rx="8" fill="rgba(109,40,217,0.1)"/>
+    <rect x="12" y="184" width="2" height="36" rx="1" fill="#6d28d9"/>
+    <text x="44" y="206" fill="#fafafa" font-size="13" font-weight="500">Repos</text>
+    <text x="44" y="242" fill="#a1a1aa" font-size="13">Cluster</text>
+    <text x="44" y="278" fill="#a1a1aa" font-size="13">Costs</text>
+
+    <!-- Main content - Header -->
+    <text x="280" y="80" fill="#f4f4f5" font-size="24" font-weight="600" letter-spacing="-0.5">Repositories</text>
+    <text x="280" y="100" fill="#a1a1aa" font-size="13">4 repositories configured</text>
+
+    <!-- Add Repository button -->
+    <rect x="1100" y="60" width="140" height="36" rx="8" fill="#6d28d9"/>
+    <text x="1170" y="82" text-anchor="middle" fill="#ffffff" font-size="12" font-weight="500">+ Add Repository</text>
+
+    <!-- Repo list -->
+    <!-- Repo 1 -->
+    <rect x="280" y="124" width="960" height="100" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <!-- Repo icon -->
+    <rect x="308" y="148" width="36" height="36" rx="8" fill="rgba(109,40,217,0.1)"/>
+    <text x="326" y="171" text-anchor="middle" fill="#6d28d9" font-size="16">&#x1F4C1;</text>
+
+    <text x="360" y="164" fill="#fafafa" font-size="15" font-weight="600">jonwiggins/optio</text>
+    <text x="520" y="164" fill="#71717a" font-size="11">&#x1F310; Public</text>
+
+    <!-- Tags row -->
+    <rect x="360" y="176" width="46" height="20" rx="4" fill="rgba(59,130,246,0.1)"/>
+    <text x="383" y="190" text-anchor="middle" fill="#3b82f6" font-size="9" font-weight="600" class="mono">node</text>
+
+    <rect x="414" y="176" width="56" height="20" rx="4" fill="rgba(34,197,94,0.1)"/>
+    <text x="442" y="190" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="500">auto-merge</text>
+
+    <rect x="478" y="176" width="52" height="20" rx="4" fill="rgba(109,40,217,0.1)"/>
+    <text x="504" y="190" text-anchor="middle" fill="#7c3aed" font-size="9" font-weight="500">review &#x2713;</text>
+
+    <text x="360" y="210" fill="#71717a" font-size="10">main &middot; sonnet &middot; 200k context &middot; 2 concurrent</text>
+
+    <!-- Active tasks indicator -->
+    <rect x="1100" y="152" width="80" height="22" rx="11" fill="rgba(109,40,217,0.1)"/>
+    <text x="1140" y="167" text-anchor="middle" fill="#6d28d9" font-size="10" font-weight="500">2 active</text>
+    <text x="1200" y="167" fill="#3f3f46" font-size="14">&#x276F;</text>
+
+    <!-- Repo 2 -->
+    <rect x="280" y="238" width="960" height="100" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <rect x="308" y="262" width="36" height="36" rx="8" fill="rgba(109,40,217,0.1)"/>
+    <text x="326" y="285" text-anchor="middle" fill="#6d28d9" font-size="16">&#x1F4C1;</text>
+
+    <text x="360" y="278" fill="#fafafa" font-size="15" font-weight="600">jonwiggins/webapp</text>
+    <text x="520" y="278" fill="#71717a" font-size="11">&#x1F512; Private</text>
+
+    <rect x="360" y="290" width="54" height="20" rx="4" fill="rgba(59,130,246,0.1)"/>
+    <text x="387" y="304" text-anchor="middle" fill="#3b82f6" font-size="9" font-weight="600" class="mono">python</text>
+
+    <rect x="422" y="290" width="52" height="20" rx="4" fill="rgba(109,40,217,0.1)"/>
+    <text x="448" y="304" text-anchor="middle" fill="#7c3aed" font-size="9" font-weight="500">review &#x2713;</text>
+
+    <text x="360" y="324" fill="#71717a" font-size="10">main &middot; opus &middot; 1M context &middot; 1 concurrent</text>
+
+    <rect x="1100" y="266" width="80" height="22" rx="11" fill="rgba(245,158,11,0.1)"/>
+    <text x="1140" y="281" text-anchor="middle" fill="#f59e0b" font-size="10" font-weight="500">1 attn</text>
+    <text x="1200" y="281" fill="#3f3f46" font-size="14">&#x276F;</text>
+
+    <!-- Repo 3 -->
+    <rect x="280" y="352" width="960" height="100" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <rect x="308" y="376" width="36" height="36" rx="8" fill="rgba(109,40,217,0.1)"/>
+    <text x="326" y="399" text-anchor="middle" fill="#6d28d9" font-size="16">&#x1F4C1;</text>
+
+    <text x="360" y="392" fill="#fafafa" font-size="15" font-weight="600">acme-corp/billing-service</text>
+    <text x="565" y="392" fill="#71717a" font-size="11">&#x1F512; Private</text>
+
+    <rect x="360" y="404" width="36" height="20" rx="4" fill="rgba(59,130,246,0.1)"/>
+    <text x="378" y="418" text-anchor="middle" fill="#3b82f6" font-size="9" font-weight="600" class="mono">go</text>
+
+    <rect x="404" y="404" width="56" height="20" rx="4" fill="rgba(34,197,94,0.1)"/>
+    <text x="432" y="418" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="500">auto-merge</text>
+
+    <text x="360" y="438" fill="#71717a" font-size="10">main &middot; sonnet &middot; 200k context &middot; 3 concurrent</text>
+
+    <rect x="1100" y="380" width="80" height="22" rx="11" fill="rgba(34,197,94,0.1)"/>
+    <text x="1140" y="395" text-anchor="middle" fill="#22c55e" font-size="10" font-weight="500">1 PR</text>
+    <text x="1200" y="395" fill="#3f3f46" font-size="14">&#x276F;</text>
+
+    <!-- Repo 4 -->
+    <rect x="280" y="466" width="960" height="100" rx="12" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <rect x="308" y="490" width="36" height="36" rx="8" fill="rgba(109,40,217,0.1)"/>
+    <text x="326" y="513" text-anchor="middle" fill="#6d28d9" font-size="16">&#x1F4C1;</text>
+
+    <text x="360" y="506" fill="#fafafa" font-size="15" font-weight="600">acme-corp/frontend</text>
+    <text x="530" y="506" fill="#71717a" font-size="11">&#x1F512; Private</text>
+
+    <rect x="360" y="518" width="40" height="20" rx="4" fill="rgba(59,130,246,0.1)"/>
+    <text x="380" y="532" text-anchor="middle" fill="#3b82f6" font-size="9" font-weight="600" class="mono">full</text>
+
+    <text x="360" y="552" fill="#71717a" font-size="10">develop &middot; sonnet &middot; 200k context &middot; 2 concurrent</text>
+
+    <rect x="1100" y="494" width="80" height="22" rx="11" fill="rgba(59,130,246,0.1)"/>
+    <text x="1140" y="509" text-anchor="middle" fill="#3b82f6" font-size="10" font-weight="500">1 queued</text>
+    <text x="1200" y="509" fill="#3f3f46" font-size="14">&#x276F;</text>
+
+    <!-- Cluster Summary section -->
+    <text x="280" y="610" fill="#f4f4f5" font-size="15" font-weight="600">Active Pods</text>
+    <text x="375" y="610" fill="#a1a1aa" font-size="12">3 pods running</text>
+
+    <!-- Pod cards -->
+    <rect x="280" y="626" width="305" height="80" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <circle cx="304" cy="650" r="5" fill="#22c55e"/>
+    <text x="318" y="654" fill="#fafafa" font-size="12" font-weight="500" class="mono">optio-repo-jonwiggins-optio</text>
+    <text x="318" y="672" fill="#a1a1aa" font-size="10">2 worktrees &middot; CPU 45% &middot; Mem 812Mi</text>
+    <text x="318" y="690" fill="#71717a" font-size="10">Up 34m &middot; 3 tasks processed</text>
+
+    <rect x="600" y="626" width="305" height="80" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <circle cx="624" cy="650" r="5" fill="#22c55e"/>
+    <text x="638" y="654" fill="#fafafa" font-size="12" font-weight="500" class="mono">optio-repo-jonwiggins-webapp</text>
+    <text x="638" y="672" fill="#a1a1aa" font-size="10">1 worktree &middot; CPU 72% &middot; Mem 1.2Gi</text>
+    <text x="638" y="690" fill="#71717a" font-size="10">Up 12m &middot; 1 task processed</text>
+
+    <rect x="920" y="626" width="305" height="80" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <circle cx="944" cy="650" r="5" fill="#22c55e"/>
+    <text x="958" y="654" fill="#fafafa" font-size="12" font-weight="500" class="mono">optio-repo-acme-billing</text>
+    <text x="958" y="672" fill="#a1a1aa" font-size="10">1 worktree &middot; CPU 28% &middot; Mem 640Mi</text>
+    <text x="958" y="690" fill="#71717a" font-size="10">Up 22m &middot; 2 tasks processed</text>
+  </g>
+</svg>

--- a/docs/screenshots/task-detail-logs.svg
+++ b/docs/screenshots/task-detail-logs.svg
@@ -1,0 +1,195 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 800" font-family="Inter, -apple-system, system-ui, sans-serif">
+  <defs>
+    <style>
+      .mono { font-family: 'JetBrains Mono', 'Fira Code', monospace; }
+    </style>
+    <clipPath id="round-corners">
+      <rect width="1280" height="800" rx="12"/>
+    </clipPath>
+  </defs>
+
+  <g clip-path="url(#round-corners)">
+    <!-- Window chrome -->
+    <rect width="1280" height="800" fill="#0a0a0c"/>
+    <rect width="1280" height="36" fill="#111113"/>
+    <circle cx="20" cy="18" r="6" fill="#ef4444" opacity="0.8"/>
+    <circle cx="40" cy="18" r="6" fill="#f59e0b" opacity="0.8"/>
+    <circle cx="60" cy="18" r="6" fill="#22c55e" opacity="0.8"/>
+    <text x="640" y="23" text-anchor="middle" fill="#a1a1aa" font-size="12" font-weight="500">Optio — Task Detail</text>
+
+    <!-- Sidebar -->
+    <rect x="0" y="36" width="240" height="764" fill="#111113"/>
+    <line x1="240" y1="36" x2="240" y2="800" stroke="#27272a" stroke-width="1"/>
+
+    <!-- Sidebar logo -->
+    <text x="52" y="76" fill="#6d28d9" font-size="14" font-weight="600">&#x26A1;</text>
+    <text x="68" y="76" fill="#fafafa" font-size="16" font-weight="600">Optio</text>
+    <text x="52" y="92" fill="#a1a1aa" font-size="10">Agent Orchestration</text>
+
+    <!-- Sidebar nav - Tasks (active) -->
+    <text x="44" y="134" fill="#a1a1aa" font-size="13">Overview</text>
+    <rect x="12" y="148" width="216" height="36" rx="8" fill="rgba(109,40,217,0.1)"/>
+    <rect x="12" y="148" width="2" height="36" rx="1" fill="#6d28d9"/>
+    <text x="44" y="170" fill="#fafafa" font-size="13" font-weight="500">Tasks</text>
+    <text x="44" y="206" fill="#a1a1aa" font-size="13">Repos</text>
+    <text x="44" y="242" fill="#a1a1aa" font-size="13">Cluster</text>
+    <text x="44" y="278" fill="#a1a1aa" font-size="13">Costs</text>
+
+    <!-- Main content - Task header -->
+    <rect x="240" y="36" width="1040" height="100" fill="#18181b"/>
+    <line x1="240" y1="136" x2="1280" y2="136" stroke="#27272a" stroke-width="1"/>
+
+    <!-- Breadcrumb -->
+    <text x="280" y="62" fill="#a1a1aa" font-size="11">Tasks</text>
+    <text x="310" y="62" fill="#71717a" font-size="11">/</text>
+    <text x="320" y="62" fill="#a1a1aa" font-size="11" class="mono">d45a3787</text>
+
+    <!-- Task title -->
+    <text x="280" y="90" fill="#f4f4f5" font-size="18" font-weight="600">feat: add pod scaling controls and worktree lifecycle</text>
+
+    <!-- Running badge -->
+    <rect x="280" y="100" width="80" height="22" rx="11" fill="rgba(109,40,217,0.1)"/>
+    <circle cx="295" cy="111" r="3" fill="#6d28d9">
+      <animate attributeName="opacity" values="1;0.3;1" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <text x="305" y="115" fill="#6d28d9" font-size="10" font-weight="600">RUNNING</text>
+
+    <!-- Metadata -->
+    <text x="375" y="115" fill="#a1a1aa" font-size="11">jonwiggins/optio</text>
+    <text x="510" y="115" fill="#71717a" font-size="11">Claude Code</text>
+    <text x="600" y="115" fill="#71717a" font-size="11">2m 34s</text>
+
+    <!-- Action buttons -->
+    <rect x="1040" y="80" width="72" height="30" rx="6" fill="rgba(239,68,68,0.1)"/>
+    <text x="1076" y="99" text-anchor="middle" fill="#ef4444" font-size="11" font-weight="500">Cancel</text>
+    <rect x="1120" y="80" width="32" height="30" rx="6" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <text x="1136" y="99" text-anchor="middle" fill="#a1a1aa" font-size="12">&#x21BB;</text>
+
+    <!-- Pipeline timeline -->
+    <rect x="280" y="150" width="760" height="50" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+
+    <!-- Stage: Queued (done) -->
+    <circle cx="340" cy="175" r="10" fill="#22c55e" opacity="0.2"/>
+    <text x="340" y="179" text-anchor="middle" fill="#22c55e" font-size="10">&#x2713;</text>
+    <text x="340" y="193" text-anchor="middle" fill="#a1a1aa" font-size="9" class="mono">Queued</text>
+    <line x1="355" y1="175" x2="430" y2="175" stroke="#22c55e" stroke-width="2" opacity="0.3"/>
+
+    <!-- Stage: Provisioning (done) -->
+    <circle cx="445" cy="175" r="10" fill="#22c55e" opacity="0.2"/>
+    <text x="445" y="179" text-anchor="middle" fill="#22c55e" font-size="10">&#x2713;</text>
+    <text x="445" y="193" text-anchor="middle" fill="#a1a1aa" font-size="9" class="mono">Provision</text>
+    <line x1="460" y1="175" x2="530" y2="175" stroke="#22c55e" stroke-width="2" opacity="0.3"/>
+
+    <!-- Stage: Running (active) -->
+    <circle cx="545" cy="175" r="10" fill="#6d28d9" opacity="0.3"/>
+    <circle cx="545" cy="175" r="4" fill="#6d28d9">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.5s" repeatCount="indefinite"/>
+    </circle>
+    <text x="545" y="193" text-anchor="middle" fill="#6d28d9" font-size="9" font-weight="600" class="mono">Running</text>
+    <line x1="560" y1="175" x2="635" y2="175" stroke="#3f3f46" stroke-width="2" stroke-dasharray="4"/>
+
+    <!-- Stage: PR (future) -->
+    <circle cx="650" cy="175" r="10" fill="transparent" stroke="#3f3f46" stroke-width="1.5"/>
+    <text x="650" y="193" text-anchor="middle" fill="#71717a" font-size="9" class="mono">PR</text>
+    <line x1="665" y1="175" x2="735" y2="175" stroke="#3f3f46" stroke-width="2" stroke-dasharray="4"/>
+
+    <!-- Stage: Review (future) -->
+    <circle cx="750" cy="175" r="10" fill="transparent" stroke="#3f3f46" stroke-width="1.5"/>
+    <text x="750" y="193" text-anchor="middle" fill="#71717a" font-size="9" class="mono">Review</text>
+    <line x1="765" y1="175" x2="835" y2="175" stroke="#3f3f46" stroke-width="2" stroke-dasharray="4"/>
+
+    <!-- Stage: Done (future) -->
+    <circle cx="850" cy="175" r="10" fill="transparent" stroke="#3f3f46" stroke-width="1.5"/>
+    <text x="850" y="193" text-anchor="middle" fill="#71717a" font-size="9" class="mono">Done</text>
+
+    <!-- Log viewer section -->
+    <rect x="280" y="218" width="960" height="36" rx="10 10 0 0" fill="#18181b" stroke="#27272a" stroke-width="1"/>
+    <text x="300" y="240" fill="#f4f4f5" font-size="13" font-weight="600">Live Logs</text>
+
+    <!-- Connected indicator -->
+    <circle cx="380" cy="236" r="4" fill="#22c55e">
+      <animate attributeName="opacity" values="1;0.4;1" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <text x="390" y="240" fill="#a1a1aa" font-size="10">Connected</text>
+
+    <text x="470" y="240" fill="#71717a" font-size="10">47 events</text>
+    <text x="540" y="240" fill="#71717a" font-size="10">2m 34s</text>
+
+    <!-- Toolbar buttons -->
+    <rect x="1080" y="226" width="68" height="22" rx="4" fill="rgba(109,40,217,0.1)"/>
+    <text x="1114" y="241" text-anchor="middle" fill="#6d28d9" font-size="10" font-weight="500">Thinking</text>
+    <rect x="1156" y="226" width="64" height="22" rx="4" fill="#27272a"/>
+    <text x="1188" y="241" text-anchor="middle" fill="#a1a1aa" font-size="10" font-weight="500">Results</text>
+
+    <!-- Log viewer content area -->
+    <rect x="280" y="254" width="960" height="536" rx="0 0 10 10" fill="#0d0d0f" stroke="#27272a" stroke-width="1"/>
+
+    <!-- Log entries -->
+    <!-- System message -->
+    <text x="300" y="280" fill="rgba(161,161,170,0.25)" font-size="10" class="mono">14:22:01</text>
+    <text x="360" y="280" fill="#3b82f6" font-size="11" class="mono">system</text>
+    <text x="420" y="280" fill="#a1a1aa" font-size="11" class="mono">Claude Code session started (session: cs_a8f3k2m1)</text>
+
+    <!-- Text entry -->
+    <text x="300" y="306" fill="rgba(161,161,170,0.25)" font-size="10" class="mono">14:22:03</text>
+    <text x="360" y="306" fill="#fafafa" font-size="11" class="mono">I'll implement the pod scaling controls and worktree</text>
+    <text x="360" y="322" fill="#fafafa" font-size="11" class="mono">lifecycle management. Let me start by reading the</text>
+    <text x="360" y="338" fill="#fafafa" font-size="11" class="mono">existing codebase to understand the current architecture.</text>
+
+    <!-- Tool use - Read -->
+    <rect x="300" y="354" width="920" height="56" rx="8" fill="rgba(109,40,217,0.05)" stroke="rgba(109,40,217,0.15)" stroke-width="1"/>
+    <text x="320" y="374" fill="rgba(161,161,170,0.25)" font-size="10" class="mono">14:22:05</text>
+    <rect x="380" y="362" width="48" height="18" rx="4" fill="rgba(109,40,217,0.15)"/>
+    <text x="404" y="375" text-anchor="middle" fill="#7c3aed" font-size="9" font-weight="600" class="mono">READ</text>
+    <text x="436" y="375" fill="#a1a1aa" font-size="11" class="mono">apps/api/src/services/repo-pool-service.ts</text>
+    <text x="320" y="398" fill="#71717a" font-size="10" class="mono">&#x2713; Read 342 lines</text>
+
+    <!-- Tool use - Read -->
+    <rect x="300" y="420" width="920" height="56" rx="8" fill="rgba(109,40,217,0.05)" stroke="rgba(109,40,217,0.15)" stroke-width="1"/>
+    <text x="320" y="440" fill="rgba(161,161,170,0.25)" font-size="10" class="mono">14:22:06</text>
+    <rect x="380" y="428" width="48" height="18" rx="4" fill="rgba(109,40,217,0.15)"/>
+    <text x="404" y="441" text-anchor="middle" fill="#7c3aed" font-size="9" font-weight="600" class="mono">READ</text>
+    <text x="436" y="441" fill="#a1a1aa" font-size="11" class="mono">packages/container-runtime/src/kubernetes.ts</text>
+    <text x="320" y="464" fill="#71717a" font-size="10" class="mono">&#x2713; Read 518 lines</text>
+
+    <!-- Text entry -->
+    <text x="300" y="496" fill="rgba(161,161,170,0.25)" font-size="10" class="mono">14:22:12</text>
+    <text x="360" y="496" fill="#fafafa" font-size="11" class="mono">Now I understand the architecture. I'll add scaling</text>
+    <text x="360" y="512" fill="#fafafa" font-size="11" class="mono">endpoints and worktree cleanup logic.</text>
+
+    <!-- Tool use - Write -->
+    <rect x="300" y="528" width="920" height="56" rx="8" fill="rgba(34,197,94,0.05)" stroke="rgba(34,197,94,0.15)" stroke-width="1"/>
+    <text x="320" y="548" fill="rgba(161,161,170,0.25)" font-size="10" class="mono">14:22:15</text>
+    <rect x="380" y="536" width="50" height="18" rx="4" fill="rgba(34,197,94,0.15)"/>
+    <text x="405" y="549" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="600" class="mono">WRITE</text>
+    <text x="438" y="549" fill="#a1a1aa" font-size="11" class="mono">apps/api/src/routes/cluster.ts</text>
+    <text x="320" y="572" fill="#71717a" font-size="10" class="mono">&#x2713; Wrote 86 lines (+62, -24)</text>
+
+    <!-- Tool use - Write -->
+    <rect x="300" y="594" width="920" height="56" rx="8" fill="rgba(34,197,94,0.05)" stroke="rgba(34,197,94,0.15)" stroke-width="1"/>
+    <text x="320" y="614" fill="rgba(161,161,170,0.25)" font-size="10" class="mono">14:22:28</text>
+    <rect x="380" y="602" width="50" height="18" rx="4" fill="rgba(34,197,94,0.15)"/>
+    <text x="405" y="615" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="600" class="mono">WRITE</text>
+    <text x="438" y="615" fill="#a1a1aa" font-size="11" class="mono">apps/api/src/services/repo-pool-service.ts</text>
+    <text x="320" y="638" fill="#71717a" font-size="10" class="mono">&#x2713; Wrote 398 lines (+84, -26)</text>
+
+    <!-- Tool use - Bash -->
+    <rect x="300" y="660" width="920" height="56" rx="8" fill="rgba(59,130,246,0.05)" stroke="rgba(59,130,246,0.15)" stroke-width="1"/>
+    <text x="320" y="680" fill="rgba(161,161,170,0.25)" font-size="10" class="mono">14:23:41</text>
+    <rect x="380" y="668" width="48" height="18" rx="4" fill="rgba(59,130,246,0.15)"/>
+    <text x="404" y="681" text-anchor="middle" fill="#3b82f6" font-size="9" font-weight="600" class="mono">BASH</text>
+    <text x="436" y="681" fill="#a1a1aa" font-size="11" class="mono">pnpm turbo typecheck</text>
+    <text x="320" y="704" fill="#22c55e" font-size="10" class="mono">&#x2713; Exit code 0 — all packages pass</text>
+
+    <!-- Text entry with cursor -->
+    <text x="300" y="736" fill="rgba(161,161,170,0.25)" font-size="10" class="mono">14:24:32</text>
+    <text x="360" y="736" fill="#fafafa" font-size="11" class="mono">All type checks pass. Now running the test suite...</text>
+    <rect x="781" y="724" width="2" height="16" fill="#6d28d9">
+      <animate attributeName="opacity" values="1;0;1" dur="1s" repeatCount="indefinite"/>
+    </rect>
+
+    <!-- Scroll indicator -->
+    <rect x="1230" y="260" width="4" height="100" rx="2" fill="#27272a"/>
+    <rect x="1230" y="460" width="4" height="200" rx="2" fill="#3f3f46"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add three SVG mockup screenshots to `docs/screenshots/` showing the dashboard overview, task detail with live streaming logs, and repository management views
- Add a new "Demo" section near the top of README.md with centered images and descriptive captions
- All images include alt text for accessibility

## Screenshots Added
1. **Dashboard Overview** — Tasks in various states (running, queued, completed, PR opened, needs attention) with stat cards
2. **Task Detail with Live Logs** — Pipeline progress tracker, live-streamed agent logs showing tool calls (Read, Write, Bash), and real-time status
3. **Repository Management** — Configured repos with image presets, review settings, concurrency limits, and active pod status

## Test plan
- [x] `pnpm format:check` passes
- [x] `pnpm turbo typecheck` passes (10/10 packages)
- [x] `pnpm turbo test` passes (160/160 tests)
- [ ] Verify SVG screenshots render correctly on GitHub

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)