### PR TITLE
fix: add dismiss button to toast notifications

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={`dark ${inter.variable} ${jetbrainsMono.variable}`}>
       <body className="antialiased">
         <LayoutShell>{children}</LayoutShell>
-        <Toaster theme="dark" position="bottom-right" richColors />
+        <Toaster theme="dark" position="bottom-right" richColors closeButton />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Add `closeButton` prop to the sonner `<Toaster>` component in the root layout
- Each toast now displays an X button for manual dismissal
- Auto-dismiss timeout still works as a fallback

## Test plan
- [ ] Trigger a toast (e.g., create a task) and verify the X button appears
- [ ] Click the X button and verify the toast is dismissed immediately
- [ ] Wait without clicking and verify the toast auto-dismisses as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)