### PR TITLE
feat: add task templates (save and reuse task configurations)

### DIFF
--- a/apps/api/src/db/migrations/0021_task_templates.sql
+++ b/apps/api/src/db/migrations/0021_task_templates.sql
@@ -1,0 +1,12 @@
+-- Task templates: save and reuse task configurations
+CREATE TABLE IF NOT EXISTS "task_templates" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" text NOT NULL,
+  "repo_url" text,
+  "prompt" text NOT NULL,
+  "agent_type" text DEFAULT 'claude-code' NOT NULL,
+  "priority" integer DEFAULT 100 NOT NULL,
+  "metadata" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1774713600000,
       "tag": "0020_max_auto_resumes",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1774800000000,
+      "tag": "0021_task_templates",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -365,6 +365,18 @@ export const taskComments = pgTable(
   (table) => [index("task_comments_task_id_idx").on(table.taskId)],
 );
 
+export const taskTemplates = pgTable("task_templates", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  name: text("name").notNull(),
+  repoUrl: text("repo_url"),
+  prompt: text("prompt").notNull(),
+  agentType: text("agent_type").notNull().default("claude-code"),
+  priority: integer("priority").notNull().default(100),
+  metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 export const promptTemplates = pgTable("prompt_templates", {
   id: uuid("id").primaryKey().defaultRandom(),
   name: text("name").notNull().unique(),

--- a/apps/api/src/routes/task-templates.ts
+++ b/apps/api/src/routes/task-templates.ts
@@ -1,0 +1,113 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import * as taskTemplateService from "../services/task-template-service.js";
+import * as taskService from "../services/task-service.js";
+import { TaskState } from "@optio/shared";
+import { taskQueue } from "../workers/task-worker.js";
+
+const createTemplateSchema = z.object({
+  name: z.string().min(1),
+  repoUrl: z.string().optional(),
+  prompt: z.string().min(1),
+  agentType: z.enum(["claude-code", "codex"]).optional(),
+  priority: z.number().int().min(1).max(1000).optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+const updateTemplateSchema = z.object({
+  name: z.string().min(1).optional(),
+  repoUrl: z.string().nullable().optional(),
+  prompt: z.string().min(1).optional(),
+  agentType: z.enum(["claude-code", "codex"]).optional(),
+  priority: z.number().int().min(1).max(1000).optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+const createFromTemplateSchema = z.object({
+  title: z.string().min(1),
+  repoUrl: z.string().url().optional(),
+  repoBranch: z.string().optional(),
+  prompt: z.string().optional(),
+  agentType: z.enum(["claude-code", "codex"]).optional(),
+  priority: z.number().int().min(1).max(1000).optional(),
+  maxRetries: z.number().int().min(0).max(10).optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export async function taskTemplateRoutes(app: FastifyInstance) {
+  // List templates
+  app.get("/api/task-templates", async (req, reply) => {
+    const query = req.query as { repoUrl?: string };
+    const templates = await taskTemplateService.listTaskTemplates(query.repoUrl);
+    reply.send({ templates });
+  });
+
+  // Get template
+  app.get("/api/task-templates/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const template = await taskTemplateService.getTaskTemplate(id);
+    if (!template) return reply.status(404).send({ error: "Template not found" });
+    reply.send({ template });
+  });
+
+  // Create template
+  app.post("/api/task-templates", async (req, reply) => {
+    const body = createTemplateSchema.parse(req.body);
+    const template = await taskTemplateService.createTaskTemplate(body);
+    reply.status(201).send({ template });
+  });
+
+  // Update template
+  app.patch("/api/task-templates/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const body = updateTemplateSchema.parse(req.body);
+    const template = await taskTemplateService.updateTaskTemplate(id, body);
+    if (!template) return reply.status(404).send({ error: "Template not found" });
+    reply.send({ template });
+  });
+
+  // Delete template
+  app.delete("/api/task-templates/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    await taskTemplateService.deleteTaskTemplate(id);
+    reply.status(204).send();
+  });
+
+  // Create task from template
+  app.post("/api/tasks/from-template/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const overrides = createFromTemplateSchema.parse(req.body);
+
+    const template = await taskTemplateService.getTaskTemplate(id);
+    if (!template) return reply.status(404).send({ error: "Template not found" });
+
+    if (!template.repoUrl && !overrides.repoUrl) {
+      return reply.status(400).send({ error: "repoUrl is required (template has no default)" });
+    }
+
+    const task = await taskService.createTask({
+      title: overrides.title,
+      prompt: overrides.prompt ?? template.prompt,
+      repoUrl: (overrides.repoUrl ?? template.repoUrl)!,
+      repoBranch: overrides.repoBranch,
+      agentType: overrides.agentType ?? template.agentType,
+      priority: overrides.priority ?? template.priority,
+      maxRetries: overrides.maxRetries,
+      metadata: overrides.metadata ?? (template.metadata as Record<string, unknown> | undefined),
+    });
+
+    await taskService.transitionTask(task.id, TaskState.QUEUED, "task_from_template");
+    await taskQueue.add(
+      "process-task",
+      { taskId: task.id },
+      {
+        jobId: task.id,
+        priority: task.priority ?? 100,
+        attempts: task.maxRetries + 1,
+        backoff: { type: "exponential", delay: 5000 },
+      },
+    );
+
+    reply.status(201).send({ task });
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -22,6 +22,7 @@ import { sessionRoutes } from "./routes/sessions.js";
 import { scheduleRoutes } from "./routes/schedules.js";
 import { commentRoutes } from "./routes/comments.js";
 import { slackRoutes } from "./routes/slack.js";
+import { taskTemplateRoutes } from "./routes/task-templates.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import { sessionTerminalWs } from "./ws/session-terminal.js";
@@ -78,6 +79,7 @@ export async function buildServer() {
   await app.register(scheduleRoutes);
   await app.register(commentRoutes);
   await app.register(slackRoutes);
+  await app.register(taskTemplateRoutes);
 
   // WebSocket routes
   await app.register(logStreamWs);

--- a/apps/api/src/services/task-template-service.ts
+++ b/apps/api/src/services/task-template-service.ts
@@ -1,0 +1,60 @@
+import { eq } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { taskTemplates } from "../db/schema.js";
+
+export async function listTaskTemplates(repoUrl?: string) {
+  if (repoUrl) {
+    return db.select().from(taskTemplates).where(eq(taskTemplates.repoUrl, repoUrl));
+  }
+  return db.select().from(taskTemplates);
+}
+
+export async function getTaskTemplate(id: string) {
+  const [template] = await db.select().from(taskTemplates).where(eq(taskTemplates.id, id));
+  return template ?? null;
+}
+
+export async function createTaskTemplate(data: {
+  name: string;
+  repoUrl?: string;
+  prompt: string;
+  agentType?: string;
+  priority?: number;
+  metadata?: Record<string, unknown>;
+}) {
+  const [template] = await db
+    .insert(taskTemplates)
+    .values({
+      name: data.name,
+      repoUrl: data.repoUrl ?? null,
+      prompt: data.prompt,
+      agentType: data.agentType ?? "claude-code",
+      priority: data.priority ?? 100,
+      metadata: data.metadata,
+    })
+    .returning();
+  return template;
+}
+
+export async function updateTaskTemplate(
+  id: string,
+  data: {
+    name?: string;
+    repoUrl?: string | null;
+    prompt?: string;
+    agentType?: string;
+    priority?: number;
+    metadata?: Record<string, unknown>;
+  },
+) {
+  const [template] = await db
+    .update(taskTemplates)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(taskTemplates.id, id))
+    .returning();
+  return template ?? null;
+}
+
+export async function deleteTaskTemplate(id: string) {
+  await db.delete(taskTemplates).where(eq(taskTemplates.id, id));
+}

--- a/apps/web/src/app/tasks/new/page.tsx
+++ b/apps/web/src/app/tasks/new/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
-import { Loader2, Sparkles } from "lucide-react";
+import { Loader2, Sparkles, Save, BookTemplate } from "lucide-react";
 import { toast } from "sonner";
 
 export default function NewTaskPage() {
@@ -13,6 +13,8 @@ export default function NewTaskPage() {
   const [loading, setLoading] = useState(false);
   const [repos, setRepos] = useState<any[]>([]);
   const [reposLoading, setReposLoading] = useState(true);
+  const [templates, setTemplates] = useState<any[]>([]);
+  const [savingTemplate, setSavingTemplate] = useState(false);
   const [form, setForm] = useState({
     title: "",
     prompt: "",
@@ -41,7 +43,56 @@ export default function NewTaskPage() {
       })
       .catch(() => {})
       .finally(() => setReposLoading(false));
+    api
+      .listTaskTemplates()
+      .then((res) => setTemplates(res.templates))
+      .catch(() => {});
   }, []);
+
+  const handleTemplateSelect = (templateId: string) => {
+    if (!templateId) return;
+    const template = templates.find((t: any) => t.id === templateId);
+    if (!template) return;
+    const repo = template.repoUrl ? repos.find((r: any) => r.repoUrl === template.repoUrl) : null;
+    setForm((f) => ({
+      ...f,
+      prompt: template.prompt,
+      agentType: template.agentType ?? f.agentType,
+      priority: template.priority ?? f.priority,
+      ...(repo
+        ? { repoId: repo.id, repoUrl: repo.repoUrl, repoBranch: repo.defaultBranch ?? "main" }
+        : {}),
+    }));
+    toast.success("Template applied");
+  };
+
+  const handleSaveAsTemplate = async () => {
+    if (!form.prompt) {
+      toast.error("Add a prompt before saving as template");
+      return;
+    }
+    const name = prompt("Template name:");
+    if (!name) return;
+    setSavingTemplate(true);
+    try {
+      await api.createTaskTemplate({
+        name,
+        prompt: form.prompt,
+        repoUrl: form.repoUrl || undefined,
+        agentType: form.agentType,
+        priority: form.priority,
+      });
+      const res = await api.listTaskTemplates();
+      setTemplates(res.templates);
+      toast.success("Template saved");
+    } catch (err) {
+      toast.error("Failed to save template", {
+        description: err instanceof Error ? err.message : undefined,
+      });
+    } finally {
+      setSavingTemplate(false);
+    }
+  };
 
   const handleRepoChange = (repoId: string) => {
     const repo = repos.find((r: any) => r.id === repoId);
@@ -86,6 +137,28 @@ export default function NewTaskPage() {
       <h1 className="text-2xl font-semibold tracking-tight mb-6">Create New Task</h1>
 
       <form onSubmit={handleSubmit} className="space-y-5">
+        {/* Template Picker */}
+        {templates.length > 0 && (
+          <div>
+            <label className="block text-sm text-text-muted mb-1.5">
+              <BookTemplate className="w-3.5 h-3.5 inline mr-1" />
+              Load from Template
+            </label>
+            <select
+              defaultValue=""
+              onChange={(e) => handleTemplateSelect(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg bg-bg-card border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 transition-colors"
+            >
+              <option value="">Select a template...</option>
+              {templates.map((t: any) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
         {/* Repository */}
         <div>
           <label className="block text-sm text-text-muted mb-1.5">Repository</label>
@@ -185,19 +258,34 @@ export default function NewTaskPage() {
           />
         </div>
 
-        {/* Submit */}
-        <button
-          type="submit"
-          disabled={loading || !form.repoUrl}
-          className="flex items-center gap-2 px-6 py-2.5 rounded-md bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors disabled:opacity-50"
-        >
-          {loading ? (
-            <Loader2 className="w-4 h-4 animate-spin" />
-          ) : (
-            <Sparkles className="w-4 h-4" />
-          )}
-          {loading ? "Creating..." : "Create Task"}
-        </button>
+        {/* Submit + Save as Template */}
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={loading || !form.repoUrl}
+            className="flex items-center gap-2 px-6 py-2.5 rounded-md bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors disabled:opacity-50"
+          >
+            {loading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Sparkles className="w-4 h-4" />
+            )}
+            {loading ? "Creating..." : "Create Task"}
+          </button>
+          <button
+            type="button"
+            onClick={handleSaveAsTemplate}
+            disabled={savingTemplate || !form.prompt}
+            className="flex items-center gap-2 px-4 py-2.5 rounded-md bg-bg-card border border-border text-text-muted text-sm font-medium hover:text-text hover:bg-bg-hover transition-colors disabled:opacity-50"
+          >
+            {savingTemplate ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Save className="w-4 h-4" />
+            )}
+            Save as Template
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/apps/web/src/app/templates/page.tsx
+++ b/apps/web/src/app/templates/page.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { api } from "@/lib/api-client";
+import { Loader2, Plus, Trash2, FileText, Pencil } from "lucide-react";
+import { toast } from "sonner";
+
+export default function TemplatesPage() {
+  const [templates, setTemplates] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [repos, setRepos] = useState<any[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState({
+    name: "",
+    prompt: "",
+    repoUrl: "",
+    agentType: "claude-code",
+    priority: 100,
+  });
+
+  const loadTemplates = () => {
+    api
+      .listTaskTemplates()
+      .then((res) => setTemplates(res.templates))
+      .catch(() => toast.error("Failed to load templates"))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadTemplates();
+    api
+      .listRepos()
+      .then((res) => setRepos(res.repos))
+      .catch(() => {});
+  }, []);
+
+  const resetForm = () => {
+    setForm({ name: "", prompt: "", repoUrl: "", agentType: "claude-code", priority: 100 });
+    setEditingId(null);
+    setShowForm(false);
+  };
+
+  const handleEdit = (template: any) => {
+    setForm({
+      name: template.name,
+      prompt: template.prompt,
+      repoUrl: template.repoUrl ?? "",
+      agentType: template.agentType,
+      priority: template.priority,
+    });
+    setEditingId(template.id);
+    setShowForm(true);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const data = {
+        name: form.name,
+        prompt: form.prompt,
+        repoUrl: form.repoUrl || undefined,
+        agentType: form.agentType,
+        priority: form.priority,
+      };
+
+      if (editingId) {
+        await api.updateTaskTemplate(editingId, data);
+        toast.success("Template updated");
+      } else {
+        await api.createTaskTemplate(data);
+        toast.success("Template created");
+      }
+      resetForm();
+      loadTemplates();
+    } catch (err) {
+      toast.error(editingId ? "Failed to update template" : "Failed to create template", {
+        description: err instanceof Error ? err.message : undefined,
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (id: string, name: string) => {
+    if (!confirm(`Delete template "${name}"?`)) return;
+    try {
+      await api.deleteTaskTemplate(id);
+      toast.success("Template deleted");
+      loadTemplates();
+    } catch {
+      toast.error("Failed to delete template");
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight">Task Templates</h1>
+        <button
+          onClick={() => {
+            if (showForm && !editingId) {
+              resetForm();
+            } else {
+              resetForm();
+              setShowForm(true);
+            }
+          }}
+          className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          New Template
+        </button>
+      </div>
+
+      {showForm && (
+        <form
+          onSubmit={handleSubmit}
+          className="mb-6 p-5 rounded-xl border border-border/50 bg-bg-card space-y-3"
+        >
+          <div>
+            <label className="block text-sm text-text-muted mb-1.5">Template Name</label>
+            <input
+              type="text"
+              required
+              value={form.name}
+              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              placeholder="e.g. Bug fix template"
+              className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 transition-colors"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm text-text-muted mb-1.5">Repository (optional)</label>
+            <select
+              value={form.repoUrl}
+              onChange={(e) => setForm((f) => ({ ...f, repoUrl: e.target.value }))}
+              className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 transition-colors"
+            >
+              <option value="">Any repository</option>
+              {repos.map((repo: any) => (
+                <option key={repo.id} value={repo.repoUrl}>
+                  {repo.fullName}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm text-text-muted mb-1.5">Prompt</label>
+            <textarea
+              required
+              rows={4}
+              value={form.prompt}
+              onChange={(e) => setForm((f) => ({ ...f, prompt: e.target.value }))}
+              placeholder="Describe the task for the agent..."
+              className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 transition-colors resize-y"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm text-text-muted mb-1.5">Agent</label>
+              <select
+                value={form.agentType}
+                onChange={(e) => setForm((f) => ({ ...f, agentType: e.target.value }))}
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 transition-colors"
+              >
+                <option value="claude-code">Claude Code</option>
+                <option value="codex">OpenAI Codex</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm text-text-muted mb-1.5">Priority</label>
+              <input
+                type="number"
+                min={1}
+                max={1000}
+                value={form.priority}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, priority: parseInt(e.target.value, 10) || 100 }))
+                }
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 transition-colors"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="px-4 py-2 rounded-md bg-primary text-white text-sm font-medium hover:bg-primary-hover transition-colors disabled:opacity-50"
+            >
+              {submitting ? "Saving..." : editingId ? "Update Template" : "Save Template"}
+            </button>
+            <button
+              type="button"
+              onClick={resetForm}
+              className="px-4 py-2 rounded-md bg-bg-hover text-text-muted text-sm font-medium hover:text-text transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12 text-text-muted">
+          <Loader2 className="w-5 h-5 animate-spin mr-2" />
+          Loading templates...
+        </div>
+      ) : templates.length === 0 ? (
+        <div className="text-center py-12 text-text-muted border border-dashed border-border rounded-xl">
+          <FileText className="w-8 h-8 mx-auto mb-2 opacity-50" />
+          <p>No task templates yet</p>
+          <p className="text-xs mt-1">Create a template to save and reuse task configurations.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {templates.map((template) => (
+            <div
+              key={template.id}
+              className="flex items-start justify-between p-4 rounded-xl border border-border/50 bg-bg-card"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-sm">{template.name}</span>
+                  <span className="text-xs text-text-muted bg-bg-hover px-1.5 py-0.5 rounded">
+                    {template.agentType}
+                  </span>
+                  {template.repoUrl && (
+                    <span className="text-xs text-text-muted bg-bg-hover px-1.5 py-0.5 rounded truncate max-w-[200px]">
+                      {template.repoUrl.replace("https://github.com/", "")}
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-text-muted mt-1 line-clamp-2">{template.prompt}</p>
+              </div>
+              <div className="flex items-center gap-1 ml-3 shrink-0">
+                <button
+                  onClick={() => handleEdit(template)}
+                  className="p-1.5 rounded-md text-text-muted hover:text-text hover:bg-bg-hover transition-colors"
+                  title="Edit"
+                >
+                  <Pencil className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={() => handleDelete(template.id, template.name)}
+                  className="p-1.5 rounded-md text-text-muted hover:text-error hover:bg-bg-hover transition-colors"
+                  title="Delete"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   DollarSign,
   Terminal,
   Clock,
+  FileText,
 } from "lucide-react";
 import { UserMenu } from "./user-menu";
 
@@ -25,6 +26,7 @@ const MAIN_NAV = [
   { href: "/cluster", label: "Cluster", icon: Server },
   { href: "/costs", label: "Costs", icon: DollarSign },
   { href: "/schedules", label: "Schedules", icon: Clock },
+  { href: "/templates", label: "Templates", icon: FileText },
 ];
 
 const SECONDARY_NAV = [

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -475,6 +475,54 @@ export const api = {
 
   logout: () => request<{ ok: boolean }>("/api/auth/logout", { method: "POST" }),
 
+  // Task Templates
+  listTaskTemplates: (repoUrl?: string) => {
+    const qs = repoUrl ? `?repoUrl=${encodeURIComponent(repoUrl)}` : "";
+    return request<{ templates: any[] }>(`/api/task-templates${qs}`);
+  },
+
+  getTaskTemplate: (id: string) => request<{ template: any }>(`/api/task-templates/${id}`),
+
+  createTaskTemplate: (data: {
+    name: string;
+    prompt: string;
+    repoUrl?: string;
+    agentType?: string;
+    priority?: number;
+    metadata?: Record<string, unknown>;
+  }) =>
+    request<{ template: any }>("/api/task-templates", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+
+  updateTaskTemplate: (id: string, data: Record<string, unknown>) =>
+    request<{ template: any }>(`/api/task-templates/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    }),
+
+  deleteTaskTemplate: (id: string) =>
+    request<void>(`/api/task-templates/${id}`, { method: "DELETE" }),
+
+  createTaskFromTemplate: (
+    templateId: string,
+    data: {
+      title: string;
+      repoUrl?: string;
+      repoBranch?: string;
+      prompt?: string;
+      agentType?: string;
+      priority?: number;
+      maxRetries?: number;
+      metadata?: Record<string, unknown>;
+    },
+  ) =>
+    request<{ task: any }>(`/api/tasks/from-template/${templateId}`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+
   // Interactive Sessions
   listSessions: (params?: {
     repoUrl?: string;


### PR DESCRIPTION
## Summary

- Add `task_templates` table and migration (0020) for saving reusable task configurations (name, repoUrl, prompt, agentType, priority, metadata)
- Add full CRUD API endpoints (`/api/task-templates`) plus `POST /api/tasks/from-template/:id` to create tasks from templates with optional field overrides
- Add `/templates` management page in the web UI with create, edit, and delete support
- Add template picker dropdown and "Save as Template" button on the task creation form
- Add Templates link to the sidebar navigation

## Test plan

- [x] `pnpm turbo typecheck` passes (all 6 packages)
- [x] `pnpm turbo test` passes (190 tests, 13 files)
- [x] `pnpm format:check` passes
- [x] Pre-commit hooks pass (lint-staged + format + typecheck)
- [ ] Manually verify template CRUD via API endpoints
- [ ] Verify template picker populates and fills form fields on the create task page
- [ ] Verify "Save as Template" button saves current form configuration
- [ ] Verify `/templates` page lists, creates, edits, and deletes templates
- [ ] Run migration on a database and verify table creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)