### PR TITLE
fix: fall back to stored GITHUB_TOKEN for private repo validation

### DIFF
--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -167,7 +167,8 @@ export async function setupRoutes(app: FastifyInstance) {
       }
       const [, owner, repo] = match;
       const headers: Record<string, string> = { "User-Agent": "Optio" };
-      if (token) headers["Authorization"] = `Bearer ${token}`;
+      const effectiveToken = token ?? (await retrieveSecret("GITHUB_TOKEN").catch(() => null));
+      if (effectiveToken) headers["Authorization"] = `Bearer ${effectiveToken}`;
 
       const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers });
       if (res.ok) {


### PR DESCRIPTION
## Summary
- When validating a repo via `POST /api/setup/validate/repo`, the endpoint only used the token from the request body. Since the frontend cannot read secret values, it always sends `token: undefined`, making private repo validation fail with a 404.
- Now falls back to the stored `GITHUB_TOKEN` secret (via `retrieveSecret`) when no token is provided in the request body.

## Test plan
- [ ] Add a private repo via the UI with a stored `GITHUB_TOKEN` secret — should validate successfully
- [ ] Add a public repo without any token — should still work (unauthenticated)
- [ ] Add a private repo without a stored `GITHUB_TOKEN` and no token in the body — should fail gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)