### PR TITLE
fix: pod overview shows incorrect active agent count

### DIFF
--- a/.optio/task.md
+++ b/.optio/task.md
@@ -1,30 +1,32 @@
-# Fix tasks view flash/flicker on auto-update
+# fix: Pod overview shows incorrect active agent count
 
-Fix tasks view flash/flicker on auto-update
+fix: Pod overview shows incorrect active agent count
 
-## Description
+## Problem
 
-The tasks list view visibly flashes or flickers when it auto-updates via WebSocket events. This likely happens because the component re-renders the entire list when new data arrives, causing a brief flash as the DOM is replaced.
+The overview dashboard "Pods" section shows workspace pods with inflated active agent counts (e.g. 13 agents running) when there are actually 0 running tasks. This gives operators a false picture of cluster utilization.
 
-## Steps to reproduce
+## Likely Cause
 
-1. Navigate to `/tasks`
-2. Have tasks running or state transitions occurring
-3. Observe the list flickering as updates arrive
+The `activeTaskCount` field on `repo_pods` is incremented in `execTaskInRepoPod()` when a task starts, and decremented in `releaseRepoPodTask()` in the `finally` block. However, if the worker process is killed (server restart, crash) before the `finally` block runs, the count is never decremented. Over multiple restarts and retries, the count accumulates.
 
-## Possible causes
+The startup reconciler resets task states but does not reset `activeTaskCount` on repo pods.
 
-- Full list re-render on each WebSocket event (no stable keys or diffing)
-- Loading state briefly shown during data refresh
-- Zustand store update triggering unmount/remount of list items
-- Race between WebSocket updates and historical data fetch (see prior fix in 547098f for log deduplication — similar pattern may apply here)
+## Fix
 
-## Acceptance criteria
+Either:
 
-- Task list updates smoothly without visible flash
-- Individual task cards update in-place when their state changes
-- No layout shift when tasks are added or removed
+1. **Reconcile on startup**: Reset `activeTaskCount` on all repo pods based on the actual number of tasks in `running` state for that repo
+2. **Derive instead of track**: Replace the stored counter with a live query that counts tasks in `running`/`provisioning` state per repo pod
+
+Option 2 is more robust since it can never drift, but may have performance implications if queried frequently.
+
+## Acceptance Criteria
+
+- [ ] Pod active agent count matches actual running tasks
+- [ ] Count stays accurate across server restarts
+- [ ] Overview dashboard reflects correct pod utilization
 
 ---
 
-_Optio Task ID: 8ae54510-7225-41d6-8e03-23658f76c6ea_
+_Optio Task ID: b8ea6ea2-1948-4197-b90d-4b559c08423c_

--- a/apps/api/src/routes/cluster.ts
+++ b/apps/api/src/routes/cluster.ts
@@ -211,6 +211,20 @@ export async function clusterRoutes(app: FastifyInstance) {
 
       const queuedMap = new Map(queuedCounts.map((r) => [r.repoUrl, r.count]));
 
+      // Live running/provisioning task count per pod (derived from actual task states)
+      const runningCounts = await db
+        .select({
+          podId: tasks.lastPodId,
+          count: sql<number>`count(*)::int`,
+        })
+        .from(tasks)
+        .where(
+          sql`${tasks.state} IN ('running', 'provisioning') AND ${tasks.lastPodId} IS NOT NULL`,
+        )
+        .groupBy(tasks.lastPodId);
+
+      const runningCountMap = new Map(runningCounts.map((r) => [r.podId, r.count]));
+
       // Scaling config per repo
       const repoConfigs =
         repoUrls.length > 0
@@ -228,10 +242,13 @@ export async function clusterRoutes(app: FastifyInstance) {
       const repoConfigMap = new Map(repoConfigs.map((r) => [r.repoUrl, r]));
 
       // Enrich repo pod records with task indicators and scaling config
+      // Use the live-derived running count instead of the stored counter, which can drift
       const enrichedRepoPods = repoPodRecords.map((rp) => {
         const config = repoConfigMap.get(rp.repoUrl);
+        const liveCount = runningCountMap.get(rp.id) ?? 0;
         return {
           ...rp,
+          activeTaskCount: liveCount,
           queuedTaskCount: queuedMap.get(rp.repoUrl) ?? 0,
           maxConcurrentTasks: config?.maxConcurrentTasks ?? 2,
           maxPodInstances: config?.maxPodInstances ?? 1,
@@ -322,7 +339,13 @@ export async function clusterRoutes(app: FastifyInstance) {
       }
     }
 
-    reply.send({ pod: { ...pod, tasks: podTasks, k8sPod } });
+    // Derive the live active task count from actual running/provisioning tasks
+    const [{ count: liveActiveCount }] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(tasks)
+      .where(sql`${tasks.state} IN ('running', 'provisioning') AND ${tasks.lastPodId} = ${pod.id}`);
+
+    reply.send({ pod: { ...pod, activeTaskCount: liveActiveCount, tasks: podTasks, k8sPod } });
   });
 
   // Pod health events

--- a/apps/api/src/services/repo-pool-service.test.ts
+++ b/apps/api/src/services/repo-pool-service.test.ts
@@ -75,6 +75,7 @@ import {
   releaseRepoPodTask,
   cleanupIdleRepoPods,
   listRepoPods,
+  reconcileActiveTaskCounts,
 } from "./repo-pool-service.js";
 
 // ── resolveImage ────────────────────────────────────────────────────
@@ -272,5 +273,54 @@ describe("listRepoPods", () => {
 
     const result = await listRepoPods();
     expect(result).toEqual(mockPods);
+  });
+});
+
+// ── reconcileActiveTaskCounts ───────────────────────────────────────
+
+describe("reconcileActiveTaskCounts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 0 when no pods exist", async () => {
+    // First call: select pods
+    vi.mocked(db.select().from as any).mockResolvedValueOnce([]);
+
+    const result = await reconcileActiveTaskCounts();
+    expect(result).toBe(0);
+  });
+
+  it("corrects inflated activeTaskCount to match actual running tasks", async () => {
+    const pods = [
+      { id: "pod-1", activeTaskCount: 13 },
+      { id: "pod-2", activeTaskCount: 5 },
+    ];
+
+    // The mock chain uses mockReturnThis, so all methods return the same db mock.
+    // where() calls are interleaved: SELECT count, UPDATE, SELECT count, UPDATE
+    const dbMock = db as any;
+    dbMock.from.mockResolvedValueOnce(pods);
+    dbMock.where
+      .mockResolvedValueOnce([{ count: 1 }]) // SELECT: pod-1 has 1 running task
+      .mockResolvedValueOnce([]) // UPDATE: correct pod-1
+      .mockResolvedValueOnce([{ count: 0 }]) // SELECT: pod-2 has 0 running tasks
+      .mockResolvedValueOnce([]); // UPDATE: correct pod-2
+
+    const result = await reconcileActiveTaskCounts();
+    // Both pods should be corrected: pod-1 from 13→1, pod-2 from 5→0
+    expect(result).toBe(2);
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it("does not update pods that already have the correct count", async () => {
+    const pods = [{ id: "pod-1", activeTaskCount: 0 }];
+
+    const dbMock = db as any;
+    dbMock.from.mockResolvedValueOnce(pods);
+    dbMock.where.mockResolvedValueOnce([{ count: 0 }]);
+
+    const result = await reconcileActiveTaskCounts();
+    expect(result).toBe(0);
   });
 });

--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -502,3 +502,39 @@ export async function listRepoPods(): Promise<RepoPod[]> {
 export async function listRepoPodsForRepo(repoUrl: string): Promise<RepoPod[]> {
   return db.select().from(repoPods).where(eq(repoPods.repoUrl, repoUrl)) as Promise<RepoPod[]>;
 }
+
+/**
+ * Reconcile activeTaskCount on all repo pods to match actual running/provisioning tasks.
+ *
+ * The stored counter can drift if the worker process is killed before the finally
+ * block decrements it. This function resets each pod's counter to the real count
+ * of tasks in running/provisioning state that reference that pod via lastPodId.
+ */
+export async function reconcileActiveTaskCounts(): Promise<number> {
+  const allPods = await db
+    .select({ id: repoPods.id, activeTaskCount: repoPods.activeTaskCount })
+    .from(repoPods);
+  if (allPods.length === 0) return 0;
+
+  let corrected = 0;
+  for (const pod of allPods) {
+    const [{ count: actual }] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(tasks)
+      .where(sql`${tasks.state} IN ('running', 'provisioning') AND ${tasks.lastPodId} = ${pod.id}`);
+
+    if (pod.activeTaskCount !== actual) {
+      await db
+        .update(repoPods)
+        .set({ activeTaskCount: actual, updatedAt: new Date() })
+        .where(eq(repoPods.id, pod.id));
+      logger.info(
+        { podId: pod.id, was: pod.activeTaskCount, now: actual },
+        "Reconciled activeTaskCount",
+      );
+      corrected++;
+    }
+  }
+
+  return corrected;
+}

--- a/apps/api/src/workers/repo-cleanup-worker.ts
+++ b/apps/api/src/workers/repo-cleanup-worker.ts
@@ -2,7 +2,11 @@ import { Queue, Worker } from "bullmq";
 import { eq, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { repoPods, podHealthEvents, tasks, taskEvents } from "../db/schema.js";
-import { cleanupIdleRepoPods, updateWorktreeState } from "../services/repo-pool-service.js";
+import {
+  cleanupIdleRepoPods,
+  updateWorktreeState,
+  reconcileActiveTaskCounts,
+} from "../services/repo-pool-service.js";
 import { getRuntime } from "../services/container-service.js";
 import { TaskState } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
@@ -306,6 +310,12 @@ export function startRepoCleanupWorker() {
         } catch (err) {
           logger.warn({ err, taskId: task.id }, "Failed to re-queue stale task");
         }
+      }
+
+      // Reconcile activeTaskCount on all repo pods to catch any drift
+      const reconciled = await reconcileActiveTaskCounts();
+      if (reconciled > 0) {
+        logger.info({ reconciled }, "Reconciled repo pod activeTaskCounts");
       }
 
       // Clean up idle pods (existing behavior)

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -595,6 +595,14 @@ export async function reconcileOrphanedTasks() {
   if (enqueued > 0) {
     logger.info({ count: enqueued }, "Reconciled orphaned tasks after startup");
   }
+
+  // Reset activeTaskCount on all repo pods to match actual running tasks.
+  // The counter can drift if the server crashes before the finally block
+  // in the task worker decrements it.
+  const corrected = await repoPool.reconcileActiveTaskCounts();
+  if (corrected > 0) {
+    logger.info({ corrected }, "Reconciled repo pod activeTaskCounts on startup");
+  }
 }
 
 export function buildAgentCommand(


### PR DESCRIPTION
## Summary

- **Root cause**: `activeTaskCount` on `repo_pods` was incremented when tasks started but only decremented in the worker's `finally` block. If the worker process crashed or was restarted before the `finally` block ran, the counter was never decremented — accumulating stale counts across restarts.
- **Fix**: Added `reconcileActiveTaskCounts()` that counts actual `running`/`provisioning` tasks per pod (via `lastPodId`) and corrects any drift in the stored counter. This runs on startup and every 60s in the health check worker.
- **API fix**: The cluster overview and pod detail endpoints now override `activeTaskCount` with a live-derived count from actual task states, so the UI always shows the correct value regardless of counter drift.

## Test plan

- [x] Added 3 unit tests for `reconcileActiveTaskCounts()` (zero pods, drift correction, no-op when correct)
- [x] All 163 existing tests pass
- [x] Typecheck passes across all 6 packages
- [ ] Manual: restart API server while tasks are running, verify pod counts reset correctly
- [ ] Manual: check cluster overview page shows 0 active agents when no tasks are running

🤖 Generated with [Claude Code](https://claude.com/claude-code)