### PR TITLE
fix: lowercase full URL path in normalizeRepoUrl

### DIFF
--- a/packages/shared/src/utils/normalize-repo-url.test.ts
+++ b/packages/shared/src/utils/normalize-repo-url.test.ts
@@ -18,6 +18,8 @@ describe("normalizeRepoUrl", () => {
     ["github.com/foo/bar", "bare host"],
     ["github.com/foo/bar.git", "bare host with .git"],
     ["HTTPS://GitHub.COM/foo/bar", "mixed case host"],
+    ["https://github.com/Foo/Bar", "mixed case owner/repo"],
+    ["git@github.com:FOO/BAR.git", "SSH shorthand with upper case path"],
   ])("normalizes %s (%s)", (input) => {
     expect(normalizeRepoUrl(input)).toBe(canonical);
   });

--- a/packages/shared/src/utils/normalize-repo-url.ts
+++ b/packages/shared/src/utils/normalize-repo-url.ts
@@ -42,17 +42,8 @@ export function normalizeRepoUrl(url: string): string {
   u = u.replace(/\.git$/, "");
   u = u.replace(/\/+$/, "");
 
-  // Lowercase the host portion only (preserve case of owner/repo for display,
-  // but GitHub is case-insensitive so we lowercase the whole thing for matching)
-  try {
-    const parsed = new URL(u);
-    parsed.hostname = parsed.hostname.toLowerCase();
-    // Reconstruct without trailing slash
-    u = `${parsed.protocol}//${parsed.hostname}${parsed.pathname}`;
-  } catch {
-    // If URL parsing fails, just lowercase the whole thing
-    u = u.toLowerCase();
-  }
+  // GitHub is case-insensitive for owner/repo, so lowercase everything for matching
+  u = u.toLowerCase();
 
   // Strip trailing slash again (URL parsing may re-add it)
   u = u.replace(/\/+$/, "");


### PR DESCRIPTION
## Summary

- GitHub treats owner/repo case-insensitively, but `normalizeRepoUrl` only lowercased the hostname
- This caused repo config lookups to fail when the task URL had different casing than the stored URL (e.g. `TheTote/strata-api` vs `thetote/strata-api`)
- Now lowercases the full URL path

## Test plan

- [ ] Existing unit tests updated and passing
- [ ] Verify repo lookup works with mixed-case URLs