### PR TITLE
feat: add task search and filtering with saved views

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -30,6 +30,26 @@ export async function taskRoutes(app: FastifyInstance) {
     reply.send({ tasks: taskList, limit, offset });
   });
 
+  // Search tasks with advanced filtering and cursor-based pagination
+  app.get("/api/tasks/search", async (req, reply) => {
+    const query = req.query as Record<string, string | undefined>;
+    const result = await taskService.searchTasks({
+      q: query.q,
+      state: query.state,
+      repoUrl: query.repoUrl,
+      agentType: query.agentType,
+      taskType: query.taskType,
+      costMin: query.costMin,
+      costMax: query.costMax,
+      createdAfter: query.createdAfter,
+      createdBefore: query.createdBefore,
+      author: query.author,
+      cursor: query.cursor,
+      limit: query.limit ? parseInt(query.limit, 10) : undefined,
+    });
+    reply.send(result);
+  });
+
   // Get task
   app.get("/api/tasks/:id", async (req, reply) => {
     const { id } = req.params as { id: string };

--- a/apps/api/src/services/task-service.test.ts
+++ b/apps/api/src/services/task-service.test.ts
@@ -37,6 +37,7 @@ import {
   transitionTask,
   tryTransitionTask,
   updateTaskPr,
+  searchTasks,
 } from "./task-service.js";
 
 describe("StateRaceError", () => {
@@ -169,5 +170,73 @@ describe("updateTaskPr", () => {
     expect(db.update(undefined as any).set).toHaveBeenCalledWith(
       expect.objectContaining({ prUrl: "https://github.com/o/r" }),
     );
+  });
+});
+
+describe("searchTasks", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns tasks with cursor when more results exist", async () => {
+    const now = new Date();
+    // Create limit+1 tasks to trigger hasMore
+    const mockTasks = Array.from({ length: 3 }, (_, i) => ({
+      id: `task-${i}`,
+      title: `Task ${i}`,
+      state: "running",
+      createdAt: new Date(now.getTime() - i * 1000),
+    }));
+    const mockDb = db as any;
+    // No filters, so chain is: select().from().orderBy().limit() → await resolves via limit
+    mockDb.limit.mockResolvedValueOnce(mockTasks);
+
+    const result = await searchTasks({ limit: 2 });
+    // 3 results returned for limit=2 means hasMore=true, items trimmed to 2
+    expect(result.hasMore).toBe(true);
+    expect(result.tasks).toHaveLength(2);
+    expect(result.nextCursor).toBeTruthy();
+  });
+
+  it("returns no cursor when all results fit", async () => {
+    const mockDb = db as any;
+    mockDb.limit.mockResolvedValueOnce([
+      { id: "t1", title: "Task", state: "running", createdAt: new Date() },
+    ]);
+
+    const result = await searchTasks({ limit: 50 });
+    expect(result.hasMore).toBe(false);
+    expect(result.tasks).toHaveLength(1);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("accepts empty params and returns results", async () => {
+    const mockDb = db as any;
+    mockDb.limit.mockResolvedValueOnce([]);
+
+    const result = await searchTasks({});
+    expect(result.hasMore).toBe(false);
+    expect(result.tasks).toHaveLength(0);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("applies filters when params are provided", async () => {
+    const mockDb = db as any;
+    // With filters, chain ends with .where() — mock that to resolve
+    mockDb.where.mockResolvedValueOnce([
+      { id: "t1", title: "Fix bug", state: "completed", createdAt: new Date() },
+    ]);
+
+    const result = await searchTasks({ q: "Fix", state: "completed" });
+    expect(result.tasks).toHaveLength(1);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("defaults limit to 50", async () => {
+    const mockDb = db as any;
+    mockDb.limit.mockResolvedValueOnce([]);
+
+    await searchTasks({});
+    // limit(51) = default 50 + 1
+    expect(mockDb.limit).toHaveBeenCalledWith(51);
   });
 });

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -68,6 +68,103 @@ export async function listTasks(opts?: { state?: string; limit?: number; offset?
   return query;
 }
 
+export interface SearchTasksOpts {
+  q?: string;
+  state?: string;
+  repoUrl?: string;
+  agentType?: string;
+  taskType?: string;
+  costMin?: string;
+  costMax?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+  author?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+export async function searchTasks(opts: SearchTasksOpts) {
+  const limit = opts.limit ?? 50;
+  const conditions = [];
+
+  // Full-text search on title and prompt
+  if (opts.q) {
+    const pattern = `%${opts.q}%`;
+    conditions.push(or(ilike(tasks.title, pattern), ilike(tasks.prompt, pattern))!);
+  }
+
+  // Exact field filters
+  if (opts.state) {
+    conditions.push(eq(tasks.state, opts.state as any));
+  }
+  if (opts.repoUrl) {
+    conditions.push(eq(tasks.repoUrl, normalizeRepoUrl(opts.repoUrl)));
+  }
+  if (opts.agentType) {
+    conditions.push(eq(tasks.agentType, opts.agentType));
+  }
+  if (opts.taskType) {
+    conditions.push(eq(tasks.taskType, opts.taskType));
+  }
+  if (opts.author) {
+    conditions.push(eq(tasks.createdBy, opts.author));
+  }
+
+  // Cost range (costUsd is stored as text, cast to numeric for comparison)
+  if (opts.costMin) {
+    conditions.push(sql`CAST(${tasks.costUsd} AS numeric) >= ${Number(opts.costMin)}`);
+  }
+  if (opts.costMax) {
+    conditions.push(sql`CAST(${tasks.costUsd} AS numeric) <= ${Number(opts.costMax)}`);
+  }
+
+  // Date range
+  if (opts.createdAfter) {
+    conditions.push(gte(tasks.createdAt, new Date(opts.createdAfter)));
+  }
+  if (opts.createdBefore) {
+    conditions.push(lte(tasks.createdAt, new Date(opts.createdBefore)));
+  }
+
+  // Cursor-based pagination: cursor is base64 of "createdAt|id"
+  if (opts.cursor) {
+    const decoded = Buffer.from(opts.cursor, "base64").toString();
+    const sepIdx = decoded.indexOf("|");
+    if (sepIdx !== -1) {
+      const cursorDate = decoded.slice(0, sepIdx);
+      const cursorId = decoded.slice(sepIdx + 1);
+      conditions.push(
+        or(
+          sql`${tasks.createdAt} < ${new Date(cursorDate)}`,
+          and(eq(tasks.createdAt, new Date(cursorDate) as any), sql`${tasks.id} < ${cursorId}`),
+        )!,
+      );
+    }
+  }
+
+  let query = db
+    .select()
+    .from(tasks)
+    .orderBy(desc(tasks.createdAt), desc(tasks.id))
+    .limit(limit + 1);
+
+  if (conditions.length > 0) {
+    query = query.where(and(...conditions)) as typeof query;
+  }
+
+  const results = await query;
+  const hasMore = results.length > limit;
+  const items = hasMore ? results.slice(0, limit) : results;
+
+  let nextCursor: string | null = null;
+  if (hasMore && items.length > 0) {
+    const last = items[items.length - 1];
+    nextCursor = Buffer.from(`${last.createdAt.toISOString()}|${last.id}`).toString("base64");
+  }
+
+  return { tasks: items, nextCursor, hasMore };
+}
+
 export async function transitionTask(
   id: string,
   toState: TaskState,

--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { TaskList } from "@/components/task-list";
 import { api } from "@/lib/api-client";
 import { toast } from "sonner";
@@ -97,7 +97,18 @@ export default function TasksPage() {
         </button>
       </div>
 
-      {tab === "tasks" && <TaskList />}
+      {tab === "tasks" && (
+        <Suspense
+          fallback={
+            <div className="flex items-center justify-center py-16 text-text-muted">
+              <Loader2 className="w-5 h-5 animate-spin mr-2" />
+              Loading tasks...
+            </div>
+          }
+        >
+          <TaskList />
+        </Suspense>
+      )}
       {tab === "issues" && <IssuesBrowser />}
     </div>
   );

--- a/apps/web/src/components/task-list.tsx
+++ b/apps/web/src/components/task-list.tsx
@@ -1,10 +1,22 @@
 "use client";
 
-import React, { useEffect, useState, useCallback, useMemo } from "react";
+import React, { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import { api } from "@/lib/api-client";
 import { useStore, type TaskSummary } from "@/hooks/use-store";
 import { TaskCard } from "./task-card";
-import { Loader2, ChevronUp, ChevronDown, ChevronRight, GripVertical, Search } from "lucide-react";
+import {
+  Loader2,
+  ChevronUp,
+  ChevronDown,
+  ChevronRight,
+  GripVertical,
+  Search,
+  X,
+  Bookmark,
+  SlidersHorizontal,
+  DollarSign,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { useShallow } from "zustand/react/shallow";
@@ -37,24 +49,13 @@ function getTaskStage(
 
   // pr_opened — determine which post-PR pipeline stage
   if (t.state === "pr_opened") {
-    // Subtask running/queued means the review agent is active
     if (subs.hasRunning) return "review";
     if (subs.hasQueued) return "review";
-
-    // Review status from GitHub
     if (t.prReviewStatus && !["none", "pending"].includes(t.prReviewStatus)) return "review";
-
-    // CI checks
     const checks = t.prChecksStatus;
     if (!checks || ["none", "pending"].includes(checks)) return "ci";
     if (checks === "failing") return "ci";
-
-    // Checks passing — if there's review activity or done subtasks, show review
-    if (checks === "passing") {
-      if (subs.allDone) return "review";
-      return "review";
-    }
-
+    if (checks === "passing") return "review";
     return "ci";
   }
 
@@ -62,7 +63,7 @@ function getTaskStage(
 }
 
 // ---------------------------------------------------------------------------
-// Filter definitions — synced with pipeline stages
+// Filter definitions
 // ---------------------------------------------------------------------------
 
 const STAGE_FILTERS = [
@@ -83,21 +84,105 @@ const TIME_FILTERS = [
   { value: "", label: "All time" },
 ];
 
-function getSinceDate(timeFilter: string): Date | null {
+const AGENT_TYPE_OPTIONS = [
+  { value: "", label: "All agents" },
+  { value: "claude-code", label: "Claude Code" },
+  { value: "codex", label: "Codex" },
+];
+
+function getDateFromTimeFilter(timeFilter: string): string | undefined {
+  if (!timeFilter) return undefined;
   const now = new Date();
   switch (timeFilter) {
     case "1d":
-      return new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      return new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
     case "7d":
-      return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
     case "30d":
-      return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
     default:
-      return null;
+      return undefined;
   }
 }
 
-const TERMINAL_STAGES: PipelineStage[] = ["done", "failed"];
+// ---------------------------------------------------------------------------
+// Saved views — persisted in localStorage
+// ---------------------------------------------------------------------------
+
+interface SavedView {
+  id: string;
+  name: string;
+  filters: FilterState;
+}
+
+interface FilterState {
+  q: string;
+  stage: string;
+  timeFilter: string;
+  repoUrl: string;
+  agentType: string;
+  costMin: string;
+  costMax: string;
+}
+
+const EMPTY_FILTERS: FilterState = {
+  q: "",
+  stage: "",
+  timeFilter: "1d",
+  repoUrl: "",
+  agentType: "",
+  costMin: "",
+  costMax: "",
+};
+
+const SAVED_VIEWS_KEY = "optio-saved-views";
+
+function loadSavedViews(): SavedView[] {
+  try {
+    const raw = localStorage.getItem(SAVED_VIEWS_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistSavedViews(views: SavedView[]) {
+  localStorage.setItem(SAVED_VIEWS_KEY, JSON.stringify(views));
+}
+
+// ---------------------------------------------------------------------------
+// URL <-> filter sync helpers
+// ---------------------------------------------------------------------------
+
+const FILTER_URL_KEYS: (keyof FilterState)[] = [
+  "q",
+  "stage",
+  "timeFilter",
+  "repoUrl",
+  "agentType",
+  "costMin",
+  "costMax",
+];
+
+function filtersFromSearchParams(params: URLSearchParams): Partial<FilterState> {
+  const partial: Partial<FilterState> = {};
+  for (const key of FILTER_URL_KEYS) {
+    const val = params.get(key);
+    if (val) partial[key] = val;
+  }
+  return partial;
+}
+
+function filtersToSearchParams(filters: FilterState): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const key of FILTER_URL_KEYS) {
+    const val = filters[key];
+    if (val && val !== EMPTY_FILTERS[key]) {
+      params.set(key, val);
+    }
+  }
+  return params;
+}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -106,24 +191,159 @@ const TERMINAL_STAGES: PipelineStage[] = ["done", "failed"];
 export function TaskList() {
   const tasks = useStore(useShallow((state) => state.tasks));
   const setTasks = useStore((state) => state.setTasks);
-  const [filter, setFilter] = useState("");
-  const [timeFilter, setTimeFilter] = useState("1d");
-  const [searchQuery, setSearchQuery] = useState("");
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // Initialize filters from URL
+  const [filters, setFilters] = useState<FilterState>(() => ({
+    ...EMPTY_FILTERS,
+    ...filtersFromSearchParams(searchParams),
+  }));
+
   const [loading, setLoading] = useState(true);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [repos, setRepos] = useState<{ id: string; repoUrl: string; fullName: string }[]>([]);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [savedViews, setSavedViews] = useState<SavedView[]>([]);
+  const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [saveViewName, setSaveViewName] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Load saved views and repos on mount
+  useEffect(() => {
+    setSavedViews(loadSavedViews());
+    api
+      .listRepos()
+      .then((res) => setRepos(res.repos))
+      .catch(() => {});
+  }, []);
+
+  // Auto-expand advanced filters if any are active from URL
+  useEffect(() => {
+    const p = filtersFromSearchParams(searchParams);
+    if (p.repoUrl || p.agentType || p.costMin || p.costMax) {
+      setShowAdvanced(true);
+    }
+  }, [searchParams]);
+
+  // Sync filters to URL
+  useEffect(() => {
+    const params = filtersToSearchParams(filters);
+    const newQuery = params.toString();
+    const currentQuery = searchParams.toString();
+    if (newQuery !== currentQuery) {
+      router.replace(`?${newQuery}`, { scroll: false });
+    }
+  }, [filters, router, searchParams]);
+
+  // Fetch tasks using search API
+  const fetchTasks = useCallback((filtersToUse: FilterState, cursor?: string) => {
+    const createdAfter = getDateFromTimeFilter(filtersToUse.timeFilter);
+    return api.searchTasks({
+      q: filtersToUse.q || undefined,
+      repoUrl: filtersToUse.repoUrl || undefined,
+      agentType: filtersToUse.agentType || undefined,
+      costMin: filtersToUse.costMin || undefined,
+      costMax: filtersToUse.costMax || undefined,
+      createdAfter,
+      cursor,
+      limit: 200,
+    });
+  }, []);
 
   const refresh = useCallback(() => {
-    api
-      .listTasks({ limit: 200 })
-      .then((res) => setTasks(res.tasks))
+    setLoading(true);
+    fetchTasks(filters)
+      .then((res) => {
+        setTasks(res.tasks);
+        setNextCursor(res.nextCursor);
+      })
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, [setTasks]);
+  }, [filters, fetchTasks, setTasks]);
 
+  // Debounced refresh when filters change
   useEffect(() => {
-    refresh();
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      refresh();
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
   }, [refresh]);
 
-  // Memoize parent→subtask map (only recalculated when tasks change)
+  const loadMore = useCallback(() => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    fetchTasks(filters, nextCursor)
+      .then((res) => {
+        setTasks([...tasks, ...res.tasks]);
+        setNextCursor(res.nextCursor);
+      })
+      .catch(() => {})
+      .finally(() => setLoadingMore(false));
+  }, [nextCursor, loadingMore, filters, fetchTasks, tasks, setTasks]);
+
+  // Filter updaters
+  const updateFilter = useCallback(<K extends keyof FilterState>(key: K, value: FilterState[K]) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setFilters(EMPTY_FILTERS);
+  }, []);
+
+  const hasActiveFilters = useMemo(
+    () =>
+      filters.q !== "" ||
+      filters.repoUrl !== "" ||
+      filters.agentType !== "" ||
+      filters.costMin !== "" ||
+      filters.costMax !== "" ||
+      filters.timeFilter !== "1d",
+    [filters],
+  );
+
+  // Saved views management
+  const handleSaveView = useCallback(() => {
+    if (!saveViewName.trim()) return;
+    const newView: SavedView = {
+      id: crypto.randomUUID(),
+      name: saveViewName.trim(),
+      filters: { ...filters },
+    };
+    const updated = [...savedViews, newView];
+    setSavedViews(updated);
+    persistSavedViews(updated);
+    setSaveViewName("");
+    setShowSaveDialog(false);
+    toast.success(`View "${newView.name}" saved`);
+  }, [saveViewName, filters, savedViews]);
+
+  const handleLoadView = useCallback((view: SavedView) => {
+    setFilters(view.filters);
+    if (
+      view.filters.repoUrl ||
+      view.filters.agentType ||
+      view.filters.costMin ||
+      view.filters.costMax
+    ) {
+      setShowAdvanced(true);
+    }
+  }, []);
+
+  const handleDeleteView = useCallback(
+    (id: string) => {
+      const updated = savedViews.filter((v) => v.id !== id);
+      setSavedViews(updated);
+      persistSavedViews(updated);
+    },
+    [savedViews],
+  );
+
+  // Memoize parent->subtask map
   const { reviewMap, topLevelAll } = useMemo(() => {
     const map = new Map<string, TaskSummary[]>();
     const topLevel: TaskSummary[] = [];
@@ -162,32 +382,10 @@ export function TaskList() {
   // Memoize filtered + sectioned data
   const { attention, running, ci, review, queued, failed, completed, visibleTasks, stageCounts } =
     useMemo(() => {
-      const sinceDate = getSinceDate(timeFilter);
-      const query = searchQuery.trim().toLowerCase();
-
-      // Apply stage filter
-      let visible = filter
-        ? topLevelAll.filter((t) => taskStages.get(t.id) === filter)
+      // Apply stage filter (client-side — stages depend on subtask status)
+      const visible = filters.stage
+        ? topLevelAll.filter((t) => taskStages.get(t.id) === filters.stage)
         : topLevelAll;
-
-      // Apply time filter — only constrains terminal tasks
-      if (sinceDate) {
-        visible = visible.filter((t) => {
-          const stage = taskStages.get(t.id)!;
-          if (!TERMINAL_STAGES.includes(stage)) return true;
-          return new Date(t.createdAt) >= sinceDate;
-        });
-      }
-
-      // Apply text search
-      if (query) {
-        visible = visible.filter((t) => {
-          if (t.title.toLowerCase().includes(query)) return true;
-          if (t.id.toLowerCase().startsWith(query)) return true;
-          if (t.ticketExternalId && t.ticketExternalId.toLowerCase().includes(query)) return true;
-          return false;
-        });
-      }
 
       // Split into sections by stage
       const sections = {
@@ -203,17 +401,15 @@ export function TaskList() {
         completed: visible.filter((t) => taskStages.get(t.id) === "done"),
       };
 
-      // Compute counts per stage for filter badges (from unfiltered + unsearched data)
+      // Compute counts per stage for filter badges
       const counts = new Map<string, number>();
       for (const t of topLevelAll) {
         const stage = taskStages.get(t.id)!;
-        if (sinceDate && TERMINAL_STAGES.includes(stage) && new Date(t.createdAt) < sinceDate)
-          continue;
         counts.set(stage, (counts.get(stage) ?? 0) + 1);
       }
 
       return { ...sections, visibleTasks: visible, stageCounts: counts };
-    }, [topLevelAll, taskStages, filter, timeFilter, searchQuery]);
+    }, [topLevelAll, taskStages, filters.stage]);
 
   const moveTask = async (index: number, direction: "up" | "down") => {
     const newIndex = direction === "up" ? index - 1 : index + 1;
@@ -250,26 +446,34 @@ export function TaskList() {
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted/50" />
           <input
             type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search by name, task ID, or issue ID..."
-            className="w-full pl-9 pr-3 py-2 bg-transparent border-b border-border/50 text-sm text-text placeholder:text-text-muted/40 focus:outline-none focus:border-text-muted transition-colors"
+            value={filters.q}
+            onChange={(e) => updateFilter("q", e.target.value)}
+            placeholder="Search tasks by title or prompt..."
+            className="w-full pl-9 pr-9 py-2 bg-transparent border-b border-border/50 text-sm text-text placeholder:text-text-muted/40 focus:outline-none focus:border-text-muted transition-colors"
           />
+          {filters.q && (
+            <button
+              onClick={() => updateFilter("q", "")}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted/50 hover:text-text transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
         </div>
       </div>
 
       {/* Filters row */}
-      <div className="flex items-center gap-4 mb-6">
+      <div className="flex items-center gap-4 mb-4">
         <div className="flex gap-1.5 flex-wrap flex-1">
           {STAGE_FILTERS.map((f) => {
             const count = f.value ? (stageCounts.get(f.value) ?? 0) : topLevelAll.length;
             return (
               <button
                 key={f.value}
-                onClick={() => setFilter(f.value)}
+                onClick={() => updateFilter("stage", f.value)}
                 className={cn(
                   "px-3 py-1.5 rounded-lg text-[13px] font-medium transition-colors flex items-center gap-1.5",
-                  filter === f.value
+                  filters.stage === f.value
                     ? "bg-bg-card border border-border text-text"
                     : "text-text-muted hover:bg-bg-hover hover:text-text",
                 )}
@@ -282,18 +486,198 @@ export function TaskList() {
             );
           })}
         </div>
-        <select
-          value={timeFilter}
-          onChange={(e) => setTimeFilter(e.target.value)}
-          className="px-2 py-1.5 rounded-lg text-[13px] font-medium bg-transparent border border-border/50 text-text-muted cursor-pointer focus:outline-none focus:border-border hover:border-border transition-colors"
-        >
-          {TIME_FILTERS.map((f) => (
-            <option key={f.value} value={f.value}>
-              {f.label}
-            </option>
-          ))}
-        </select>
+        <div className="flex items-center gap-2">
+          <select
+            value={filters.timeFilter}
+            onChange={(e) => updateFilter("timeFilter", e.target.value)}
+            className="px-2 py-1.5 rounded-lg text-[13px] font-medium bg-transparent border border-border/50 text-text-muted cursor-pointer focus:outline-none focus:border-border hover:border-border transition-colors"
+          >
+            {TIME_FILTERS.map((f) => (
+              <option key={f.value} value={f.value}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={() => setShowAdvanced((v) => !v)}
+            className={cn(
+              "p-1.5 rounded-lg border transition-colors",
+              showAdvanced
+                ? "bg-bg-card border-border text-text"
+                : "border-border/50 text-text-muted hover:border-border hover:text-text",
+            )}
+            title="Advanced filters"
+          >
+            <SlidersHorizontal className="w-4 h-4" />
+          </button>
+        </div>
       </div>
+
+      {/* Advanced filters */}
+      {showAdvanced && (
+        <div className="mb-4 p-3 rounded-lg border border-border/50 bg-bg-card/50 space-y-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {/* Repo filter */}
+            <div>
+              <label className="block text-[11px] font-medium text-text-muted mb-1">
+                Repository
+              </label>
+              <select
+                value={filters.repoUrl}
+                onChange={(e) => updateFilter("repoUrl", e.target.value)}
+                className="w-full px-2 py-1.5 rounded-md text-[13px] bg-transparent border border-border/50 text-text cursor-pointer focus:outline-none focus:border-border transition-colors"
+              >
+                <option value="">All repos</option>
+                {repos.map((r) => (
+                  <option key={r.id} value={r.repoUrl}>
+                    {r.fullName}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Agent type filter */}
+            <div>
+              <label className="block text-[11px] font-medium text-text-muted mb-1">
+                Agent Type
+              </label>
+              <select
+                value={filters.agentType}
+                onChange={(e) => updateFilter("agentType", e.target.value)}
+                className="w-full px-2 py-1.5 rounded-md text-[13px] bg-transparent border border-border/50 text-text cursor-pointer focus:outline-none focus:border-border transition-colors"
+              >
+                {AGENT_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Cost range */}
+            <div>
+              <label className="block text-[11px] font-medium text-text-muted mb-1">
+                <DollarSign className="w-3 h-3 inline" /> Cost Min
+              </label>
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                value={filters.costMin}
+                onChange={(e) => updateFilter("costMin", e.target.value)}
+                placeholder="0.00"
+                className="w-full px-2 py-1.5 rounded-md text-[13px] bg-transparent border border-border/50 text-text placeholder:text-text-muted/40 focus:outline-none focus:border-border transition-colors"
+              />
+            </div>
+            <div>
+              <label className="block text-[11px] font-medium text-text-muted mb-1">
+                <DollarSign className="w-3 h-3 inline" /> Cost Max
+              </label>
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                value={filters.costMax}
+                onChange={(e) => updateFilter("costMax", e.target.value)}
+                placeholder="99.99"
+                className="w-full px-2 py-1.5 rounded-md text-[13px] bg-transparent border border-border/50 text-text placeholder:text-text-muted/40 focus:outline-none focus:border-border transition-colors"
+              />
+            </div>
+          </div>
+
+          {/* Active filter tags + actions */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5 flex-wrap">
+              {hasActiveFilters && (
+                <button
+                  onClick={clearFilters}
+                  className="text-[11px] text-text-muted hover:text-text transition-colors underline"
+                >
+                  Clear all filters
+                </button>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              {/* Saved views dropdown */}
+              {savedViews.length > 0 && (
+                <div className="relative group">
+                  <button className="flex items-center gap-1 text-[11px] text-text-muted hover:text-text transition-colors">
+                    <Bookmark className="w-3 h-3" />
+                    Saved Views ({savedViews.length})
+                  </button>
+                  <div className="absolute right-0 top-full mt-1 w-48 bg-bg-card border border-border rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10">
+                    {savedViews.map((view) => (
+                      <div
+                        key={view.id}
+                        className="flex items-center justify-between px-3 py-2 hover:bg-bg-hover first:rounded-t-lg last:rounded-b-lg"
+                      >
+                        <button
+                          onClick={() => handleLoadView(view)}
+                          className="text-[12px] text-text truncate flex-1 text-left"
+                        >
+                          {view.name}
+                        </button>
+                        <button
+                          onClick={() => handleDeleteView(view.id)}
+                          className="text-text-muted/50 hover:text-error ml-2 shrink-0 transition-colors"
+                        >
+                          <X className="w-3 h-3" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Save current view */}
+              {showSaveDialog ? (
+                <div className="flex items-center gap-1">
+                  <input
+                    type="text"
+                    value={saveViewName}
+                    onChange={(e) => setSaveViewName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleSaveView();
+                      if (e.key === "Escape") setShowSaveDialog(false);
+                    }}
+                    placeholder="View name"
+                    className="px-2 py-1 text-[11px] bg-transparent border border-border rounded-md text-text placeholder:text-text-muted/40 focus:outline-none w-28"
+                    autoFocus
+                  />
+                  <button
+                    onClick={handleSaveView}
+                    className="text-[11px] text-primary hover:text-primary-hover transition-colors"
+                  >
+                    Save
+                  </button>
+                  <button
+                    onClick={() => setShowSaveDialog(false)}
+                    className="text-[11px] text-text-muted hover:text-text transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setShowSaveDialog(true)}
+                  className="flex items-center gap-1 text-[11px] text-text-muted hover:text-text transition-colors"
+                >
+                  <Bookmark className="w-3 h-3" />
+                  Save View
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Loaded count */}
+          {!loading && (
+            <div className="text-[11px] text-text-muted/50">
+              {topLevelAll.length} task{topLevelAll.length !== 1 ? "s" : ""} loaded
+              {nextCursor ? " (more available)" : ""}
+            </div>
+          )}
+        </div>
+      )}
 
       {loading && tasks.length === 0 ? (
         <div className="flex items-center justify-center py-16 text-text-muted">
@@ -303,10 +687,17 @@ export function TaskList() {
       ) : visibleTasks.length === 0 ? (
         <div className="text-center py-16 text-text-muted">
           <p>No tasks found</p>
+          {hasActiveFilters && (
+            <button
+              onClick={clearFilters}
+              className="mt-2 text-sm text-primary hover:text-primary-hover transition-colors"
+            >
+              Clear filters
+            </button>
+          )}
         </div>
       ) : (
         <div className="space-y-8">
-          {/* Needs human input — most important */}
           {attention.length > 0 && (
             <Section label="Needs Your Input" count={attention.length}>
               {attention.map((task) => (
@@ -315,7 +706,6 @@ export function TaskList() {
             </Section>
           )}
 
-          {/* Running */}
           {running.length > 0 && (
             <Section label="Running" count={running.length}>
               {running.map((task) => (
@@ -324,7 +714,6 @@ export function TaskList() {
             </Section>
           )}
 
-          {/* CI Checks */}
           {ci.length > 0 && (
             <Section label="CI Checks" count={ci.length}>
               {ci.map((task) => (
@@ -333,7 +722,6 @@ export function TaskList() {
             </Section>
           )}
 
-          {/* Review */}
           {review.length > 0 && (
             <Section label="Review" count={review.length}>
               {review.map((task) => (
@@ -342,7 +730,6 @@ export function TaskList() {
             </Section>
           )}
 
-          {/* Queue */}
           {queued.length > 0 && (
             <Section label="Queue" count={queued.length}>
               {queued.length > 1 && (
@@ -379,13 +766,12 @@ export function TaskList() {
             </Section>
           )}
 
-          {/* Failed */}
           {failed.length > 0 && (
             <Section
               label="Failed"
               count={failed.length}
               collapsible
-              initialLimit={filter ? undefined : 5}
+              initialLimit={filters.stage ? undefined : 5}
             >
               {failed.map((task) => (
                 <TaskCard key={task.id} task={task} subtasks={reviewMap.get(task.id)} />
@@ -393,18 +779,31 @@ export function TaskList() {
             </Section>
           )}
 
-          {/* Done */}
           {completed.length > 0 && (
             <Section
               label="Done"
               count={completed.length}
               collapsible
-              initialLimit={filter ? undefined : 5}
+              initialLimit={filters.stage ? undefined : 5}
             >
               {completed.map((task) => (
                 <TaskCard key={task.id} task={task} subtasks={reviewMap.get(task.id)} />
               ))}
             </Section>
+          )}
+
+          {/* Load more */}
+          {nextCursor && (
+            <div className="flex justify-center pt-2">
+              <button
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg text-xs font-medium bg-bg-card border border-border text-text-muted hover:text-text hover:bg-bg-hover disabled:opacity-50 transition-colors"
+              >
+                {loadingMore && <Loader2 className="w-3 h-3 animate-spin" />}
+                Load more tasks
+              </button>
+            </div>
           )}
         </div>
       )}
@@ -433,7 +832,6 @@ function Section({
   const childArray = React.Children.toArray(children);
   const shouldLimit = collapsible && initialLimit != null && childArray.length > initialLimit;
   const visibleChildren = shouldLimit && !expanded ? childArray.slice(0, initialLimit) : childArray;
-  const hiddenCount = shouldLimit ? childArray.length - initialLimit : 0;
 
   return (
     <div>

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -29,6 +29,32 @@ export const api = {
     return request<{ tasks: any[] }>(`/api/tasks${query ? `?${query}` : ""}`);
   },
 
+  searchTasks: (params?: {
+    q?: string;
+    state?: string;
+    repoUrl?: string;
+    agentType?: string;
+    taskType?: string;
+    costMin?: string;
+    costMax?: string;
+    createdAfter?: string;
+    createdBefore?: string;
+    author?: string;
+    cursor?: string;
+    limit?: number;
+  }) => {
+    const qs = new URLSearchParams();
+    if (params) {
+      for (const [key, val] of Object.entries(params)) {
+        if (val != null && val !== "") qs.set(key, String(val));
+      }
+    }
+    const query = qs.toString();
+    return request<{ tasks: any[]; nextCursor: string | null; hasMore: boolean }>(
+      `/api/tasks/search${query ? `?${query}` : ""}`,
+    );
+  },
+
   getTask: (id: string) => request<{ task: any }>(`/api/tasks/${id}`),
 
   createTask: (data: {


### PR DESCRIPTION
## Summary
- Add server-side `GET /api/tasks/search` endpoint with full-text search on title/prompt, multi-field filtering (state, repo, agent type, cost range, date range, author), and cursor-based pagination
- Update web UI task list with advanced filters panel (repo, agent type, cost range dropdowns), saved views persisted in localStorage, URL-synced filters for shareable links, and "Load more" cursor pagination
- Add unit tests for the `searchTasks` service function

## Test plan
- [ ] Verify `GET /api/tasks/search` returns tasks matching `q` parameter (searches title and prompt)
- [ ] Verify multi-field filtering works with AND logic (state + repoUrl + agentType)
- [ ] Verify cost range filtering (`costMin`/`costMax`) works correctly
- [ ] Verify cursor-based pagination returns correct `nextCursor` and `hasMore`
- [ ] Verify web UI search bar triggers server-side search with debounce
- [ ] Verify advanced filter panel toggles and filters apply correctly
- [ ] Verify saved views can be created, loaded, and deleted from localStorage
- [ ] Verify URL reflects current filters and can be shared
- [ ] Verify existing task list features (stage filters, reordering, sections) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)