### PR TITLE
feat: make auto-resume limit configurable (default 10)

### DIFF
--- a/.optio/task.md
+++ b/.optio/task.md
@@ -1,31 +1,29 @@
-# feat: Slack integration
+# Make auto-resume limit configurable (default 10)
 
-feat: Slack integration
+Make auto-resume limit configurable (default 10)
 
 ## Problem
 
-Teams use Slack for coordination. No way to get Optio notifications in Slack or take quick actions from there.
+The auto-resume limit in the PR watcher is hardcoded to 3 (`MAX_AUTO_RESUMES` in `apps/api/src/workers/pr-watcher-worker.ts:329`). This is too low — tasks with persistent merge conflicts or CI failures hit the limit quickly and park in `needs_attention`, requiring manual intervention.
 
-## Features
+## Proposed Changes
 
-- **Incoming notifications**: Post to a Slack channel on task events (completed, failed, needs_attention, PR opened)
-- **Rich formatting**: Slack Block Kit messages with task details, cost, PR link
-- **Quick actions**: Buttons in Slack messages (Retry, View Logs, Cancel)
-- **Configuration**: Per-repo or global Slack webhook URL in settings
+1. **Increase default from 3 to 10**
+2. **Add per-repo setting** `maxAutoResumes` on the `repos` table (nullable, falls back to default)
+3. **Add env var** `OPTIO_MAX_AUTO_RESUMES` as the global default (falls back to 10)
 
-## Implementation
+Priority chain: per-repo `maxAutoResumes` → `OPTIO_MAX_AUTO_RESUMES` env var → hardcoded default of 10.
 
-- Build on top of the webhook/notification system (#49)
-- Slack-specific payload formatter
-- Action endpoint for Slack interactive components
+## Context
 
-## Acceptance Criteria
+Observed on task `9b6d80f5` (PR #68) — the agent kept hitting the limit after 3 conflict-resume cycles, then got manually force-restarted repeatedly, creating a long loop. A higher limit would give the agent more chances to resolve transient issues without manual intervention.
 
-- [ ] Slack channel receives formatted notifications on task events
-- [ ] Messages include task details, cost, and PR link
-- [ ] Quick action buttons work (retry, view)
-- [ ] Configurable per-repo or globally
+## Files to change
+
+- `apps/api/src/db/schema.ts` — add `maxAutoResumes` to `repos` table
+- `apps/api/src/workers/pr-watcher-worker.ts` — read from repo setting / env var instead of hardcoded constant
+- Generate and apply migration
 
 ---
 
-_Optio Task ID: 6f7d42e2-7920-4b7f-96b4-4f472e718cb9_
+_Optio Task ID: f2c87a47-c4ca-4703-a4d8-64311ca2d264_

--- a/apps/api/src/db/migrations/0020_max_auto_resumes.sql
+++ b/apps/api/src/db/migrations/0020_max_auto_resumes.sql
@@ -1,0 +1,2 @@
+-- Add configurable auto-resume limit per repo (nullable, falls back to env var or default of 10)
+ALTER TABLE "repos" ADD COLUMN IF NOT EXISTS "max_auto_resumes" integer;

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1774627200000,
       "tag": "0019_slack_integration",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1774713600000,
+      "tag": "0020_max_auto_resumes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -155,6 +155,7 @@ export const repos = pgTable("repos", {
   reviewPromptTemplate: text("review_prompt_template"), // null = use default
   testCommand: text("test_command"), // "npm test", "cargo test", etc.
   reviewModel: text("review_model").default("sonnet"), // can use cheaper model for reviews
+  maxAutoResumes: integer("max_auto_resumes"), // null = use OPTIO_MAX_AUTO_RESUMES env var or default (10)
   slackWebhookUrl: text("slack_webhook_url"), // Slack incoming webhook URL
   slackChannel: text("slack_channel"), // override channel (optional)
   slackNotifyOn: jsonb("slack_notify_on").$type<string[]>(), // e.g. ["completed","failed","pr_opened","needs_attention"]

--- a/apps/api/src/routes/repos.ts
+++ b/apps/api/src/routes/repos.ts
@@ -32,6 +32,7 @@ const updateRepoSchema = z.object({
   reviewPromptTemplate: z.string().nullable().optional(),
   testCommand: z.string().optional(),
   reviewModel: z.string().optional(),
+  maxAutoResumes: z.number().int().min(1).max(100).nullable().optional(),
   slackWebhookUrl: z.string().nullable().optional(),
   slackChannel: z.string().nullable().optional(),
   slackNotifyOn: z

--- a/apps/api/src/services/repo-service.ts
+++ b/apps/api/src/services/repo-service.ts
@@ -30,6 +30,7 @@ export interface RepoRecord {
   reviewPromptTemplate: string | null;
   testCommand: string | null;
   reviewModel: string | null;
+  maxAutoResumes: number | null;
   slackWebhookUrl: string | null;
   slackChannel: string | null;
   slackNotifyOn: string[] | null;

--- a/apps/api/src/services/slack-service.test.ts
+++ b/apps/api/src/services/slack-service.test.ts
@@ -35,6 +35,7 @@ function makeRepoConfig(overrides: Partial<RepoRecord> = {}): RepoRecord {
     reviewPromptTemplate: null,
     testCommand: null,
     reviewModel: "sonnet",
+    maxAutoResumes: null,
     slackWebhookUrl: "https://hooks.slack.com/services/T00/B00/xxx",
     slackChannel: null,
     slackNotifyOn: null,

--- a/apps/api/src/workers/pr-watcher-worker.ts
+++ b/apps/api/src/workers/pr-watcher-worker.ts
@@ -326,7 +326,12 @@ export function startPrWatcherWorker() {
             };
 
             // Loop prevention: cap auto-resumes to avoid infinite cycles
-            const MAX_AUTO_RESUMES = 3;
+            // Priority: per-repo maxAutoResumes → OPTIO_MAX_AUTO_RESUMES env var → default 10
+            const DEFAULT_MAX_AUTO_RESUMES = 10;
+            const envMaxAutoResumes = process.env.OPTIO_MAX_AUTO_RESUMES
+              ? parseInt(process.env.OPTIO_MAX_AUTO_RESUMES, 10)
+              : DEFAULT_MAX_AUTO_RESUMES;
+            const maxAutoResumes = repoConfig?.maxAutoResumes ?? envMaxAutoResumes;
             if (
               ["resume_conflicts", "resume_ci_failure", "resume_review"].includes(action.action)
             ) {
@@ -336,9 +341,9 @@ export function startPrWatcherWorker() {
                 .where(
                   sql`${taskEvents.taskId} = ${task.id} AND ${taskEvents.trigger} LIKE 'auto_resume_%'`,
                 );
-              if (Number(resumeCount) >= MAX_AUTO_RESUMES) {
+              if (Number(resumeCount) >= maxAutoResumes) {
                 logger.info(
-                  { taskId: task.id, resumeCount, action: action.action },
+                  { taskId: task.id, resumeCount, maxAutoResumes, action: action.action },
                   "Auto-resume limit reached — escalating to needs_attention",
                 );
                 action = {


### PR DESCRIPTION
## Summary

- Increased the hardcoded `MAX_AUTO_RESUMES` from 3 to a configurable default of 10
- Added per-repo `maxAutoResumes` column to the `repos` table (nullable integer)
- Added `OPTIO_MAX_AUTO_RESUMES` env var as a global default override

Priority chain: per-repo `maxAutoResumes` → `OPTIO_MAX_AUTO_RESUMES` env var → hardcoded default of 10.

## Changes

- `apps/api/src/db/schema.ts` — added `maxAutoResumes` column to repos table
- `apps/api/src/services/repo-service.ts` — added field to `RepoRecord` interface
- `apps/api/src/routes/repos.ts` — added validation for the new field in `updateRepoSchema`
- `apps/api/src/workers/pr-watcher-worker.ts` — replaced hardcoded constant with configurable priority chain
- `apps/api/src/db/migrations/0020_max_auto_resumes.sql` — DB migration
- `apps/api/src/services/slack-service.test.ts` — updated mock to include new field

## Test plan

- [x] All 210 existing tests pass
- [x] Typecheck passes across all 6 packages
- [x] Formatting checks pass
- [ ] Verify per-repo setting overrides env var when set
- [ ] Verify env var overrides default when set
- [ ] Verify default of 10 is used when neither is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)