### PR TITLE
feat: add notification webhooks (Slack, custom endpoints)

### DIFF
--- a/apps/api/src/db/migrations/0016_notification_webhooks.sql
+++ b/apps/api/src/db/migrations/0016_notification_webhooks.sql
@@ -1,0 +1,30 @@
+DO $$ BEGIN
+  CREATE TYPE "public"."webhook_event" AS ENUM('task.completed', 'task.failed', 'task.needs_attention', 'task.pr_opened', 'review.completed');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "webhooks" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "url" text NOT NULL,
+  "events" jsonb NOT NULL,
+  "secret" text,
+  "description" text,
+  "active" boolean NOT NULL DEFAULT true,
+  "created_by" uuid,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "webhook_deliveries" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "webhook_id" uuid NOT NULL REFERENCES "webhooks"("id") ON DELETE CASCADE,
+  "event" text NOT NULL,
+  "payload" jsonb NOT NULL,
+  "status_code" integer,
+  "response_body" text,
+  "success" boolean NOT NULL DEFAULT false,
+  "attempt" integer NOT NULL DEFAULT 1,
+  "error" text,
+  "delivered_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -200,6 +200,41 @@ export const sessions = pgTable("sessions", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
+export const webhookEventEnum = pgEnum("webhook_event", [
+  "task.completed",
+  "task.failed",
+  "task.needs_attention",
+  "task.pr_opened",
+  "review.completed",
+]);
+
+export const webhooks = pgTable("webhooks", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  url: text("url").notNull(),
+  events: jsonb("events").$type<string[]>().notNull(), // array of webhook_event values
+  secret: text("secret"), // HMAC-SHA256 signing secret (plaintext; only used for outbound signing)
+  description: text("description"),
+  active: boolean("active").notNull().default(true),
+  createdBy: uuid("created_by"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export const webhookDeliveries = pgTable("webhook_deliveries", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  webhookId: uuid("webhook_id")
+    .notNull()
+    .references(() => webhooks.id, { onDelete: "cascade" }),
+  event: text("event").notNull(),
+  payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+  statusCode: integer("status_code"),
+  responseBody: text("response_body"),
+  success: boolean("success").notNull().default(false),
+  attempt: integer("attempt").notNull().default(1),
+  error: text("error"),
+  deliveredAt: timestamp("delivered_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 export const promptTemplates = pgTable("prompt_templates", {
   id: uuid("id").primaryKey().defaultRandom(),
   name: text("name").notNull().unique(),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import { startTaskWorker, reconcileOrphanedTasks } from "./workers/task-worker.j
 import { startTicketSyncWorker } from "./workers/ticket-sync-worker.js";
 import { startRepoCleanupWorker } from "./workers/repo-cleanup-worker.js";
 import { startPrWatcherWorker } from "./workers/pr-watcher-worker.js";
+import { startWebhookWorker } from "./workers/webhook-worker.js";
 import { logger } from "./logger.js";
 
 const redisConnection = {
@@ -71,6 +72,9 @@ async function main() {
   const prWatcherWorker = startPrWatcherWorker();
   logger.info("PR watcher worker started");
 
+  const webhookWorker = startWebhookWorker();
+  logger.info("Webhook worker started");
+
   // Re-enqueue any tasks orphaned by a Redis restart
   await reconcileOrphanedTasks();
 
@@ -85,6 +89,7 @@ async function main() {
     await ticketSyncWorker.close();
     await repoCleanupWorker.close();
     await prWatcherWorker.close();
+    await webhookWorker.close();
     await app.close();
     process.exit(0);
   };

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,0 +1,70 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import * as webhookService from "../services/webhook-service.js";
+
+const createWebhookSchema = z.object({
+  url: z.string().url(),
+  events: z
+    .array(
+      z.enum([
+        "task.completed",
+        "task.failed",
+        "task.needs_attention",
+        "task.pr_opened",
+        "review.completed",
+      ]),
+    )
+    .min(1),
+  secret: z.string().min(1).optional(),
+  description: z.string().optional(),
+});
+
+export async function webhookRoutes(app: FastifyInstance) {
+  // List all webhooks
+  app.get("/api/webhooks", async (_req, reply) => {
+    const hooks = await webhookService.listWebhooks();
+    // Mask secrets in the response
+    const masked = hooks.map((h) => ({
+      ...h,
+      secret: h.secret ? "••••••" : null,
+    }));
+    reply.send({ webhooks: masked });
+  });
+
+  // Get a single webhook
+  app.get("/api/webhooks/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const webhook = await webhookService.getWebhook(id);
+    if (!webhook) return reply.status(404).send({ error: "Webhook not found" });
+    reply.send({
+      webhook: { ...webhook, secret: webhook.secret ? "••••••" : null },
+    });
+  });
+
+  // Create a webhook
+  app.post("/api/webhooks", async (req, reply) => {
+    const body = createWebhookSchema.parse(req.body);
+    const webhook = await webhookService.createWebhook(body, (req as any).user?.id);
+    reply.status(201).send({ webhook: { ...webhook, secret: webhook.secret ? "••••••" : null } });
+  });
+
+  // Delete a webhook
+  app.delete("/api/webhooks/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const deleted = await webhookService.deleteWebhook(id);
+    if (!deleted) return reply.status(404).send({ error: "Webhook not found" });
+    reply.status(204).send();
+  });
+
+  // List deliveries for a webhook (delivery log)
+  app.get("/api/webhooks/:id/deliveries", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const webhook = await webhookService.getWebhook(id);
+    if (!webhook) return reply.status(404).send({ error: "Webhook not found" });
+    const { limit } = (req.query as { limit?: string }) ?? {};
+    const deliveries = await webhookService.getWebhookDeliveries(id, {
+      limit: limit ? parseInt(limit, 10) : 50,
+    });
+    reply.send({ deliveries });
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -16,6 +16,7 @@ import { bulkRoutes } from "./routes/bulk.js";
 import { issueRoutes } from "./routes/issues.js";
 import { subtaskRoutes } from "./routes/subtasks.js";
 import { analyticsRoutes } from "./routes/analytics.js";
+import { webhookRoutes } from "./routes/webhooks.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import authPlugin from "./plugins/auth.js";
@@ -65,6 +66,7 @@ export async function buildServer() {
   await app.register(issueRoutes);
   await app.register(subtaskRoutes);
   await app.register(analyticsRoutes);
+  await app.register(webhookRoutes);
 
   // WebSocket routes
   await app.register(logStreamWs);

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -4,6 +4,8 @@ import { tasks, taskEvents, taskLogs } from "../db/schema.js";
 import { TaskState, transition, normalizeRepoUrl, type CreateTaskInput } from "@optio/shared";
 import { publishEvent } from "./event-bus.js";
 import { logger } from "../logger.js";
+import { enqueueWebhookEvent } from "../workers/webhook-worker.js";
+import type { WebhookEvent } from "./webhook-service.js";
 
 /**
  * Thrown when a state transition fails because another worker changed the
@@ -143,6 +145,28 @@ export async function transitionTask(
     closeGitHubIssue(task.repoUrl, task.ticketExternalId, task.prUrl).catch((err) =>
       logger.warn({ err, taskId: id }, "Failed to close linked GitHub issue"),
     );
+  }
+
+  // Dispatch webhook notifications for relevant state changes
+  const webhookEventMap: Partial<Record<TaskState, WebhookEvent>> = {
+    [TaskState.COMPLETED]: task.taskType === "review" ? "review.completed" : "task.completed",
+    [TaskState.FAILED]: "task.failed",
+    [TaskState.NEEDS_ATTENTION]: "task.needs_attention",
+    [TaskState.PR_OPENED]: "task.pr_opened",
+  };
+  const webhookEvent = webhookEventMap[toState];
+  if (webhookEvent) {
+    enqueueWebhookEvent(webhookEvent, {
+      taskId: id,
+      taskTitle: task.title,
+      repoUrl: task.repoUrl,
+      repoBranch: task.repoBranch,
+      fromState: currentState,
+      toState,
+      prUrl: updated[0].prUrl ?? undefined,
+      errorMessage: updated[0].errorMessage ?? undefined,
+      taskType: task.taskType,
+    }).catch((err) => logger.warn({ err, taskId: id }, "Failed to enqueue webhook event"));
   }
 
   return updated[0];

--- a/apps/api/src/services/webhook-service.test.ts
+++ b/apps/api/src/services/webhook-service.test.ts
@@ -1,0 +1,45 @@
+import crypto from "node:crypto";
+import { describe, it, expect } from "vitest";
+import { signPayload, VALID_EVENTS } from "./webhook-service.js";
+
+describe("signPayload", () => {
+  it("produces a valid HMAC-SHA256 hex signature", () => {
+    const payload = JSON.stringify({ event: "task.completed", data: { taskId: "123" } });
+    const secret = "test-secret-key";
+    const signature = signPayload(payload, secret);
+
+    // Verify it matches what Node's crypto would produce
+    const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+    expect(signature).toBe(expected);
+  });
+
+  it("produces different signatures for different secrets", () => {
+    const payload = JSON.stringify({ event: "task.completed" });
+    const sig1 = signPayload(payload, "secret-1");
+    const sig2 = signPayload(payload, "secret-2");
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it("produces different signatures for different payloads", () => {
+    const secret = "same-secret";
+    const sig1 = signPayload(JSON.stringify({ event: "task.completed" }), secret);
+    const sig2 = signPayload(JSON.stringify({ event: "task.failed" }), secret);
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it("returns a 64-character hex string", () => {
+    const signature = signPayload("test", "secret");
+    expect(signature).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("VALID_EVENTS", () => {
+  it("contains all expected webhook events", () => {
+    expect(VALID_EVENTS).toContain("task.completed");
+    expect(VALID_EVENTS).toContain("task.failed");
+    expect(VALID_EVENTS).toContain("task.needs_attention");
+    expect(VALID_EVENTS).toContain("task.pr_opened");
+    expect(VALID_EVENTS).toContain("review.completed");
+    expect(VALID_EVENTS).toHaveLength(5);
+  });
+});

--- a/apps/api/src/services/webhook-service.ts
+++ b/apps/api/src/services/webhook-service.ts
@@ -1,0 +1,245 @@
+import crypto from "node:crypto";
+import { eq, desc } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { webhooks, webhookDeliveries } from "../db/schema.js";
+import { logger } from "../logger.js";
+
+export type WebhookEvent =
+  | "task.completed"
+  | "task.failed"
+  | "task.needs_attention"
+  | "task.pr_opened"
+  | "review.completed";
+
+export const VALID_EVENTS: WebhookEvent[] = [
+  "task.completed",
+  "task.failed",
+  "task.needs_attention",
+  "task.pr_opened",
+  "review.completed",
+];
+
+export interface CreateWebhookInput {
+  url: string;
+  events: WebhookEvent[];
+  secret?: string;
+  description?: string;
+}
+
+export async function createWebhook(input: CreateWebhookInput, createdBy?: string) {
+  const [webhook] = await db
+    .insert(webhooks)
+    .values({
+      url: input.url,
+      events: input.events,
+      secret: input.secret ?? null,
+      description: input.description ?? null,
+      createdBy: createdBy ?? null,
+    })
+    .returning();
+  return webhook;
+}
+
+export async function listWebhooks() {
+  return db.select().from(webhooks).orderBy(desc(webhooks.createdAt));
+}
+
+export async function getWebhook(id: string) {
+  const [webhook] = await db.select().from(webhooks).where(eq(webhooks.id, id));
+  return webhook ?? null;
+}
+
+export async function deleteWebhook(id: string) {
+  const result = await db.delete(webhooks).where(eq(webhooks.id, id)).returning();
+  return result.length > 0;
+}
+
+export async function getWebhookDeliveries(webhookId: string, opts?: { limit?: number }) {
+  let query = db
+    .select()
+    .from(webhookDeliveries)
+    .where(eq(webhookDeliveries.webhookId, webhookId))
+    .orderBy(desc(webhookDeliveries.deliveredAt));
+  if (opts?.limit) query = query.limit(opts.limit) as typeof query;
+  return query;
+}
+
+/**
+ * Sign a payload using HMAC-SHA256 with the webhook's secret.
+ */
+export function signPayload(payload: string, secret: string): string {
+  return crypto.createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+/**
+ * Build a Slack-compatible payload with blocks for task details.
+ */
+function buildSlackPayload(
+  event: WebhookEvent,
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  const taskTitle = (data.taskTitle as string) ?? "Unknown task";
+  const taskId = (data.taskId as string) ?? "";
+  const repoUrl = (data.repoUrl as string) ?? "";
+  const prUrl = data.prUrl as string | undefined;
+  const errorMessage = data.errorMessage as string | undefined;
+
+  const statusEmoji: Record<string, string> = {
+    "task.completed": ":white_check_mark:",
+    "task.failed": ":x:",
+    "task.needs_attention": ":warning:",
+    "task.pr_opened": ":rocket:",
+    "review.completed": ":mag:",
+  };
+
+  const statusText: Record<string, string> = {
+    "task.completed": "Task Completed",
+    "task.failed": "Task Failed",
+    "task.needs_attention": "Task Needs Attention",
+    "task.pr_opened": "PR Opened",
+    "review.completed": "Review Completed",
+  };
+
+  const blocks: Record<string, unknown>[] = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: `${statusEmoji[event] ?? ""} ${statusText[event] ?? event}`,
+        emoji: true,
+      },
+    },
+    {
+      type: "section",
+      fields: [
+        { type: "mrkdwn", text: `*Task:*\n${taskTitle}` },
+        { type: "mrkdwn", text: `*ID:*\n\`${taskId}\`` },
+      ],
+    },
+  ];
+
+  if (repoUrl) {
+    blocks.push({
+      type: "section",
+      fields: [{ type: "mrkdwn", text: `*Repository:*\n${repoUrl}` }],
+    });
+  }
+
+  if (prUrl) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*Pull Request:* <${prUrl}|View PR>` },
+    });
+  }
+
+  if (errorMessage) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Error:*\n\`\`\`${errorMessage.slice(0, 500)}\`\`\``,
+      },
+    });
+  }
+
+  // Slack requires a top-level `text` as fallback for notifications
+  return {
+    text: `${statusText[event] ?? event}: ${taskTitle}`,
+    blocks,
+  };
+}
+
+/**
+ * Determine if a URL is a Slack incoming webhook.
+ */
+function isSlackWebhook(url: string): boolean {
+  return url.includes("hooks.slack.com/");
+}
+
+/**
+ * Deliver a webhook payload to a single endpoint.
+ * Returns the delivery record.
+ */
+export async function deliverWebhook(
+  webhook: typeof webhooks.$inferSelect,
+  event: WebhookEvent,
+  data: Record<string, unknown>,
+  attempt: number = 1,
+): Promise<typeof webhookDeliveries.$inferSelect> {
+  const isSlack = isSlackWebhook(webhook.url);
+  const payload = isSlack
+    ? buildSlackPayload(event, data)
+    : { event, timestamp: new Date().toISOString(), data };
+
+  const payloadStr = JSON.stringify(payload);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "User-Agent": "Optio-Webhooks/1.0",
+    "X-Optio-Event": event,
+  };
+
+  if (webhook.secret) {
+    headers["X-Optio-Signature"] = signPayload(payloadStr, webhook.secret);
+  }
+
+  let statusCode: number | undefined;
+  let responseBody: string | undefined;
+  let success = false;
+  let error: string | undefined;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000); // 10s timeout
+
+    const res = await fetch(webhook.url, {
+      method: "POST",
+      headers,
+      body: payloadStr,
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+    statusCode = res.status;
+    responseBody = await res.text().catch(() => undefined);
+    // Truncate response body to avoid storing huge payloads
+    if (responseBody && responseBody.length > 2000) {
+      responseBody = responseBody.slice(0, 2000) + "...(truncated)";
+    }
+    success = res.ok;
+    if (!res.ok) {
+      error = `HTTP ${res.status}: ${responseBody?.slice(0, 200) ?? ""}`;
+    }
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+    logger.warn({ webhookId: webhook.id, event, attempt, error }, "Webhook delivery failed");
+  }
+
+  const [delivery] = await db
+    .insert(webhookDeliveries)
+    .values({
+      webhookId: webhook.id,
+      event,
+      payload,
+      statusCode,
+      responseBody,
+      success,
+      attempt,
+      error,
+    })
+    .returning();
+
+  return delivery;
+}
+
+/**
+ * Find all active webhooks subscribed to an event and dispatch delivery jobs.
+ */
+export async function getWebhooksForEvent(event: WebhookEvent) {
+  const allWebhooks = await db.select().from(webhooks).where(eq(webhooks.active, true));
+
+  return allWebhooks.filter((w) => {
+    const events = w.events as string[];
+    return events.includes(event);
+  });
+}

--- a/apps/api/src/workers/webhook-worker.ts
+++ b/apps/api/src/workers/webhook-worker.ts
@@ -1,0 +1,85 @@
+import { Queue, Worker } from "bullmq";
+import { logger } from "../logger.js";
+import {
+  getWebhooksForEvent,
+  deliverWebhook,
+  getWebhook,
+  type WebhookEvent,
+} from "../services/webhook-service.js";
+
+const redisConnection = {
+  url: process.env.REDIS_URL ?? "redis://localhost:6379",
+  maxRetriesPerRequest: null,
+};
+
+const webhookQueue = new Queue("webhooks", { connection: redisConnection });
+
+/**
+ * Enqueue a webhook delivery job for all active webhooks that subscribe to the event.
+ */
+export async function enqueueWebhookEvent(event: WebhookEvent, data: Record<string, unknown>) {
+  const matchingWebhooks = await getWebhooksForEvent(event);
+  if (matchingWebhooks.length === 0) return;
+
+  for (const webhook of matchingWebhooks) {
+    await webhookQueue.add(
+      "deliver",
+      { webhookId: webhook.id, event, data },
+      {
+        attempts: 3,
+        backoff: { type: "exponential", delay: 5000 }, // 5s, 10s, 20s
+        removeOnComplete: { count: 1000 },
+        removeOnFail: { count: 500 },
+      },
+    );
+  }
+
+  logger.info({ event, webhookCount: matchingWebhooks.length }, "Enqueued webhook deliveries");
+}
+
+/**
+ * Start the BullMQ worker that processes webhook delivery jobs.
+ */
+export function startWebhookWorker() {
+  const worker = new Worker(
+    "webhooks",
+    async (job) => {
+      const { webhookId, event, data } = job.data as {
+        webhookId: string;
+        event: WebhookEvent;
+        data: Record<string, unknown>;
+      };
+
+      const webhook = await getWebhook(webhookId);
+      if (!webhook || !webhook.active) {
+        logger.info({ webhookId }, "Webhook not found or inactive, skipping delivery");
+        return;
+      }
+
+      const attempt = (job.attemptsMade ?? 0) + 1;
+      const delivery = await deliverWebhook(webhook, event, data, attempt);
+
+      if (!delivery.success) {
+        throw new Error(delivery.error ?? `Delivery failed with status ${delivery.statusCode}`);
+      }
+
+      logger.info(
+        { webhookId, event, statusCode: delivery.statusCode },
+        "Webhook delivered successfully",
+      );
+    },
+    {
+      connection: redisConnection,
+      concurrency: 10,
+    },
+  );
+
+  worker.on("failed", (job, err) => {
+    logger.warn(
+      { jobId: job?.id, webhookId: job?.data?.webhookId, err: err.message },
+      "Webhook delivery job failed",
+    );
+  });
+
+  return worker;
+}


### PR DESCRIPTION
## Summary

- Add webhook CRUD endpoints (`POST/GET/DELETE /api/webhooks`) for registering external notification endpoints
- Deliver JSON payloads with HMAC-SHA256 signatures (`X-Optio-Signature` header) on task state changes: `task.completed`, `task.failed`, `task.needs_attention`, `task.pr_opened`, `review.completed`
- BullMQ worker with exponential backoff retry (3 attempts at 5s/10s/20s intervals)
- Auto-detect Slack incoming webhook URLs and format payloads with Block Kit blocks (header, fields, action links)
- Delivery log endpoint (`GET /api/webhooks/:id/deliveries`) for debugging
- Webhook secrets masked in all API responses

## New files
- `apps/api/src/db/schema.ts` — `webhooks` and `webhook_deliveries` tables
- `apps/api/src/db/migrations/0016_notification_webhooks.sql` — migration
- `apps/api/src/services/webhook-service.ts` — CRUD, HMAC signing, delivery, Slack payload formatting
- `apps/api/src/workers/webhook-worker.ts` — async delivery with BullMQ retry
- `apps/api/src/routes/webhooks.ts` — REST API endpoints with Zod validation
- `apps/api/src/services/webhook-service.test.ts` — tests for HMAC signing

## Test plan
- [x] Typecheck passes (`pnpm turbo typecheck`)
- [x] All 168 tests pass (`pnpm turbo test`)
- [x] Format check passes on all new/modified files
- [ ] Manual: create webhook via `POST /api/webhooks`, verify Slack message on task completion
- [ ] Manual: verify HMAC signature matches expected value
- [ ] Manual: verify retry behavior on failed delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)