### PR TITLE
feat: add task comments and activity feed

### DIFF
--- a/apps/api/src/db/migrations/0019_task_comments_activity.sql
+++ b/apps/api/src/db/migrations/0019_task_comments_activity.sql
@@ -1,0 +1,17 @@
+-- Add task_comments table
+CREATE TABLE IF NOT EXISTS "task_comments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"task_id" uuid NOT NULL,
+	"user_id" uuid,
+	"content" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "task_comments_task_id_tasks_id_fk" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE no action ON UPDATE no action,
+	CONSTRAINT "task_comments_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action
+);
+
+CREATE INDEX IF NOT EXISTS "task_comments_task_id_idx" ON "task_comments" USING btree ("task_id");
+
+-- Add user_id column to task_events for audit trail
+ALTER TABLE "task_events" ADD COLUMN IF NOT EXISTS "user_id" uuid;
+ALTER TABLE "task_events" ADD CONSTRAINT "task_events_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -85,6 +85,7 @@ export const taskEvents = pgTable(
     toState: taskStateEnum("to_state").notNull(),
     trigger: text("trigger").notNull(),
     message: text("message"),
+    userId: uuid("user_id").references(() => users.id),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [index("task_events_task_id_idx").on(table.taskId)],
@@ -301,6 +302,21 @@ export const scheduleRuns = pgTable(
     triggeredAt: timestamp("triggered_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [index("schedule_runs_schedule_id_idx").on(table.scheduleId)],
+);
+
+export const taskComments = pgTable(
+  "task_comments",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    taskId: uuid("task_id")
+      .notNull()
+      .references(() => tasks.id),
+    userId: uuid("user_id").references(() => users.id),
+    content: text("content").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("task_comments_task_id_idx").on(table.taskId)],
 );
 
 export const promptTemplates = pgTable("prompt_templates", {

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -1,0 +1,97 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import * as commentService from "../services/comment-service.js";
+import * as taskService from "../services/task-service.js";
+
+const createCommentSchema = z.object({
+  content: z.string().min(1).max(10000),
+});
+
+const updateCommentSchema = z.object({
+  content: z.string().min(1).max(10000),
+});
+
+export async function commentRoutes(app: FastifyInstance) {
+  // List comments for a task
+  app.get("/api/tasks/:id/comments", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const task = await taskService.getTask(id);
+    if (!task) return reply.status(404).send({ error: "Task not found" });
+    const comments = await commentService.listComments(id);
+    reply.send({ comments });
+  });
+
+  // Add a comment to a task
+  app.post("/api/tasks/:id/comments", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const task = await taskService.getTask(id);
+    if (!task) return reply.status(404).send({ error: "Task not found" });
+    const { content } = createCommentSchema.parse(req.body);
+    const comment = await commentService.addComment(id, content, req.user?.id);
+    reply.status(201).send({ comment });
+  });
+
+  // Update a comment
+  app.patch("/api/tasks/:taskId/comments/:commentId", async (req, reply) => {
+    const { commentId } = req.params as { taskId: string; commentId: string };
+    const { content } = updateCommentSchema.parse(req.body);
+    try {
+      const comment = await commentService.updateComment(commentId, content, req.user?.id);
+      reply.send({ comment });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === "Comment not found") return reply.status(404).send({ error: message });
+      if (message.includes("Not authorized")) return reply.status(403).send({ error: message });
+      throw err;
+    }
+  });
+
+  // Delete a comment
+  app.delete("/api/tasks/:taskId/comments/:commentId", async (req, reply) => {
+    const { commentId } = req.params as { taskId: string; commentId: string };
+    try {
+      await commentService.deleteComment(commentId, req.user?.id);
+      reply.status(204).send();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === "Comment not found") return reply.status(404).send({ error: message });
+      if (message.includes("Not authorized")) return reply.status(403).send({ error: message });
+      throw err;
+    }
+  });
+
+  // Activity feed: interleaved comments + events
+  app.get("/api/tasks/:id/activity", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const task = await taskService.getTask(id);
+    if (!task) return reply.status(404).send({ error: "Task not found" });
+    const [comments, events] = await Promise.all([
+      commentService.listComments(id),
+      taskService.getTaskEvents(id),
+    ]);
+
+    const activity = [
+      ...comments.map((c) => ({
+        type: "comment" as const,
+        id: c.id,
+        taskId: c.taskId,
+        content: c.content,
+        user: c.user,
+        createdAt: c.createdAt,
+      })),
+      ...events.map((e) => ({
+        type: "event" as const,
+        id: e.id,
+        taskId: e.taskId,
+        fromState: e.fromState,
+        toState: e.toState,
+        trigger: e.trigger,
+        message: e.message,
+        userId: e.userId,
+        createdAt: e.createdAt,
+      })),
+    ].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+    reply.send({ activity });
+  });
+}

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -64,7 +64,13 @@ export async function taskRoutes(app: FastifyInstance) {
     const task = await taskService.createTask(input);
 
     // Enqueue for processing
-    await taskService.transitionTask(task.id, TaskState.QUEUED, "task_submitted");
+    await taskService.transitionTask(
+      task.id,
+      TaskState.QUEUED,
+      "task_submitted",
+      undefined,
+      req.user?.id,
+    );
     await taskQueue.add(
       "process-task",
       { taskId: task.id },
@@ -82,14 +88,26 @@ export async function taskRoutes(app: FastifyInstance) {
   // Cancel task
   app.post("/api/tasks/:id/cancel", async (req, reply) => {
     const { id } = req.params as { id: string };
-    const task = await taskService.transitionTask(id, TaskState.CANCELLED, "user_cancel");
+    const task = await taskService.transitionTask(
+      id,
+      TaskState.CANCELLED,
+      "user_cancel",
+      undefined,
+      req.user?.id,
+    );
     reply.send({ task });
   });
 
   // Retry task
   app.post("/api/tasks/:id/retry", async (req, reply) => {
     const { id } = req.params as { id: string };
-    const task = await taskService.transitionTask(id, TaskState.QUEUED, "user_retry");
+    const task = await taskService.transitionTask(
+      id,
+      TaskState.QUEUED,
+      "user_retry",
+      undefined,
+      req.user?.id,
+    );
     await taskQueue.add(
       "process-task",
       { taskId: id },

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -18,6 +18,7 @@ import { subtaskRoutes } from "./routes/subtasks.js";
 import { analyticsRoutes } from "./routes/analytics.js";
 import { webhookRoutes } from "./routes/webhooks.js";
 import { scheduleRoutes } from "./routes/schedules.js";
+import { commentRoutes } from "./routes/comments.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import authPlugin from "./plugins/auth.js";
@@ -69,6 +70,7 @@ export async function buildServer() {
   await app.register(analyticsRoutes);
   await app.register(webhookRoutes);
   await app.register(scheduleRoutes);
+  await app.register(commentRoutes);
 
   // WebSocket routes
   await app.register(logStreamWs);

--- a/apps/api/src/services/comment-service.test.ts
+++ b/apps/api/src/services/comment-service.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue([]),
+    update: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  taskComments: {
+    id: "id",
+    taskId: "task_id",
+    userId: "user_id",
+    content: "content",
+    createdAt: "created_at",
+    updatedAt: "updated_at",
+  },
+  users: {
+    id: "id",
+    displayName: "display_name",
+    avatarUrl: "avatar_url",
+  },
+}));
+
+vi.mock("./event-bus.js", () => ({ publishEvent: vi.fn() }));
+
+import { db } from "../db/client.js";
+import { publishEvent } from "./event-bus.js";
+import { addComment, listComments, updateComment, deleteComment } from "./comment-service.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("addComment", () => {
+  it("inserts a comment and publishes event", async () => {
+    const mockComment = {
+      id: "comment-1",
+      taskId: "task-1",
+      userId: "user-1",
+      content: "hello",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    (db.insert as any).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([mockComment]),
+      }),
+    });
+
+    const result = await addComment("task-1", "hello", "user-1");
+
+    expect(result).toEqual(mockComment);
+    expect(publishEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "task:comment",
+        taskId: "task-1",
+        commentId: "comment-1",
+      }),
+    );
+  });
+});
+
+describe("listComments", () => {
+  it("returns comments with user info", async () => {
+    const rows = [
+      {
+        id: "c1",
+        taskId: "t1",
+        userId: "u1",
+        content: "test",
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-01-01"),
+        userName: "Alice",
+        userAvatar: "https://example.com/avatar.png",
+      },
+    ];
+    (db.select as any).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue(rows),
+          }),
+        }),
+      }),
+    });
+
+    const result = await listComments("t1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].user).toEqual({
+      id: "u1",
+      displayName: "Alice",
+      avatarUrl: "https://example.com/avatar.png",
+    });
+  });
+
+  it("returns undefined user when userId is null", async () => {
+    const rows = [
+      {
+        id: "c1",
+        taskId: "t1",
+        userId: null,
+        content: "system comment",
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-01-01"),
+        userName: null,
+        userAvatar: null,
+      },
+    ];
+    (db.select as any).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        leftJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue(rows),
+          }),
+        }),
+      }),
+    });
+
+    const result = await listComments("t1");
+
+    expect(result[0].user).toBeUndefined();
+  });
+});
+
+describe("updateComment", () => {
+  it("throws when comment not found", async () => {
+    (db.select as any).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    await expect(updateComment("nonexistent", "new content")).rejects.toThrow("Comment not found");
+  });
+
+  it("throws when user is not the author", async () => {
+    (db.select as any).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: "c1", userId: "user-a", content: "old" }]),
+      }),
+    });
+
+    await expect(updateComment("c1", "new content", "user-b")).rejects.toThrow("Not authorized");
+  });
+});
+
+describe("deleteComment", () => {
+  it("throws when comment not found", async () => {
+    (db.select as any).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    await expect(deleteComment("nonexistent")).rejects.toThrow("Comment not found");
+  });
+
+  it("throws when user is not the author", async () => {
+    (db.select as any).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: "c1", userId: "user-a", content: "test" }]),
+      }),
+    });
+
+    await expect(deleteComment("c1", "user-b")).rejects.toThrow("Not authorized");
+  });
+});

--- a/apps/api/src/services/comment-service.ts
+++ b/apps/api/src/services/comment-service.ts
@@ -1,0 +1,70 @@
+import { eq, desc } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { taskComments, users } from "../db/schema.js";
+import { publishEvent } from "./event-bus.js";
+
+export async function addComment(taskId: string, content: string, userId?: string) {
+  const [comment] = await db.insert(taskComments).values({ taskId, content, userId }).returning();
+
+  await publishEvent({
+    type: "task:comment",
+    taskId,
+    commentId: comment.id,
+    timestamp: new Date().toISOString(),
+  });
+
+  return comment;
+}
+
+export async function listComments(taskId: string) {
+  const rows = await db
+    .select({
+      id: taskComments.id,
+      taskId: taskComments.taskId,
+      userId: taskComments.userId,
+      content: taskComments.content,
+      createdAt: taskComments.createdAt,
+      updatedAt: taskComments.updatedAt,
+      userName: users.displayName,
+      userAvatar: users.avatarUrl,
+    })
+    .from(taskComments)
+    .leftJoin(users, eq(taskComments.userId, users.id))
+    .where(eq(taskComments.taskId, taskId))
+    .orderBy(taskComments.createdAt);
+
+  return rows.map((row) => ({
+    id: row.id,
+    taskId: row.taskId,
+    userId: row.userId,
+    content: row.content,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    user: row.userId
+      ? { id: row.userId, displayName: row.userName!, avatarUrl: row.userAvatar }
+      : undefined,
+  }));
+}
+
+export async function updateComment(commentId: string, content: string, userId?: string) {
+  const [existing] = await db.select().from(taskComments).where(eq(taskComments.id, commentId));
+  if (!existing) throw new Error("Comment not found");
+  if (existing.userId && existing.userId !== userId) {
+    throw new Error("Not authorized to edit this comment");
+  }
+  const [updated] = await db
+    .update(taskComments)
+    .set({ content, updatedAt: new Date() })
+    .where(eq(taskComments.id, commentId))
+    .returning();
+  return updated;
+}
+
+export async function deleteComment(commentId: string, userId?: string) {
+  const [existing] = await db.select().from(taskComments).where(eq(taskComments.id, commentId));
+  if (!existing) throw new Error("Comment not found");
+  if (existing.userId && existing.userId !== userId) {
+    throw new Error("Not authorized to delete this comment");
+  }
+  await db.delete(taskComments).where(eq(taskComments.id, commentId));
+}

--- a/apps/api/src/services/task-service.test.ts
+++ b/apps/api/src/services/task-service.test.ts
@@ -15,13 +15,15 @@ vi.mock("../db/client.js", () => ({
     delete: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
     offset: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
   },
 }));
 
 vi.mock("../db/schema.js", () => ({
   tasks: { id: "id", state: "state", createdAt: "createdAt", taskId: "taskId" },
-  taskEvents: { taskId: "taskId", createdAt: "createdAt" },
+  taskEvents: { taskId: "taskId", createdAt: "createdAt", userId: "userId" },
   taskLogs: { taskId: "taskId", timestamp: "timestamp" },
+  users: { id: "id", displayName: "display_name", avatarUrl: "avatar_url" },
 }));
 
 vi.mock("./event-bus.js", () => ({ publishEvent: vi.fn() }));

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -1,6 +1,6 @@
 import { eq, desc, and, or, ilike, gte, lte, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { tasks, taskEvents, taskLogs } from "../db/schema.js";
+import { tasks, taskEvents, taskLogs, users } from "../db/schema.js";
 import { TaskState, transition, normalizeRepoUrl, type CreateTaskInput } from "@optio/shared";
 import { publishEvent } from "./event-bus.js";
 import { logger } from "../logger.js";
@@ -172,6 +172,7 @@ export async function transitionTask(
   toState: TaskState,
   trigger: string,
   message?: string,
+  userId?: string,
 ) {
   const task = await getTask(id);
   if (!task) throw new Error(`Task not found: ${id}`);
@@ -227,6 +228,7 @@ export async function transitionTask(
     toState,
     trigger,
     message,
+    userId,
   });
 
   await publishEvent({
@@ -315,9 +317,10 @@ export async function tryTransitionTask(
   toState: TaskState,
   trigger: string,
   message?: string,
+  userId?: string,
 ) {
   try {
-    return await transitionTask(id, toState, trigger, message);
+    return await transitionTask(id, toState, trigger, message, userId);
   } catch (err) {
     if (err instanceof StateRaceError) {
       return null;
@@ -439,9 +442,35 @@ export async function forceRedoTask(id: string) {
 }
 
 export async function getTaskEvents(taskId: string) {
-  return db
-    .select()
+  const rows = await db
+    .select({
+      id: taskEvents.id,
+      taskId: taskEvents.taskId,
+      fromState: taskEvents.fromState,
+      toState: taskEvents.toState,
+      trigger: taskEvents.trigger,
+      message: taskEvents.message,
+      userId: taskEvents.userId,
+      createdAt: taskEvents.createdAt,
+      userName: users.displayName,
+      userAvatar: users.avatarUrl,
+    })
     .from(taskEvents)
+    .leftJoin(users, eq(taskEvents.userId, users.id))
     .where(eq(taskEvents.taskId, taskId))
     .orderBy(taskEvents.createdAt);
+
+  return rows.map((row) => ({
+    id: row.id,
+    taskId: row.taskId,
+    fromState: row.fromState,
+    toState: row.toState,
+    trigger: row.trigger,
+    message: row.message,
+    userId: row.userId,
+    createdAt: row.createdAt,
+    user: row.userId
+      ? { id: row.userId, displayName: row.userName!, avatarUrl: row.userAvatar }
+      : undefined,
+  }));
 }

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -6,6 +6,7 @@ import { usePageTitle } from "@/hooks/use-page-title";
 import { useTask } from "@/hooks/use-task";
 import { LogViewer } from "@/components/log-viewer";
 import { PipelineTimeline } from "@/components/pipeline-timeline";
+import { ActivityFeed } from "@/components/activity-feed";
 import { StateBadge } from "@/components/state-badge";
 import { api } from "@/lib/api-client";
 import { classifyError } from "@optio/shared";
@@ -33,6 +34,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   const [actionLoading, setActionLoading] = useState(false);
   const [resumePrompt, setResumePrompt] = useState("");
   const [showTimeline, setShowTimeline] = useState(true);
+  const [sidebarTab, setSidebarTab] = useState<"pipeline" | "activity">("pipeline");
   const [subtasks, setSubtasks] = useState<any[]>([]);
   const [showCreateSubtask, setShowCreateSubtask] = useState(false);
   const [newSubtask, setNewSubtask] = useState({
@@ -586,9 +588,38 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
 
         {/* Timeline sidebar */}
         {showTimeline && (
-          <div className="w-72 shrink-0 border-l border-border overflow-auto p-3 bg-bg-card">
-            <h3 className="text-xs font-medium text-text-muted mb-3">Pipeline</h3>
-            <PipelineTimeline task={task} events={events} subtasks={subtasks} />
+          <div className="w-80 shrink-0 border-l border-border overflow-auto bg-bg-card flex flex-col">
+            <div className="flex items-center gap-1 p-2 border-b border-border">
+              <button
+                onClick={() => setSidebarTab("pipeline")}
+                className={cn(
+                  "px-2.5 py-1 rounded text-xs transition-colors",
+                  sidebarTab === "pipeline"
+                    ? "bg-primary/10 text-primary font-medium"
+                    : "text-text-muted hover:bg-bg-hover",
+                )}
+              >
+                Pipeline
+              </button>
+              <button
+                onClick={() => setSidebarTab("activity")}
+                className={cn(
+                  "px-2.5 py-1 rounded text-xs transition-colors",
+                  sidebarTab === "activity"
+                    ? "bg-primary/10 text-primary font-medium"
+                    : "text-text-muted hover:bg-bg-hover",
+                )}
+              >
+                Activity
+              </button>
+            </div>
+            <div className="flex-1 overflow-auto p-3">
+              {sidebarTab === "pipeline" ? (
+                <PipelineTimeline task={task} events={events} subtasks={subtasks} />
+              ) : (
+                <ActivityFeed taskId={id} />
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/apps/web/src/components/activity-feed.tsx
+++ b/apps/web/src/components/activity-feed.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api-client";
+import { StateBadge } from "./state-badge";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import { MessageSquare, Send, Loader2, Pencil, Trash2, X, Check } from "lucide-react";
+import { toast } from "sonner";
+
+interface ActivityItem {
+  type: "comment" | "event";
+  id: string;
+  taskId: string;
+  createdAt: string;
+  // Comment fields
+  content?: string;
+  user?: { id: string; displayName: string; avatarUrl?: string | null };
+  // Event fields
+  fromState?: string;
+  toState?: string;
+  trigger?: string;
+  message?: string;
+  userId?: string;
+}
+
+const STATE_DOT_COLORS: Record<string, string> = {
+  running: "bg-primary",
+  provisioning: "bg-info",
+  queued: "bg-info",
+  pending: "bg-text-muted",
+  completed: "bg-success",
+  pr_opened: "bg-success",
+  failed: "bg-error",
+  cancelled: "bg-text-muted",
+  needs_attention: "bg-warning",
+};
+
+export function ActivityFeed({ taskId }: { taskId: string }) {
+  const [activity, setActivity] = useState<ActivityItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newComment, setNewComment] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editContent, setEditContent] = useState("");
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await api.getTaskActivity(taskId);
+      setActivity(res.activity);
+    } catch {
+      // silent fail
+    } finally {
+      setLoading(false);
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Poll for updates every 10 seconds
+  useEffect(() => {
+    const interval = setInterval(refresh, 10000);
+    return () => clearInterval(interval);
+  }, [refresh]);
+
+  const handleAddComment = async () => {
+    if (!newComment.trim() || submitting) return;
+    setSubmitting(true);
+    try {
+      await api.addTaskComment(taskId, newComment.trim());
+      setNewComment("");
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to add comment");
+    }
+    setSubmitting(false);
+  };
+
+  const handleUpdate = async (commentId: string) => {
+    if (!editContent.trim()) return;
+    try {
+      await api.updateTaskComment(taskId, commentId, editContent.trim());
+      setEditingId(null);
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to update comment");
+    }
+  };
+
+  const handleDelete = async (commentId: string) => {
+    if (!confirm("Delete this comment?")) return;
+    try {
+      await api.deleteTaskComment(taskId, commentId);
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to delete comment");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8 text-text-muted">
+        <Loader2 className="w-4 h-4 animate-spin mr-2" />
+        Loading activity...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-0">
+      {/* Activity items */}
+      {activity.map((item, i) => {
+        const isLast = i === activity.length - 1;
+
+        if (item.type === "event") {
+          const dotColor = STATE_DOT_COLORS[item.toState ?? ""] ?? "bg-text-muted";
+          return (
+            <div key={`event-${item.id}`} className="flex items-start gap-3">
+              <div className="flex flex-col items-center">
+                <div className={cn("w-2 h-2 rounded-full mt-2 shrink-0", dotColor)} />
+                {!isLast && <div className="w-px flex-1 mt-1 bg-border/60" />}
+              </div>
+              <div className="min-w-0 flex-1 pb-4">
+                <div className="flex items-center gap-2 flex-wrap">
+                  {item.fromState && (
+                    <>
+                      <StateBadge state={item.fromState} showDot={false} />
+                      <span className="text-text-muted/40 text-xs">&rarr;</span>
+                    </>
+                  )}
+                  <StateBadge state={item.toState!} showDot={false} />
+                  {item.user && (
+                    <span className="text-[11px] text-text-muted/60">
+                      by {item.user.displayName}
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-text-muted/70 mt-1 font-medium">
+                  {item.trigger?.replace(/_/g, " ")}
+                  {item.message && (
+                    <span className="font-normal text-text-muted/50"> &mdash; {item.message}</span>
+                  )}
+                </div>
+                <div className="text-[11px] text-text-muted/40 mt-0.5 tabular-nums">
+                  {formatRelativeTime(item.createdAt)}
+                </div>
+              </div>
+            </div>
+          );
+        }
+
+        // Comment item
+        const isEditing = editingId === item.id;
+        return (
+          <div key={`comment-${item.id}`} className="flex items-start gap-3">
+            <div className="flex flex-col items-center">
+              <div className="w-2 h-2 rounded-full mt-2 shrink-0 bg-info" />
+              {!isLast && <div className="w-px flex-1 mt-1 bg-border/60" />}
+            </div>
+            <div className="min-w-0 flex-1 pb-4">
+              <div className="rounded-md border border-border bg-bg-card p-2.5">
+                <div className="flex items-center justify-between gap-2 mb-1.5">
+                  <div className="flex items-center gap-1.5">
+                    <MessageSquare className="w-3 h-3 text-info" />
+                    <span className="text-xs font-medium text-text">
+                      {item.user?.displayName ?? "System"}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    {item.user && !isEditing && (
+                      <>
+                        <button
+                          onClick={() => {
+                            setEditingId(item.id);
+                            setEditContent(item.content ?? "");
+                          }}
+                          className="p-0.5 rounded hover:bg-bg-hover text-text-muted/50 hover:text-text-muted"
+                        >
+                          <Pencil className="w-3 h-3" />
+                        </button>
+                        <button
+                          onClick={() => handleDelete(item.id)}
+                          className="p-0.5 rounded hover:bg-error/10 text-text-muted/50 hover:text-error"
+                        >
+                          <Trash2 className="w-3 h-3" />
+                        </button>
+                      </>
+                    )}
+                    <span className="text-[11px] text-text-muted/40 tabular-nums">
+                      {formatRelativeTime(item.createdAt)}
+                    </span>
+                  </div>
+                </div>
+                {isEditing ? (
+                  <div className="space-y-1.5">
+                    <textarea
+                      value={editContent}
+                      onChange={(e) => setEditContent(e.target.value)}
+                      className="w-full px-2 py-1.5 rounded bg-bg border border-border text-xs focus:outline-none focus:border-primary resize-y"
+                      rows={3}
+                    />
+                    <div className="flex gap-1.5">
+                      <button
+                        onClick={() => handleUpdate(item.id)}
+                        className="flex items-center gap-1 px-2 py-0.5 rounded bg-primary text-white text-xs hover:bg-primary-hover"
+                      >
+                        <Check className="w-3 h-3" />
+                        Save
+                      </button>
+                      <button
+                        onClick={() => setEditingId(null)}
+                        className="flex items-center gap-1 px-2 py-0.5 rounded bg-bg-hover text-text-muted text-xs"
+                      >
+                        <X className="w-3 h-3" />
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-xs text-text/80 whitespace-pre-wrap">{item.content}</p>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+
+      {activity.length === 0 && (
+        <div className="text-center text-text-muted/40 text-sm py-6">No activity yet</div>
+      )}
+
+      {/* Add comment input */}
+      <div className="pt-3 border-t border-border mt-2">
+        <div className="flex gap-2">
+          <textarea
+            value={newComment}
+            onChange={(e) => setNewComment(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleAddComment();
+            }}
+            placeholder="Add a comment..."
+            rows={2}
+            className="flex-1 px-3 py-1.5 rounded-lg bg-bg border border-border text-xs focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-y"
+          />
+          <button
+            onClick={handleAddComment}
+            disabled={!newComment.trim() || submitting}
+            className="self-end px-3 py-1.5 rounded-md bg-primary text-white text-xs hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <Send className="w-3.5 h-3.5" />
+            )}
+          </button>
+        </div>
+        <p className="text-[10px] text-text-muted/40 mt-1">Cmd+Enter to submit</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -103,6 +103,26 @@ export const api = {
 
   getTaskEvents: (id: string) => request<{ events: any[] }>(`/api/tasks/${id}/events`),
 
+  // Comments & Activity
+  getTaskComments: (id: string) => request<{ comments: any[] }>(`/api/tasks/${id}/comments`),
+
+  addTaskComment: (id: string, content: string) =>
+    request<{ comment: any }>(`/api/tasks/${id}/comments`, {
+      method: "POST",
+      body: JSON.stringify({ content }),
+    }),
+
+  updateTaskComment: (taskId: string, commentId: string, content: string) =>
+    request<{ comment: any }>(`/api/tasks/${taskId}/comments/${commentId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ content }),
+    }),
+
+  deleteTaskComment: (taskId: string, commentId: string) =>
+    request<void>(`/api/tasks/${taskId}/comments/${commentId}`, { method: "DELETE" }),
+
+  getTaskActivity: (id: string) => request<{ activity: any[] }>(`/api/tasks/${id}/activity`),
+
   // Secrets
   listSecrets: (scope?: string) => {
     const qs = scope ? `?scope=${scope}` : "";

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -1,6 +1,11 @@
 import type { TaskState } from "./task.js";
 
-export type WsEvent = TaskStateChangedEvent | TaskLogEvent | TaskCreatedEvent | AuthFailedEvent;
+export type WsEvent =
+  | TaskStateChangedEvent
+  | TaskLogEvent
+  | TaskCreatedEvent
+  | AuthFailedEvent
+  | TaskCommentEvent;
 
 export interface TaskStateChangedEvent {
   type: "task:state_changed";
@@ -28,5 +33,12 @@ export interface TaskCreatedEvent {
 export interface AuthFailedEvent {
   type: "auth:failed";
   message: string;
+  timestamp: string;
+}
+
+export interface TaskCommentEvent {
+  type: "task:comment";
+  taskId: string;
+  commentId: string;
   timestamp: string;
 }

--- a/packages/shared/src/types/task.ts
+++ b/packages/shared/src/types/task.ts
@@ -40,7 +40,22 @@ export interface TaskEvent {
   toState: TaskState;
   trigger: string;
   message?: string;
+  userId?: string;
   createdAt: Date;
+}
+
+export interface TaskComment {
+  id: string;
+  taskId: string;
+  userId?: string;
+  content: string;
+  createdAt: Date;
+  updatedAt: Date;
+  user?: {
+    id: string;
+    displayName: string;
+    avatarUrl?: string;
+  };
 }
 
 export interface CreateTaskInput {


### PR DESCRIPTION
## Summary
- Add `task_comments` table for commenting on tasks with user attribution
- Extend `task_events` with `userId` column to track who triggered each state transition
- Comment service with add/list/update/delete operations and authorization checks
- API routes: `GET/POST` `/api/tasks/:id/comments`, `PATCH/DELETE` `/api/tasks/:taskId/comments/:commentId`
- Activity feed endpoint `GET /api/tasks/:id/activity` that interleaves comments and events chronologically
- User-initiated state transitions (create, cancel, retry) now record the acting user's ID
- Activity feed component in task detail sidebar with real-time polling, inline edit/delete
- Pipeline/Activity tab switcher in the sidebar
- Database migration (0019) for new table and column
- Tests for comment service (authorization, CRUD, edge cases)
- Updated existing task-service tests for new schema shape

## Test plan
- [x] All 190 tests pass (13 test files) including new comment-service tests
- [x] TypeScript typecheck passes across all 6 packages
- [x] Prettier formatting verified
- [x] Pre-commit hooks (lint-staged, format:check, typecheck) all pass
- [ ] Verify comments can be created and displayed on task detail page
- [ ] Verify state transitions show the acting user in the activity feed
- [ ] Verify comment edit/delete works with authorization checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)