### PR TITLE
feat: add theme selector and visual polish

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -21,6 +21,22 @@
   --font-mono: var(--font-jetbrains), "JetBrains Mono", "Fira Code", ui-monospace, monospace;
 }
 
+/* Light theme overrides */
+html.light {
+  --color-bg: #f8f9fb;
+  --color-bg-subtle: #f0f1f4;
+  --color-bg-card: #ffffff;
+  --color-bg-card-hover: #f5f5f7;
+  --color-bg-hover: #ebebef;
+  --color-border: #e0e1e6;
+  --color-border-strong: #c8c9d0;
+  --color-text: #111113;
+  --color-text-heading: #18181b;
+  --color-text-muted: #6b6b76;
+  --color-primary: #7c3aed;
+  --color-primary-hover: #6d28d9;
+}
+
 body {
   background: var(--color-bg);
   color: var(--color-text);
@@ -41,4 +57,23 @@ body {
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-text-muted);
+}
+
+/* Focus ring utility — consistent keyboard nav indicator */
+*:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Smooth transitions on theme switch */
+html.theme-transition,
+html.theme-transition *,
+html.theme-transition *::before,
+html.theme-transition *::after {
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease !important;
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
-import { Toaster } from "sonner";
 import { LayoutShell } from "@/components/layout/layout-shell";
 import "./globals.css";
 
@@ -23,11 +22,23 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  // Default to dark; ThemeProvider applies the correct class on mount
   return (
-    <html lang="en" className={`dark ${inter.variable} ${jetbrainsMono.variable}`}>
+    <html
+      lang="en"
+      className={`dark ${inter.variable} ${jetbrainsMono.variable}`}
+      suppressHydrationWarning
+    >
+      <head>
+        {/* Inline script to prevent flash of wrong theme */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem("optio_theme");if(t==="light"){document.documentElement.classList.remove("dark");document.documentElement.classList.add("light")}else if(t==="system"&&window.matchMedia("(prefers-color-scheme: light)").matches){document.documentElement.classList.remove("dark");document.documentElement.classList.add("light")}}catch(e){}})()`,
+          }}
+        />
+      </head>
       <body className="antialiased">
         <LayoutShell>{children}</LayoutShell>
-        <Toaster theme="dark" position="bottom-right" richColors closeButton />
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -926,16 +926,18 @@ function EmptyState({
   action?: { label: string; href: string };
 }) {
   return (
-    <div className="flex flex-col items-center justify-center py-12 px-4 rounded-xl border border-dashed border-border bg-bg-card/50">
-      <div className="p-3 rounded-xl bg-bg-hover mb-3">
-        <Icon className="w-6 h-6 text-text-muted" />
+    <div className="flex flex-col items-center justify-center py-14 px-6 rounded-xl border border-dashed border-border bg-bg-card/50">
+      <div className="p-3.5 rounded-2xl bg-bg-hover/70 mb-4">
+        <Icon className="w-7 h-7 text-text-muted/60" />
       </div>
       <span className="text-sm font-medium text-text-heading">{title}</span>
-      <p className="text-xs text-text-muted mt-1 text-center max-w-xs">{description}</p>
+      <p className="text-xs text-text-muted mt-1.5 text-center max-w-xs leading-relaxed">
+        {description}
+      </p>
       {action && (
         <Link
           href={action.href}
-          className="mt-4 inline-flex items-center gap-1.5 px-3.5 py-1.5 text-xs font-medium rounded-lg bg-primary text-white hover:bg-primary-hover transition-colors"
+          className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 text-xs font-medium rounded-lg bg-primary text-white hover:bg-primary-hover transition-colors shadow-sm"
         >
           <Plus className="w-3.5 h-3.5" />
           {action.label}
@@ -958,12 +960,28 @@ function StatCard({
   value: number;
   color: string;
 }) {
+  const accentMap: Record<string, string> = {
+    "text-primary": "border-l-primary/40",
+    "text-warning": "border-l-warning/40",
+    "text-success": "border-l-success/40",
+    "text-error": "border-l-error/40",
+    "text-info": "border-l-info/40",
+  };
+  const accent = accentMap[color] ?? "border-l-primary/40";
+
   return (
-    <div className="p-4 rounded-xl border border-border/50 bg-bg-card relative overflow-hidden">
-      <Icon className={cn("w-8 h-8 absolute top-3 right-3 opacity-25", color)} />
+    <div
+      className={cn(
+        "p-4 rounded-xl border border-border/50 bg-bg-card relative overflow-hidden border-l-2 hover:bg-bg-card-hover transition-colors",
+        accent,
+      )}
+    >
+      <Icon className={cn("w-8 h-8 absolute top-3 right-3 opacity-15", color)} />
       <span className="text-xs font-medium uppercase tracking-wider text-text-muted">{label}</span>
       <div className="mt-1.5">
-        <span className="text-3xl font-semibold tabular-nums">{value}</span>
+        <span className={cn("text-3xl font-semibold tabular-nums", value > 0 && color)}>
+          {value}
+        </span>
       </div>
     </div>
   );

--- a/apps/web/src/components/layout/layout-shell.tsx
+++ b/apps/web/src/components/layout/layout-shell.tsx
@@ -4,6 +4,8 @@ import { usePathname } from "next/navigation";
 import { Sidebar } from "./sidebar";
 import { GlobalWebSocketProvider } from "./ws-provider";
 import { SetupCheck } from "./setup-check";
+import { ThemeProvider } from "./theme-provider";
+import { ThemedToaster } from "./themed-toaster";
 
 export function LayoutShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -11,7 +13,7 @@ export function LayoutShell({ children }: { children: React.ReactNode }) {
   const isLogin = pathname === "/login";
 
   return (
-    <>
+    <ThemeProvider>
       {!isLogin && <SetupCheck />}
       {!isLogin && <GlobalWebSocketProvider />}
       {isSetup || isLogin ? (
@@ -22,6 +24,7 @@ export function LayoutShell({ children }: { children: React.ReactNode }) {
           <main className="flex-1 overflow-auto">{children}</main>
         </div>
       )}
-    </>
+      <ThemedToaster />
+    </ThemeProvider>
   );
 }

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -54,13 +54,13 @@ function NavLink({
     <Link
       href={href}
       className={cn(
-        "flex items-center gap-3 py-2.5 px-3 rounded-lg text-[13px] font-medium transition-colors",
+        "flex items-center gap-2.5 py-2 px-2.5 rounded-lg text-[13px] font-medium transition-all duration-150",
         active
-          ? "bg-primary/10 text-text border-l-2 border-primary -ml-px"
+          ? "bg-primary/12 text-text border-l-2 border-primary -ml-px shadow-[inset_0_0_0_1px_rgba(109,40,217,0.08)]"
           : "text-text-muted hover:bg-bg-hover hover:text-text",
       )}
     >
-      <Icon className="w-4 h-4 shrink-0" />
+      <Icon className={cn("w-4 h-4 shrink-0", active && "text-primary")} />
       {label}
     </Link>
   );
@@ -73,38 +73,40 @@ export function Sidebar() {
     href === "/" ? pathname === "/" : pathname === href || pathname.startsWith(href + "/");
 
   return (
-    <aside className="w-60 shrink-0 border-r border-border bg-bg flex flex-col">
-      <div className="px-5 py-5 border-b border-border">
-        <Link href="/" className="flex items-center gap-2.5 text-primary">
-          <Zap className="w-5 h-5" />
+    <aside className="w-60 shrink-0 border-r border-border bg-bg-subtle flex flex-col">
+      <div className="px-4 py-4 border-b border-border">
+        <Link href="/" className="flex items-center gap-2.5 text-primary group">
+          <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center group-hover:bg-primary/15 transition-colors">
+            <Zap className="w-4.5 h-4.5" />
+          </div>
           <div>
-            <span className="font-semibold text-lg tracking-tight">Optio</span>
+            <span className="font-semibold text-base tracking-tight text-text">Optio</span>
             <span className="block text-[10px] text-text-muted font-normal tracking-wide">
               Agent Orchestration
             </span>
           </div>
         </Link>
       </div>
-      <div className="px-3 py-2 border-b border-border">
+      <div className="px-2.5 py-2 border-b border-border">
         <WorkspaceSwitcher />
       </div>
-      <nav className="flex-1 px-3 py-4">
-        <div className="space-y-1">
+      <nav className="flex-1 px-2.5 py-3 overflow-y-auto">
+        <div className="space-y-0.5">
           {MAIN_NAV.map((item) => (
             <NavLink key={item.href} {...item} active={isActive(item.href)} />
           ))}
         </div>
-        <div className="my-4 mx-3 border-t border-border" />
-        <div className="space-y-1">
+        <div className="my-3 mx-2.5 border-t border-border" />
+        <div className="space-y-0.5">
           {SECONDARY_NAV.map((item) => (
             <NavLink key={item.href} {...item} active={isActive(item.href)} />
           ))}
         </div>
       </nav>
-      <div className="border-t border-border px-3 py-3">
+      <div className="border-t border-border px-2.5 py-2.5">
         <UserMenu />
       </div>
-      <div className="px-5 py-2 text-[11px] text-text-muted/50">Optio v0.1.0</div>
+      <div className="px-4 py-1.5 text-[10px] text-text-muted/40">Optio v0.1.0</div>
     </aside>
   );
 }

--- a/apps/web/src/components/layout/theme-provider.tsx
+++ b/apps/web/src/components/layout/theme-provider.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark" | "system";
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolvedTheme: "light" | "dark";
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "dark",
+  resolvedTheme: "dark",
+  setTheme: () => {},
+});
+
+const STORAGE_KEY = "optio_theme";
+
+function getStoredTheme(): Theme {
+  if (typeof window === "undefined") return "dark";
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark" || stored === "system") return stored;
+  } catch {}
+  return "dark";
+}
+
+function getSystemTheme(): "light" | "dark" {
+  if (typeof window === "undefined") return "dark";
+  return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+}
+
+function applyTheme(theme: Theme) {
+  const resolved = theme === "system" ? getSystemTheme() : theme;
+  const html = document.documentElement;
+  html.classList.remove("light", "dark");
+  html.classList.add(resolved);
+  return resolved;
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("dark");
+  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">("dark");
+
+  // Initialize from localStorage on mount
+  useEffect(() => {
+    const stored = getStoredTheme();
+    setThemeState(stored);
+    const resolved = applyTheme(stored);
+    setResolvedTheme(resolved);
+  }, []);
+
+  // Listen for system theme changes when in "system" mode
+  useEffect(() => {
+    if (theme !== "system") return;
+
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      const resolved = applyTheme("system");
+      setResolvedTheme(resolved);
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  const setTheme = useCallback((newTheme: Theme) => {
+    setThemeState(newTheme);
+    try {
+      localStorage.setItem(STORAGE_KEY, newTheme);
+    } catch {}
+    const resolved = applyTheme(newTheme);
+    setResolvedTheme(resolved);
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/apps/web/src/components/layout/themed-toaster.tsx
+++ b/apps/web/src/components/layout/themed-toaster.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { Toaster } from "sonner";
+import { useTheme } from "./theme-provider";
+
+export function ThemedToaster() {
+  const { resolvedTheme } = useTheme();
+  return <Toaster theme={resolvedTheme} position="bottom-right" richColors closeButton />;
+}

--- a/apps/web/src/components/layout/user-menu.tsx
+++ b/apps/web/src/components/layout/user-menu.tsx
@@ -2,7 +2,9 @@
 
 import { useState, useEffect, useRef } from "react";
 import { api } from "@/lib/api-client";
-import { LogOut, User, ChevronUp } from "lucide-react";
+import { LogOut, User, ChevronUp, Sun, Moon, Monitor } from "lucide-react";
+import { useTheme, type Theme } from "./theme-provider";
+import { cn } from "@/lib/utils";
 
 interface UserInfo {
   id: string;
@@ -12,11 +14,18 @@ interface UserInfo {
   avatarUrl: string | null;
 }
 
+const THEME_OPTIONS: { value: Theme; label: string; icon: typeof Sun }[] = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+];
+
 export function UserMenu() {
   const [user, setUser] = useState<UserInfo | null>(null);
   const [authDisabled, setAuthDisabled] = useState(false);
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const { theme, setTheme } = useTheme();
 
   useEffect(() => {
     api
@@ -85,6 +94,29 @@ export function UserMenu() {
               <p className="text-[10px] text-text-muted capitalize mt-0.5">via {user.provider}</p>
             )}
           </div>
+
+          {/* Theme selector */}
+          <div className="px-3 py-2 border-b border-border">
+            <p className="text-[10px] text-text-muted mb-1.5">Theme</p>
+            <div className="flex gap-1">
+              {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+                <button
+                  key={value}
+                  onClick={() => setTheme(value)}
+                  className={cn(
+                    "flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-[11px] font-medium transition-colors flex-1 justify-center",
+                    theme === value
+                      ? "bg-primary/15 text-primary"
+                      : "text-text-muted hover:bg-bg-hover hover:text-text",
+                  )}
+                >
+                  <Icon className="w-3 h-3" />
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
           {!authDisabled && (
             <button
               onClick={handleLogout}

--- a/apps/web/src/components/task-card.tsx
+++ b/apps/web/src/components/task-card.tsx
@@ -39,7 +39,7 @@ export const TaskCard = React.memo(function TaskCard({ task, subtasks }: TaskCar
   return (
     <div
       onClick={() => router.push(`/tasks/${task.id}`)}
-      className="block rounded-xl border border-border/50 bg-bg-card hover:border-border hover:bg-bg-card-hover transition-all cursor-pointer overflow-hidden"
+      className="block rounded-xl border border-border/50 bg-bg-card hover:border-border-strong hover:bg-bg-card-hover hover:shadow-md transition-all duration-150 cursor-pointer overflow-hidden"
     >
       <div className="p-5">
         {/* Top row: title + badges */}
@@ -111,7 +111,7 @@ export const TaskCard = React.memo(function TaskCard({ task, subtasks }: TaskCar
                   }, 2000);
                 }
               }}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs bg-primary/10 text-primary hover:bg-primary/20 shrink-0"
+              className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs bg-primary/10 text-primary hover:bg-primary/20 transition-colors shrink-0"
             >
               <RotateCcw className="w-3 h-3" />
               Retry


### PR DESCRIPTION
## Summary

- **Theme selector** (light / dark / system) accessible from the user menu dropdown, with localStorage persistence and inline script to prevent flash of wrong theme
- **Light theme** defined via CSS custom property overrides on `html.light`, keeping the dark theme as default
- **Visual polish**: tighter sidebar spacing, prominent active nav state with colored icon, accent-bordered dashboard stats cards, improved empty states, better hover/shadow transitions, global `focus-visible` rings for keyboard accessibility
- **Themed toaster**: Sonner toast notifications now match the active theme

## Test plan

- [ ] Verify dark theme still looks correct (default behavior)
- [ ] Switch to light theme via user menu and verify all pages render properly
- [ ] Switch to system theme and verify it follows OS preference
- [ ] Reload the page after selecting light — verify no flash of dark theme
- [ ] Check sidebar active state and hover states look polished
- [ ] Check dashboard stats cards have accent left borders
- [ ] Tab through interactive elements to verify focus rings appear
- [ ] Run `pnpm turbo typecheck` — all pass
- [ ] Run `npx next build` in apps/web — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)