### PR TITLE
feat: MCP server and custom skills support for agents

### DIFF
--- a/apps/api/src/db/migrations/0024_mcp_servers_custom_skills.sql
+++ b/apps/api/src/db/migrations/0024_mcp_servers_custom_skills.sql
@@ -1,0 +1,38 @@
+-- MCP Servers table
+CREATE TABLE IF NOT EXISTS "mcp_servers" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" text NOT NULL,
+  "command" text NOT NULL,
+  "args" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "env" jsonb,
+  "install_command" text,
+  "scope" text NOT NULL DEFAULT 'global',
+  "repo_url" text,
+  "workspace_id" uuid,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "mcp_servers_scope_idx" ON "mcp_servers" USING btree ("scope");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "mcp_servers_repo_url_idx" ON "mcp_servers" USING btree ("repo_url");
+--> statement-breakpoint
+
+-- Custom Skills table
+CREATE TABLE IF NOT EXISTS "custom_skills" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" text NOT NULL,
+  "description" text,
+  "prompt" text NOT NULL,
+  "scope" text NOT NULL DEFAULT 'global',
+  "repo_url" text,
+  "workspace_id" uuid,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "custom_skills_scope_idx" ON "custom_skills" USING btree ("scope");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "custom_skills_repo_url_idx" ON "custom_skills" USING btree ("repo_url");

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1774972800000,
       "tag": "0023_task_dependencies_workflows",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1775059200000,
+      "tag": "0024_mcp_servers_custom_skills",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -495,6 +495,52 @@ export const workflowRuns = pgTable(
   (table) => [index("workflow_runs_template_id_idx").on(table.workflowTemplateId)],
 );
 
+// ── MCP Servers ──────────────────────────────────────────────────────────────
+
+export const mcpServers = pgTable(
+  "mcp_servers",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: text("name").notNull(),
+    command: text("command").notNull(),
+    args: jsonb("args").$type<string[]>().notNull().default([]),
+    env: jsonb("env").$type<Record<string, string>>(),
+    installCommand: text("install_command"),
+    scope: text("scope").notNull().default("global"), // "global" or repo URL
+    repoUrl: text("repo_url"), // null = global, set = repo-scoped
+    workspaceId: uuid("workspace_id"),
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("mcp_servers_scope_idx").on(table.scope),
+    index("mcp_servers_repo_url_idx").on(table.repoUrl),
+  ],
+);
+
+// ── Custom Skills ────────────────────────────────────────────────────────────
+
+export const customSkills = pgTable(
+  "custom_skills",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: text("name").notNull(),
+    description: text("description"),
+    prompt: text("prompt").notNull(), // markdown content
+    scope: text("scope").notNull().default("global"), // "global" or repo URL
+    repoUrl: text("repo_url"), // null = global, set = repo-scoped
+    workspaceId: uuid("workspace_id"),
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("custom_skills_scope_idx").on(table.scope),
+    index("custom_skills_repo_url_idx").on(table.repoUrl),
+  ],
+);
+
 export const promptTemplates = pgTable("prompt_templates", {
   id: uuid("id").primaryKey().defaultRandom(),
   name: text("name").notNull().unique(),

--- a/apps/api/src/routes/mcp-servers.ts
+++ b/apps/api/src/routes/mcp-servers.ts
@@ -1,0 +1,93 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import * as mcpService from "../services/mcp-server-service.js";
+
+const createMcpServerSchema = z.object({
+  name: z.string().min(1),
+  command: z.string().min(1),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  installCommand: z.string().optional(),
+  repoUrl: z.string().optional(),
+  enabled: z.boolean().optional(),
+});
+
+const updateMcpServerSchema = z.object({
+  name: z.string().min(1).optional(),
+  command: z.string().min(1).optional(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).nullable().optional(),
+  installCommand: z.string().nullable().optional(),
+  enabled: z.boolean().optional(),
+});
+
+export async function mcpServerRoutes(app: FastifyInstance) {
+  // List MCP servers (global or filtered by scope)
+  app.get("/api/mcp-servers", async (req, reply) => {
+    const query = req.query as { scope?: string };
+    const workspaceId = req.user?.workspaceId ?? null;
+    const servers = await mcpService.listMcpServers(query.scope, workspaceId);
+    reply.send({ servers });
+  });
+
+  // Get a single MCP server
+  app.get("/api/mcp-servers/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const server = await mcpService.getMcpServer(id);
+    if (!server) return reply.status(404).send({ error: "MCP server not found" });
+    reply.send({ server });
+  });
+
+  // Create a global MCP server
+  app.post("/api/mcp-servers", async (req, reply) => {
+    const input = createMcpServerSchema.parse(req.body);
+    const workspaceId = req.user?.workspaceId ?? null;
+    const server = await mcpService.createMcpServer(input, workspaceId);
+    reply.status(201).send({ server });
+  });
+
+  // Update an MCP server
+  app.patch("/api/mcp-servers/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const existing = await mcpService.getMcpServer(id);
+    if (!existing) return reply.status(404).send({ error: "MCP server not found" });
+    const input = updateMcpServerSchema.parse(req.body);
+    const server = await mcpService.updateMcpServer(id, input);
+    reply.send({ server });
+  });
+
+  // Delete an MCP server
+  app.delete("/api/mcp-servers/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const existing = await mcpService.getMcpServer(id);
+    if (!existing) return reply.status(404).send({ error: "MCP server not found" });
+    await mcpService.deleteMcpServer(id);
+    reply.status(204).send();
+  });
+
+  // List MCP servers for a specific repo (includes global servers)
+  app.get("/api/repos/:id/mcp-servers", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const { getRepo } = await import("../services/repo-service.js");
+    const repo = await getRepo(id);
+    if (!repo) return reply.status(404).send({ error: "Repo not found" });
+    const workspaceId = req.user?.workspaceId ?? null;
+    const servers = await mcpService.getMcpServersForTask(repo.repoUrl, workspaceId);
+    reply.send({ servers });
+  });
+
+  // Create a repo-scoped MCP server
+  app.post("/api/repos/:id/mcp-servers", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const { getRepo } = await import("../services/repo-service.js");
+    const repo = await getRepo(id);
+    if (!repo) return reply.status(404).send({ error: "Repo not found" });
+    const input = createMcpServerSchema.parse(req.body);
+    const workspaceId = req.user?.workspaceId ?? null;
+    const server = await mcpService.createMcpServer(
+      { ...input, repoUrl: repo.repoUrl },
+      workspaceId,
+    );
+    reply.status(201).send({ server });
+  });
+}

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -1,0 +1,63 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import * as skillService from "../services/skill-service.js";
+
+const createSkillSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  prompt: z.string().min(1),
+  repoUrl: z.string().optional(),
+  enabled: z.boolean().optional(),
+});
+
+const updateSkillSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().nullable().optional(),
+  prompt: z.string().min(1).optional(),
+  enabled: z.boolean().optional(),
+});
+
+export async function skillRoutes(app: FastifyInstance) {
+  // List skills (global or filtered by scope)
+  app.get("/api/skills", async (req, reply) => {
+    const query = req.query as { scope?: string };
+    const workspaceId = req.user?.workspaceId ?? null;
+    const skills = await skillService.listSkills(query.scope, workspaceId);
+    reply.send({ skills });
+  });
+
+  // Get a single skill
+  app.get("/api/skills/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const skill = await skillService.getSkill(id);
+    if (!skill) return reply.status(404).send({ error: "Skill not found" });
+    reply.send({ skill });
+  });
+
+  // Create a skill
+  app.post("/api/skills", async (req, reply) => {
+    const input = createSkillSchema.parse(req.body);
+    const workspaceId = req.user?.workspaceId ?? null;
+    const skill = await skillService.createSkill(input, workspaceId);
+    reply.status(201).send({ skill });
+  });
+
+  // Update a skill
+  app.patch("/api/skills/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const existing = await skillService.getSkill(id);
+    if (!existing) return reply.status(404).send({ error: "Skill not found" });
+    const input = updateSkillSchema.parse(req.body);
+    const skill = await skillService.updateSkill(id, input);
+    reply.send({ skill });
+  });
+
+  // Delete a skill
+  app.delete("/api/skills/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const existing = await skillService.getSkill(id);
+    if (!existing) return reply.status(404).send({ error: "Skill not found" });
+    await skillService.deleteSkill(id);
+    reply.status(204).send();
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -26,6 +26,8 @@ import { taskTemplateRoutes } from "./routes/task-templates.js";
 import { workspaceRoutes } from "./routes/workspaces.js";
 import { dependencyRoutes } from "./routes/dependencies.js";
 import { workflowRoutes } from "./routes/workflows.js";
+import { mcpServerRoutes } from "./routes/mcp-servers.js";
+import { skillRoutes } from "./routes/skills.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import { sessionTerminalWs } from "./ws/session-terminal.js";
@@ -86,6 +88,8 @@ export async function buildServer() {
   await app.register(workspaceRoutes);
   await app.register(dependencyRoutes);
   await app.register(workflowRoutes);
+  await app.register(mcpServerRoutes);
+  await app.register(skillRoutes);
 
   // WebSocket routes
   await app.register(logStreamWs);

--- a/apps/api/src/services/mcp-server-service.ts
+++ b/apps/api/src/services/mcp-server-service.ts
@@ -1,0 +1,222 @@
+import { eq, and, or, isNull } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { mcpServers } from "../db/schema.js";
+import type { McpServerConfig } from "@optio/shared";
+import { retrieveSecret } from "./secret-service.js";
+
+export async function listMcpServers(
+  scope?: string,
+  workspaceId?: string | null,
+): Promise<McpServerConfig[]> {
+  const conditions = [];
+  if (scope) conditions.push(eq(mcpServers.scope, scope));
+  if (workspaceId) {
+    conditions.push(or(eq(mcpServers.workspaceId, workspaceId), isNull(mcpServers.workspaceId))!);
+  }
+
+  const query =
+    conditions.length > 0
+      ? db
+          .select()
+          .from(mcpServers)
+          .where(and(...conditions))
+      : db.select().from(mcpServers);
+  const rows = await query;
+  return rows.map(mapRow);
+}
+
+export async function getMcpServer(id: string): Promise<McpServerConfig | null> {
+  const [row] = await db.select().from(mcpServers).where(eq(mcpServers.id, id));
+  return row ? mapRow(row) : null;
+}
+
+export async function createMcpServer(
+  input: {
+    name: string;
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+    installCommand?: string;
+    repoUrl?: string;
+    enabled?: boolean;
+  },
+  workspaceId?: string | null,
+): Promise<McpServerConfig> {
+  const [row] = await db
+    .insert(mcpServers)
+    .values({
+      name: input.name,
+      command: input.command,
+      args: input.args ?? [],
+      env: input.env ?? undefined,
+      installCommand: input.installCommand ?? undefined,
+      scope: input.repoUrl ?? "global",
+      repoUrl: input.repoUrl ?? undefined,
+      workspaceId: workspaceId ?? undefined,
+      enabled: input.enabled ?? true,
+    })
+    .returning();
+  return mapRow(row);
+}
+
+export async function updateMcpServer(
+  id: string,
+  input: {
+    name?: string;
+    command?: string;
+    args?: string[];
+    env?: Record<string, string> | null;
+    installCommand?: string | null;
+    enabled?: boolean;
+  },
+): Promise<McpServerConfig> {
+  const updates: Record<string, unknown> = { updatedAt: new Date() };
+  if (input.name !== undefined) updates.name = input.name;
+  if (input.command !== undefined) updates.command = input.command;
+  if (input.args !== undefined) updates.args = input.args;
+  if (input.env !== undefined) updates.env = input.env;
+  if (input.installCommand !== undefined) updates.installCommand = input.installCommand;
+  if (input.enabled !== undefined) updates.enabled = input.enabled;
+
+  const [row] = await db.update(mcpServers).set(updates).where(eq(mcpServers.id, id)).returning();
+  return mapRow(row);
+}
+
+export async function deleteMcpServer(id: string): Promise<void> {
+  await db.delete(mcpServers).where(eq(mcpServers.id, id));
+}
+
+/**
+ * Get all enabled MCP servers for a task (global + repo-scoped).
+ * Repo-scoped servers with the same name override global ones.
+ */
+export async function getMcpServersForTask(
+  repoUrl: string,
+  workspaceId?: string | null,
+): Promise<McpServerConfig[]> {
+  const conditions = [
+    eq(mcpServers.enabled, true),
+    or(eq(mcpServers.scope, "global"), eq(mcpServers.scope, repoUrl))!,
+  ];
+  if (workspaceId) {
+    conditions.push(or(eq(mcpServers.workspaceId, workspaceId), isNull(mcpServers.workspaceId))!);
+  }
+
+  const rows = await db
+    .select()
+    .from(mcpServers)
+    .where(and(...conditions));
+
+  // Repo-scoped servers override global ones with the same name
+  const byName = new Map<string, McpServerConfig>();
+  for (const row of rows) {
+    const config = mapRow(row);
+    const existing = byName.get(config.name);
+    if (!existing || (config.scope !== "global" && existing.scope === "global")) {
+      byName.set(config.name, config);
+    }
+  }
+  return Array.from(byName.values());
+}
+
+/**
+ * Resolve ${{SECRET_NAME}} references in MCP server env vars against Optio's secrets.
+ */
+export async function resolveSecretRefs(
+  env: Record<string, string>,
+  repoUrl: string,
+): Promise<Record<string, string>> {
+  const resolved: Record<string, string> = {};
+  const secretRefPattern = /\$\{\{([^}]+)\}\}/g;
+
+  for (const [key, value] of Object.entries(env)) {
+    let resolvedValue = value;
+    const matches = [...value.matchAll(secretRefPattern)];
+    for (const match of matches) {
+      const secretName = match[1].trim();
+      try {
+        // Try repo-scoped first, fall back to global
+        let secretValue: string;
+        try {
+          secretValue = await retrieveSecret(secretName, repoUrl);
+        } catch {
+          secretValue = await retrieveSecret(secretName, "global");
+        }
+        resolvedValue = resolvedValue.replace(match[0], secretValue);
+      } catch {
+        // Secret not found — leave the reference as-is so it's visible in logs
+      }
+    }
+    resolved[key] = resolvedValue;
+  }
+  return resolved;
+}
+
+/**
+ * Build the .mcp.json file content from a list of MCP server configs.
+ * Resolves secret references in env vars.
+ */
+export async function buildMcpJsonContent(
+  servers: McpServerConfig[],
+  repoUrl: string,
+): Promise<string> {
+  const mcpConfig: Record<
+    string,
+    { command: string; args: string[]; env?: Record<string, string> }
+  > = {};
+
+  for (const server of servers) {
+    // Resolve secret refs in args
+    const resolvedArgs: string[] = [];
+    const secretRefPattern = /\$\{\{([^}]+)\}\}/g;
+    for (const arg of server.args) {
+      let resolvedArg = arg;
+      const matches = [...arg.matchAll(secretRefPattern)];
+      for (const match of matches) {
+        const secretName = match[1].trim();
+        try {
+          let secretValue: string;
+          try {
+            secretValue = await retrieveSecret(secretName, repoUrl);
+          } catch {
+            secretValue = await retrieveSecret(secretName, "global");
+          }
+          resolvedArg = resolvedArg.replace(match[0], secretValue);
+        } catch {
+          // Leave as-is
+        }
+      }
+      resolvedArgs.push(resolvedArg);
+    }
+
+    const entry: { command: string; args: string[]; env?: Record<string, string> } = {
+      command: server.command,
+      args: resolvedArgs,
+    };
+
+    if (server.env && Object.keys(server.env).length > 0) {
+      entry.env = await resolveSecretRefs(server.env, repoUrl);
+    }
+
+    mcpConfig[server.name] = entry;
+  }
+
+  return JSON.stringify({ mcpServers: mcpConfig }, null, 2);
+}
+
+function mapRow(row: typeof mcpServers.$inferSelect): McpServerConfig {
+  return {
+    id: row.id,
+    name: row.name,
+    command: row.command,
+    args: (row.args as string[]) ?? [],
+    env: row.env as Record<string, string> | null,
+    installCommand: row.installCommand,
+    scope: row.scope,
+    repoUrl: row.repoUrl,
+    workspaceId: row.workspaceId,
+    enabled: row.enabled,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/apps/api/src/services/skill-service.ts
+++ b/apps/api/src/services/skill-service.ts
@@ -1,0 +1,146 @@
+import { eq, and, or, isNull } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { customSkills } from "../db/schema.js";
+import type { CustomSkillConfig } from "@optio/shared";
+
+export async function listSkills(
+  scope?: string,
+  workspaceId?: string | null,
+): Promise<CustomSkillConfig[]> {
+  const conditions = [];
+  if (scope) conditions.push(eq(customSkills.scope, scope));
+  if (workspaceId) {
+    conditions.push(
+      or(eq(customSkills.workspaceId, workspaceId), isNull(customSkills.workspaceId))!,
+    );
+  }
+
+  const query =
+    conditions.length > 0
+      ? db
+          .select()
+          .from(customSkills)
+          .where(and(...conditions))
+      : db.select().from(customSkills);
+  const rows = await query;
+  return rows.map(mapRow);
+}
+
+export async function getSkill(id: string): Promise<CustomSkillConfig | null> {
+  const [row] = await db.select().from(customSkills).where(eq(customSkills.id, id));
+  return row ? mapRow(row) : null;
+}
+
+export async function createSkill(
+  input: {
+    name: string;
+    description?: string;
+    prompt: string;
+    repoUrl?: string;
+    enabled?: boolean;
+  },
+  workspaceId?: string | null,
+): Promise<CustomSkillConfig> {
+  const [row] = await db
+    .insert(customSkills)
+    .values({
+      name: input.name,
+      description: input.description ?? undefined,
+      prompt: input.prompt,
+      scope: input.repoUrl ?? "global",
+      repoUrl: input.repoUrl ?? undefined,
+      workspaceId: workspaceId ?? undefined,
+      enabled: input.enabled ?? true,
+    })
+    .returning();
+  return mapRow(row);
+}
+
+export async function updateSkill(
+  id: string,
+  input: {
+    name?: string;
+    description?: string | null;
+    prompt?: string;
+    enabled?: boolean;
+  },
+): Promise<CustomSkillConfig> {
+  const updates: Record<string, unknown> = { updatedAt: new Date() };
+  if (input.name !== undefined) updates.name = input.name;
+  if (input.description !== undefined) updates.description = input.description;
+  if (input.prompt !== undefined) updates.prompt = input.prompt;
+  if (input.enabled !== undefined) updates.enabled = input.enabled;
+
+  const [row] = await db
+    .update(customSkills)
+    .set(updates)
+    .where(eq(customSkills.id, id))
+    .returning();
+  return mapRow(row);
+}
+
+export async function deleteSkill(id: string): Promise<void> {
+  await db.delete(customSkills).where(eq(customSkills.id, id));
+}
+
+/**
+ * Get all enabled skills for a task (global + repo-scoped).
+ * Repo-scoped skills with the same name override global ones.
+ */
+export async function getSkillsForTask(
+  repoUrl: string,
+  workspaceId?: string | null,
+): Promise<CustomSkillConfig[]> {
+  const conditions = [
+    eq(customSkills.enabled, true),
+    or(eq(customSkills.scope, "global"), eq(customSkills.scope, repoUrl))!,
+  ];
+  if (workspaceId) {
+    conditions.push(
+      or(eq(customSkills.workspaceId, workspaceId), isNull(customSkills.workspaceId))!,
+    );
+  }
+
+  const rows = await db
+    .select()
+    .from(customSkills)
+    .where(and(...conditions));
+
+  // Repo-scoped skills override global ones with the same name
+  const byName = new Map<string, CustomSkillConfig>();
+  for (const row of rows) {
+    const config = mapRow(row);
+    const existing = byName.get(config.name);
+    if (!existing || (config.scope !== "global" && existing.scope === "global")) {
+      byName.set(config.name, config);
+    }
+  }
+  return Array.from(byName.values());
+}
+
+/**
+ * Build setup files for custom skills to be written to .claude/commands/ in the worktree.
+ */
+export function buildSkillSetupFiles(
+  skills: CustomSkillConfig[],
+): Array<{ path: string; content: string }> {
+  return skills.map((skill) => ({
+    path: `.claude/commands/${skill.name}.md`,
+    content: skill.prompt,
+  }));
+}
+
+function mapRow(row: typeof customSkills.$inferSelect): CustomSkillConfig {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    prompt: row.prompt,
+    scope: row.scope,
+    repoUrl: row.repoUrl,
+    workspaceId: row.workspaceId,
+    enabled: row.enabled,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -229,6 +229,40 @@ export function startTaskWorker() {
           claudeEffort: repoConfig?.claudeEffort ?? undefined,
         });
 
+        // ── MCP servers & custom skills injection ────────────────────
+        const { getMcpServersForTask, buildMcpJsonContent } =
+          await import("../services/mcp-server-service.js");
+        const { getSkillsForTask, buildSkillSetupFiles } =
+          await import("../services/skill-service.js");
+
+        const taskWorkspaceId = (task as any).workspaceId ?? null;
+        const mcpServers = await getMcpServersForTask(task.repoUrl, taskWorkspaceId);
+        if (mcpServers.length > 0) {
+          const mcpJsonContent = await buildMcpJsonContent(mcpServers, task.repoUrl);
+          agentConfig.setupFiles = agentConfig.setupFiles ?? [];
+          agentConfig.setupFiles.push({
+            path: ".mcp.json",
+            content: mcpJsonContent,
+          });
+
+          // Collect install commands
+          const installCommands = mcpServers
+            .filter((s) => s.installCommand)
+            .map((s) => s.installCommand!);
+          if (installCommands.length > 0) {
+            agentConfig.env.OPTIO_MCP_INSTALL_COMMANDS = installCommands.join(" && ");
+          }
+          log.info({ count: mcpServers.length }, "Injecting MCP servers");
+        }
+
+        const skills = await getSkillsForTask(task.repoUrl, taskWorkspaceId);
+        if (skills.length > 0) {
+          agentConfig.setupFiles = agentConfig.setupFiles ?? [];
+          const skillFiles = buildSkillSetupFiles(skills);
+          agentConfig.setupFiles.push(...skillFiles);
+          log.info({ count: skills.length }, "Injecting custom skills");
+        }
+
         // Encode setup files
         if (agentConfig.setupFiles && agentConfig.setupFiles.length > 0) {
           agentConfig.env.OPTIO_SETUP_FILES = Buffer.from(

--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -20,6 +20,9 @@ import {
   Terminal,
   Plus,
   CircleDot,
+  Server,
+  Sparkles,
+  X,
 } from "lucide-react";
 import { formatRelativeTime, formatDuration } from "@/lib/utils";
 import { cn } from "@/lib/utils";
@@ -62,6 +65,22 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
   const [sessions, setSessions] = useState<any[]>([]);
   const [sessionCount, setSessionCount] = useState(0);
   const [creatingSession, setCreatingSession] = useState(false);
+
+  // MCP Servers
+  const [mcpServers, setMcpServers] = useState<any[]>([]);
+  const [showAddMcp, setShowAddMcp] = useState(false);
+  const [newMcpName, setNewMcpName] = useState("");
+  const [newMcpCommand, setNewMcpCommand] = useState("");
+  const [newMcpArgs, setNewMcpArgs] = useState("");
+  const [newMcpEnv, setNewMcpEnv] = useState("");
+  const [newMcpInstallCmd, setNewMcpInstallCmd] = useState("");
+
+  // Custom Skills
+  const [skills, setSkills] = useState<any[]>([]);
+  const [showAddSkill, setShowAddSkill] = useState(false);
+  const [newSkillName, setNewSkillName] = useState("");
+  const [newSkillDescription, setNewSkillDescription] = useState("");
+  const [newSkillPrompt, setNewSkillPrompt] = useState("");
 
   useEffect(() => {
     api
@@ -112,6 +131,19 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
       })
       .catch(() => {});
   }, [repo?.repoUrl]);
+
+  // Fetch MCP servers and skills for this repo
+  useEffect(() => {
+    if (!repo?.id) return;
+    api
+      .listRepoMcpServers(repo.id)
+      .then((res) => setMcpServers(res.servers))
+      .catch(() => {});
+    api
+      .listSkills(repo.repoUrl)
+      .then((res) => setSkills(res.skills))
+      .catch(() => {});
+  }, [repo?.id, repo?.repoUrl]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -609,6 +641,334 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
             className="w-48 px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
           />
         </div>
+      </section>
+
+      {/* MCP Servers */}
+      <section className="p-5 rounded-xl border border-border/50 bg-bg-card space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Server className="w-4 h-4 text-text-muted" />
+            <h2 className="text-sm font-medium">MCP Servers</h2>
+          </div>
+          <button
+            onClick={() => setShowAddMcp(!showAddMcp)}
+            className="flex items-center gap-1 text-xs text-primary hover:underline"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add Server
+          </button>
+        </div>
+        <p className="text-xs text-text-muted">
+          MCP servers give agents access to databases, APIs, and other tools. Servers configured
+          here are injected into the agent&apos;s <code className="text-primary">.mcp.json</code> at
+          runtime. Use <code className="text-primary">{"${{SECRET_NAME}}"}</code> to reference Optio
+          secrets in args or env vars.
+        </p>
+
+        {mcpServers.length > 0 && (
+          <div className="space-y-2">
+            {mcpServers.map((server: any) => (
+              <div
+                key={server.id}
+                className="flex items-center gap-3 p-3 rounded-lg border border-border bg-bg"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{server.name}</span>
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-hover text-text-muted">
+                      {server.scope === "global" ? "global" : "repo"}
+                    </span>
+                    {!server.enabled && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-warning/10 text-warning">
+                        disabled
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-text-muted mt-0.5 font-mono truncate">
+                    {server.command} {(server.args ?? []).join(" ")}
+                  </p>
+                </div>
+                <button
+                  onClick={async () => {
+                    await api.updateMcpServer(server.id, { enabled: !server.enabled });
+                    setMcpServers((prev) =>
+                      prev.map((s) => (s.id === server.id ? { ...s, enabled: !s.enabled } : s)),
+                    );
+                  }}
+                  className="text-xs text-text-muted hover:text-text"
+                >
+                  {server.enabled ? "Disable" : "Enable"}
+                </button>
+                {server.scope !== "global" && (
+                  <button
+                    onClick={async () => {
+                      await api.deleteMcpServer(server.id);
+                      setMcpServers((prev) => prev.filter((s) => s.id !== server.id));
+                      toast.success("MCP server removed");
+                    }}
+                    className="text-text-muted hover:text-error"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {showAddMcp && (
+          <div className="space-y-3 p-3 rounded-lg border border-primary/30 bg-primary/5">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-text-muted mb-1">Name</label>
+                <input
+                  value={newMcpName}
+                  onChange={(e) => setNewMcpName(e.target.value)}
+                  placeholder="postgres"
+                  className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-text-muted mb-1">Command</label>
+                <input
+                  value={newMcpCommand}
+                  onChange={(e) => setNewMcpCommand(e.target.value)}
+                  placeholder="npx"
+                  className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Args (one per line)</label>
+              <textarea
+                value={newMcpArgs}
+                onChange={(e) => setNewMcpArgs(e.target.value)}
+                rows={2}
+                placeholder={"-y\n@modelcontextprotocol/server-postgres\n${{POSTGRES_URL}}"}
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-y"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-text-muted mb-1">
+                Env vars (KEY=VALUE, one per line)
+              </label>
+              <textarea
+                value={newMcpEnv}
+                onChange={(e) => setNewMcpEnv(e.target.value)}
+                rows={2}
+                placeholder={"POSTGRES_URL=${{POSTGRES_URL}}"}
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-y"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-text-muted mb-1">
+                Install command (optional)
+              </label>
+              <input
+                value={newMcpInstallCmd}
+                onChange={(e) => setNewMcpInstallCmd(e.target.value)}
+                placeholder="npm install -g @modelcontextprotocol/server-postgres"
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  setShowAddMcp(false);
+                  setNewMcpName("");
+                  setNewMcpCommand("");
+                  setNewMcpArgs("");
+                  setNewMcpEnv("");
+                  setNewMcpInstallCmd("");
+                }}
+                className="px-3 py-1.5 rounded-md text-xs text-text-muted hover:bg-bg-hover"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={async () => {
+                  if (!newMcpName || !newMcpCommand) {
+                    toast.error("Name and command are required");
+                    return;
+                  }
+                  const args = newMcpArgs
+                    .split("\n")
+                    .map((a) => a.trim())
+                    .filter(Boolean);
+                  const env: Record<string, string> = {};
+                  for (const line of newMcpEnv.split("\n")) {
+                    const idx = line.indexOf("=");
+                    if (idx > 0) env[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+                  }
+                  const res = await api.createRepoMcpServer(id, {
+                    name: newMcpName,
+                    command: newMcpCommand,
+                    args: args.length > 0 ? args : undefined,
+                    env: Object.keys(env).length > 0 ? env : undefined,
+                    installCommand: newMcpInstallCmd || undefined,
+                  });
+                  setMcpServers((prev) => [...prev, res.server]);
+                  setShowAddMcp(false);
+                  setNewMcpName("");
+                  setNewMcpCommand("");
+                  setNewMcpArgs("");
+                  setNewMcpEnv("");
+                  setNewMcpInstallCmd("");
+                  toast.success("MCP server added");
+                }}
+                className="px-3 py-1.5 rounded-md bg-primary text-white text-xs font-medium hover:bg-primary-hover"
+              >
+                Add Server
+              </button>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Custom Skills */}
+      <section className="p-5 rounded-xl border border-border/50 bg-bg-card space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-text-muted" />
+            <h2 className="text-sm font-medium">Custom Skills</h2>
+          </div>
+          <button
+            onClick={() => setShowAddSkill(!showAddSkill)}
+            className="flex items-center gap-1 text-xs text-primary hover:underline"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add Skill
+          </button>
+        </div>
+        <p className="text-xs text-text-muted">
+          Custom skills are reusable prompt commands written to{" "}
+          <code className="text-primary">.claude/commands/</code> before the agent starts. The agent
+          can invoke them as slash commands.
+        </p>
+
+        {skills.filter((s: any) => s.scope === repo.repoUrl || s.scope === "global").length > 0 && (
+          <div className="space-y-2">
+            {skills
+              .filter((s: any) => s.scope === repo.repoUrl || s.scope === "global")
+              .map((skill: any) => (
+                <div
+                  key={skill.id}
+                  className="flex items-center gap-3 p-3 rounded-lg border border-border bg-bg"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium">/{skill.name}</span>
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-hover text-text-muted">
+                        {skill.scope === "global" ? "global" : "repo"}
+                      </span>
+                      {!skill.enabled && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-warning/10 text-warning">
+                          disabled
+                        </span>
+                      )}
+                    </div>
+                    {skill.description && (
+                      <p className="text-xs text-text-muted mt-0.5 truncate">{skill.description}</p>
+                    )}
+                  </div>
+                  <button
+                    onClick={async () => {
+                      await api.updateSkill(skill.id, { enabled: !skill.enabled });
+                      setSkills((prev) =>
+                        prev.map((s) => (s.id === skill.id ? { ...s, enabled: !s.enabled } : s)),
+                      );
+                    }}
+                    className="text-xs text-text-muted hover:text-text"
+                  >
+                    {skill.enabled ? "Disable" : "Enable"}
+                  </button>
+                  {skill.scope !== "global" && (
+                    <button
+                      onClick={async () => {
+                        await api.deleteSkill(skill.id);
+                        setSkills((prev) => prev.filter((s) => s.id !== skill.id));
+                        toast.success("Skill removed");
+                      }}
+                      className="text-text-muted hover:text-error"
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </button>
+                  )}
+                </div>
+              ))}
+          </div>
+        )}
+
+        {showAddSkill && (
+          <div className="space-y-3 p-3 rounded-lg border border-primary/30 bg-primary/5">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-text-muted mb-1">Name</label>
+                <input
+                  value={newSkillName}
+                  onChange={(e) => setNewSkillName(e.target.value)}
+                  placeholder="run-tests"
+                  className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-text-muted mb-1">Description</label>
+                <input
+                  value={newSkillDescription}
+                  onChange={(e) => setNewSkillDescription(e.target.value)}
+                  placeholder="Run the full test suite"
+                  className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Prompt (markdown)</label>
+              <textarea
+                value={newSkillPrompt}
+                onChange={(e) => setNewSkillPrompt(e.target.value)}
+                rows={6}
+                placeholder="Run the full test suite and analyze any failures..."
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-y"
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  setShowAddSkill(false);
+                  setNewSkillName("");
+                  setNewSkillDescription("");
+                  setNewSkillPrompt("");
+                }}
+                className="px-3 py-1.5 rounded-md text-xs text-text-muted hover:bg-bg-hover"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={async () => {
+                  if (!newSkillName || !newSkillPrompt) {
+                    toast.error("Name and prompt are required");
+                    return;
+                  }
+                  const res = await api.createSkill({
+                    name: newSkillName,
+                    description: newSkillDescription || undefined,
+                    prompt: newSkillPrompt,
+                    repoUrl: repo.repoUrl,
+                  });
+                  setSkills((prev) => [...prev, res.skill]);
+                  setShowAddSkill(false);
+                  setNewSkillName("");
+                  setNewSkillDescription("");
+                  setNewSkillPrompt("");
+                  toast.success("Skill added");
+                }}
+                className="px-3 py-1.5 rounded-md bg-primary text-white text-xs font-medium hover:bg-primary-hover"
+              >
+                Add Skill
+              </button>
+            </div>
+          </div>
+        )}
       </section>
 
       {/* Image */}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -4,7 +4,18 @@ import { useState, useEffect } from "react";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { api } from "@/lib/api-client";
 import { toast } from "sonner";
-import { Loader2, Bell, RefreshCw, Shield, CheckCircle2, XCircle } from "lucide-react";
+import {
+  Loader2,
+  Bell,
+  RefreshCw,
+  Shield,
+  CheckCircle2,
+  XCircle,
+  Server,
+  Sparkles,
+  Plus,
+  X,
+} from "lucide-react";
 
 function PromptTemplateEditor() {
   const [template, setTemplate] = useState("");
@@ -299,6 +310,372 @@ function DefaultReviewEditor() {
   );
 }
 
+function GlobalMcpServers() {
+  const [servers, setServers] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAdd, setShowAdd] = useState(false);
+  const [name, setName] = useState("");
+  const [command, setCommand] = useState("");
+  const [args, setArgs] = useState("");
+  const [env, setEnv] = useState("");
+  const [installCmd, setInstallCmd] = useState("");
+
+  useEffect(() => {
+    api
+      .listMcpServers("global")
+      .then((res) => setServers(res.servers))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="p-5 rounded-xl border border-border/50 bg-bg-card text-center text-text-muted text-sm">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" /> Loading...
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-5 rounded-xl border border-border/50 bg-bg-card space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-text-muted">
+          Global MCP servers are available to all repos. Use{" "}
+          <code className="text-primary">{"${{SECRET_NAME}}"}</code> to reference Optio secrets.
+        </p>
+        <button
+          onClick={() => setShowAdd(!showAdd)}
+          className="flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          Add
+        </button>
+      </div>
+
+      {servers.length > 0 && (
+        <div className="space-y-2">
+          {servers.map((server: any) => (
+            <div
+              key={server.id}
+              className="flex items-center gap-3 p-3 rounded-lg border border-border bg-bg"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{server.name}</span>
+                  {!server.enabled && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-warning/10 text-warning">
+                      disabled
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-text-muted mt-0.5 font-mono truncate">
+                  {server.command} {(server.args ?? []).join(" ")}
+                </p>
+              </div>
+              <button
+                onClick={async () => {
+                  await api.updateMcpServer(server.id, { enabled: !server.enabled });
+                  setServers((prev) =>
+                    prev.map((s) => (s.id === server.id ? { ...s, enabled: !s.enabled } : s)),
+                  );
+                }}
+                className="text-xs text-text-muted hover:text-text"
+              >
+                {server.enabled ? "Disable" : "Enable"}
+              </button>
+              <button
+                onClick={async () => {
+                  await api.deleteMcpServer(server.id);
+                  setServers((prev) => prev.filter((s) => s.id !== server.id));
+                  toast.success("MCP server removed");
+                }}
+                className="text-text-muted hover:text-error"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {servers.length === 0 && !showAdd && (
+        <p className="text-xs text-text-muted/60 text-center py-2">
+          No global MCP servers configured.
+        </p>
+      )}
+
+      {showAdd && (
+        <div className="space-y-3 p-3 rounded-lg border border-primary/30 bg-primary/5">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Name</label>
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="postgres"
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Command</label>
+              <input
+                value={command}
+                onChange={(e) => setCommand(e.target.value)}
+                placeholder="npx"
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs text-text-muted mb-1">Args (one per line)</label>
+            <textarea
+              value={args}
+              onChange={(e) => setArgs(e.target.value)}
+              rows={2}
+              placeholder={"-y\n@modelcontextprotocol/server-postgres"}
+              className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-y"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-text-muted mb-1">
+              Env vars (KEY=VALUE, one per line)
+            </label>
+            <textarea
+              value={env}
+              onChange={(e) => setEnv(e.target.value)}
+              rows={2}
+              placeholder={"POSTGRES_URL=${{POSTGRES_URL}}"}
+              className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-y"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-text-muted mb-1">Install command (optional)</label>
+            <input
+              value={installCmd}
+              onChange={(e) => setInstallCmd(e.target.value)}
+              placeholder="npm install -g @modelcontextprotocol/server-postgres"
+              className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={() => {
+                setShowAdd(false);
+                setName("");
+                setCommand("");
+                setArgs("");
+                setEnv("");
+                setInstallCmd("");
+              }}
+              className="px-3 py-1.5 rounded-md text-xs text-text-muted hover:bg-bg-hover"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={async () => {
+                if (!name || !command) {
+                  toast.error("Name and command are required");
+                  return;
+                }
+                const parsedArgs = args
+                  .split("\n")
+                  .map((a) => a.trim())
+                  .filter(Boolean);
+                const parsedEnv: Record<string, string> = {};
+                for (const line of env.split("\n")) {
+                  const idx = line.indexOf("=");
+                  if (idx > 0) parsedEnv[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+                }
+                const res = await api.createMcpServer({
+                  name,
+                  command,
+                  args: parsedArgs.length > 0 ? parsedArgs : undefined,
+                  env: Object.keys(parsedEnv).length > 0 ? parsedEnv : undefined,
+                  installCommand: installCmd || undefined,
+                });
+                setServers((prev) => [...prev, res.server]);
+                setShowAdd(false);
+                setName("");
+                setCommand("");
+                setArgs("");
+                setEnv("");
+                setInstallCmd("");
+                toast.success("MCP server added");
+              }}
+              className="px-3 py-1.5 rounded-md bg-primary text-white text-xs font-medium hover:bg-primary-hover"
+            >
+              Add Server
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GlobalSkills() {
+  const [skills, setSkills] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAdd, setShowAdd] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [prompt, setPrompt] = useState("");
+
+  useEffect(() => {
+    api
+      .listSkills("global")
+      .then((res) => setSkills(res.skills))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="p-5 rounded-xl border border-border/50 bg-bg-card text-center text-text-muted text-sm">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" /> Loading...
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-5 rounded-xl border border-border/50 bg-bg-card space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-text-muted">
+          Global skills are available as slash commands to agents in all repos. Written to{" "}
+          <code className="text-primary">.claude/commands/</code> before the agent starts.
+        </p>
+        <button
+          onClick={() => setShowAdd(!showAdd)}
+          className="flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          Add
+        </button>
+      </div>
+
+      {skills.length > 0 && (
+        <div className="space-y-2">
+          {skills.map((skill: any) => (
+            <div
+              key={skill.id}
+              className="flex items-center gap-3 p-3 rounded-lg border border-border bg-bg"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">/{skill.name}</span>
+                  {!skill.enabled && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-warning/10 text-warning">
+                      disabled
+                    </span>
+                  )}
+                </div>
+                {skill.description && (
+                  <p className="text-xs text-text-muted mt-0.5 truncate">{skill.description}</p>
+                )}
+              </div>
+              <button
+                onClick={async () => {
+                  await api.updateSkill(skill.id, { enabled: !skill.enabled });
+                  setSkills((prev) =>
+                    prev.map((s) => (s.id === skill.id ? { ...s, enabled: !s.enabled } : s)),
+                  );
+                }}
+                className="text-xs text-text-muted hover:text-text"
+              >
+                {skill.enabled ? "Disable" : "Enable"}
+              </button>
+              <button
+                onClick={async () => {
+                  await api.deleteSkill(skill.id);
+                  setSkills((prev) => prev.filter((s) => s.id !== skill.id));
+                  toast.success("Skill removed");
+                }}
+                className="text-text-muted hover:text-error"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {skills.length === 0 && !showAdd && (
+        <p className="text-xs text-text-muted/60 text-center py-2">No global skills configured.</p>
+      )}
+
+      {showAdd && (
+        <div className="space-y-3 p-3 rounded-lg border border-primary/30 bg-primary/5">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Name</label>
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="run-tests"
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Description</label>
+              <input
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Run the full test suite"
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs text-text-muted mb-1">Prompt (markdown)</label>
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              rows={6}
+              placeholder="Run the full test suite and analyze any failures..."
+              className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-y"
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={() => {
+                setShowAdd(false);
+                setName("");
+                setDescription("");
+                setPrompt("");
+              }}
+              className="px-3 py-1.5 rounded-md text-xs text-text-muted hover:bg-bg-hover"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={async () => {
+                if (!name || !prompt) {
+                  toast.error("Name and prompt are required");
+                  return;
+                }
+                const res = await api.createSkill({
+                  name,
+                  description: description || undefined,
+                  prompt,
+                });
+                setSkills((prev) => [...prev, res.skill]);
+                setShowAdd(false);
+                setName("");
+                setDescription("");
+                setPrompt("");
+                toast.success("Skill added");
+              }}
+              className="px-3 py-1.5 rounded-md bg-primary text-white text-xs font-medium hover:bg-primary-hover"
+            >
+              Add Skill
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function AuthenticationSettings() {
   const [providers, setProviders] = useState<Array<{ name: string; displayName: string }>>([]);
   const [authDisabled, setAuthDisabled] = useState(false);
@@ -504,6 +881,24 @@ export default function SettingsPage() {
             Sync Now
           </button>
         </div>
+      </section>
+
+      {/* MCP Servers */}
+      <section>
+        <h2 className="text-sm font-medium text-text-muted mb-3 flex items-center gap-2">
+          <Server className="w-4 h-4" />
+          Global MCP Servers
+        </h2>
+        <GlobalMcpServers />
+      </section>
+
+      {/* Custom Skills */}
+      <section>
+        <h2 className="text-sm font-medium text-text-muted mb-3 flex items-center gap-2">
+          <Sparkles className="w-4 h-4" />
+          Global Custom Skills
+        </h2>
+        <GlobalSkills />
       </section>
 
       {/* Prompt Template */}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -806,4 +806,81 @@ export const api = {
     request<{ runs: any[] }>(`/api/workflows/${templateId}/runs`),
 
   getWorkflowRun: (id: string) => request<{ workflowRun: any }>(`/api/workflow-runs/${id}`),
+
+  // MCP Servers
+  listMcpServers: (scope?: string) => {
+    const qs = scope ? `?scope=${encodeURIComponent(scope)}` : "";
+    return request<{ servers: any[] }>(`/api/mcp-servers${qs}`);
+  },
+
+  getMcpServer: (id: string) => request<{ server: any }>(`/api/mcp-servers/${id}`),
+
+  createMcpServer: (data: {
+    name: string;
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+    installCommand?: string;
+    repoUrl?: string;
+    enabled?: boolean;
+  }) =>
+    request<{ server: any }>("/api/mcp-servers", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+
+  updateMcpServer: (id: string, data: Record<string, unknown>) =>
+    request<{ server: any }>(`/api/mcp-servers/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    }),
+
+  deleteMcpServer: (id: string) => request<void>(`/api/mcp-servers/${id}`, { method: "DELETE" }),
+
+  listRepoMcpServers: (repoId: string) =>
+    request<{ servers: any[] }>(`/api/repos/${repoId}/mcp-servers`),
+
+  createRepoMcpServer: (
+    repoId: string,
+    data: {
+      name: string;
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+      installCommand?: string;
+      enabled?: boolean;
+    },
+  ) =>
+    request<{ server: any }>(`/api/repos/${repoId}/mcp-servers`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+
+  // Custom Skills
+  listSkills: (scope?: string) => {
+    const qs = scope ? `?scope=${encodeURIComponent(scope)}` : "";
+    return request<{ skills: any[] }>(`/api/skills${qs}`);
+  },
+
+  getSkill: (id: string) => request<{ skill: any }>(`/api/skills/${id}`),
+
+  createSkill: (data: {
+    name: string;
+    description?: string;
+    prompt: string;
+    repoUrl?: string;
+    enabled?: boolean;
+  }) =>
+    request<{ skill: any }>("/api/skills", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+
+  updateSkill: (id: string, data: Record<string, unknown>) =>
+    request<{ skill: any }>(`/api/skills/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    }),
+
+  deleteSkill: (id: string) => request<void>(`/api/skills/${id}`, { method: "DELETE" }),
 };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,3 +14,4 @@ export * from "./prompt-template.js";
 export * from "./types/image.js";
 export * from "./error-classifier.js";
 export * from "./types/session.js";
+export * from "./types/mcp.js";

--- a/packages/shared/src/types/mcp.ts
+++ b/packages/shared/src/types/mcp.ts
@@ -1,0 +1,61 @@
+export interface McpServerConfig {
+  id: string;
+  name: string;
+  command: string;
+  args: string[];
+  env?: Record<string, string> | null;
+  installCommand?: string | null;
+  scope: string; // "global" or repo URL
+  repoUrl?: string | null;
+  workspaceId?: string | null;
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateMcpServerInput {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  installCommand?: string;
+  repoUrl?: string;
+  enabled?: boolean;
+}
+
+export interface UpdateMcpServerInput {
+  name?: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string> | null;
+  installCommand?: string | null;
+  enabled?: boolean;
+}
+
+export interface CustomSkillConfig {
+  id: string;
+  name: string;
+  description?: string | null;
+  prompt: string;
+  scope: string; // "global" or repo URL
+  repoUrl?: string | null;
+  workspaceId?: string | null;
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateCustomSkillInput {
+  name: string;
+  description?: string;
+  prompt: string;
+  repoUrl?: string;
+  enabled?: boolean;
+}
+
+export interface UpdateCustomSkillInput {
+  name?: string;
+  description?: string | null;
+  prompt?: string;
+  enabled?: boolean;
+}


### PR DESCRIPTION
## Summary

- Add MCP (Model Context Protocol) server configuration with global and per-repo scoping, enabling agents to access databases, APIs, and other tools during task execution
- Add custom skills/commands system that writes reusable markdown prompts to `.claude/commands/` for agents to use as slash commands
- Secret references (`${{SECRET_NAME}}`) in MCP server args and env vars are resolved securely from Optio's encrypted secrets store at runtime

## Changes

**Database:**
- New `mcp_servers` table — stores server configs (name, command, args, env, installCommand) with global/repo scope
- New `custom_skills` table — stores skill configs (name, description, prompt markdown) with global/repo scope
- Migration `0024_mcp_servers_custom_skills.sql`

**API:**
- `GET/POST /api/mcp-servers` — list/create global MCP servers
- `GET/POST /api/repos/:id/mcp-servers` — list/create per-repo MCP servers (includes global)
- `PATCH/DELETE /api/mcp-servers/:id` — update/delete
- `GET/POST /api/skills` — list/create custom skills
- `PATCH/DELETE /api/skills/:id` — update/delete

**Task Worker Integration:**
- Fetches global + repo-scoped MCP servers before agent launch
- Builds `.mcp.json` with resolved secret references and adds to setup files
- Collects `installCommand` values into `OPTIO_MCP_INSTALL_COMMANDS` env var
- Fetches custom skills and writes them to `.claude/commands/` via setup files

**Web UI:**
- Repo settings page: new "MCP Servers" and "Custom Skills" sections with add/enable/disable/delete
- Global settings page: new "Global MCP Servers" and "Global Custom Skills" sections

## Test plan

- [x] `pnpm turbo typecheck` — all 10 packages pass
- [x] `pnpm turbo test` — all 216 tests pass (15 test files)
- [x] `pnpm format:check` — all files pass Prettier
- [ ] Manual: create a global MCP server in settings, verify it appears in repo settings
- [ ] Manual: create a repo-scoped MCP server, verify it overrides global with same name
- [ ] Manual: create a custom skill, run a task, verify `.claude/commands/` contains the skill file
- [ ] Manual: use `${{SECRET_NAME}}` in env vars, verify secret resolution at runtime


🤖 Generated with [Claude Code](https://claude.com/claude-code)