### PR TITLE
feat: install metrics-server in local setup, show N/A for unavailable metrics

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -49,6 +49,23 @@ process.on("uncaughtException", (err) => {
   process.exit(1);
 });
 
+async function checkMetricsServer() {
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+    await execFileAsync("kubectl", ["get", "--raw", "/apis/metrics.k8s.io"], {
+      timeout: 5000,
+    });
+    logger.info("metrics-server detected");
+  } catch {
+    logger.warn(
+      "metrics-server not detected — resource utilization will be unavailable. " +
+        "Install with: kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml",
+    );
+  }
+}
+
 async function main() {
   // Run database migrations before anything else
   const { migrate } = await import("drizzle-orm/postgres-js/migrator");
@@ -95,6 +112,9 @@ async function main() {
 
   const scheduleWorker = startScheduleWorker();
   logger.info("Schedule worker started");
+
+  // Check if metrics-server is available
+  checkMetricsServer().catch(() => {});
 
   // Re-enqueue any tasks orphaned by a Redis restart.
   // The heavy obliterate() call runs last to minimize startup impact.

--- a/apps/api/src/routes/cluster.ts
+++ b/apps/api/src/routes/cluster.ts
@@ -264,6 +264,7 @@ export async function clusterRoutes(app: FastifyInstance) {
         services,
         events,
         repoPods: enrichedRepoPods,
+        metricsAvailable: nodeMetricsList !== null,
         summary: {
           totalPods: pods.length,
           runningPods: pods.filter((p) => p.status === "Running").length,

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -110,8 +110,15 @@ export default function OverviewPage() {
     sevenDayOpus?: { utilization: number | null; resetsAt: string | null };
   } | null>(null);
   const [showMetrics, setShowMetrics] = useState(false);
+  const [metricsAvailable, setMetricsAvailable] = useState<boolean | null>(null);
   const [metricsHistory, setMetricsHistory] = useState<
-    { time: number; cpuPercent: number; memoryPercent: number; pods: number; agents: number }[]
+    {
+      time: number;
+      cpuPercent: number | null;
+      memoryPercent: number | null;
+      pods: number;
+      agents: number;
+    }[]
   >([]);
   const MAX_HISTORY = 60; // 10 minutes at 10s intervals
 
@@ -140,18 +147,19 @@ export default function OverviewPage() {
         setRepoCount(reposRes.repos.length);
         if (clusterRes) {
           setCluster(clusterRes);
+          setMetricsAvailable(clusterRes.metricsAvailable ?? null);
           const node = clusterRes.nodes?.[0];
           if (node) {
             const memPercent =
-              node.memoryUsedGi && node.memoryTotalGi
+              node.memoryUsedGi != null && node.memoryTotalGi
                 ? Math.round((parseFloat(node.memoryUsedGi) / parseFloat(node.memoryTotalGi)) * 100)
-                : 0;
+                : null;
             setMetricsHistory((prev) => {
               const next = [
                 ...prev,
                 {
                   time: Date.now(),
-                  cpuPercent: node.cpuPercent ?? 0,
+                  cpuPercent: node.cpuPercent ?? null,
                   memoryPercent: memPercent,
                   pods: clusterRes.summary?.totalPods ?? 0,
                   agents: clusterRes.summary?.agentPods ?? 0,
@@ -371,7 +379,10 @@ export default function OverviewPage() {
                     {nodes[0].cpu} cores
                   </>
                 ) : (
-                  <>{nodes[0].cpu} cores</>
+                  <>
+                    <span className="font-medium text-text-muted/50">N/A</span> · {nodes[0].cpu}{" "}
+                    cores
+                  </>
                 )}
               </span>
               <span className="flex items-center gap-1">
@@ -382,7 +393,10 @@ export default function OverviewPage() {
                     {nodes[0].memoryTotalGi} Gi
                   </>
                 ) : (
-                  <>{formatK8sResource(nodes[0].memory)}</>
+                  <>
+                    <span className="font-medium text-text-muted/50">N/A</span> ·{" "}
+                    {formatK8sResource(nodes[0].memory)}
+                  </>
                 )}
               </span>
               {totalCost > 0 && (
@@ -409,19 +423,28 @@ export default function OverviewPage() {
 
         {showMetrics && (
           <div className="border-t border-border/30 px-4 py-4">
-            {metricsHistory.length > 1 ? (
+            {metricsAvailable === false ? (
+              <div className="text-xs text-text-muted/50 text-center py-3">
+                metrics-server not detected — CPU and memory charts unavailable.
+                <br />
+                <span className="text-[10px]">
+                  Install with: kubectl apply -f
+                  https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+                </span>
+              </div>
+            ) : metricsHistory.length > 1 ? (
               <>
                 <div className="grid grid-cols-3 gap-6">
                   <MiniChart
                     label="CPU"
-                    data={metricsHistory.map((m) => m.cpuPercent)}
+                    data={metricsHistory.map((m) => m.cpuPercent ?? 0)}
                     suffix="%"
                     color="var(--color-primary)"
                     max={100}
                   />
                   <MiniChart
                     label="Memory"
-                    data={metricsHistory.map((m) => m.memoryPercent)}
+                    data={metricsHistory.map((m) => m.memoryPercent ?? 0)}
                     suffix="%"
                     color="var(--color-info)"
                     max={100}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -218,6 +218,7 @@ export const api = {
       services: any[];
       events: any[];
       repoPods: any[];
+      metricsAvailable: boolean;
       summary: {
         totalPods: number;
         runningPods: number;

--- a/helm/optio/templates/NOTES.txt
+++ b/helm/optio/templates/NOTES.txt
@@ -1,0 +1,30 @@
+Optio has been installed in the {{ .Values.namespace }} namespace.
+
+{{- if eq .Values.api.service.type "NodePort" }}
+
+API server:  http://localhost:{{ .Values.api.service.nodePort | default .Values.api.port }}
+{{- else }}
+
+API server:  kubectl port-forward -n {{ .Values.namespace }} svc/{{ .Release.Name }}-api {{ .Values.api.port }}:{{ .Values.api.port }}
+{{- end }}
+{{- if eq .Values.web.service.type "NodePort" }}
+Web UI:      http://localhost:{{ .Values.web.service.nodePort | default .Values.web.port }}
+{{- else }}
+Web UI:      kubectl port-forward -n {{ .Values.namespace }} svc/{{ .Release.Name }}-web {{ .Values.web.port }}:{{ .Values.web.port }}
+{{- end }}
+
+---
+
+METRICS SERVER
+
+Resource utilization on the overview page requires metrics-server.
+If your cluster does not have it installed, run:
+
+  kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+
+For Docker Desktop / kind / minikube, also patch with --kubelet-insecure-tls:
+
+  kubectl patch deployment metrics-server -n kube-system --type=json \
+    -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
+
+Without metrics-server, CPU and memory usage will show as "N/A".

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -20,33 +20,46 @@ if ! kubectl cluster-info >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "[1/8] Installing dependencies..."
+echo "[1/9] Installing dependencies..."
 pnpm install
 
-echo "[2/8] Creating optio namespace..."
+echo "[2/9] Creating optio namespace..."
 kubectl apply -f k8s/namespace.yaml
 
-echo "[3/8] Pre-pulling infrastructure images..."
+echo "[3/9] Pre-pulling infrastructure images..."
 docker pull postgres:16 -q
 docker pull redis:7-alpine -q
 
-echo "[4/8] Deploying Postgres and Redis to K8s..."
+echo "[4/9] Deploying Postgres and Redis to K8s..."
 kubectl apply -f k8s/infrastructure.yaml
 kubectl wait --namespace optio --for=condition=available deployment/postgres --timeout=120s
 kubectl wait --namespace optio --for=condition=available deployment/redis --timeout=60s
 echo "   Infrastructure ready."
 
-echo "[5/8] Setting up port-forwards..."
+echo "[5/9] Installing metrics-server..."
+if kubectl get deployment metrics-server -n kube-system &>/dev/null; then
+  echo "   metrics-server already installed, skipping"
+else
+  kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml 2>/dev/null || {
+    echo "   ⚠ Failed to install metrics-server (resource utilization will show N/A)"
+  }
+  # Docker Desktop / kind / minikube need --kubelet-insecure-tls
+  kubectl patch deployment metrics-server -n kube-system --type=json \
+    -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]' 2>/dev/null || true
+  echo "   metrics-server installed (may take a minute to become ready)"
+fi
+
+echo "[6/9] Setting up port-forwards..."
 pkill -f "kubectl port-forward.*optio" 2>/dev/null || true
 sleep 1
 kubectl port-forward -n optio svc/postgres 5432:5432 &>/dev/null &
 kubectl port-forward -n optio svc/redis 6379:6379 &>/dev/null &
 sleep 2
 
-echo "[6/8] Running database migrations..."
+echo "[7/9] Running database migrations..."
 cd apps/api && npx drizzle-kit migrate && cd "$ROOT_DIR"
 
-echo "[7/8] Creating .env file..."
+echo "[8/9] Creating .env file..."
 if [ ! -f .env ]; then
   cp .env.example .env
   # Ensure auth is disabled for local dev
@@ -60,7 +73,7 @@ else
   echo "   .env already exists, skipping"
 fi
 
-echo "[8/8] Building agent container image..."
+echo "[9/9] Building agent container image..."
 docker build -t optio-agent:latest -f Dockerfile.agent . -q
 echo "   Agent image built (optio-agent:latest)"
 


### PR DESCRIPTION
## Summary
- Adds metrics-server installation (with `--kubelet-insecure-tls` patch) to `scripts/setup-local.sh` so resource utilization works out of the box in local dev
- Adds `helm/optio/templates/NOTES.txt` with post-install instructions including metrics-server setup guidance
- Checks metrics API availability on API startup and logs a warning if metrics-server is not detected
- Returns `metricsAvailable` flag from the cluster overview API endpoint
- Shows "N/A" in the overview UI when metrics are unavailable instead of misleading 0% values; shows install instructions in the expanded metrics panel

## Test plan
- [ ] Run `scripts/setup-local.sh` on a fresh cluster — verify metrics-server is installed and patched
- [ ] Run setup again — verify it skips if metrics-server already exists
- [ ] Start API server without metrics-server — verify warning is logged
- [ ] Open overview page without metrics-server — verify "N/A" is shown for CPU/memory and expanded charts show install instructions
- [ ] Open overview page with metrics-server — verify real CPU/memory values and charts render normally
- [ ] `helm install` and verify NOTES.txt output includes metrics-server instructions
- [ ] `pnpm turbo typecheck` passes
- [ ] `pnpm turbo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)