### PR TITLE
perf: add database indexes for common query patterns

### DIFF
--- a/.optio/task.md
+++ b/.optio/task.md
@@ -1,61 +1,26 @@
-# fix: Auth security hardening before production
+# perf: Add database indexes for common query patterns
 
-fix: Auth security hardening before production
+perf: Add database indexes for common query patterns
 
-## Summary
+## Problem
 
-The OAuth auth system (#29) is functionally complete but has several security gaps that need addressing before production use.
+No indexes exist on frequently queried columns. As task volume grows, queries will degrade to full table scans.
 
-## Issues
+## Missing Indexes
 
-### Critical: CORS accepts any origin
-
-- **File**: `apps/api/src/server.ts`
-- CORS is configured with `origin: true`, allowing requests from any origin
-- **Fix**: Whitelist specific origins via `OPTIO_ALLOWED_ORIGINS` env var (e.g. `http://localhost:3100,https://optio.example.com`)
-
-### High: No `Secure` flag on session cookie
-
-- **File**: `apps/api/src/routes/auth.ts`
-- Session cookies are set with `HttpOnly` and `SameSite=Lax` but no `Secure` flag
-- In production over HTTPS, cookies could be transmitted over unencrypted connections
-- **Fix**: Conditionally add `Secure` when `NODE_ENV=production` or behind a config flag
-
-### High: No expired session cleanup
-
-- Sessions accumulate in the DB indefinitely — `validateSession()` checks expiry but never deletes old rows
-- **Fix**: Add periodic cleanup (e.g. in `repo-cleanup-worker`) to delete sessions where `expires_at < now()`
-
-### High: OAuth providers don't check response status
-
-- **Files**: `apps/api/src/services/oauth/github.ts`, `google.ts`, `gitlab.ts`
-- `exchangeCode` and `fetchUser` call `.json()` without checking `res.ok` first
-- Non-2xx responses (rate limits, server errors) will throw confusing parse errors
-- **Fix**: Add `if (!res.ok) throw new Error(...)` before parsing
-
-### Medium: Unbounded in-memory OAuth state map
-
-- **File**: `apps/api/src/routes/auth.ts`
-- The `oauthStates` Map has a 10-minute TTL cleanup but no size limit
-- An attacker could flood login requests to grow the map unboundedly
-- **Fix**: Use a size-limited LRU cache or move state to Redis
-
-### Medium: Error messages in redirect URLs
-
-- **File**: `apps/api/src/routes/auth.ts`
-- Raw error strings (including potential stack traces) are URL-encoded in redirect query params
-- Visible in browser history and server logs
-- **Fix**: Use generic error codes in redirects, fetch details via API if needed
+- `tasks(repoUrl, state)` — filtering tasks by repo and state
+- `tasks(state)` — state-based filtering on task list
+- `tasks(parentTaskId)` — finding subtasks
+- `tasks(createdAt DESC)` — sorting by creation time
+- `taskLogs(taskId, timestamp)` — fetching logs for a task
+- `repoPods(repoUrl)` — finding pods by repo
+- `taskEvents(taskId)` — fetching event history
 
 ## Acceptance Criteria
 
-- [ ] CORS restricted to configured origins
-- [ ] Session cookie has `Secure` flag in production
-- [ ] Expired sessions are cleaned up periodically
-- [ ] OAuth HTTP responses validated before parsing
-- [ ] OAuth state map bounded or moved to Redis
-- [ ] Error messages not leaked in URLs
+- [ ] Migration adds indexes for the above columns
+- [ ] No noticeable regression on write performance
 
 ---
 
-_Optio Task ID: b5043ba0-5447-434b-aa87-e3baf712629d_
+_Optio Task ID: e0c05c2e-9c70-4ea1-82c7-06f3f931c7b5_

--- a/apps/api/src/db/migrations/0016_add_query_indexes.sql
+++ b/apps/api/src/db/migrations/0016_add_query_indexes.sql
@@ -1,0 +1,8 @@
+-- Add indexes for common query patterns
+CREATE INDEX IF NOT EXISTS "tasks_repo_url_state_idx" ON "tasks" ("repo_url", "state");
+CREATE INDEX IF NOT EXISTS "tasks_state_idx" ON "tasks" ("state");
+CREATE INDEX IF NOT EXISTS "tasks_parent_task_id_idx" ON "tasks" ("parent_task_id");
+CREATE INDEX IF NOT EXISTS "tasks_created_at_idx" ON "tasks" ("created_at" DESC);
+CREATE INDEX IF NOT EXISTS "task_logs_task_id_timestamp_idx" ON "task_logs" ("task_id", "timestamp");
+CREATE INDEX IF NOT EXISTS "repo_pods_repo_url_idx" ON "repo_pods" ("repo_url");
+CREATE INDEX IF NOT EXISTS "task_events_task_id_idx" ON "task_events" ("task_id");

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1774281600000,
       "tag": "0015_auth_users_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1774368000000,
+      "tag": "0016_add_query_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -9,6 +9,7 @@ import {
   boolean,
   customType,
   unique,
+  index,
 } from "drizzle-orm/pg-core";
 
 export const taskStateEnum = pgEnum("task_state", [
@@ -23,67 +24,84 @@ export const taskStateEnum = pgEnum("task_state", [
   "cancelled",
 ]);
 
-export const tasks = pgTable("tasks", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  title: text("title").notNull(),
-  prompt: text("prompt").notNull(),
-  repoUrl: text("repo_url").notNull(),
-  repoBranch: text("repo_branch").notNull().default("main"),
-  state: taskStateEnum("state").notNull().default("pending"),
-  agentType: text("agent_type").notNull(),
-  containerId: text("container_id"),
-  sessionId: text("session_id"),
-  prUrl: text("pr_url"),
-  prNumber: integer("pr_number"),
-  prState: text("pr_state"), // "open" | "merged" | "closed"
-  prChecksStatus: text("pr_checks_status"), // "pending" | "passing" | "failing" | "none"
-  prReviewStatus: text("pr_review_status"), // "approved" | "changes_requested" | "pending" | "none"
-  prReviewComments: text("pr_review_comments"), // latest review comments (for resume)
-  resultSummary: text("result_summary"),
-  costUsd: text("cost_usd"), // stored as string to avoid float precision issues
-  errorMessage: text("error_message"),
-  ticketSource: text("ticket_source"),
-  ticketExternalId: text("ticket_external_id"),
-  metadata: jsonb("metadata").$type<Record<string, unknown>>(),
-  retryCount: integer("retry_count").notNull().default(0),
-  maxRetries: integer("max_retries").notNull().default(3),
-  priority: integer("priority").notNull().default(100), // lower = higher priority
-  parentTaskId: uuid("parent_task_id"), // for review tasks linked to a coding task
-  taskType: text("task_type").notNull().default("coding"), // "coding" | "review"
-  subtaskOrder: integer("subtask_order").default(0), // ordering within parent's subtasks
-  blocksParent: boolean("blocks_parent").notNull().default(false), // if true, parent waits for this
-  worktreeState: text("worktree_state"), // "active" | "dirty" | "reset" | "preserved" | "removed"
-  lastPodId: uuid("last_pod_id"), // last pod this task ran on (for same-pod retry affinity)
-  createdBy: uuid("created_by"), // nullable FK to users (null when auth is disabled)
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-  startedAt: timestamp("started_at", { withTimezone: true }),
-  completedAt: timestamp("completed_at", { withTimezone: true }),
-});
+export const tasks = pgTable(
+  "tasks",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    title: text("title").notNull(),
+    prompt: text("prompt").notNull(),
+    repoUrl: text("repo_url").notNull(),
+    repoBranch: text("repo_branch").notNull().default("main"),
+    state: taskStateEnum("state").notNull().default("pending"),
+    agentType: text("agent_type").notNull(),
+    containerId: text("container_id"),
+    sessionId: text("session_id"),
+    prUrl: text("pr_url"),
+    prNumber: integer("pr_number"),
+    prState: text("pr_state"), // "open" | "merged" | "closed"
+    prChecksStatus: text("pr_checks_status"), // "pending" | "passing" | "failing" | "none"
+    prReviewStatus: text("pr_review_status"), // "approved" | "changes_requested" | "pending" | "none"
+    prReviewComments: text("pr_review_comments"), // latest review comments (for resume)
+    resultSummary: text("result_summary"),
+    costUsd: text("cost_usd"), // stored as string to avoid float precision issues
+    errorMessage: text("error_message"),
+    ticketSource: text("ticket_source"),
+    ticketExternalId: text("ticket_external_id"),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    retryCount: integer("retry_count").notNull().default(0),
+    maxRetries: integer("max_retries").notNull().default(3),
+    priority: integer("priority").notNull().default(100), // lower = higher priority
+    parentTaskId: uuid("parent_task_id"), // for review tasks linked to a coding task
+    taskType: text("task_type").notNull().default("coding"), // "coding" | "review"
+    subtaskOrder: integer("subtask_order").default(0), // ordering within parent's subtasks
+    blocksParent: boolean("blocks_parent").notNull().default(false), // if true, parent waits for this
+    worktreeState: text("worktree_state"), // "active" | "dirty" | "reset" | "preserved" | "removed"
+    lastPodId: uuid("last_pod_id"), // last pod this task ran on (for same-pod retry affinity)
+    createdBy: uuid("created_by"), // nullable FK to users (null when auth is disabled)
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    startedAt: timestamp("started_at", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("tasks_repo_url_state_idx").on(table.repoUrl, table.state),
+    index("tasks_state_idx").on(table.state),
+    index("tasks_parent_task_id_idx").on(table.parentTaskId),
+    index("tasks_created_at_idx").on(table.createdAt.desc()),
+  ],
+);
 
-export const taskEvents = pgTable("task_events", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  taskId: uuid("task_id")
-    .notNull()
-    .references(() => tasks.id),
-  fromState: taskStateEnum("from_state"),
-  toState: taskStateEnum("to_state").notNull(),
-  trigger: text("trigger").notNull(),
-  message: text("message"),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-});
+export const taskEvents = pgTable(
+  "task_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    taskId: uuid("task_id")
+      .notNull()
+      .references(() => tasks.id),
+    fromState: taskStateEnum("from_state"),
+    toState: taskStateEnum("to_state").notNull(),
+    trigger: text("trigger").notNull(),
+    message: text("message"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("task_events_task_id_idx").on(table.taskId)],
+);
 
-export const taskLogs = pgTable("task_logs", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  taskId: uuid("task_id")
-    .notNull()
-    .references(() => tasks.id),
-  stream: text("stream").notNull().default("stdout"),
-  content: text("content").notNull(),
-  logType: text("log_type"), // "text" | "tool_use" | "tool_result" | "thinking" | "system" | "error" | "info"
-  metadata: jsonb("metadata").$type<Record<string, unknown>>(),
-  timestamp: timestamp("timestamp", { withTimezone: true }).notNull().defaultNow(),
-});
+export const taskLogs = pgTable(
+  "task_logs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    taskId: uuid("task_id")
+      .notNull()
+      .references(() => tasks.id),
+    stream: text("stream").notNull().default("stdout"),
+    content: text("content").notNull(),
+    logType: text("log_type"), // "text" | "tool_use" | "tool_result" | "thinking" | "system" | "error" | "info"
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    timestamp: timestamp("timestamp", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("task_logs_task_id_timestamp_idx").on(table.taskId, table.timestamp)],
+);
 
 const bytea = customType<{ data: Buffer }>({
   dataType() {
@@ -153,20 +171,24 @@ export const repoPodStateEnum = pgEnum("repo_pod_state", [
   "terminating",
 ]);
 
-export const repoPods = pgTable("repo_pods", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  repoUrl: text("repo_url").notNull(),
-  repoBranch: text("repo_branch").notNull().default("main"),
-  instanceIndex: integer("instance_index").notNull().default(0),
-  podName: text("pod_name"),
-  podId: text("pod_id"),
-  state: repoPodStateEnum("state").notNull().default("provisioning"),
-  activeTaskCount: integer("active_task_count").notNull().default(0),
-  lastTaskAt: timestamp("last_task_at", { withTimezone: true }),
-  errorMessage: text("error_message"),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+export const repoPods = pgTable(
+  "repo_pods",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    repoUrl: text("repo_url").notNull(),
+    repoBranch: text("repo_branch").notNull().default("main"),
+    instanceIndex: integer("instance_index").notNull().default(0),
+    podName: text("pod_name"),
+    podId: text("pod_id"),
+    state: repoPodStateEnum("state").notNull().default("provisioning"),
+    activeTaskCount: integer("active_task_count").notNull().default(0),
+    lastTaskAt: timestamp("last_task_at", { withTimezone: true }),
+    errorMessage: text("error_message"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("repo_pods_repo_url_idx").on(table.repoUrl)],
+);
 
 export const podHealthEvents = pgTable("pod_health_events", {
   id: uuid("id").primaryKey().defaultRandom(),


### PR DESCRIPTION
## Summary
- Adds 7 database indexes on frequently queried columns to prevent full table scans as task volume grows
- Updates Drizzle schema with index definitions and includes a SQL migration (`0016_add_query_indexes`)
- Indexes cover: `tasks(repo_url, state)`, `tasks(state)`, `tasks(parent_task_id)`, `tasks(created_at DESC)`, `task_logs(task_id, timestamp)`, `repo_pods(repo_url)`, `task_events(task_id)`

## Test plan
- [x] Typecheck passes across all 10 packages
- [x] All 163 tests pass
- [x] Formatting check passes
- [ ] Verify migration applies cleanly against a running database (`drizzle-kit migrate`)
- [ ] Confirm no noticeable regression on write performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)