### PR TITLE
fix: remove duplicate pnpm/yarn install from node and full Dockerfiles

### DIFF
--- a/images/full.Dockerfile
+++ b/images/full.Dockerfile
@@ -12,9 +12,8 @@ RUN apt-get update && apt-get install -y \
     docker.io \
     && rm -rf /var/lib/apt/lists/*
 
-# Node.js package managers
-RUN npm install -g pnpm yarn \
-    && curl -fsSL https://bun.sh/install | bash \
+# Node.js package managers (pnpm and yarn are already provided by corepack in the base image)
+RUN curl -fsSL https://bun.sh/install | bash \
     && mv /root/.bun/bin/bun /usr/local/bin/ \
     && rm -rf /root/.bun
 

--- a/images/node.Dockerfile
+++ b/images/node.Dockerfile
@@ -3,9 +3,8 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-# pnpm, yarn, bun
-RUN npm install -g pnpm yarn \
-    && curl -fsSL https://bun.sh/install | bash \
+# bun (pnpm and yarn are already provided by corepack in the base image)
+RUN curl -fsSL https://bun.sh/install | bash \
     && mv /root/.bun/bin/bun /usr/local/bin/ \
     && rm -rf /root/.bun
 


### PR DESCRIPTION
## Summary
- Remove `pnpm yarn` from `npm install -g` in `images/node.Dockerfile` and `images/full.Dockerfile`
- The base image (`images/base.Dockerfile`) already provides both via `corepack enable && corepack prepare pnpm@10 --activate`
- This fixes CI failures where `npm install -g yarn` conflicts with the existing corepack shim at `/usr/bin/yarn` (EEXIST error)

## Test plan
- [ ] CI build for the node agent image passes without EEXIST error
- [ ] CI build for the full agent image passes without EEXIST error
- [ ] `pnpm` and `yarn` are still available inside both images (provided by corepack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)