### PR TITLE
fix: harden auth security for production readiness

### DIFF
--- a/.optio/task.md
+++ b/.optio/task.md
@@ -1,124 +1,61 @@
-# feat: Add authentication with multi-provider OAuth support
+# fix: Auth security hardening before production
 
-feat: Add authentication with multi-provider OAuth support
+fix: Auth security hardening before production
 
 ## Summary
 
-Optio currently has no authentication on the web UI or API — all endpoints are open to anyone with network access. We need a proper auth layer that supports multiple OAuth providers, is admin-configurable, and can be disabled for local development.
+The OAuth auth system (#29) is functionally complete but has several security gaps that need addressing before production use.
 
-## Motivation
+## Issues
 
-- **Security**: Anyone with network access can submit tasks, view logs, cancel jobs, and read secrets
-- **Audit trail**: No way to know who submitted a task or performed an action
-- **Production readiness**: Auth is a prerequisite for any non-localhost deployment
+### Critical: CORS accepts any origin
 
-## Design
+- **File**: `apps/api/src/server.ts`
+- CORS is configured with `origin: true`, allowing requests from any origin
+- **Fix**: Whitelist specific origins via `OPTIO_ALLOWED_ORIGINS` env var (e.g. `http://localhost:3100,https://optio.example.com`)
 
-### Multi-Provider OAuth
+### High: No `Secure` flag on session cookie
 
-Support GitHub, Google, and GitLab as OAuth providers. All three use standard OAuth2 flows and share a common interface:
+- **File**: `apps/api/src/routes/auth.ts`
+- Session cookies are set with `HttpOnly` and `SameSite=Lax` but no `Secure` flag
+- In production over HTTPS, cookies could be transmitted over unencrypted connections
+- **Fix**: Conditionally add `Secure` when `NODE_ENV=production` or behind a config flag
 
-```ts
-interface OAuthProvider {
-  name: string;
-  authorizeUrl(state: string): string;
-  exchangeCode(code: string): Promise<{ accessToken: string; refreshToken?: string }>;
-  fetchUser(
-    accessToken: string,
-  ): Promise<{ externalId: string; email: string; displayName: string; avatarUrl?: string }>;
-}
-```
+### High: No expired session cleanup
 
-Auth flow:
+- Sessions accumulate in the DB indefinitely — `validateSession()` checks expiry but never deletes old rows
+- **Fix**: Add periodic cleanup (e.g. in `repo-cleanup-worker`) to delete sessions where `expires_at < now()`
 
-1. User clicks "Sign in with {Provider}" on `/login`
-2. Redirected to `/api/auth/:provider/login` → provider's OAuth consent screen
-3. Provider redirects back to `/api/auth/:provider/callback`
-4. API exchanges code for token, fetches user profile, creates/updates user record, creates session
-5. Session cookie set, user redirected to `/`
+### High: OAuth providers don't check response status
 
-### Admin Configuration
+- **Files**: `apps/api/src/services/oauth/github.ts`, `google.ts`, `gitlab.ts`
+- `exchangeCode` and `fetchUser` call `.json()` without checking `res.ok` first
+- Non-2xx responses (rate limits, server errors) will throw confusing parse errors
+- **Fix**: Add `if (!res.ok) throw new Error(...)` before parsing
 
-Provider credentials are stored as env vars or in the existing secrets system:
+### Medium: Unbounded in-memory OAuth state map
 
-```
-GITHUB_OAUTH_CLIENT_ID / GITHUB_OAUTH_CLIENT_SECRET
-GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET
-GITLAB_OAUTH_CLIENT_ID / GITLAB_OAUTH_CLIENT_SECRET
-```
+- **File**: `apps/api/src/routes/auth.ts`
+- The `oauthStates` Map has a 10-minute TTL cleanup but no size limit
+- An attacker could flood login requests to grow the map unboundedly
+- **Fix**: Use a size-limited LRU cache or move state to Redis
 
-A new "Authentication" section on the `/settings` page allows admins to:
+### Medium: Error messages in redirect URLs
 
-- See which providers are available (auto-detected from configured client IDs)
-- Toggle individual providers on/off
-- Set an allowed email domain filter (e.g. `@yourcompany.com`)
-- Set a GitHub org restriction (e.g. only members of `my-org` can log in)
-
-### Disable Auth for Local Dev
-
-A single env var disables all auth checks:
-
-```
-OPTIO_AUTH_DISABLED=true
-```
-
-- The Fastify auth `preHandler` hook short-circuits when this is set
-- `setup-local.sh` sets this in `.env` by default
-- The Helm chart defaults it to `false`
-- The web UI shows a "Authentication is disabled" banner and a "Local Dev" placeholder avatar
-- The Next.js middleware skips the login redirect
-
-## Database Changes
-
-Three schema changes (one new migration):
-
-1. **`users` table** — id, provider, externalId, email, displayName, avatarUrl, lastLoginAt
-2. **`sessions` table** — id, userId (FK), tokenHash, expiresAt (server-side sessions allow revocation)
-3. **`tasks.createdBy`** — nullable FK to users (null when auth is disabled)
-
-## Implementation Scope
-
-### API (`apps/api`) ~8 files
-
-- [ ] `services/oauth/provider.ts` — OAuthProvider interface
-- [ ] `services/oauth/github.ts` — GitHub OAuth implementation
-- [ ] `services/oauth/google.ts` — Google OAuth implementation
-- [ ] `services/oauth/gitlab.ts` — GitLab OAuth implementation
-- [ ] `services/session-service.ts` — create, validate, revoke sessions
-- [ ] `routes/auth.ts` — extend with `/:provider/login`, `/:provider/callback`, `/me`, `/logout`
-- [ ] `plugins/auth.ts` — Fastify `preHandler` hook (validate session cookie, skip if `OPTIO_AUTH_DISABLED`)
-- [ ] DB migration for users, sessions tables, and tasks.createdBy column
-
-### Web (`apps/web`) ~4 files
-
-- [ ] `middleware.ts` — check session cookie, redirect to `/login` if missing (skip if auth disabled)
-- [ ] `app/login/page.tsx` — login page with provider buttons (fetches enabled providers from API)
-- [ ] `components/layout/user-menu.tsx` — avatar dropdown with user info + logout in sidebar
-- [ ] Settings page — new "Authentication" section for provider management
-
-### Config / Infra
-
-- [ ] `setup-local.sh` — add `OPTIO_AUTH_DISABLED=true` to generated `.env`
-- [ ] `.env.example` — add OAuth env vars and `OPTIO_AUTH_DISABLED`
-- [ ] Helm `values.yaml` — add auth config section (OAuth secrets, `authDisabled: false`)
-
-## Non-Goals (for now)
-
-- **Roles/permissions** — all authenticated users are equal. RBAC can come later.
-- **API keys for programmatic access** — can add `/api/auth/api-keys` CRUD in a follow-up.
-- **SAML/OIDC enterprise SSO** — out of scope for v1, but the provider interface makes it easy to add.
+- **File**: `apps/api/src/routes/auth.ts`
+- Raw error strings (including potential stack traces) are URL-encoded in redirect query params
+- Visible in browser history and server logs
+- **Fix**: Use generic error codes in redirects, fetch details via API if needed
 
 ## Acceptance Criteria
 
-- [ ] At least one OAuth provider (GitHub) works end-to-end: login → session → protected routes → logout
-- [ ] Google and GitLab providers implemented and tested
-- [ ] Unauthenticated requests to protected API routes return 401
-- [ ] Unauthenticated web access redirects to `/login`
-- [ ] `OPTIO_AUTH_DISABLED=true` bypasses all auth (local dev works unchanged)
-- [ ] Admin can see and toggle providers on the settings page
-- [ ] Tasks show who created them (`createdBy`)
-- [ ] Helm chart supports OAuth configuration
+- [ ] CORS restricted to configured origins
+- [ ] Session cookie has `Secure` flag in production
+- [ ] Expired sessions are cleaned up periodically
+- [ ] OAuth HTTP responses validated before parsing
+- [ ] OAuth state map bounded or moved to Redis
+- [ ] Error messages not leaked in URLs
 
 ---
 
-_Optio Task ID: 9ed465eb-5796-45c8-8104-df2be1d286e2_
+_Optio Task ID: b5043ba0-5447-434b-aa87-e3baf712629d_

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -10,17 +10,41 @@ import { createSession, revokeSession, validateSession } from "../services/sessi
 import { SESSION_COOKIE_NAME } from "../plugins/auth.js";
 
 const WEB_URL = process.env.WEB_PUBLIC_URL ?? "http://localhost:3000";
+const IS_PRODUCTION = process.env.NODE_ENV === "production";
 
-// In-memory state store for CSRF protection (short-lived, 10 min TTL)
+// In-memory state store for CSRF protection (short-lived, 10 min TTL, bounded size)
+const OAUTH_STATE_MAX_SIZE = 10_000;
+const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
 const oauthStates = new Map<string, { provider: string; createdAt: number }>();
 
 // Clean expired states periodically
 setInterval(() => {
   const now = Date.now();
   for (const [key, val] of oauthStates) {
-    if (now - val.createdAt > 10 * 60 * 1000) oauthStates.delete(key);
+    if (now - val.createdAt > OAUTH_STATE_TTL_MS) oauthStates.delete(key);
   }
 }, 60_000);
+
+function addOAuthState(state: string, provider: string): void {
+  // Evict oldest entries if at capacity
+  if (oauthStates.size >= OAUTH_STATE_MAX_SIZE) {
+    let oldest: string | undefined;
+    let oldestTime = Infinity;
+    for (const [key, val] of oauthStates) {
+      if (val.createdAt < oldestTime) {
+        oldestTime = val.createdAt;
+        oldest = key;
+      }
+    }
+    if (oldest) oauthStates.delete(oldest);
+  }
+  oauthStates.set(state, { provider, createdAt: Date.now() });
+}
+
+function buildSessionCookie(token: string): string {
+  const secure = IS_PRODUCTION ? "; Secure" : "";
+  return `${SESSION_COOKIE_NAME}=${token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${30 * 24 * 60 * 60}${secure}`;
+}
 
 export async function authRoutes(app: FastifyInstance) {
   // ─── Existing Claude auth endpoints ───
@@ -80,7 +104,7 @@ export async function authRoutes(app: FastifyInstance) {
     }
 
     const state = randomBytes(16).toString("hex");
-    oauthStates.set(state, { provider: providerName, createdAt: Date.now() });
+    addOAuthState(state, providerName);
 
     const url = provider.authorizeUrl(state);
     reply.redirect(url);
@@ -95,7 +119,7 @@ export async function authRoutes(app: FastifyInstance) {
     const { code, state, error } = req.query;
 
     if (error) {
-      return reply.redirect(`${WEB_URL}/login?error=${encodeURIComponent(error)}`);
+      return reply.redirect(`${WEB_URL}/login?error=provider_error`);
     }
 
     if (!code || !state) {
@@ -120,16 +144,10 @@ export async function authRoutes(app: FastifyInstance) {
       const { token } = await createSession(providerName, profile);
 
       // Set session cookie and redirect to web app
-      reply
-        .header(
-          "Set-Cookie",
-          `${SESSION_COOKIE_NAME}=${token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${30 * 24 * 60 * 60}`,
-        )
-        .redirect(`${WEB_URL}/`);
+      reply.header("Set-Cookie", buildSessionCookie(token)).redirect(`${WEB_URL}/`);
     } catch (err) {
       app.log.error(err, "OAuth callback failed");
-      const msg = err instanceof Error ? err.message : "unknown_error";
-      reply.redirect(`${WEB_URL}/login?error=${encodeURIComponent(msg)}`);
+      reply.redirect(`${WEB_URL}/login?error=auth_failed`);
     }
   });
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -32,8 +32,11 @@ export async function buildServer() {
   const app = Fastify({ logger: loggerConfig });
 
   // Plugins
+  const allowedOrigins = process.env.OPTIO_ALLOWED_ORIGINS
+    ? process.env.OPTIO_ALLOWED_ORIGINS.split(",").map((o) => o.trim())
+    : undefined;
   await app.register(cors, {
-    origin: true,
+    origin: allowedOrigins ?? true,
     credentials: true,
     methods: ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
   });

--- a/apps/api/src/services/oauth/github.ts
+++ b/apps/api/src/services/oauth/github.ts
@@ -36,6 +36,9 @@ export class GitHubOAuthProvider implements OAuthProvider {
         redirect_uri: getCallbackUrl("github"),
       }),
     });
+    if (!res.ok) {
+      throw new Error(`GitHub token exchange failed: ${res.status} ${res.statusText}`);
+    }
     const data = (await res.json()) as Record<string, string>;
     if (data.error) {
       throw new Error(`GitHub OAuth error: ${data.error_description ?? data.error}`);
@@ -53,6 +56,12 @@ export class GitHubOAuthProvider implements OAuthProvider {
       }),
     ]);
 
+    if (!userRes.ok) {
+      throw new Error(`GitHub user fetch failed: ${userRes.status} ${userRes.statusText}`);
+    }
+    if (!emailsRes.ok) {
+      throw new Error(`GitHub emails fetch failed: ${emailsRes.status} ${emailsRes.statusText}`);
+    }
     const user = (await userRes.json()) as Record<string, any>;
     const emails = (await emailsRes.json()) as Array<{
       email: string;

--- a/apps/api/src/services/oauth/gitlab.ts
+++ b/apps/api/src/services/oauth/gitlab.ts
@@ -39,6 +39,9 @@ export class GitLabOAuthProvider implements OAuthProvider {
         grant_type: "authorization_code",
       }),
     });
+    if (!res.ok) {
+      throw new Error(`GitLab token exchange failed: ${res.status} ${res.statusText}`);
+    }
     const data = (await res.json()) as Record<string, any>;
     if (data.error) {
       throw new Error(`GitLab OAuth error: ${data.error_description ?? data.error}`);
@@ -50,6 +53,9 @@ export class GitLabOAuthProvider implements OAuthProvider {
     const res = await fetch(`${this.baseUrl}/api/v4/user`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
+    if (!res.ok) {
+      throw new Error(`GitLab user fetch failed: ${res.status} ${res.statusText}`);
+    }
     const data = (await res.json()) as Record<string, any>;
     return {
       externalId: String(data.id),

--- a/apps/api/src/services/oauth/google.ts
+++ b/apps/api/src/services/oauth/google.ts
@@ -37,6 +37,9 @@ export class GoogleOAuthProvider implements OAuthProvider {
         grant_type: "authorization_code",
       }),
     });
+    if (!res.ok) {
+      throw new Error(`Google token exchange failed: ${res.status} ${res.statusText}`);
+    }
     const data = (await res.json()) as Record<string, any>;
     if (data.error) {
       throw new Error(`Google OAuth error: ${data.error_description ?? data.error}`);
@@ -48,6 +51,9 @@ export class GoogleOAuthProvider implements OAuthProvider {
     const res = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
+    if (!res.ok) {
+      throw new Error(`Google user fetch failed: ${res.status} ${res.statusText}`);
+    }
     const data = (await res.json()) as Record<string, any>;
     return {
       externalId: String(data.id),

--- a/apps/api/src/services/session-service.ts
+++ b/apps/api/src/services/session-service.ts
@@ -1,7 +1,7 @@
 import { randomBytes, createHash } from "node:crypto";
 import { db } from "../db/client.js";
 import { users, sessions } from "../db/schema.js";
-import { eq, and, gt } from "drizzle-orm";
+import { eq, and, gt, lt } from "drizzle-orm";
 import type { OAuthUser } from "./oauth/provider.js";
 
 const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -122,4 +122,10 @@ export async function revokeSession(token: string): Promise<void> {
 /** Revoke all sessions for a user. */
 export async function revokeAllUserSessions(userId: string): Promise<void> {
   await db.delete(sessions).where(eq(sessions.userId, userId));
+}
+
+/** Delete all expired sessions. Returns count of deleted rows. */
+export async function cleanupExpiredSessions(): Promise<number> {
+  const result = await db.delete(sessions).where(lt(sessions.expiresAt, new Date())).returning();
+  return result.length;
 }

--- a/apps/api/src/workers/repo-cleanup-worker.ts
+++ b/apps/api/src/workers/repo-cleanup-worker.ts
@@ -10,6 +10,7 @@ import {
 import { getRuntime } from "../services/container-service.js";
 import { TaskState } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
+import { cleanupExpiredSessions } from "../services/session-service.js";
 import { logger } from "../logger.js";
 
 const connectionOpts = {
@@ -322,6 +323,16 @@ export function startRepoCleanupWorker() {
       const cleaned = await cleanupIdleRepoPods();
       if (cleaned > 0) {
         logger.info({ cleaned }, "Cleaned up idle repo pods");
+      }
+
+      // Clean up expired auth sessions
+      try {
+        const expiredSessions = await cleanupExpiredSessions();
+        if (expiredSessions > 0) {
+          logger.info({ expiredSessions }, "Cleaned up expired sessions");
+        }
+      } catch (err) {
+        logger.warn({ err }, "Failed to clean up expired sessions");
       }
     },
     {


### PR DESCRIPTION
## Summary

Addresses six security gaps in the OAuth auth system before production use:

- **CORS restriction**: CORS now whitelists origins from `OPTIO_ALLOWED_ORIGINS` env var (comma-separated). Falls back to permissive mode when unset for local dev compatibility.
- **Secure cookie flag**: Session cookie includes `Secure` flag when `NODE_ENV=production`, preventing transmission over unencrypted connections.
- **Expired session cleanup**: `repo-cleanup-worker` now periodically deletes sessions where `expires_at < now()`, preventing unbounded table growth.
- **OAuth response validation**: All three OAuth providers (GitHub, Google, GitLab) now check `res.ok` before calling `.json()` on both `exchangeCode` and `fetchUser` responses, producing clear error messages instead of confusing parse failures.
- **Bounded OAuth state map**: In-memory `oauthStates` map capped at 10,000 entries with LRU eviction, preventing memory exhaustion from login flooding.
- **Generic error codes in redirects**: OAuth callback redirects now use opaque error codes (`provider_error`, `auth_failed`) instead of raw error messages, preventing information leakage in URLs and browser history.

## Test plan

- [x] `pnpm turbo typecheck` passes (all 10 tasks)
- [x] `pnpm turbo test` passes (163 tests)
- [ ] Verify CORS blocks requests from unlisted origins when `OPTIO_ALLOWED_ORIGINS` is set
- [ ] Verify session cookie includes `Secure` when `NODE_ENV=production`
- [ ] Verify expired sessions are cleaned up on health check cycle
- [ ] Verify OAuth login flow still works end-to-end with each provider
- [ ] Verify error redirects show generic codes, not raw messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)