### PR TITLE
fix: implement pagination for GitHub and Linear ticket providers

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -5,6 +5,7 @@ export const DEFAULT_AGENT_IMAGE = "optio-agent:latest";
 export const DEFAULT_TICKET_LABEL = "optio";
 export const DEFAULT_MAX_TURNS_CODING = 250;
 export const DEFAULT_MAX_TURNS_REVIEW = 10;
+export const DEFAULT_MAX_TICKET_PAGES = 20;
 
 /**
  * Max length for K8s resource names.

--- a/packages/ticket-providers/package.json
+++ b/packages/ticket-providers/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@optio/shared": "workspace:*",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.2.1"
   }
 }

--- a/packages/ticket-providers/src/github.test.ts
+++ b/packages/ticket-providers/src/github.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from "vitest";
+import { GitHubTicketProvider } from "./github.js";
+import type { GitHubProviderConfig } from "./github.js";
+
+// Mock Octokit
+vi.mock("@octokit/rest", () => {
+  return {
+    Octokit: vi.fn().mockImplementation(() => ({
+      issues: {
+        listForRepo: vi.fn(),
+      },
+    })),
+  };
+});
+
+import { Octokit } from "@octokit/rest";
+
+function makeIssue(number: number) {
+  return {
+    number,
+    title: `Issue ${number}`,
+    body: `Body ${number}`,
+    html_url: `https://github.com/owner/repo/issues/${number}`,
+    labels: [{ name: "optio" }],
+    assignee: { login: "user1" },
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    pull_request: undefined,
+  };
+}
+
+function baseConfig(): GitHubProviderConfig {
+  return { token: "test-token", owner: "owner", repo: "repo" };
+}
+
+describe("GitHubTicketProvider pagination", () => {
+  it("fetches a single page when fewer than 100 issues", async () => {
+    const issues = Array.from({ length: 3 }, (_, i) => makeIssue(i + 1));
+    const listForRepo = vi.fn().mockResolvedValueOnce({
+      data: issues,
+      headers: { link: "" },
+    });
+    vi.mocked(Octokit).mockImplementation(
+      () => ({ issues: { listForRepo } }) as unknown as InstanceType<typeof Octokit>,
+    );
+
+    const provider = new GitHubTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(3);
+    expect(listForRepo).toHaveBeenCalledTimes(1);
+    expect(listForRepo).toHaveBeenCalledWith(expect.objectContaining({ per_page: 100, page: 1 }));
+  });
+
+  it("paginates across multiple pages using Link header", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => makeIssue(i + 1));
+    const page2 = Array.from({ length: 30 }, (_, i) => makeIssue(i + 101));
+
+    const listForRepo = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: page1,
+        headers: {
+          link: '<https://api.github.com/repos/owner/repo/issues?page=2>; rel="next"',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: page2,
+        headers: { link: "" },
+      });
+
+    vi.mocked(Octokit).mockImplementation(
+      () => ({ issues: { listForRepo } }) as unknown as InstanceType<typeof Octokit>,
+    );
+
+    const provider = new GitHubTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(130);
+    expect(listForRepo).toHaveBeenCalledTimes(2);
+    expect(listForRepo).toHaveBeenNthCalledWith(1, expect.objectContaining({ page: 1 }));
+    expect(listForRepo).toHaveBeenNthCalledWith(2, expect.objectContaining({ page: 2 }));
+  });
+
+  it("respects maxPages limit", async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => makeIssue(i + 1));
+    const listForRepo = vi.fn().mockResolvedValue({
+      data: fullPage,
+      headers: {
+        link: '<https://api.github.com/repos/owner/repo/issues?page=2>; rel="next"',
+      },
+    });
+
+    vi.mocked(Octokit).mockImplementation(
+      () => ({ issues: { listForRepo } }) as unknown as InstanceType<typeof Octokit>,
+    );
+
+    const provider = new GitHubTicketProvider();
+    const config: GitHubProviderConfig = { ...baseConfig(), maxPages: 2 };
+    const tickets = await provider.fetchActionableTickets(config);
+
+    expect(listForRepo).toHaveBeenCalledTimes(2);
+    expect(tickets).toHaveLength(200);
+  });
+
+  it("stops when an empty page is returned", async () => {
+    const listForRepo = vi.fn().mockResolvedValueOnce({
+      data: [],
+      headers: { link: "" },
+    });
+
+    vi.mocked(Octokit).mockImplementation(
+      () => ({ issues: { listForRepo } }) as unknown as InstanceType<typeof Octokit>,
+    );
+
+    const provider = new GitHubTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(0);
+    expect(listForRepo).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters out pull requests", async () => {
+    const issues = [
+      makeIssue(1),
+      { ...makeIssue(2), pull_request: { url: "https://..." } },
+      makeIssue(3),
+    ];
+    const listForRepo = vi.fn().mockResolvedValueOnce({
+      data: issues,
+      headers: { link: "" },
+    });
+
+    vi.mocked(Octokit).mockImplementation(
+      () => ({ issues: { listForRepo } }) as unknown as InstanceType<typeof Octokit>,
+    );
+
+    const provider = new GitHubTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(2);
+    expect(tickets.map((t) => t.externalId)).toEqual(["1", "3"]);
+  });
+});

--- a/packages/ticket-providers/src/github.ts
+++ b/packages/ticket-providers/src/github.ts
@@ -2,6 +2,7 @@ import { Octokit } from "@octokit/rest";
 import {
   TicketSource,
   DEFAULT_TICKET_LABEL,
+  DEFAULT_MAX_TICKET_PAGES,
   type Ticket,
   type TicketProviderConfig,
 } from "@optio/shared";
@@ -12,6 +13,8 @@ export interface GitHubProviderConfig extends TicketProviderConfig {
   owner: string;
   repo: string;
   label?: string;
+  /** Max pages to fetch (default: DEFAULT_MAX_TICKET_PAGES). Set to prevent runaway pagination. */
+  maxPages?: number;
 }
 
 function asGitHubConfig(config: TicketProviderConfig): GitHubProviderConfig {
@@ -29,34 +32,52 @@ export class GitHubTicketProvider implements TicketProvider {
     const ghConfig = asGitHubConfig(config);
     const octokit = new Octokit({ auth: ghConfig.token });
     const label = ghConfig.label ?? DEFAULT_TICKET_LABEL;
+    const maxPages = ghConfig.maxPages ?? DEFAULT_MAX_TICKET_PAGES;
 
-    const { data: issues } = await octokit.issues.listForRepo({
-      owner: ghConfig.owner,
-      repo: ghConfig.repo,
-      labels: label,
-      state: "open",
-      per_page: 50,
-    });
+    const allTickets: Ticket[] = [];
+    let page = 1;
 
-    return issues
-      .filter((issue) => !issue.pull_request)
-      .map((issue) => ({
-        externalId: String(issue.number),
-        source: TicketSource.GITHUB,
-        title: issue.title,
-        body: issue.body ?? "",
-        url: issue.html_url,
-        labels: issue.labels
-          .map((l) => (typeof l === "string" ? l : l.name))
-          .filter((n): n is string => !!n),
-        assignee: issue.assignee?.login,
-        repo: `${ghConfig.owner}/${ghConfig.repo}`,
-        metadata: {
-          number: issue.number,
-          createdAt: issue.created_at,
-          updatedAt: issue.updated_at,
-        },
-      }));
+    while (page <= maxPages) {
+      const { data: issues, headers } = await octokit.issues.listForRepo({
+        owner: ghConfig.owner,
+        repo: ghConfig.repo,
+        labels: label,
+        state: "open",
+        per_page: 100,
+        page,
+      });
+
+      if (issues.length === 0) break;
+
+      for (const issue of issues) {
+        if (issue.pull_request) continue;
+        allTickets.push({
+          externalId: String(issue.number),
+          source: TicketSource.GITHUB,
+          title: issue.title,
+          body: issue.body ?? "",
+          url: issue.html_url,
+          labels: issue.labels
+            .map((l) => (typeof l === "string" ? l : l.name))
+            .filter((n): n is string => !!n),
+          assignee: issue.assignee?.login,
+          repo: `${ghConfig.owner}/${ghConfig.repo}`,
+          metadata: {
+            number: issue.number,
+            createdAt: issue.created_at,
+            updatedAt: issue.updated_at,
+          },
+        });
+      }
+
+      // Check if there's a next page via the Link header
+      const linkHeader = headers.link ?? "";
+      if (!linkHeader.includes('rel="next"')) break;
+
+      page++;
+    }
+
+    return allTickets;
   }
 
   async addComment(ticketId: string, comment: string, config: TicketProviderConfig): Promise<void> {

--- a/packages/ticket-providers/src/linear.test.ts
+++ b/packages/ticket-providers/src/linear.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from "vitest";
+import { LinearTicketProvider } from "./linear.js";
+import type { LinearProviderConfig } from "./linear.js";
+
+// Mock Linear SDK
+vi.mock("@linear/sdk", () => {
+  return {
+    LinearClient: vi.fn().mockImplementation(() => ({
+      issues: vi.fn(),
+    })),
+  };
+});
+
+import { LinearClient } from "@linear/sdk";
+
+function makeLinearIssue(id: string, num: number) {
+  return {
+    id,
+    identifier: `ENG-${num}`,
+    title: `Issue ${num}`,
+    description: `Description ${num}`,
+    url: `https://linear.app/team/issue/ENG-${num}`,
+    priority: 1,
+    createdAt: new Date("2025-01-01"),
+  };
+}
+
+function baseConfig(): LinearProviderConfig {
+  return { apiKey: "test-key" };
+}
+
+describe("LinearTicketProvider pagination", () => {
+  it("fetches a single page when hasNextPage is false", async () => {
+    const nodes = Array.from({ length: 3 }, (_, i) => makeLinearIssue(`id-${i}`, i + 1));
+    const issuesFn = vi.fn().mockResolvedValueOnce({
+      nodes,
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
+
+    vi.mocked(LinearClient).mockImplementation(
+      () => ({ issues: issuesFn }) as unknown as InstanceType<typeof LinearClient>,
+    );
+
+    const provider = new LinearTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(3);
+    expect(issuesFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("paginates across multiple pages using endCursor", async () => {
+    const page1Nodes = Array.from({ length: 50 }, (_, i) => makeLinearIssue(`id-${i}`, i + 1));
+    const page2Nodes = Array.from({ length: 10 }, (_, i) =>
+      makeLinearIssue(`id-${i + 50}`, i + 51),
+    );
+
+    const issuesFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        nodes: page1Nodes,
+        pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+      })
+      .mockResolvedValueOnce({
+        nodes: page2Nodes,
+        pageInfo: { hasNextPage: false, endCursor: null },
+      });
+
+    vi.mocked(LinearClient).mockImplementation(
+      () => ({ issues: issuesFn }) as unknown as InstanceType<typeof LinearClient>,
+    );
+
+    const provider = new LinearTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(60);
+    expect(issuesFn).toHaveBeenCalledTimes(2);
+    // Second call should include the cursor
+    expect(issuesFn).toHaveBeenNthCalledWith(2, expect.objectContaining({ after: "cursor-1" }));
+  });
+
+  it("respects maxPages limit", async () => {
+    const fullPage = Array.from({ length: 50 }, (_, i) => makeLinearIssue(`id-${i}`, i + 1));
+
+    const issuesFn = vi.fn().mockResolvedValue({
+      nodes: fullPage,
+      pageInfo: { hasNextPage: true, endCursor: "cursor-next" },
+    });
+
+    vi.mocked(LinearClient).mockImplementation(
+      () => ({ issues: issuesFn }) as unknown as InstanceType<typeof LinearClient>,
+    );
+
+    const provider = new LinearTicketProvider();
+    const config: LinearProviderConfig = { ...baseConfig(), maxPages: 3 };
+    const tickets = await provider.fetchActionableTickets(config);
+
+    expect(issuesFn).toHaveBeenCalledTimes(3);
+    expect(tickets).toHaveLength(150);
+  });
+
+  it("returns empty when no issues match", async () => {
+    const issuesFn = vi.fn().mockResolvedValueOnce({
+      nodes: [],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
+
+    vi.mocked(LinearClient).mockImplementation(
+      () => ({ issues: issuesFn }) as unknown as InstanceType<typeof LinearClient>,
+    );
+
+    const provider = new LinearTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(0);
+    expect(issuesFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes team filter when teamId is configured", async () => {
+    const issuesFn = vi.fn().mockResolvedValueOnce({
+      nodes: [makeLinearIssue("id-1", 1)],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
+
+    vi.mocked(LinearClient).mockImplementation(
+      () => ({ issues: issuesFn }) as unknown as InstanceType<typeof LinearClient>,
+    );
+
+    const provider = new LinearTicketProvider();
+    const config: LinearProviderConfig = {
+      ...baseConfig(),
+      teamId: "team-123",
+    };
+    await provider.fetchActionableTickets(config);
+
+    expect(issuesFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: expect.objectContaining({
+          team: { id: { eq: "team-123" } },
+        }),
+      }),
+    );
+  });
+});

--- a/packages/ticket-providers/src/linear.ts
+++ b/packages/ticket-providers/src/linear.ts
@@ -2,6 +2,7 @@ import { LinearClient } from "@linear/sdk";
 import {
   TicketSource,
   DEFAULT_TICKET_LABEL,
+  DEFAULT_MAX_TICKET_PAGES,
   type Ticket,
   type TicketProviderConfig,
 } from "@optio/shared";
@@ -12,6 +13,8 @@ export interface LinearProviderConfig extends TicketProviderConfig {
   teamId?: string;
   projectId?: string;
   label?: string;
+  /** Max pages to fetch (default: DEFAULT_MAX_TICKET_PAGES). Set to prevent runaway pagination. */
+  maxPages?: number;
 }
 
 function asLinearConfig(config: TicketProviderConfig): LinearProviderConfig {
@@ -29,38 +32,58 @@ export class LinearTicketProvider implements TicketProvider {
     const linearConfig = asLinearConfig(config);
     const client = new LinearClient({ apiKey: linearConfig.apiKey });
     const label = linearConfig.label ?? DEFAULT_TICKET_LABEL;
+    const maxPages = linearConfig.maxPages ?? DEFAULT_MAX_TICKET_PAGES;
 
-    // Fetch issues with the optio label
-    const issues = await client.issues({
-      filter: {
-        labels: { name: { eq: label } },
-        state: { type: { nin: ["completed", "canceled"] } },
-        ...(linearConfig.teamId ? { team: { id: { eq: linearConfig.teamId } } } : {}),
-      },
-      first: 50,
-    });
+    const filter = {
+      labels: { name: { eq: label } },
+      state: { type: { nin: ["completed", "canceled"] } },
+      ...(linearConfig.teamId ? { team: { id: { eq: linearConfig.teamId } } } : {}),
+    };
 
-    return issues.nodes.map((issue) => ({
-      externalId: issue.identifier,
-      source: TicketSource.LINEAR,
-      title: issue.title,
-      body: issue.description ?? "",
-      url: issue.url,
-      labels: [],
-      assignee: undefined,
-      repo: undefined,
-      metadata: {
-        id: issue.id,
-        identifier: issue.identifier,
-        priority: issue.priority,
-        createdAt: issue.createdAt,
-      },
-    }));
+    const allTickets: Ticket[] = [];
+    let afterCursor: string | undefined;
+    let pageCount = 0;
+
+    while (pageCount < maxPages) {
+      const issues = await client.issues({
+        filter,
+        first: 50,
+        ...(afterCursor ? { after: afterCursor } : {}),
+      });
+
+      for (const issue of issues.nodes) {
+        allTickets.push({
+          externalId: issue.identifier,
+          source: TicketSource.LINEAR,
+          title: issue.title,
+          body: issue.description ?? "",
+          url: issue.url,
+          labels: [],
+          assignee: undefined,
+          repo: undefined,
+          metadata: {
+            id: issue.id,
+            identifier: issue.identifier,
+            priority: issue.priority,
+            createdAt: issue.createdAt,
+          },
+        });
+      }
+
+      if (!issues.pageInfo.hasNextPage) break;
+      afterCursor = issues.pageInfo.endCursor;
+      pageCount++;
+    }
+
+    return allTickets;
   }
 
   private async findIssueByIdentifier(client: LinearClient, identifier: string) {
     // Search by the identifier string (e.g., "ENG-123")
-    const results = await client.issueSearch({ query: identifier, first: 5 });
+    const results = await client.issueSearch({
+      query: identifier,
+      first: 5,
+    });
     return results.nodes.find((issue) => issue.identifier === identifier) ?? null;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 


### PR DESCRIPTION
## Summary

- **GitHub provider**: Implement page-based pagination using Link header (`rel="next"`) with 100 items per page (up from 50 with no pagination)
- **Linear provider**: Implement cursor-based pagination using `endCursor`/`hasNextPage` from the Linear SDK connection response
- **Configurable max pages**: Add `DEFAULT_MAX_TICKET_PAGES` constant (default 20) to `@optio/shared` and `maxPages` config option on both providers to prevent runaway fetches
- **Tests**: Add 10 comprehensive tests covering single-page, multi-page, max-page limit, empty results, and filter behavior

## Test plan

- [x] All 10 new pagination tests pass (`pnpm --filter @optio/ticket-providers test`)
- [x] Full test suite passes (190 tests across all packages)
- [x] Typecheck passes across all 6 packages
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)