### PR TITLE
feat: Session Phase 2 — interactive agent chat + split pane

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -25,10 +25,10 @@ export async function sessionRoutes(app: FastifyInstance) {
     reply.send({ sessions, activeCount });
   });
 
-  // Get session
+  // Get session (includes repo model config)
   app.get("/api/sessions/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
-    const session = await sessionService.getSession(id);
+    const session = await sessionService.getSessionWithRepoConfig(id);
     if (!session) return reply.status(404).send({ error: "Session not found" });
     reply.send({ session });
   });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -27,6 +27,7 @@ import { workspaceRoutes } from "./routes/workspaces.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import { sessionTerminalWs } from "./ws/session-terminal.js";
+import { sessionChatWs } from "./ws/session-chat.js";
 import authPlugin from "./plugins/auth.js";
 
 const loggerConfig =
@@ -87,6 +88,7 @@ export async function buildServer() {
   await app.register(logStreamWs);
   await app.register(eventsWs);
   await app.register(sessionTerminalWs);
+  await app.register(sessionChatWs);
 
   // Global error handler for Zod validation
   app.setErrorHandler((error: FastifyError | Error, _req, reply) => {

--- a/apps/api/src/services/interactive-session-service.ts
+++ b/apps/api/src/services/interactive-session-service.ts
@@ -182,6 +182,38 @@ export async function updateSessionPr(
   return updated;
 }
 
+export async function updateSessionCost(id: string, costUsd: string) {
+  const [updated] = await db
+    .update(interactiveSessions)
+    .set({ costUsd })
+    .where(eq(interactiveSessions.id, id))
+    .returning();
+
+  await publishSessionEvent(id, {
+    type: "session:cost_updated",
+    sessionId: id,
+    costUsd,
+    timestamp: new Date().toISOString(),
+  });
+
+  return updated;
+}
+
+export async function getSessionWithRepoConfig(id: string) {
+  const session = await getSession(id);
+  if (!session) return null;
+
+  const [repoConfig] = await db.select().from(repos).where(eq(repos.repoUrl, session.repoUrl));
+
+  return {
+    ...session,
+    claudeModel: repoConfig?.claudeModel ?? null,
+    claudeContextWindow: repoConfig?.claudeContextWindow ?? null,
+    claudeThinking: repoConfig?.claudeThinking ?? null,
+    claudeEffort: repoConfig?.claudeEffort ?? null,
+  };
+}
+
 export async function getActiveSessionCount(repoUrl?: string) {
   const conditions = [eq(interactiveSessions.state, "active")];
   if (repoUrl) conditions.push(eq(interactiveSessions.repoUrl, repoUrl));

--- a/apps/api/src/ws/session-chat.ts
+++ b/apps/api/src/ws/session-chat.ts
@@ -1,0 +1,284 @@
+import type { FastifyInstance } from "fastify";
+import { getRuntime } from "../services/container-service.js";
+import {
+  getSession,
+  updateSessionCost,
+  addSessionPr,
+} from "../services/interactive-session-service.js";
+import { db } from "../db/client.js";
+import { repoPods, repos } from "../db/schema.js";
+import { eq } from "drizzle-orm";
+import { logger } from "../logger.js";
+import { parseClaudeEvent } from "../services/agent-event-parser.js";
+import type { ContainerHandle, ExecSession } from "@optio/shared";
+import type { ChatClientMessage, ChatServerMessage, ChatEventMessage } from "@optio/shared";
+
+const PR_URL_REGEX = /https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/g;
+
+export async function sessionChatWs(app: FastifyInstance) {
+  app.get("/ws/sessions/:sessionId/chat", { websocket: true }, async (socket, req) => {
+    const { sessionId } = req.params as { sessionId: string };
+    const log = logger.child({ sessionId, handler: "session-chat" });
+
+    const session = await getSession(sessionId);
+    if (!session) {
+      socket.send(JSON.stringify({ type: "chat:error", message: "Session not found" }));
+      socket.close();
+      return;
+    }
+
+    if (session.state !== "active") {
+      socket.send(JSON.stringify({ type: "chat:error", message: "Session is not active" }));
+      socket.close();
+      return;
+    }
+
+    if (!session.podId) {
+      socket.send(JSON.stringify({ type: "chat:error", message: "Session has no pod assigned" }));
+      socket.close();
+      return;
+    }
+
+    // Get pod info
+    const [pod] = await db.select().from(repoPods).where(eq(repoPods.id, session.podId));
+    if (!pod || !pod.podName) {
+      socket.send(JSON.stringify({ type: "chat:error", message: "Pod not found or not ready" }));
+      socket.close();
+      return;
+    }
+
+    // Get repo config for model settings
+    const [repoConfig] = await db.select().from(repos).where(eq(repos.repoUrl, session.repoUrl));
+
+    const rt = getRuntime();
+    const handle: ContainerHandle = { id: pod.podId ?? pod.podName, name: pod.podName };
+    const worktreePath = session.worktreePath ?? "/workspace/repo";
+
+    // State for the long-running claude process
+    let claudeExec: ExecSession | null = null;
+    let lineBuffer = "";
+    let totalCostUsd = parseFloat(session.costUsd ?? "0");
+    let currentMessageCost = 0;
+    const chatHistory: ChatEventMessage[] = [];
+    const detectedPrs = new Set<number>();
+
+    const send = (msg: ChatServerMessage) => {
+      if (socket.readyState === 1) {
+        socket.send(JSON.stringify(msg));
+      }
+    };
+
+    // Send initial status
+    send({ type: "chat:status", status: "idle" });
+    send({ type: "chat:cost", totalCostUsd: totalCostUsd.toFixed(4) });
+
+    // Build auth env for the claude process
+    const buildAuthEnv = async (): Promise<string[]> => {
+      const envLines: string[] = [];
+      try {
+        const { retrieveSecret } = await import("../services/secret-service.js");
+        const authMode =
+          ((await retrieveSecret("CLAUDE_AUTH_MODE").catch(() => null)) as any) ?? "api-key";
+
+        if (authMode === "max-subscription") {
+          const { getClaudeAuthToken } = await import("../services/auth-service.js");
+          const authResult = getClaudeAuthToken();
+          if (authResult.available && authResult.token) {
+            envLines.push(`export CLAUDE_CODE_OAUTH_TOKEN="${authResult.token}"`);
+          }
+        } else {
+          const apiKey = await retrieveSecret("ANTHROPIC_API_KEY").catch(() => null);
+          if (apiKey) {
+            envLines.push(`export ANTHROPIC_API_KEY="${apiKey}"`);
+          }
+        }
+      } catch (err) {
+        log.warn({ err }, "Failed to build auth env for chat");
+      }
+      return envLines;
+    };
+
+    const launchClaude = async (userMessage: string) => {
+      if (claudeExec) {
+        // Write the message to stdin of the existing process if it's in conversation mode
+        // But we use one-shot -p for each message, so we need to start a new process
+        claudeExec.close();
+        claudeExec = null;
+      }
+
+      send({ type: "chat:status", status: "thinking" });
+      currentMessageCost = 0;
+
+      // Record user message in history
+      const userEvent: ChatEventMessage = {
+        type: "chat:event",
+        role: "user",
+        eventType: "text",
+        content: userMessage,
+        timestamp: new Date().toISOString(),
+      };
+      chatHistory.push(userEvent);
+      send(userEvent);
+
+      // Build model flags
+      const model = repoConfig?.claudeModel ?? "sonnet";
+      const modelFlag = model ? `--model ${model}` : "";
+
+      const authEnv = await buildAuthEnv();
+
+      const script = [
+        "set -e",
+        // Wait for repo to be ready
+        "for i in $(seq 1 30); do [ -f /workspace/.ready ] && break; sleep 1; done",
+        '[ -f /workspace/.ready ] || { echo "Repo not ready"; exit 1; }',
+        `cd "${worktreePath}"`,
+        ...authEnv,
+        // Run claude in one-shot mode with streaming JSON output
+        `claude -p ${shellEscape(userMessage)} --dangerously-skip-permissions --output-format stream-json --verbose ${modelFlag} --max-turns 50`,
+      ].join("\n");
+
+      try {
+        claudeExec = await rt.exec(handle, ["bash", "-c", script], { tty: false });
+
+        claudeExec.stdout.on("data", (chunk: Buffer) => {
+          const text = chunk.toString("utf-8");
+          lineBuffer += text;
+
+          // Process complete NDJSON lines
+          const lines = lineBuffer.split("\n");
+          lineBuffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            processAgentLine(line);
+          }
+        });
+
+        claudeExec.stderr.on("data", (chunk: Buffer) => {
+          const text = chunk.toString("utf-8").trim();
+          if (text) {
+            log.debug({ stderr: text }, "Claude stderr");
+          }
+        });
+
+        claudeExec.stdout.on("end", () => {
+          // Process any remaining buffer
+          if (lineBuffer.trim()) {
+            processAgentLine(lineBuffer);
+            lineBuffer = "";
+          }
+          claudeExec = null;
+          send({ type: "chat:status", status: "idle" });
+        });
+
+        claudeExec.stdout.on("error", (err: Error) => {
+          log.error({ err }, "Claude stdout error");
+          claudeExec = null;
+          send({ type: "chat:error", message: "Agent process error" });
+          send({ type: "chat:status", status: "idle" });
+        });
+      } catch (err) {
+        log.error({ err }, "Failed to launch claude process");
+        send({ type: "chat:error", message: "Failed to start agent" });
+        send({ type: "chat:status", status: "idle" });
+      }
+    };
+
+    const processAgentLine = (line: string) => {
+      const { entries } = parseClaudeEvent(line, sessionId);
+
+      for (const entry of entries) {
+        // Check for cost info in result events
+        if (entry.type === "info" && entry.metadata?.cost) {
+          currentMessageCost = entry.metadata.cost as number;
+          totalCostUsd += currentMessageCost;
+
+          // Persist cost
+          updateSessionCost(sessionId, totalCostUsd.toFixed(4)).catch((err) => {
+            log.warn({ err }, "Failed to update session cost");
+          });
+
+          send({
+            type: "chat:cost",
+            totalCostUsd: totalCostUsd.toFixed(4),
+            messageCostUsd: currentMessageCost.toFixed(4),
+          });
+        }
+
+        // Detect PR URLs in text content
+        if (entry.content) {
+          for (const match of entry.content.matchAll(PR_URL_REGEX)) {
+            const prNumber = parseInt(match[1], 10);
+            if (!detectedPrs.has(prNumber)) {
+              detectedPrs.add(prNumber);
+              addSessionPr(sessionId, match[0], prNumber).catch((err) => {
+                log.warn({ err, prUrl: match[0] }, "Failed to register session PR from chat");
+              });
+            }
+          }
+        }
+
+        // Send to client
+        const chatEvent: ChatEventMessage = {
+          type: "chat:event",
+          role: "assistant",
+          eventType: entry.type,
+          content: entry.content,
+          metadata: entry.metadata,
+          timestamp: entry.timestamp,
+        };
+        chatHistory.push(chatEvent);
+        send(chatEvent);
+
+        // Update status based on event type
+        if (entry.type === "thinking") {
+          send({ type: "chat:status", status: "thinking" });
+        } else if (entry.type === "text" || entry.type === "tool_use") {
+          send({ type: "chat:status", status: "responding" });
+        }
+      }
+    };
+
+    // Handle incoming messages from client
+    socket.on("message", (data: Buffer | string) => {
+      const str = typeof data === "string" ? data : data.toString("utf-8");
+
+      let msg: ChatClientMessage;
+      try {
+        msg = JSON.parse(str);
+      } catch {
+        send({ type: "chat:error", message: "Invalid message format" });
+        return;
+      }
+
+      if (msg.type === "message" && msg.content) {
+        launchClaude(msg.content).catch((err) => {
+          log.error({ err }, "Failed to handle chat message");
+          send({ type: "chat:error", message: "Failed to process message" });
+        });
+      } else if (msg.type === "interrupt") {
+        if (claudeExec) {
+          log.info("Interrupting claude process");
+          claudeExec.close();
+          claudeExec = null;
+          send({ type: "chat:status", status: "idle" });
+        }
+      }
+    });
+
+    // Handle WebSocket close
+    socket.on("close", () => {
+      log.info("Session chat disconnected");
+      if (claudeExec) {
+        claudeExec.close();
+        claudeExec = null;
+      }
+    });
+  });
+}
+
+/** Escape a string for safe use in a single-quoted shell argument */
+function shellEscape(str: string): string {
+  // Use $'...' syntax which handles special chars
+  return "'" + str.replace(/'/g, "'\\''") + "'";
+}

--- a/apps/web/src/app/sessions/[id]/page.tsx
+++ b/apps/web/src/app/sessions/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useState, useEffect, useRef } from "react";
+import { use, useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api-client";
 import { toast } from "sonner";
 import Link from "next/link";
@@ -17,8 +17,12 @@ import {
   XCircle,
   Clock,
   AlertTriangle,
+  DollarSign,
+  Bot,
 } from "lucide-react";
 import { SessionTerminal } from "@/components/session-terminal";
+import { SessionChat } from "@/components/session-chat";
+import { SplitPane } from "@/components/split-pane";
 
 export default function SessionDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -27,6 +31,8 @@ export default function SessionDetailPage({ params }: { params: Promise<{ id: st
   const [loading, setLoading] = useState(true);
   const [ending, setEnding] = useState(false);
   const [showEndWarning, setShowEndWarning] = useState(false);
+  const [liveCost, setLiveCost] = useState<string | null>(null);
+  const [sendToAgent, setSendToAgent] = useState<string | null>(null);
 
   const fetchSession = async () => {
     try {
@@ -69,6 +75,14 @@ export default function SessionDetailPage({ params }: { params: Promise<{ id: st
     setEnding(false);
   };
 
+  const handleCostUpdate = useCallback((costUsd: string) => {
+    setLiveCost(costUsd);
+  }, []);
+
+  const handleSendToAgentHandled = useCallback(() => {
+    setSendToAgent(null);
+  }, []);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full text-text-muted">
@@ -88,6 +102,8 @@ export default function SessionDetailPage({ params }: { params: Promise<{ id: st
 
   const isActive = session.state === "active";
   const repoName = session.repoUrl?.replace("https://github.com/", "") ?? "Unknown";
+  const displayCost = liveCost ?? session.costUsd;
+  const modelLabel = session.claudeModel ?? "sonnet";
 
   return (
     <div className="h-full flex flex-col">
@@ -133,9 +149,18 @@ export default function SessionDetailPage({ params }: { params: Promise<{ id: st
           </div>
 
           <div className="flex items-center gap-2">
-            {session.costUsd && (
-              <span className="text-xs text-text-muted px-2 py-1 bg-bg-card rounded-md border border-border">
-                ${parseFloat(session.costUsd).toFixed(2)}
+            {/* Model badge */}
+            {isActive && (
+              <span className="text-xs text-text-muted px-2 py-1 bg-bg-card rounded-md border border-border flex items-center gap-1">
+                <Bot className="w-3 h-3" />
+                {modelLabel}
+              </span>
+            )}
+            {/* Live cost counter */}
+            {displayCost && (
+              <span className="text-xs text-text-muted px-2 py-1 bg-bg-card rounded-md border border-border flex items-center gap-1 tabular-nums">
+                <DollarSign className="w-3 h-3" />
+                {parseFloat(displayCost).toFixed(4)}
               </span>
             )}
             {isActive && (
@@ -187,11 +212,24 @@ export default function SessionDetailPage({ params }: { params: Promise<{ id: st
 
       {/* Main content */}
       <div className="flex-1 flex min-h-0">
-        {/* Terminal area */}
-        <div className="flex-1 min-w-0">
-          {isActive ? (
-            <SessionTerminal sessionId={id} />
-          ) : (
+        {isActive ? (
+          <div className="flex-1 min-w-0">
+            <SplitPane
+              leftLabel="Agent Chat"
+              rightLabel="Terminal"
+              left={
+                <SessionChat
+                  sessionId={id}
+                  onCostUpdate={handleCostUpdate}
+                  sendToAgent={sendToAgent}
+                  onSendToAgentHandled={handleSendToAgentHandled}
+                />
+              }
+              right={<SessionTerminal sessionId={id} onSendToAgent={setSendToAgent} />}
+            />
+          </div>
+        ) : (
+          <div className="flex-1 min-w-0">
             <div className="h-full flex items-center justify-center text-text-muted bg-[#09090b]">
               <div className="text-center">
                 <Terminal className="w-8 h-8 mx-auto mb-2 opacity-30" />
@@ -203,8 +241,8 @@ export default function SessionDetailPage({ params }: { params: Promise<{ id: st
                 )}
               </div>
             </div>
-          )}
-        </div>
+          </div>
+        )}
 
         {/* PR sidebar */}
         {prs.length > 0 && (

--- a/apps/web/src/components/session-chat.tsx
+++ b/apps/web/src/components/session-chat.tsx
@@ -1,0 +1,512 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import {
+  Send,
+  Square,
+  Bot,
+  User,
+  Terminal,
+  FileText,
+  Pencil,
+  Search,
+  Wrench,
+  Info,
+  AlertCircle,
+  Brain,
+  Loader2,
+  ChevronRight,
+  ChevronDown,
+  DollarSign,
+} from "lucide-react";
+import type { ChatAgentStatus, ChatServerMessage, ChatEventMessage } from "@optio/shared";
+
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? "ws://localhost:4000";
+
+const TOOL_ICONS: Record<string, React.ElementType> = {
+  Bash: Terminal,
+  Read: FileText,
+  Edit: Pencil,
+  Write: FileText,
+  Grep: Search,
+  Glob: Search,
+};
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  eventType: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  timestamp: string;
+}
+
+interface SessionChatProps {
+  sessionId: string;
+  onCostUpdate?: (costUsd: string) => void;
+  sendToAgent?: string | null;
+  onSendToAgentHandled?: () => void;
+}
+
+export function SessionChat({
+  sessionId,
+  onCostUpdate,
+  sendToAgent,
+  onSendToAgentHandled,
+}: SessionChatProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [status, setStatus] = useState<ChatAgentStatus>("idle");
+  const [connected, setConnected] = useState(false);
+  const [messageCost, setMessageCost] = useState<string | null>(null);
+  const [collapsedTools, setCollapsedTools] = useState<Set<number>>(new Set());
+  const wsRef = useRef<WebSocket | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const scrollToBottom = useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, scrollToBottom]);
+
+  // Handle "send to agent" from terminal
+  useEffect(() => {
+    if (sendToAgent && connected && status === "idle") {
+      setInput(sendToAgent);
+      onSendToAgentHandled?.();
+      // Focus input
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [sendToAgent, connected, status, onSendToAgentHandled]);
+
+  // WebSocket connection
+  useEffect(() => {
+    const ws = new WebSocket(`${WS_URL}/ws/sessions/${sessionId}/chat`);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      setConnected(true);
+    };
+
+    ws.onmessage = (event) => {
+      let msg: ChatServerMessage;
+      try {
+        msg = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+
+      switch (msg.type) {
+        case "chat:event":
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: msg.role,
+              eventType: msg.eventType,
+              content: msg.content,
+              metadata: msg.metadata,
+              timestamp: msg.timestamp,
+            },
+          ]);
+          break;
+
+        case "chat:status":
+          setStatus(msg.status);
+          break;
+
+        case "chat:cost":
+          onCostUpdate?.(msg.totalCostUsd);
+          if (msg.messageCostUsd) {
+            setMessageCost(msg.messageCostUsd);
+          }
+          break;
+
+        case "chat:error":
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: "assistant",
+              eventType: "error",
+              content: msg.message,
+              timestamp: new Date().toISOString(),
+            },
+          ]);
+          break;
+
+        case "chat:history":
+          setMessages(
+            msg.messages.map((m) => ({
+              role: m.role,
+              eventType: m.eventType,
+              content: m.content,
+              metadata: m.metadata,
+              timestamp: m.timestamp,
+            })),
+          );
+          break;
+      }
+    };
+
+    ws.onclose = () => {
+      setConnected(false);
+    };
+
+    return () => {
+      ws.close();
+    };
+  }, [sessionId, onCostUpdate]);
+
+  const sendMessage = useCallback(() => {
+    if (!input.trim() || !wsRef.current || status !== "idle") return;
+    wsRef.current.send(JSON.stringify({ type: "message", content: input.trim() }));
+    setInput("");
+    setMessageCost(null);
+  }, [input, status]);
+
+  const handleInterrupt = useCallback(() => {
+    wsRef.current?.send(JSON.stringify({ type: "interrupt" }));
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage();
+      }
+    },
+    [sendMessage],
+  );
+
+  const toggleToolCollapse = useCallback((index: number) => {
+    setCollapsedTools((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  }, []);
+
+  // Group consecutive assistant messages for rendering
+  const groups = groupMessages(messages);
+
+  return (
+    <div className="h-full flex flex-col bg-bg">
+      {/* Header */}
+      <div className="shrink-0 flex items-center justify-between px-4 py-2.5 border-b border-border bg-bg-card">
+        <div className="flex items-center gap-2 text-xs text-text-muted">
+          <Bot className="w-3.5 h-3.5 text-primary" />
+          <span className="font-medium">Agent Chat</span>
+          <span
+            className={cn(
+              "w-1.5 h-1.5 rounded-full",
+              connected ? "bg-success animate-pulse" : "bg-text-muted/30",
+            )}
+          />
+          {status !== "idle" && (
+            <span className="text-primary text-[11px] flex items-center gap-1">
+              {status === "thinking" ? (
+                <>
+                  <Brain className="w-3 h-3 animate-pulse" />
+                  Thinking...
+                </>
+              ) : (
+                <>
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                  Responding...
+                </>
+              )}
+            </span>
+          )}
+        </div>
+        {messageCost && (
+          <span className="text-[10px] text-text-muted flex items-center gap-0.5 tabular-nums">
+            <DollarSign className="w-2.5 h-2.5" />
+            {parseFloat(messageCost).toFixed(4)} last message
+          </span>
+        )}
+      </div>
+
+      {/* Messages area */}
+      <div className="flex-1 overflow-auto px-4 py-3 space-y-1">
+        {groups.length === 0 && (
+          <div className="flex items-center justify-center h-full">
+            <div className="text-center text-text-muted/40">
+              <Bot className="w-10 h-10 mx-auto mb-3 opacity-30" />
+              <p className="text-sm font-medium">Agent Chat</p>
+              <p className="text-xs mt-1">Send a message to start working with the AI agent.</p>
+              <p className="text-xs mt-0.5">
+                The agent can read, edit, and run commands in this workspace.
+              </p>
+            </div>
+          </div>
+        )}
+        {groups.map((group, gi) => (
+          <MessageGroup
+            key={gi}
+            group={group}
+            groupIndex={gi}
+            collapsedTools={collapsedTools}
+            onToggleToolCollapse={toggleToolCollapse}
+          />
+        ))}
+        {/* Typing indicator */}
+        {status !== "idle" && (
+          <div className="flex items-start gap-2 py-1">
+            <div className="shrink-0 w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center mt-0.5">
+              <Bot className="w-3 h-3 text-primary" />
+            </div>
+            <div className="flex items-center gap-1 text-xs text-text-muted py-1">
+              <span className="inline-flex gap-0.5">
+                <span
+                  className="w-1 h-1 rounded-full bg-text-muted animate-bounce"
+                  style={{ animationDelay: "0ms" }}
+                />
+                <span
+                  className="w-1 h-1 rounded-full bg-text-muted animate-bounce"
+                  style={{ animationDelay: "150ms" }}
+                />
+                <span
+                  className="w-1 h-1 rounded-full bg-text-muted animate-bounce"
+                  style={{ animationDelay: "300ms" }}
+                />
+              </span>
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input area */}
+      <div className="shrink-0 border-t border-border bg-bg-card p-3">
+        <div className="flex items-end gap-2">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={
+              !connected
+                ? "Connecting..."
+                : status !== "idle"
+                  ? "Agent is working..."
+                  : "Send a message to the agent..."
+            }
+            disabled={!connected}
+            rows={1}
+            className={cn(
+              "flex-1 bg-bg border border-border rounded-lg px-3 py-2 text-sm resize-none",
+              "placeholder:text-text-muted/40 outline-none focus:border-primary/50 transition-colors",
+              "min-h-[38px] max-h-[120px]",
+              !connected && "opacity-50",
+            )}
+            style={{ fieldSizing: "content" as any }}
+          />
+          {status !== "idle" ? (
+            <button
+              onClick={handleInterrupt}
+              className="shrink-0 p-2 rounded-lg bg-error/10 text-error hover:bg-error/20 transition-colors"
+              title="Interrupt agent"
+            >
+              <Square className="w-4 h-4" />
+            </button>
+          ) : (
+            <button
+              onClick={sendMessage}
+              disabled={!input.trim() || !connected}
+              className={cn(
+                "shrink-0 p-2 rounded-lg transition-colors",
+                input.trim() && connected
+                  ? "bg-primary text-white hover:bg-primary/90"
+                  : "bg-bg border border-border text-text-muted/30",
+              )}
+              title="Send message (Enter)"
+            >
+              <Send className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Message grouping ────────────────────────────────────────────────────────
+
+type MessageGroupData =
+  | { type: "user"; message: ChatMessage }
+  | {
+      type: "assistant";
+      events: Array<{ message: ChatMessage; originalIndex: number }>;
+    };
+
+function groupMessages(messages: ChatMessage[]): MessageGroupData[] {
+  const groups: MessageGroupData[] = [];
+  let currentAssistantEvents: Array<{ message: ChatMessage; originalIndex: number }> = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "user") {
+      if (currentAssistantEvents.length > 0) {
+        groups.push({ type: "assistant", events: currentAssistantEvents });
+        currentAssistantEvents = [];
+      }
+      groups.push({ type: "user", message: msg });
+    } else {
+      currentAssistantEvents.push({ message: msg, originalIndex: i });
+    }
+  }
+
+  if (currentAssistantEvents.length > 0) {
+    groups.push({ type: "assistant", events: currentAssistantEvents });
+  }
+
+  return groups;
+}
+
+// ── Message rendering ───────────────────────────────────────────────────────
+
+function MessageGroup({
+  group,
+  groupIndex,
+  collapsedTools,
+  onToggleToolCollapse,
+}: {
+  group: MessageGroupData;
+  groupIndex: number;
+  collapsedTools: Set<number>;
+  onToggleToolCollapse: (index: number) => void;
+}) {
+  if (group.type === "user") {
+    return (
+      <div className="flex items-start gap-2 py-2">
+        <div className="shrink-0 w-5 h-5 rounded-full bg-bg-card border border-border flex items-center justify-center mt-0.5">
+          <User className="w-3 h-3 text-text-muted" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm whitespace-pre-wrap break-words">{group.message.content}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-2 py-2">
+      <div className="shrink-0 w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center mt-0.5">
+        <Bot className="w-3 h-3 text-primary" />
+      </div>
+      <div className="flex-1 min-w-0 space-y-0.5">
+        {group.events.map(({ message, originalIndex }) => (
+          <ChatEventLine
+            key={originalIndex}
+            message={message}
+            index={originalIndex}
+            isCollapsed={collapsedTools.has(originalIndex)}
+            onToggleCollapse={() => onToggleToolCollapse(originalIndex)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChatEventLine({
+  message,
+  index,
+  isCollapsed,
+  onToggleCollapse,
+}: {
+  message: ChatMessage;
+  index: number;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+}) {
+  const { eventType, content, metadata } = message;
+
+  if (eventType === "text") {
+    return (
+      <div className="text-sm whitespace-pre-wrap break-words text-text/90 leading-relaxed">
+        {content}
+      </div>
+    );
+  }
+
+  if (eventType === "thinking") {
+    return (
+      <div className="text-xs text-text-muted/50 italic pl-3 border-l-2 border-text-muted/15 py-1 my-1">
+        {content.length > 200 ? content.slice(0, 200) + "..." : content}
+      </div>
+    );
+  }
+
+  if (eventType === "tool_use") {
+    const toolName = (metadata?.toolName as string) ?? "Tool";
+    const Icon = TOOL_ICONS[toolName] ?? Wrench;
+
+    return (
+      <div className="rounded-md border border-border/50 my-1 overflow-hidden text-xs">
+        <button
+          onClick={onToggleCollapse}
+          className="flex items-center gap-1.5 w-full px-2.5 py-1.5 text-left bg-bg-card hover:bg-bg-card-hover transition-colors"
+        >
+          {isCollapsed ? (
+            <ChevronRight className="w-2.5 h-2.5 text-text-muted/40 shrink-0" />
+          ) : (
+            <ChevronDown className="w-2.5 h-2.5 text-text-muted/40 shrink-0" />
+          )}
+          <Icon className="w-3 h-3 text-primary shrink-0" />
+          <span className="font-medium text-primary font-sans">{toolName}</span>
+          <span className="text-text-muted/60 truncate flex-1">{content}</span>
+        </button>
+      </div>
+    );
+  }
+
+  if (eventType === "tool_result") {
+    if (isCollapsed) return null;
+    return (
+      <div className="text-[11px] text-text-muted/50 pl-4 py-1 max-h-40 overflow-auto">
+        <pre className="whitespace-pre-wrap break-all">{content}</pre>
+      </div>
+    );
+  }
+
+  if (eventType === "system") {
+    return (
+      <div className="flex items-center gap-1.5 py-1 text-info/50 text-[11px]">
+        <Info className="w-3 h-3 shrink-0" />
+        <span>{content}</span>
+      </div>
+    );
+  }
+
+  if (eventType === "error") {
+    return (
+      <div className="flex items-start gap-1.5 py-1.5 px-2 rounded-md bg-error/5 text-error text-xs my-1">
+        <AlertCircle className="w-3 h-3 mt-0.5 shrink-0" />
+        <span className="whitespace-pre-wrap">{content}</span>
+      </div>
+    );
+  }
+
+  if (eventType === "info") {
+    const cost = metadata?.cost as number | undefined;
+    return (
+      <div className="flex items-start gap-1.5 py-1 text-success/80 text-xs">
+        <ChevronRight className="w-3 h-3 mt-0.5 shrink-0" />
+        <span className="whitespace-pre-wrap">{content}</span>
+        {cost != null && cost > 0 && (
+          <span className="ml-1 text-text-muted/40 inline-flex items-center gap-0.5 tabular-nums">
+            <DollarSign className="w-2.5 h-2.5" />
+            {cost.toFixed(4)}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  // Fallback
+  return <div className="text-xs text-text-muted py-0.5">{content}</div>;
+}

--- a/apps/web/src/components/session-terminal.tsx
+++ b/apps/web/src/components/session-terminal.tsx
@@ -1,16 +1,32 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { Bot } from "lucide-react";
 import "@xterm/xterm/css/xterm.css";
 
 const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? "ws://localhost:4000";
 
-export function SessionTerminal({ sessionId }: { sessionId: string }) {
+interface SessionTerminalProps {
+  sessionId: string;
+  onSendToAgent?: (text: string) => void;
+}
+
+export function SessionTerminal({ sessionId, onSendToAgent }: SessionTerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<XTerm | null>(null);
+  const [hasSelection, setHasSelection] = useState(false);
+
+  const handleSendSelection = useCallback(() => {
+    const term = termRef.current;
+    if (!term || !onSendToAgent) return;
+    const selection = term.getSelection();
+    if (selection) {
+      onSendToAgent(`Fix this:\n\`\`\`\n${selection}\n\`\`\``);
+    }
+  }, [onSendToAgent]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -41,6 +57,11 @@ export function SessionTerminal({ sessionId }: { sessionId: string }) {
     term.open(containerRef.current);
     fitAddon.fit();
     termRef.current = term;
+
+    // Track selection state
+    term.onSelectionChange(() => {
+      setHasSelection(!!term.getSelection());
+    });
 
     // WebSocket connection to session terminal
     const ws = new WebSocket(`${WS_URL}/ws/sessions/${sessionId}/terminal`);
@@ -100,8 +121,19 @@ export function SessionTerminal({ sessionId }: { sessionId: string }) {
   }, [sessionId]);
 
   return (
-    <div className="h-full bg-[#09090b]">
+    <div className="h-full bg-[#09090b] relative">
       <div ref={containerRef} className="h-full" />
+      {/* Send to agent floating button */}
+      {hasSelection && onSendToAgent && (
+        <button
+          onClick={handleSendSelection}
+          className="absolute bottom-3 right-3 flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary text-white text-xs font-medium shadow-lg hover:bg-primary/90 transition-colors z-10"
+          title="Send selection to agent chat"
+        >
+          <Bot className="w-3 h-3" />
+          Send to Agent
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/split-pane.tsx
+++ b/apps/web/src/components/split-pane.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import { cn } from "@/lib/utils";
+import { PanelLeftClose, PanelRightClose } from "lucide-react";
+
+const STORAGE_KEY = "optio-session-split-ratio";
+const MIN_PANE_PCT = 15;
+const DEFAULT_RATIO = 50;
+
+interface SplitPaneProps {
+  left: React.ReactNode;
+  right: React.ReactNode;
+  leftLabel?: string;
+  rightLabel?: string;
+}
+
+export function SplitPane({ left, right, leftLabel, rightLabel }: SplitPaneProps) {
+  const [ratio, setRatio] = useState(() => {
+    if (typeof window === "undefined") return DEFAULT_RATIO;
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? parseFloat(stored) : DEFAULT_RATIO;
+  });
+  const [collapsed, setCollapsed] = useState<"left" | "right" | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragging = useRef(false);
+
+  // Persist ratio
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, String(ratio));
+  }, [ratio]);
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!dragging.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const pct = ((ev.clientX - rect.left) / rect.width) * 100;
+      const clamped = Math.max(MIN_PANE_PCT, Math.min(100 - MIN_PANE_PCT, pct));
+      setRatio(clamped);
+      setCollapsed(null);
+    };
+
+    const onMouseUp = () => {
+      dragging.current = false;
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }, []);
+
+  const leftWidth = collapsed === "left" ? 0 : collapsed === "right" ? 100 : ratio;
+  const rightWidth = 100 - leftWidth;
+
+  return (
+    <div ref={containerRef} className="flex h-full min-h-0 relative">
+      {/* Left pane */}
+      {leftWidth > 0 && (
+        <div className="min-h-0 overflow-hidden" style={{ width: `${leftWidth}%` }}>
+          {left}
+        </div>
+      )}
+
+      {/* Divider */}
+      <div
+        className={cn(
+          "shrink-0 flex flex-col items-center justify-center gap-1",
+          "w-[5px] bg-border/50 hover:bg-primary/30 transition-colors cursor-col-resize",
+          "group relative",
+        )}
+        onMouseDown={onMouseDown}
+      >
+        {/* Collapse buttons */}
+        <div className="absolute top-2 flex flex-col gap-1 z-10 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setCollapsed(collapsed === "left" ? null : "left");
+            }}
+            className="p-0.5 rounded bg-bg-card border border-border text-text-muted hover:text-text transition-colors"
+            title={
+              collapsed === "left" ? `Show ${leftLabel ?? "left"}` : `Hide ${leftLabel ?? "left"}`
+            }
+          >
+            <PanelLeftClose className="w-3 h-3" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setCollapsed(collapsed === "right" ? null : "right");
+            }}
+            className="p-0.5 rounded bg-bg-card border border-border text-text-muted hover:text-text transition-colors"
+            title={
+              collapsed === "right"
+                ? `Show ${rightLabel ?? "right"}`
+                : `Hide ${rightLabel ?? "right"}`
+            }
+          >
+            <PanelRightClose className="w-3 h-3" />
+          </button>
+        </div>
+      </div>
+
+      {/* Right pane */}
+      {rightWidth > 0 && (
+        <div className="min-h-0 overflow-hidden" style={{ width: `${rightWidth}%` }}>
+          {right}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/ws-client.ts
+++ b/apps/web/src/lib/ws-client.ts
@@ -102,3 +102,7 @@ export function createTerminalClient(taskId: string, tokenProvider?: TokenProvid
 export function createSessionTerminalClient(sessionId: string): WsClient {
   return new WsClient(`${WS_URL}/ws/sessions/${sessionId}/terminal`);
 }
+
+export function createSessionChatClient(sessionId: string): WsClient {
+  return new WsClient(`${WS_URL}/ws/sessions/${sessionId}/chat`);
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -8,6 +8,7 @@ export type WsEvent =
   | AuthFailedEvent
   | SessionCreatedEvent
   | SessionEndedEvent
+  | SessionCostUpdatedEvent
   | TaskCommentEvent;
 
 export interface TaskStateChangedEvent {
@@ -50,6 +51,13 @@ export interface SessionCreatedEvent {
 export interface SessionEndedEvent {
   type: "session:ended";
   sessionId: string;
+  timestamp: string;
+}
+
+export interface SessionCostUpdatedEvent {
+  type: "session:cost_updated";
+  sessionId: string;
+  costUsd: string;
   timestamp: string;
 }
 

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -31,3 +31,48 @@ export interface SessionPr {
 export interface CreateSessionInput {
   repoUrl: string;
 }
+
+// ── Chat types ──────────────────────────────────────────────────────────────
+
+export type ChatAgentStatus = "idle" | "thinking" | "responding";
+
+/** Client → Server messages on WS /ws/sessions/:id/chat */
+export type ChatClientMessage = { type: "message"; content: string } | { type: "interrupt" };
+
+/** Server → Client messages on WS /ws/sessions/:id/chat */
+export type ChatServerMessage =
+  | ChatEventMessage
+  | ChatStatusMessage
+  | ChatCostMessage
+  | ChatErrorMessage
+  | ChatHistoryMessage;
+
+export interface ChatEventMessage {
+  type: "chat:event";
+  role: "user" | "assistant";
+  eventType: "text" | "tool_use" | "tool_result" | "thinking" | "system" | "error" | "info";
+  content: string;
+  metadata?: Record<string, unknown>;
+  timestamp: string;
+}
+
+export interface ChatStatusMessage {
+  type: "chat:status";
+  status: ChatAgentStatus;
+}
+
+export interface ChatCostMessage {
+  type: "chat:cost";
+  totalCostUsd: string;
+  messageCostUsd?: string;
+}
+
+export interface ChatErrorMessage {
+  type: "chat:error";
+  message: string;
+}
+
+export interface ChatHistoryMessage {
+  type: "chat:history";
+  messages: ChatEventMessage[];
+}


### PR DESCRIPTION
## Summary

- Adds a resizable split-pane layout to sessions: **agent chat on the left, terminal on the right**, both operating on the same worktree
- New WebSocket endpoint (`WS /ws/sessions/:id/chat`) launches Claude Code per message, streams NDJSON events, and tracks cost
- Agent chat UI with streaming responses, tool use visibility (file reads/edits, commands), thinking indicators, and interrupt button
- **"Send to Agent" action**: select terminal output and send it as context to the chat pane
- Live cost counter and model badge in the session header
- Layout preference (split ratio) persisted in localStorage; either pane collapsible to full-width

## Changes

**Backend:**
- `apps/api/src/ws/session-chat.ts` — new WebSocket handler for agent chat
- `apps/api/src/services/interactive-session-service.ts` — `updateSessionCost()`, `getSessionWithRepoConfig()`
- `apps/api/src/routes/sessions.ts` — `GET /api/sessions/:id` now returns model config
- `apps/api/src/server.ts` — register new WebSocket route

**Frontend:**
- `apps/web/src/components/session-chat.tsx` — agent chat component
- `apps/web/src/components/split-pane.tsx` — resizable split pane component
- `apps/web/src/components/session-terminal.tsx` — added "Send to Agent" selection action
- `apps/web/src/app/sessions/[id]/page.tsx` — split pane layout, cost counter, model badge
- `apps/web/src/lib/ws-client.ts` — `createSessionChatClient()` factory

**Shared types:**
- `packages/shared/src/types/session.ts` — chat protocol types (`ChatClientMessage`, `ChatServerMessage`, etc.)
- `packages/shared/src/types/events.ts` — `SessionCostUpdatedEvent`

## Test plan

- [ ] Verify typecheck passes (`npx turbo typecheck`) — **done, all 10 tasks pass**
- [ ] Verify tests pass (`npx turbo test`) — **done, 216 tests pass**
- [ ] Verify web build succeeds (`cd apps/web && npx next build`) — **done**
- [ ] Create a session, verify split pane renders with chat on left and terminal on right
- [ ] Send a message in the chat pane, verify streaming response with tool use visibility
- [ ] Use interrupt button to cancel an in-progress response
- [ ] Select terminal output and verify "Send to Agent" button appears and pre-fills chat input
- [ ] Verify cost counter updates in header as agent responds
- [ ] Collapse left/right pane using divider buttons, verify they restore correctly
- [ ] Resize the split pane, navigate away and back, verify ratio persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)