### PR TITLE
fix: page titles should reflect current page, not project name

### DIFF
--- a/.optio/task.md
+++ b/.optio/task.md
@@ -1,27 +1,33 @@
-# feat: Cost optimization insights and forecasting
+# fix: Page titles should reflect current page, not project name
 
-feat: Cost optimization insights and forecasting
+fix: Page titles should reflect current page, not project name
 
 ## Problem
 
-Cost tracking shows totals but doesn't help users optimize. No way to compare models, detect anomalies, or forecast spending.
+The browser tab/title bar shows the project name and description on every page (e.g. "Optio — AI Agent Orchestration") instead of the current page context. When multiple Optio tabs are open, they all look identical.
 
-## Features
+## Fix
 
-- **Per-model cost comparison**: Show cost breakdown by model (Opus vs Sonnet vs Haiku) with success rates
-- **"Try cheaper model" suggestions**: If a task succeeded with Opus, suggest trying Sonnet next time
-- **Cost anomaly alerts**: Flag tasks that cost 3x+ the repo average
-- **Forecasting**: "At current rate, you'll spend $X this month"
-- **Per-task cost breakdown**: Input tokens, output tokens, thinking tokens (where available)
-- **Token tracking**: Store `inputTokens`, `outputTokens` on tasks for detailed analysis
+Set dynamic page titles based on the current route:
+
+- `/` → "Overview — Optio"
+- `/tasks` → "Tasks — Optio"
+- `/tasks/[id]` → "{task title} — Optio"
+- `/repos` → "Repositories — Optio"
+- `/repos/[id]` → "{repo name} — Optio"
+- `/cluster` → "Cluster — Optio"
+- `/costs` → "Costs — Optio"
+- `/secrets` → "Secrets — Optio"
+- `/settings` → "Settings — Optio"
+
+Use Next.js `metadata` exports or `<title>` in each page for static titles, and `generateMetadata()` for dynamic ones (task detail, repo detail).
 
 ## Acceptance Criteria
 
-- [ ] Cost breakdown by model on analytics page
-- [ ] Anomaly detection with visual indicators
-- [ ] Monthly forecast based on rolling average
-- [ ] Token-level cost breakdown per task
+- [ ] Each page has a unique, descriptive title
+- [ ] Task and repo detail pages show the entity name in the title
+- [ ] "Optio" appears as suffix for brand recognition
 
 ---
 
-_Optio Task ID: 428ee0d9-6ba2-482e-aed6-2b6b74b44baa_
+_Optio Task ID: 4bdee718-0e03-48d5-ad1e-909e5f6c3103_

--- a/apps/web/src/app/cluster/[id]/page.tsx
+++ b/apps/web/src/app/cluster/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useEffect, useState } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -23,6 +24,7 @@ export default function PodDetailPage({ params }: { params: Promise<{ id: string
   const { id } = use(params);
   const router = useRouter();
   const [pod, setPod] = useState<any>(null);
+  usePageTitle(pod?.podName ?? "Pod");
   const [loading, setLoading] = useState(true);
   const [healthEvents, setHealthEvents] = useState<any[]>([]);
   const [restarting, setRestarting] = useState(false);

--- a/apps/web/src/app/cluster/page.tsx
+++ b/apps/web/src/app/cluster/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import Link from "next/link";
 import { cn, formatRelativeTime } from "@/lib/utils";
@@ -38,6 +39,7 @@ const STATUS_COLORS: Record<string, string> = {
 };
 
 export default function ClusterPage() {
+  usePageTitle("Cluster");
   const [data, setData] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState<"pods" | "events" | "services">("pods");

--- a/apps/web/src/app/costs/page.tsx
+++ b/apps/web/src/app/costs/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import { cn, formatRelativeTime, truncate } from "@/lib/utils";
 import Link from "next/link";
@@ -168,6 +169,7 @@ function ChartTooltipContent({
 }
 
 export default function CostsPage() {
+  usePageTitle("Costs");
   const [data, setData] = useState<CostAnalytics | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -15,7 +15,7 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Optio — AI Agent Orchestration",
+  title: "Optio",
   description: "Workflow orchestration for AI coding agents",
   icons: {
     icon: "/favicon.svg",

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import { TaskCard } from "@/components/task-card";
 import Link from "next/link";
@@ -89,6 +90,7 @@ interface TaskStats {
 }
 
 export default function OverviewPage() {
+  usePageTitle("Overview");
   const [taskStats, setTaskStats] = useState<TaskStats | null>(null);
   const [recentTasks, setRecentTasks] = useState<any[]>([]);
   const [repoCount, setRepoCount] = useState<number | null>(null);

--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useEffect, useState } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -24,6 +25,7 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
   const { id } = use(params);
   const router = useRouter();
   const [repo, setRepo] = useState<any>(null);
+  usePageTitle(repo?.fullName ?? "Repository");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 

--- a/apps/web/src/app/repos/new/page.tsx
+++ b/apps/web/src/app/repos/new/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import { toast } from "sonner";
 import { PRESET_IMAGES, type PresetImageId } from "@optio/shared";
@@ -29,6 +30,7 @@ const STEPS = [
 type StepId = (typeof STEPS)[number]["id"];
 
 export default function NewRepoPage() {
+  usePageTitle("Add Repository");
   const router = useRouter();
   const [stepIndex, setStepIndex] = useState(0);
   const currentStep = STEPS[stepIndex];

--- a/apps/web/src/app/repos/page.tsx
+++ b/apps/web/src/app/repos/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import Link from "next/link";
 import { Loader2, FolderGit2, Lock, Globe, ChevronRight, Settings2, Plus } from "lucide-react";
 
 export default function ReposPage() {
+  usePageTitle("Repositories");
   const [repos, setRepos] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
 

--- a/apps/web/src/app/secrets/page.tsx
+++ b/apps/web/src/app/secrets/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import { toast } from "sonner";
 import { Loader2, Plus, Trash2, KeyRound, Globe, FolderGit2, Filter } from "lucide-react";
 
 export default function SecretsPage() {
+  usePageTitle("Secrets");
   const [secrets, setSecrets] = useState<any[]>([]);
   const [repos, setRepos] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import { toast } from "sonner";
 import { Loader2, Bell, RefreshCw, Shield, CheckCircle2, XCircle } from "lucide-react";
@@ -385,6 +386,7 @@ function AuthenticationSettings() {
 }
 
 export default function SettingsPage() {
+  usePageTitle("Settings");
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [providers, setProviders] = useState<any[]>([]);

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { use, useState, useEffect } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { useTask } from "@/hooks/use-task";
 import { LogViewer } from "@/components/log-viewer";
 import { PipelineTimeline } from "@/components/pipeline-timeline";
@@ -28,6 +29,7 @@ import { toast } from "sonner";
 export default function TaskDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const { task, events, loading, error, refresh } = useTask(id);
+  usePageTitle(task?.title ?? "Task");
   const [actionLoading, setActionLoading] = useState(false);
   const [resumePrompt, setResumePrompt] = useState("");
   const [showTimeline, setShowTimeline] = useState(true);

--- a/apps/web/src/app/tasks/new/page.tsx
+++ b/apps/web/src/app/tasks/new/page.tsx
@@ -2,11 +2,13 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import { Loader2, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 
 export default function NewTaskPage() {
+  usePageTitle("New Task");
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [repos, setRepos] = useState<any[]>([]);

--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, Suspense } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
 import { TaskList } from "@/components/task-list";
 import { api } from "@/lib/api-client";
 import { toast } from "sonner";
@@ -9,6 +10,7 @@ import { cn, formatRelativeTime } from "@/lib/utils";
 import { Plus, RotateCcw, XCircle, Loader2, Zap, GitBranch, CircleDot, Check } from "lucide-react";
 
 export default function TasksPage() {
+  usePageTitle("Tasks");
   const [tab, setTab] = useState<"tasks" | "issues">("tasks");
   const [bulkLoading, setBulkLoading] = useState(false);
 

--- a/apps/web/src/hooks/use-page-title.ts
+++ b/apps/web/src/hooks/use-page-title.ts
@@ -1,0 +1,9 @@
+import { useEffect } from "react";
+
+const SUFFIX = "Optio";
+
+export function usePageTitle(title: string | undefined) {
+  useEffect(() => {
+    document.title = title ? `${title} — ${SUFFIX}` : SUFFIX;
+  }, [title]);
+}


### PR DESCRIPTION
## Summary
- Add `usePageTitle` hook that sets `document.title` dynamically based on the current route
- Each page now shows a descriptive title (e.g. "Tasks — Optio", "Costs — Optio") instead of the generic "Optio — AI Agent Orchestration"
- Dynamic pages (task detail, repo detail, pod detail) show the entity name in the title once data loads

## Changes
- **New**: `apps/web/src/hooks/use-page-title.ts` — reusable hook for setting page titles
- **Modified**: All 13 page components to call `usePageTitle()` with appropriate titles
- **Modified**: Root layout default title simplified to "Optio" (individual pages override via `document.title`)

## Page title mapping
| Route | Title |
|-------|-------|
| `/` | Overview — Optio |
| `/tasks` | Tasks — Optio |
| `/tasks/new` | New Task — Optio |
| `/tasks/[id]` | {task title} — Optio |
| `/repos` | Repositories — Optio |
| `/repos/new` | Add Repository — Optio |
| `/repos/[id]` | {repo name} — Optio |
| `/cluster` | Cluster — Optio |
| `/cluster/[id]` | {pod name} — Optio |
| `/costs` | Costs — Optio |
| `/secrets` | Secrets — Optio |
| `/settings` | Settings — Optio |

## Test plan
- [ ] Open each page and verify the browser tab shows the correct title
- [ ] Open task detail page and verify the task title appears in the tab
- [ ] Open repo detail page and verify the repo name appears in the tab
- [ ] Open multiple tabs to different pages and verify they're distinguishable

🤖 Generated with [Claude Code](https://claude.com/claude-code)