### PR TITLE
feat: cost optimization insights and forecasting

### DIFF
--- a/.optio/task.md
+++ b/.optio/task.md
@@ -1,28 +1,27 @@
-# fix: Turborepo silently drops web app during pnpm dev
+# feat: Cost optimization insights and forecasting
 
-fix: Turborepo silently drops web app during pnpm dev
+feat: Cost optimization insights and forecasting
 
 ## Problem
 
-Running `pnpm dev` (which calls `turbo dev`) sometimes only starts the API server — the Next.js web app never launches. No error is shown. The web app works fine when started manually with `cd apps/web && npx next dev`.
+Cost tracking shows totals but doesn't help users optimize. No way to compare models, detect anomalies, or forecast spending.
 
-## Observed Behavior
+## Features
 
-- `turbo dev` output only shows `@optio/api:dev` logs
-- No `@optio/web:dev` output at all
-- API healthy on :4000, web unreachable on :3100
-- Seems intermittent — may relate to the `taskQueue.obliterate()` call blocking the event loop early in API startup
+- **Per-model cost comparison**: Show cost breakdown by model (Opus vs Sonnet vs Haiku) with success rates
+- **"Try cheaper model" suggestions**: If a task succeeded with Opus, suggest trying Sonnet next time
+- **Cost anomaly alerts**: Flag tasks that cost 3x+ the repo average
+- **Forecasting**: "At current rate, you'll spend $X this month"
+- **Per-task cost breakdown**: Input tokens, output tokens, thinking tokens (where available)
+- **Token tracking**: Store `inputTokens`, `outputTokens` on tasks for detailed analysis
 
-## Workaround
+## Acceptance Criteria
 
-Start web manually: `cd apps/web && npx next dev --port 3100`
-
-## Investigation Needed
-
-- Check if turbo is timing out on the web task
-- Check if the API's startup is blocking turbo's process management
-- May need to split API and web into separate `pnpm dev:api` and `pnpm dev:web` scripts
+- [ ] Cost breakdown by model on analytics page
+- [ ] Anomaly detection with visual indicators
+- [ ] Monthly forecast based on rolling average
+- [ ] Token-level cost breakdown per task
 
 ---
 
-_Optio Task ID: 27c499f3-58d1-4957-b6dc-3652a63caf91_
+_Optio Task ID: 428ee0d9-6ba2-482e-aed6-2b6b74b44baa_

--- a/apps/api/src/db/migrations/0017_cost_optimization_tokens.sql
+++ b/apps/api/src/db/migrations/0017_cost_optimization_tokens.sql
@@ -1,0 +1,4 @@
+-- Add token tracking and model columns for cost optimization insights
+ALTER TABLE "tasks" ADD COLUMN "input_tokens" integer;
+ALTER TABLE "tasks" ADD COLUMN "output_tokens" integer;
+ALTER TABLE "tasks" ADD COLUMN "model_used" text;

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1774368000000,
       "tag": "0016_add_query_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1774454400000,
+      "tag": "0017_cost_optimization_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -44,6 +44,9 @@ export const tasks = pgTable(
     prReviewComments: text("pr_review_comments"), // latest review comments (for resume)
     resultSummary: text("result_summary"),
     costUsd: text("cost_usd"), // stored as string to avoid float precision issues
+    inputTokens: integer("input_tokens"), // total input tokens used
+    outputTokens: integer("output_tokens"), // total output tokens used
+    modelUsed: text("model_used"), // model ID used (e.g., "claude-sonnet-4-20250514")
     errorMessage: text("error_message"),
     ticketSource: text("ticket_source"),
     ticketExternalId: text("ticket_external_id"),

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -96,7 +96,146 @@ export async function analyticsRoutes(app: FastifyInstance) {
       ORDER BY total_cost DESC
     `);
 
-    // Top most expensive tasks
+    // Cost by model — includes success rate
+    const costByModel = await db.execute<{
+      model: string;
+      total_cost: string;
+      task_count: string;
+      success_count: string;
+      avg_cost: string;
+      total_input_tokens: string;
+      total_output_tokens: string;
+    }>(sql`
+      SELECT
+        COALESCE(model_used, 'unknown') AS model,
+        COALESCE(SUM(CAST(cost_usd AS NUMERIC)), 0) AS total_cost,
+        COUNT(*) AS task_count,
+        COUNT(*) FILTER (WHERE state IN ('completed', 'pr_opened')) AS success_count,
+        COALESCE(AVG(CAST(cost_usd AS NUMERIC)), 0) AS avg_cost,
+        COALESCE(SUM(input_tokens), 0) AS total_input_tokens,
+        COALESCE(SUM(output_tokens), 0) AS total_output_tokens
+      FROM tasks
+      WHERE cost_usd IS NOT NULL
+        ${dateFilter}
+        ${repoFilter}
+      GROUP BY COALESCE(model_used, 'unknown')
+      ORDER BY total_cost DESC
+    `);
+
+    // Cost anomalies — tasks costing 3x+ the repo average
+    const anomalies = await db.execute<{
+      id: string;
+      title: string;
+      repo_url: string;
+      task_type: string;
+      state: string;
+      cost_usd: string;
+      model_used: string;
+      repo_avg_cost: string;
+      cost_ratio: string;
+      created_at: string;
+    }>(sql`
+      WITH repo_avgs AS (
+        SELECT
+          repo_url,
+          AVG(CAST(cost_usd AS NUMERIC)) AS avg_cost
+        FROM tasks
+        WHERE cost_usd IS NOT NULL
+          ${dateFilter}
+        GROUP BY repo_url
+        HAVING COUNT(*) >= 3
+      )
+      SELECT
+        t.id,
+        t.title,
+        t.repo_url,
+        t.task_type,
+        t.state,
+        t.cost_usd,
+        COALESCE(t.model_used, 'unknown') AS model_used,
+        ra.avg_cost::text AS repo_avg_cost,
+        (CAST(t.cost_usd AS NUMERIC) / ra.avg_cost)::text AS cost_ratio,
+        t.created_at::text
+      FROM tasks t
+      JOIN repo_avgs ra ON t.repo_url = ra.repo_url
+      WHERE t.cost_usd IS NOT NULL
+        AND CAST(t.cost_usd AS NUMERIC) >= ra.avg_cost * 3
+        ${dateFilter}
+        ${repoFilter}
+      ORDER BY CAST(t.cost_usd AS NUMERIC) DESC
+      LIMIT 20
+    `);
+
+    // Monthly forecast — based on daily average in the period
+    const totalCost = parseFloat(totals.total_cost) || 0;
+    const tasksWithCost = parseInt(totals.tasks_with_cost) || 0;
+
+    // Calculate daily average spend for forecasting
+    const uniqueDays = dailyCosts.length;
+    const dailyAvgCost = uniqueDays > 0 ? totalCost / uniqueDays : 0;
+    // Days remaining in the current month
+    const now = new Date();
+    const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+    const dayOfMonth = now.getDate();
+    const daysRemaining = daysInMonth - dayOfMonth;
+
+    // Cost so far this month
+    const [monthTotals] = await db.execute<{
+      month_cost: string;
+      month_tasks: string;
+    }>(sql`
+      SELECT
+        COALESCE(SUM(CAST(cost_usd AS NUMERIC)), 0) AS month_cost,
+        COUNT(*) AS month_tasks
+      FROM tasks
+      WHERE cost_usd IS NOT NULL
+        AND created_at >= DATE_TRUNC('month', NOW())
+        ${repoFilter}
+    `);
+    const monthCostSoFar = parseFloat(monthTotals.month_cost) || 0;
+    const forecastedMonthTotal = monthCostSoFar + dailyAvgCost * daysRemaining;
+
+    // Model suggestions — tasks that succeeded with expensive models
+    const modelSuggestions = await db.execute<{
+      repo_url: string;
+      model_used: string;
+      task_count: string;
+      avg_cost: string;
+      cheaper_model_avg: string;
+    }>(sql`
+      WITH model_stats AS (
+        SELECT
+          repo_url,
+          model_used,
+          COUNT(*) AS task_count,
+          AVG(CAST(cost_usd AS NUMERIC)) AS avg_cost,
+          COUNT(*) FILTER (WHERE state IN ('completed', 'pr_opened')) AS success_count
+        FROM tasks
+        WHERE cost_usd IS NOT NULL
+          AND model_used IS NOT NULL
+          ${dateFilter}
+          ${repoFilter}
+        GROUP BY repo_url, model_used
+        HAVING COUNT(*) >= 2
+      )
+      SELECT
+        ms.repo_url,
+        ms.model_used,
+        ms.task_count::text,
+        ms.avg_cost::text,
+        COALESCE(cheaper.avg_cost, 0)::text AS cheaper_model_avg
+      FROM model_stats ms
+      LEFT JOIN model_stats cheaper ON ms.repo_url = cheaper.repo_url
+        AND cheaper.model_used LIKE '%sonnet%'
+        AND cheaper.success_count > 0
+      WHERE ms.model_used LIKE '%opus%'
+        AND ms.success_count > 0
+        AND (cheaper.avg_cost IS NULL OR cheaper.avg_cost < ms.avg_cost)
+      ORDER BY ms.avg_cost DESC
+      LIMIT 10
+    `);
+
+    // Top most expensive tasks — with token breakdown
     const topTasks = await db.execute<{
       id: string;
       title: string;
@@ -104,9 +243,16 @@ export async function analyticsRoutes(app: FastifyInstance) {
       task_type: string;
       state: string;
       cost_usd: string;
+      input_tokens: string;
+      output_tokens: string;
+      model_used: string;
       created_at: string;
     }>(sql`
-      SELECT id, title, repo_url, task_type, state, cost_usd, created_at
+      SELECT id, title, repo_url, task_type, state, cost_usd,
+        COALESCE(input_tokens, 0)::text AS input_tokens,
+        COALESCE(output_tokens, 0)::text AS output_tokens,
+        COALESCE(model_used, 'unknown') AS model_used,
+        created_at
       FROM tasks
       WHERE cost_usd IS NOT NULL
         ${dateFilter}
@@ -115,10 +261,8 @@ export async function analyticsRoutes(app: FastifyInstance) {
       LIMIT 10
     `);
 
-    const totalCost = parseFloat(totals.total_cost) || 0;
     const prevCost = parseFloat(prevTotals.total_cost) || 0;
     const taskCount = parseInt(totals.task_count) || 0;
-    const tasksWithCost = parseInt(totals.tasks_with_cost) || 0;
     const avgCost = tasksWithCost > 0 ? totalCost / tasksWithCost : 0;
     const costTrend = prevCost > 0 ? ((totalCost - prevCost) / prevCost) * 100 : 0;
 
@@ -131,6 +275,12 @@ export async function analyticsRoutes(app: FastifyInstance) {
         costTrend: costTrend.toFixed(1),
         prevPeriodCost: prevCost.toFixed(4),
         days,
+      },
+      forecast: {
+        dailyAvgCost: dailyAvgCost.toFixed(4),
+        monthCostSoFar: monthCostSoFar.toFixed(4),
+        forecastedMonthTotal: forecastedMonthTotal.toFixed(4),
+        daysRemaining,
       },
       dailyCosts: dailyCosts.map((r) => ({
         date: r.date,
@@ -147,6 +297,38 @@ export async function analyticsRoutes(app: FastifyInstance) {
         totalCost: parseFloat(r.total_cost) || 0,
         taskCount: parseInt(r.task_count) || 0,
       })),
+      costByModel: costByModel.map((r) => {
+        const count = parseInt(r.task_count) || 0;
+        const successCount = parseInt(r.success_count) || 0;
+        return {
+          model: r.model,
+          totalCost: parseFloat(r.total_cost) || 0,
+          taskCount: count,
+          successRate: count > 0 ? Math.round((successCount / count) * 100) : 0,
+          avgCost: parseFloat(r.avg_cost) || 0,
+          totalInputTokens: parseInt(r.total_input_tokens) || 0,
+          totalOutputTokens: parseInt(r.total_output_tokens) || 0,
+        };
+      }),
+      anomalies: anomalies.map((r) => ({
+        id: r.id,
+        title: r.title,
+        repoUrl: r.repo_url,
+        taskType: r.task_type,
+        state: r.state,
+        costUsd: r.cost_usd,
+        modelUsed: r.model_used,
+        repoAvgCost: parseFloat(r.repo_avg_cost) || 0,
+        costRatio: parseFloat(r.cost_ratio) || 0,
+        createdAt: r.created_at,
+      })),
+      modelSuggestions: modelSuggestions.map((r) => ({
+        repoUrl: r.repo_url,
+        currentModel: r.model_used,
+        taskCount: parseInt(r.task_count) || 0,
+        avgCost: parseFloat(r.avg_cost) || 0,
+        cheaperModelAvgCost: parseFloat(r.cheaper_model_avg) || 0,
+      })),
       topTasks: topTasks.map((r) => ({
         id: r.id,
         title: r.title,
@@ -154,6 +336,9 @@ export async function analyticsRoutes(app: FastifyInstance) {
         taskType: r.task_type,
         state: r.state,
         costUsd: r.cost_usd,
+        inputTokens: parseInt(r.input_tokens) || 0,
+        outputTokens: parseInt(r.output_tokens) || 0,
+        modelUsed: r.model_used,
         createdAt: r.created_at,
       })),
     });

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -381,11 +381,14 @@ export function startTaskWorker() {
         const result = adapter.parseResult(inferredExitCode, allLogs);
         await taskService.updateTaskResult(taskId, result.summary, result.error);
 
-        if (result.costUsd != null) {
-          await db
-            .update(tasks)
-            .set({ costUsd: String(result.costUsd) })
-            .where(eq(tasks.id, taskId));
+        // Persist cost, token usage, and model data
+        const costFields: Record<string, unknown> = {};
+        if (result.costUsd != null) costFields.costUsd = String(result.costUsd);
+        if (result.inputTokens != null) costFields.inputTokens = result.inputTokens;
+        if (result.outputTokens != null) costFields.outputTokens = result.outputTokens;
+        if (result.model) costFields.modelUsed = result.model;
+        if (Object.keys(costFields).length > 0) {
+          await db.update(tasks).set(costFields).where(eq(tasks.id, taskId));
         }
 
         // Pick the best PR URL.  Priority:

--- a/apps/web/src/app/costs/page.tsx
+++ b/apps/web/src/app/costs/page.tsx
@@ -10,15 +10,16 @@ import {
   TrendingDown,
   Minus,
   BarChart3,
-  Activity,
   Loader2,
   ArrowUpRight,
+  AlertTriangle,
+  Lightbulb,
+  Calendar,
+  Cpu,
 } from "lucide-react";
 import {
   AreaChart,
   Area,
-  BarChart,
-  Bar,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -49,6 +50,13 @@ const REPO_COLORS = [
   "#14b8a6", // teal
 ];
 
+const MODEL_COLORS: Record<string, string> = {
+  opus: "#6366f1",
+  sonnet: "#8b5cf6",
+  haiku: "#06b6d4",
+  unknown: "#6b7280",
+};
+
 function repoShortName(repoUrl: string): string {
   const match = repoUrl.match(/([^/]+\/[^/]+?)(?:\.git)?$/);
   return match ? match[1] : repoUrl;
@@ -61,6 +69,29 @@ function formatCost(value: string | number): string {
   return `$${n.toFixed(2)}`;
 }
 
+function formatTokens(count: number): string {
+  if (count === 0) return "0";
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
+  return String(count);
+}
+
+function modelShortName(model: string): string {
+  if (model === "unknown") return "Unknown";
+  if (model.includes("opus")) return "Opus";
+  if (model.includes("sonnet")) return "Sonnet";
+  if (model.includes("haiku")) return "Haiku";
+  return model;
+}
+
+function getModelColor(model: string): string {
+  const lower = model.toLowerCase();
+  if (lower.includes("opus")) return MODEL_COLORS.opus;
+  if (lower.includes("sonnet")) return MODEL_COLORS.sonnet;
+  if (lower.includes("haiku")) return MODEL_COLORS.haiku;
+  return MODEL_COLORS.unknown;
+}
+
 function StatCard({
   label,
   value,
@@ -71,7 +102,7 @@ function StatCard({
   label: string;
   value: string;
   sub?: string;
-  icon: any;
+  icon: React.ComponentType<{ className?: string }>;
   trend?: { value: number; label: string };
 }) {
   return (
@@ -114,12 +145,20 @@ function StatCard({
   );
 }
 
-function ChartTooltipContent({ active, payload, label }: any) {
+function ChartTooltipContent({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ color: string; name: string; value: number }>;
+  label?: string;
+}) {
   if (!active || !payload?.length) return null;
   return (
     <div className="bg-bg-card border border-border rounded-lg px-3 py-2 shadow-lg">
       <p className="text-xs text-text-muted mb-1">{label}</p>
-      {payload.map((p: any, i: number) => (
+      {payload.map((p, i) => (
         <p key={i} className="text-sm font-medium" style={{ color: p.color }}>
           {p.name}: {p.name === "Tasks" ? p.value : formatCost(p.value)}
         </p>
@@ -186,8 +225,21 @@ export default function CostsPage() {
 
   if (!data) return null;
 
-  const { summary, dailyCosts, costByRepo, costByType, topTasks } = data;
+  const {
+    summary,
+    forecast,
+    dailyCosts,
+    costByRepo,
+    costByType,
+    costByModel,
+    anomalies,
+    modelSuggestions,
+    topTasks,
+  } = data;
   const trend = parseFloat(summary.costTrend);
+
+  // Build anomaly ID set for highlighting in top tasks table
+  const anomalyIds = new Set(anomalies.map((a) => a.id));
 
   return (
     <div className="p-6 max-w-7xl mx-auto space-y-6">
@@ -207,7 +259,7 @@ export default function CostsPage() {
             className="bg-bg-card border border-border rounded-lg px-3 py-1.5 text-sm text-text focus:outline-none focus:ring-1 focus:ring-primary"
           >
             <option value="">All repos</option>
-            {repos.map((r: any) => (
+            {repos.map((r: { repoUrl: string; fullName?: string }) => (
               <option key={r.repoUrl} value={r.repoUrl}>
                 {r.fullName || repoShortName(r.repoUrl)}
               </option>
@@ -249,10 +301,10 @@ export default function CostsPage() {
           sub={`across ${summary.tasksWithCost} tasks`}
         />
         <StatCard
-          label="Tasks with Cost"
-          value={String(summary.tasksWithCost)}
-          icon={Activity}
-          sub={`of ${summary.taskCount} total`}
+          label="Monthly Forecast"
+          value={formatCost(forecast.forecastedMonthTotal)}
+          icon={Calendar}
+          sub={`${formatCost(forecast.monthCostSoFar)} spent · ${forecast.daysRemaining}d left`}
         />
         <StatCard
           label="Prev Period"
@@ -261,6 +313,77 @@ export default function CostsPage() {
           sub={`previous ${summary.days}d`}
         />
       </div>
+
+      {/* Model suggestions banner */}
+      {modelSuggestions.length > 0 && (
+        <div className="bg-amber-500/5 border border-amber-500/20 rounded-xl p-4">
+          <div className="flex items-start gap-3">
+            <Lightbulb className="w-5 h-5 text-amber-400 mt-0.5 shrink-0" />
+            <div>
+              <h3 className="text-sm font-medium text-text mb-1">Cost Optimization Suggestions</h3>
+              <div className="space-y-1.5">
+                {modelSuggestions.map((s, i) => {
+                  const savings = s.avgCost - s.cheaperModelAvgCost;
+                  const savingsPercent = s.avgCost > 0 ? (savings / s.avgCost) * 100 : 0;
+                  return (
+                    <p key={i} className="text-xs text-text-muted">
+                      <span className="text-text">{repoShortName(s.repoUrl)}</span>: {s.taskCount}{" "}
+                      tasks ran with {modelShortName(s.currentModel)} (avg {formatCost(s.avgCost)}).
+                      {s.cheaperModelAvgCost > 0 ? (
+                        <>
+                          {" "}
+                          Try Sonnet to save ~{savingsPercent.toFixed(0)}% ({formatCost(savings)}
+                          /task).
+                        </>
+                      ) : (
+                        <> Consider trying Sonnet for potential savings.</>
+                      )}
+                    </p>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Anomaly alerts */}
+      {anomalies.length > 0 && (
+        <div className="bg-error/5 border border-error/20 rounded-xl p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 text-error mt-0.5 shrink-0" />
+            <div>
+              <h3 className="text-sm font-medium text-text mb-1">
+                Cost Anomalies ({anomalies.length})
+              </h3>
+              <p className="text-xs text-text-muted mb-2">
+                These tasks cost 3x or more than the repository average:
+              </p>
+              <div className="space-y-1">
+                {anomalies.slice(0, 5).map((a) => (
+                  <div key={a.id} className="flex items-center gap-2 text-xs">
+                    <Link
+                      href={`/tasks/${a.id}`}
+                      className="text-text hover:text-primary flex items-center gap-1"
+                    >
+                      {truncate(a.title, 40)}
+                      <ArrowUpRight className="w-3 h-3 text-text-muted" />
+                    </Link>
+                    <span className="text-error font-medium">{formatCost(a.costUsd)}</span>
+                    <span className="text-text-muted">
+                      ({a.costRatio.toFixed(1)}x avg of {formatCost(a.repoAvgCost)})
+                    </span>
+                    <span className="text-text-muted">· {modelShortName(a.modelUsed)}</span>
+                  </div>
+                ))}
+                {anomalies.length > 5 && (
+                  <p className="text-xs text-text-muted">+{anomalies.length - 5} more anomalies</p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Cost over time chart */}
       <div className="bg-bg-card border border-border rounded-xl p-5">
@@ -309,8 +432,55 @@ export default function CostsPage() {
         )}
       </div>
 
-      {/* Two-column layout: Cost by Repo + Cost by Type */}
-      <div className="grid grid-cols-2 gap-4">
+      {/* Three-column layout: Cost by Model + Cost by Repo + Cost by Type */}
+      <div className="grid grid-cols-3 gap-4">
+        {/* Cost by model */}
+        <div className="bg-bg-card border border-border rounded-xl p-5">
+          <div className="flex items-center gap-2 mb-4">
+            <Cpu className="w-4 h-4 text-text-muted" />
+            <h2 className="text-sm font-medium text-text">Cost by Model</h2>
+          </div>
+          {costByModel.length === 0 ? (
+            <div className="h-48 flex items-center justify-center text-text-muted text-sm">
+              No data
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {costByModel.map((m) => {
+                const maxCost = costByModel[0]?.totalCost || 1;
+                const pct = (m.totalCost / maxCost) * 100;
+                return (
+                  <div key={m.model}>
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-xs text-text font-medium">
+                        {modelShortName(m.model)}
+                      </span>
+                      <span className="text-xs text-text-muted">{formatCost(m.totalCost)}</span>
+                    </div>
+                    <div className="h-2 bg-bg rounded-full overflow-hidden">
+                      <div
+                        className="h-full rounded-full transition-all"
+                        style={{
+                          width: `${pct}%`,
+                          backgroundColor: getModelColor(m.model),
+                        }}
+                      />
+                    </div>
+                    <div className="flex items-center justify-between mt-1">
+                      <span className="text-[10px] text-text-muted">
+                        {m.taskCount} tasks · {m.successRate}% success
+                      </span>
+                      <span className="text-[10px] text-text-muted">
+                        avg {formatCost(m.avgCost)}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
         {/* Cost by repo */}
         <div className="bg-bg-card border border-border rounded-xl p-5">
           <h2 className="text-sm font-medium text-text mb-4">Cost by Repository</h2>
@@ -405,7 +575,7 @@ export default function CostsPage() {
         </div>
       </div>
 
-      {/* Top most expensive tasks */}
+      {/* Top most expensive tasks with token breakdown */}
       <div className="bg-bg-card border border-border rounded-xl p-5">
         <h2 className="text-sm font-medium text-text mb-4">Most Expensive Tasks</h2>
         {topTasks.length === 0 ? (
@@ -417,9 +587,13 @@ export default function CostsPage() {
                 <tr className="border-b border-border">
                   <th className="text-left py-2 px-3 text-xs font-medium text-text-muted">Task</th>
                   <th className="text-left py-2 px-3 text-xs font-medium text-text-muted">Repo</th>
+                  <th className="text-left py-2 px-3 text-xs font-medium text-text-muted">Model</th>
                   <th className="text-left py-2 px-3 text-xs font-medium text-text-muted">Type</th>
                   <th className="text-left py-2 px-3 text-xs font-medium text-text-muted">State</th>
                   <th className="text-right py-2 px-3 text-xs font-medium text-text-muted">Cost</th>
+                  <th className="text-right py-2 px-3 text-xs font-medium text-text-muted">
+                    Tokens (In/Out)
+                  </th>
                   <th className="text-right py-2 px-3 text-xs font-medium text-text-muted">When</th>
                 </tr>
               </thead>
@@ -427,19 +601,38 @@ export default function CostsPage() {
                 {topTasks.map((task) => (
                   <tr
                     key={task.id}
-                    className="border-b border-border/50 hover:bg-bg-hover transition-colors"
+                    className={cn(
+                      "border-b border-border/50 hover:bg-bg-hover transition-colors",
+                      anomalyIds.has(task.id) && "bg-error/5",
+                    )}
                   >
                     <td className="py-2.5 px-3">
-                      <Link
-                        href={`/tasks/${task.id}`}
-                        className="text-text hover:text-primary flex items-center gap-1"
-                      >
-                        {truncate(task.title, 50)}
-                        <ArrowUpRight className="w-3 h-3 text-text-muted" />
-                      </Link>
+                      <div className="flex items-center gap-1.5">
+                        {anomalyIds.has(task.id) && (
+                          <AlertTriangle className="w-3.5 h-3.5 text-error shrink-0" />
+                        )}
+                        <Link
+                          href={`/tasks/${task.id}`}
+                          className="text-text hover:text-primary flex items-center gap-1"
+                        >
+                          {truncate(task.title, 40)}
+                          <ArrowUpRight className="w-3 h-3 text-text-muted" />
+                        </Link>
+                      </div>
                     </td>
                     <td className="py-2.5 px-3 text-text-muted text-xs">
                       {repoShortName(task.repoUrl)}
+                    </td>
+                    <td className="py-2.5 px-3">
+                      <span
+                        className="text-xs px-2 py-0.5 rounded-full"
+                        style={{
+                          backgroundColor: `${getModelColor(task.modelUsed)}15`,
+                          color: getModelColor(task.modelUsed),
+                        }}
+                      >
+                        {modelShortName(task.modelUsed)}
+                      </span>
                     </td>
                     <td className="py-2.5 px-3">
                       <span
@@ -458,6 +651,15 @@ export default function CostsPage() {
                     </td>
                     <td className="py-2.5 px-3 text-right font-medium text-text">
                       {formatCost(task.costUsd)}
+                    </td>
+                    <td className="py-2.5 px-3 text-right text-xs text-text-muted">
+                      {task.inputTokens > 0 || task.outputTokens > 0 ? (
+                        <span>
+                          {formatTokens(task.inputTokens)} / {formatTokens(task.outputTokens)}
+                        </span>
+                      ) : (
+                        <span className="text-text-muted/50">—</span>
+                      )}
                     </td>
                     <td className="py-2.5 px-3 text-right text-xs text-text-muted">
                       {formatRelativeTime(task.createdAt)}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -355,9 +355,43 @@ export const api = {
         prevPeriodCost: string;
         days: number;
       };
+      forecast: {
+        dailyAvgCost: string;
+        monthCostSoFar: string;
+        forecastedMonthTotal: string;
+        daysRemaining: number;
+      };
       dailyCosts: Array<{ date: string; cost: number; taskCount: number }>;
       costByRepo: Array<{ repoUrl: string; totalCost: number; taskCount: number }>;
       costByType: Array<{ taskType: string; totalCost: number; taskCount: number }>;
+      costByModel: Array<{
+        model: string;
+        totalCost: number;
+        taskCount: number;
+        successRate: number;
+        avgCost: number;
+        totalInputTokens: number;
+        totalOutputTokens: number;
+      }>;
+      anomalies: Array<{
+        id: string;
+        title: string;
+        repoUrl: string;
+        taskType: string;
+        state: string;
+        costUsd: string;
+        modelUsed: string;
+        repoAvgCost: number;
+        costRatio: number;
+        createdAt: string;
+      }>;
+      modelSuggestions: Array<{
+        repoUrl: string;
+        currentModel: string;
+        taskCount: number;
+        avgCost: number;
+        cheaperModelAvgCost: number;
+      }>;
       topTasks: Array<{
         id: string;
         title: string;
@@ -365,6 +399,9 @@ export const api = {
         taskType: string;
         state: string;
         costUsd: string;
+        inputTokens: number;
+        outputTokens: number;
+        modelUsed: string;
         createdAt: string;
       }>;
     }>(`/api/analytics/costs${query ? `?${query}` : ""}`);

--- a/packages/agent-adapters/src/claude-code.ts
+++ b/packages/agent-adapters/src/claude-code.ts
@@ -83,27 +83,50 @@ export class ClaudeCodeAdapter implements AgentAdapter {
     const prMatch = logs.match(/https:\/\/github\.com\/[^\s"]+\/pull\/\d+/);
     const costMatch = logs.match(/"total_cost_usd":\s*([\d.]+)/);
 
-    // Extract the actual error message from Claude's NDJSON result event
+    // Extract error, token usage, and model from Claude's NDJSON events
     let error: string | undefined;
-    if (exitCode !== 0) {
-      for (const line of logs.split("\n")) {
-        try {
-          const event = JSON.parse(line);
-          if (event.type === "result" && event.is_error && event.result) {
-            error = event.result;
-            break;
-          }
-        } catch {
-          // Not JSON, skip
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let model: string | undefined;
+
+    for (const line of logs.split("\n")) {
+      try {
+        const event = JSON.parse(line);
+
+        // Extract model from system init event
+        if (event.type === "system" && event.subtype === "init" && event.model && !model) {
+          model = event.model;
         }
+
+        // Accumulate token usage from assistant messages
+        if (event.type === "assistant" && event.message?.usage) {
+          totalInputTokens += event.message.usage.input_tokens || 0;
+          totalOutputTokens += event.message.usage.output_tokens || 0;
+          if (!model && event.message.model) {
+            model = event.message.model;
+          }
+        }
+
+        // Extract error from result event
+        if (exitCode !== 0 && event.type === "result" && event.is_error && event.result) {
+          error = event.result;
+        }
+      } catch {
+        // Not JSON, skip
       }
-      error = error || `Exit code: ${exitCode}`;
+    }
+
+    if (exitCode !== 0 && !error) {
+      error = `Exit code: ${exitCode}`;
     }
 
     return {
       success: exitCode === 0,
       prUrl: prMatch?.[0],
       costUsd: costMatch ? parseFloat(costMatch[1]) : undefined,
+      inputTokens: totalInputTokens > 0 ? totalInputTokens : undefined,
+      outputTokens: totalOutputTokens > 0 ? totalOutputTokens : undefined,
+      model,
       summary:
         exitCode === 0 ? "Agent completed successfully" : `Agent exited with code ${exitCode}`,
       error,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -35,6 +35,9 @@ export interface AgentResult {
   summary?: string;
   error?: string;
   costUsd?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  model?: string;
 }
 
 export interface AgentConfig {


### PR DESCRIPTION
## Summary
- **Token tracking**: Store `inputTokens`, `outputTokens`, and `modelUsed` on tasks (new DB columns + migration)
- **Per-model cost comparison**: Analytics API returns cost breakdown by model with success rates, avg cost, and token totals
- **Cost anomaly detection**: Flags tasks costing 3x+ the repository average with visual alerts in the dashboard
- **Monthly forecast**: Predicts end-of-month spend based on rolling daily average from the selected period
- **"Try cheaper model" suggestions**: When Opus tasks succeed, suggests trying Sonnet with estimated savings
- **Token-level breakdown**: Top tasks table now shows input/output token counts per task
- **Enhanced dashboard**: New Cost by Model chart, forecast card, anomaly alerts banner, and model optimization suggestions

## Changes
- `apps/api/src/db/migrations/0017_cost_optimization_tokens.sql` — new migration adding `input_tokens`, `output_tokens`, `model_used` columns
- `apps/api/src/db/schema.ts` — Drizzle schema updated with new columns
- `packages/shared/src/types/agent.ts` — `AgentResult` extended with `inputTokens`, `outputTokens`, `model`
- `packages/agent-adapters/src/claude-code.ts` — `parseResult()` now extracts token usage from assistant messages and model from init/assistant events
- `apps/api/src/workers/task-worker.ts` — persists token and model data after task completion
- `apps/api/src/routes/analytics.ts` — new queries for `costByModel`, `anomalies`, `forecast`, `modelSuggestions`, enhanced `topTasks` with tokens
- `apps/web/src/lib/api-client.ts` — updated response types for new analytics data
- `apps/web/src/app/costs/page.tsx` — new UI sections: Cost by Model chart, forecast card, anomaly alerts, model suggestions, token breakdown

## Test plan
- [x] `pnpm turbo typecheck` passes (all 6 packages)
- [x] `pnpm turbo test` passes (183 tests across 12 files)
- [x] `pnpm format:check` passes
- [x] `next build` succeeds for web app
- [ ] Verify cost analytics page renders correctly with new sections
- [ ] Verify anomaly detection triggers for tasks >3x repo average
- [ ] Verify token data is captured from Claude Code stream events

🤖 Generated with [Claude Code](https://claude.com/claude-code)