### PR TITLE
fix: validate GitHub webhook signatures with HMAC-SHA256

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,10 @@ OPTIO_AUTH_DISABLED=true
 # GITLAB_OAUTH_CLIENT_ID=
 # GITLAB_OAUTH_CLIENT_SECRET=
 
+# GitHub webhook signature validation (generate with: openssl rand -hex 32)
+# Must match the secret configured in GitHub's webhook settings
+# GITHUB_WEBHOOK_SECRET=
+
 # Public URLs (used for OAuth callback URLs and redirects)
 # API_PUBLIC_URL=http://localhost:4000
 # WEB_PUBLIC_URL=http://localhost:3000

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -12,7 +12,7 @@ declare module "fastify" {
 const SESSION_COOKIE_NAME = "optio_session";
 
 /** Routes that never require authentication. */
-const PUBLIC_ROUTES = ["/api/health", "/api/auth/", "/api/setup/"];
+const PUBLIC_ROUTES = ["/api/health", "/api/auth/", "/api/setup/", "/api/webhooks/"];
 
 function isPublicRoute(url: string): boolean {
   return PUBLIC_ROUTES.some((prefix) => url.startsWith(prefix));

--- a/apps/api/src/routes/tickets.test.ts
+++ b/apps/api/src/routes/tickets.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { createHmac } from "node:crypto";
+import { verifyGitHubSignature, isReplayedEvent } from "./tickets.js";
+
+describe("verifyGitHubSignature", () => {
+  const secret = "test-webhook-secret";
+  const body = Buffer.from(JSON.stringify({ action: "labeled" }));
+
+  function sign(payload: Buffer, key: string): string {
+    return "sha256=" + createHmac("sha256", key).update(payload).digest("hex");
+  }
+
+  it("accepts a valid signature", () => {
+    const signature = sign(body, secret);
+    expect(verifyGitHubSignature(body, signature, secret)).toBe(true);
+  });
+
+  it("rejects a signature computed with the wrong secret", () => {
+    const signature = sign(body, "wrong-secret");
+    expect(verifyGitHubSignature(body, signature, secret)).toBe(false);
+  });
+
+  it("rejects a completely invalid signature string", () => {
+    expect(verifyGitHubSignature(body, "sha256=invalid", secret)).toBe(false);
+  });
+
+  it("rejects when body differs from what was signed", () => {
+    const signature = sign(Buffer.from("different body"), secret);
+    expect(verifyGitHubSignature(body, signature, secret)).toBe(false);
+  });
+
+  it("rejects a signature with wrong length", () => {
+    expect(verifyGitHubSignature(body, "sha256=abc", secret)).toBe(false);
+  });
+});
+
+describe("isReplayedEvent", () => {
+  it("returns false when no timestamp header is provided", () => {
+    expect(isReplayedEvent(undefined)).toBe(false);
+  });
+
+  it("returns false for a recent timestamp", () => {
+    const nowSec = Math.floor(Date.now() / 1000).toString();
+    expect(isReplayedEvent(nowSec)).toBe(false);
+  });
+
+  it("returns true for a timestamp older than the max age", () => {
+    const tenMinutesAgoSec = Math.floor((Date.now() - 10 * 60 * 1000) / 1000).toString();
+    expect(isReplayedEvent(tenMinutesAgoSec, 5)).toBe(true);
+  });
+
+  it("returns false for a non-numeric timestamp", () => {
+    expect(isReplayedEvent("not-a-number")).toBe(false);
+  });
+
+  it("uses the custom max age when provided", () => {
+    const threeMinutesAgoSec = Math.floor((Date.now() - 3 * 60 * 1000) / 1000).toString();
+    expect(isReplayedEvent(threeMinutesAgoSec, 2)).toBe(true);
+    expect(isReplayedEvent(threeMinutesAgoSec, 5)).toBe(false);
+  });
+});

--- a/apps/api/src/routes/tickets.ts
+++ b/apps/api/src/routes/tickets.ts
@@ -1,11 +1,41 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import { eq } from "drizzle-orm";
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { Readable } from "node:stream";
 import { db } from "../db/client.js";
 import { ticketProviders } from "../db/schema.js";
 import { TaskState } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
 import { syncAllTickets } from "../services/ticket-sync-service.js";
 import { logger } from "../logger.js";
+
+/** Maximum age (in minutes) for a webhook event before it is rejected. */
+const WEBHOOK_MAX_AGE_MINUTES = 5;
+
+/**
+ * Verify the HMAC-SHA256 signature sent by GitHub in the X-Hub-Signature-256
+ * header against the raw request body and the configured secret.
+ */
+export function verifyGitHubSignature(rawBody: Buffer, signature: string, secret: string): boolean {
+  const expected = "sha256=" + createHmac("sha256", secret).update(rawBody).digest("hex");
+  if (expected.length !== signature.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+}
+
+/**
+ * Check whether the webhook delivery timestamp is within the acceptable window.
+ * Returns true if the event should be rejected (too old).
+ */
+export function isReplayedEvent(
+  timestampHeader: string | undefined,
+  maxAgeMinutes: number = WEBHOOK_MAX_AGE_MINUTES,
+): boolean {
+  if (!timestampHeader) return false;
+  const ts = Number(timestampHeader);
+  if (Number.isNaN(ts)) return false;
+  const ageMs = Date.now() - ts * 1000;
+  return ageMs > maxAgeMinutes * 60 * 1000;
+}
 
 export async function ticketRoutes(app: FastifyInstance) {
   // List configured ticket providers
@@ -42,39 +72,78 @@ export async function ticketRoutes(app: FastifyInstance) {
   });
 
   // GitHub webhook endpoint for real-time ticket events
-  app.post("/api/webhooks/github", async (req, reply) => {
-    const event = req.headers["x-github-event"];
-    const payload = req.body as any;
-
-    if (event === "issues" && payload.action === "labeled") {
-      const label = payload.label?.name;
-      if (label === "optio") {
-        logger.info({ issue: payload.issue?.number }, "GitHub issue labeled with optio");
-        // Trigger a sync — handles deduplication
-        await syncAllTickets();
+  app.post("/api/webhooks/github", {
+    // Capture raw body before JSON parsing so we can verify the HMAC signature
+    preParsing: async (req, _reply, payload) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of payload) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as any));
       }
-    }
+      const rawBody = Buffer.concat(chunks);
+      (req as any).rawBody = rawBody;
+      return Readable.from(rawBody);
+    },
+    handler: async (req, reply) => {
+      const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
 
-    if (event === "pull_request" && payload.action === "closed" && payload.pull_request?.merged) {
-      const prUrl = payload.pull_request.html_url;
-      const allTasks = await taskService.listTasks({ limit: 500 });
-      const matchingTask = allTasks.find((t: any) => t.prUrl === prUrl);
+      if (!webhookSecret) {
+        logger.error("GITHUB_WEBHOOK_SECRET is not set — rejecting webhook request");
+        return reply.status(401).send({ error: "Webhook secret not configured" });
+      }
 
-      if (matchingTask) {
-        try {
-          await taskService.transitionTask(
-            matchingTask.id,
-            TaskState.COMPLETED,
-            "pr_merged",
-            prUrl,
-          );
-          logger.info({ taskId: matchingTask.id, prUrl }, "Task completed via PR merge");
-        } catch {
-          // May already be completed
+      // Validate HMAC-SHA256 signature
+      const signature = req.headers["x-hub-signature-256"] as string | undefined;
+      if (!signature) {
+        logger.warn("Webhook request missing X-Hub-Signature-256 header");
+        return reply.status(401).send({ error: "Missing signature" });
+      }
+
+      const rawBody = (req as any).rawBody as Buffer;
+      if (!verifyGitHubSignature(rawBody, signature, webhookSecret)) {
+        logger.warn("Webhook signature verification failed");
+        return reply.status(401).send({ error: "Invalid signature" });
+      }
+
+      // Replay protection — reject events with stale timestamps
+      const timestamp = req.headers["x-github-delivery-timestamp"] as string | undefined;
+      if (isReplayedEvent(timestamp)) {
+        logger.warn({ timestamp }, "Rejecting replayed webhook event");
+        return reply.status(401).send({ error: "Replayed event" });
+      }
+
+      const event = req.headers["x-github-event"];
+      const payload = req.body as any;
+
+      if (event === "issues" && payload.action === "labeled") {
+        const label = payload.label?.name;
+        if (label === "optio") {
+          logger.info({ issue: payload.issue?.number }, "GitHub issue labeled with optio");
+          // Trigger a sync — handles deduplication
+          await syncAllTickets();
         }
       }
-    }
 
-    reply.status(200).send({ ok: true });
+      if (event === "pull_request" && payload.action === "closed" && payload.pull_request?.merged) {
+        const prUrl = payload.pull_request.html_url;
+        const allTasks = await taskService.listTasks({ limit: 500 });
+        const matchingTask = allTasks.find((t: any) => t.prUrl === prUrl);
+
+        if (matchingTask) {
+          try {
+            await taskService.transitionTask(
+              matchingTask.id,
+              TaskState.COMPLETED,
+              "pr_merged",
+              prUrl,
+            );
+            logger.info({ taskId: matchingTask.id, prUrl }, "Task completed via PR merge");
+          } catch {
+            // May already be completed
+          }
+        }
+      }
+
+      reply.status(200).send({ ok: true });
+    },
   });
 }

--- a/helm/optio/templates/secrets.yaml
+++ b/helm/optio/templates/secrets.yaml
@@ -26,3 +26,6 @@ stringData:
   GITLAB_OAUTH_CLIENT_ID: {{ .Values.auth.gitlab.clientId | quote }}
   GITLAB_OAUTH_CLIENT_SECRET: {{ .Values.auth.gitlab.clientSecret | quote }}
   {{- end }}
+  {{- if .Values.webhook.githubSecret }}
+  GITHUB_WEBHOOK_SECRET: {{ .Values.webhook.githubSecret | quote }}
+  {{- end }}

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -102,6 +102,10 @@ auth:
     clientSecret: ""
     # baseUrl: https://gitlab.com  # Self-hosted GitLab URL
 
+# GitHub webhook signature validation
+webhook:
+  githubSecret: ""  # Generate with: openssl rand -hex 32. Must match GitHub's webhook config.
+
 # Secrets encryption
 encryption:
   key: ""  # Generate with: openssl rand -hex 32. Required.


### PR DESCRIPTION
## Summary

- Add HMAC-SHA256 signature verification to `/api/webhooks/github` endpoint using `X-Hub-Signature-256` header
- Add replay protection that rejects webhook events with timestamps older than 5 minutes
- Add `/api/webhooks/` to public auth routes (webhooks authenticate via signature, not session cookies)
- Update `.env.example` and Helm chart (`values.yaml` + `secrets.yaml`) with `GITHUB_WEBHOOK_SECRET` configuration

## Test plan

- [x] Unit tests for `verifyGitHubSignature()` — valid signatures accepted, invalid/wrong-secret/tampered rejected
- [x] Unit tests for `isReplayedEvent()` — recent events accepted, stale events rejected, missing timestamps handled gracefully
- [x] All 173 existing tests pass
- [x] TypeScript typecheck passes across all packages
- [ ] Manual: configure `GITHUB_WEBHOOK_SECRET` and verify valid webhooks are accepted
- [ ] Manual: verify requests without signature header return 401
- [ ] Manual: verify requests with wrong signature return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)