### PR TITLE
fix: exclude .optio/ directory from git tracking in agent worktrees

### DIFF
--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -398,6 +398,12 @@ export async function execTaskInRepoPod(
     `    print(f'  wrote {p}')`,
     `"`,
     `fi`,
+    // Exclude Optio runtime files from git tracking using the local exclude file
+    // (never committed, unlike .gitignore modifications)
+    `EXCLUDE_FILE="$(git rev-parse --git-dir)/info/exclude"`,
+    `mkdir -p "$(dirname "$EXCLUDE_FILE")"`,
+    `grep -qxF '.optio/' "$EXCLUDE_FILE" 2>/dev/null || echo '.optio/' >> "$EXCLUDE_FILE"`,
+    `grep -qxF '.optio-run-token' "$EXCLUDE_FILE" 2>/dev/null || echo '.optio-run-token' >> "$EXCLUDE_FILE"`,
     // EXIT trap: preserve the worktree — cleanup is handled by the cleanup worker
     // based on task state. Only clean up Claude Code's internal worktrees (-wt suffix).
     `trap 'cd /workspace/repo 2>/dev/null; git worktree remove --force /workspace/tasks/${taskId}-wt 2>/dev/null || true; git worktree prune 2>/dev/null || true' EXIT`,


### PR DESCRIPTION
## Summary
- Adds `.optio/` and `.optio-run-token` to the git local exclude file (`$(git rev-parse --git-dir)/info/exclude`) during worktree setup in `repo-pool-service.ts`
- Prevents agents from staging and committing Optio runtime files (`.optio/task.md`, etc.) in their PRs
- Uses the local exclude file rather than modifying `.gitignore`, so the target repository is never modified

## Test plan
- [ ] Verify agent PRs no longer contain `.optio/task.md` or `.optio-run-token`
- [ ] Verify existing repos are not modified (no `.gitignore` changes committed)
- [ ] Verify idempotent behavior on task retries (grep guards prevent duplicate entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)