### PR TITLE
fix: thread workspaceId through task worker and PR watcher for correct secret resolution

### DIFF
--- a/apps/api/src/services/secret-service.ts
+++ b/apps/api/src/services/secret-service.ts
@@ -125,22 +125,42 @@ export async function deleteSecret(
   await db.delete(secrets).where(and(...conditions));
 }
 
+/**
+ * Retrieve a secret with workspace-then-global fallback.
+ * If workspaceId is provided, tries workspace-scoped first, then global.
+ */
+export async function retrieveSecretWithFallback(
+  name: string,
+  scope = "global",
+  workspaceId?: string | null,
+): Promise<string> {
+  if (workspaceId) {
+    try {
+      return await retrieveSecret(name, scope, workspaceId);
+    } catch {
+      // Not found in workspace — fall through to global
+    }
+  }
+  return retrieveSecret(name, scope);
+}
+
 export async function resolveSecretsForTask(
   requiredSecrets: string[],
   scope = "global",
+  workspaceId?: string | null,
 ): Promise<Record<string, string>> {
   const resolved: Record<string, string> = {};
   for (const name of requiredSecrets) {
     if (scope !== "global") {
       // Try repo-scoped secret first, fall back to global
       try {
-        resolved[name] = await retrieveSecret(name, scope);
+        resolved[name] = await retrieveSecretWithFallback(name, scope, workspaceId);
         continue;
       } catch {
         // Not found at repo scope — fall through to global
       }
     }
-    resolved[name] = await retrieveSecret(name, "global");
+    resolved[name] = await retrieveSecretWithFallback(name, "global", workspaceId);
   }
   return resolved;
 }

--- a/apps/api/src/workers/pr-watcher-worker.ts
+++ b/apps/api/src/workers/pr-watcher-worker.ts
@@ -3,7 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { tasks, taskEvents, sessionPrs, interactiveSessions } from "../db/schema.js";
 import { TaskState } from "@optio/shared";
-import { retrieveSecret } from "../services/secret-service.js";
+import { retrieveSecretWithFallback } from "../services/secret-service.js";
 import * as taskService from "../services/task-service.js";
 import { updateSessionPr } from "../services/interactive-session-service.js";
 import { taskQueue } from "./task-worker.js";
@@ -148,13 +148,20 @@ export function startPrWatcherWorker() {
   const worker = new Worker(
     "pr-watcher",
     async () => {
-      // Fetch GitHub token once for both task and session PR watching
-      let githubToken: string | null = null;
-      try {
-        githubToken = await retrieveSecret("GITHUB_TOKEN");
-      } catch {
-        // No token, can't check PRs
-      }
+      // Cache GitHub tokens per workspace to avoid repeated DB lookups
+      const tokenCache = new Map<string, string | null>();
+      const getGithubToken = async (workspaceId: string | null): Promise<string | null> => {
+        const cacheKey = workspaceId ?? "__global__";
+        if (tokenCache.has(cacheKey)) return tokenCache.get(cacheKey)!;
+        try {
+          const token = await retrieveSecretWithFallback("GITHUB_TOKEN", "global", workspaceId);
+          tokenCache.set(cacheKey, token);
+          return token;
+        } catch {
+          tokenCache.set(cacheKey, null);
+          return null;
+        }
+      };
 
       // --- Task PR watching ---
       // Find all tasks with open PRs
@@ -167,14 +174,17 @@ export function startPrWatcherWorker() {
           sql`${tasks.state} IN ('pr_opened', 'failed') AND ${tasks.prUrl} IS NOT NULL AND (${tasks.taskType} = 'coding' OR ${tasks.taskType} IS NULL)`,
         );
 
-      if (openPrTasks.length > 0 && githubToken) {
-        const headers = {
-          Authorization: `Bearer ${githubToken}`,
-          "User-Agent": "Optio",
-          Accept: "application/vnd.github.v3+json",
-        };
-
+      if (openPrTasks.length > 0) {
         for (const task of openPrTasks) {
+          const taskWsId = (task as any).workspaceId ?? null;
+          const githubToken = await getGithubToken(taskWsId);
+          if (!githubToken) continue;
+
+          const headers = {
+            Authorization: `Bearer ${githubToken}`,
+            "User-Agent": "Optio",
+            Accept: "application/vnd.github.v3+json",
+          };
           if (!task.prUrl) continue;
 
           try {
@@ -270,7 +280,7 @@ export function startPrWatcherWorker() {
 
             // --- Decide what action to take ---
             const { getRepoByUrl } = await import("../services/repo-service.js");
-            const repoConfig = await getRepoByUrl(task.repoUrl);
+            const repoConfig = await getRepoByUrl(task.repoUrl, taskWsId);
             const existingReview = await db
               .select({ id: tasks.id })
               .from(tasks)
@@ -464,7 +474,7 @@ export function startPrWatcherWorker() {
             logger.warn({ err, taskId: task.id }, "Failed to check PR status");
           }
         }
-      } // end if (openPrTasks.length > 0 && githubToken)
+      } // end if (openPrTasks.length > 0)
 
       // --- Session PR watching ---
       // Poll PRs tracked in active sessions to keep CI/review/merge status up to date
@@ -483,9 +493,10 @@ export function startPrWatcherWorker() {
               sql`${sessionPrs.sessionId} IN ${sessionIds} AND (${sessionPrs.prState} IS NULL OR ${sessionPrs.prState} = 'open')`,
             );
 
-          if (openSessionPrs.length > 0 && githubToken) {
+          const sessionGithubToken = await getGithubToken(null);
+          if (openSessionPrs.length > 0 && sessionGithubToken) {
             const sessionHeaders = {
-              Authorization: `Bearer ${githubToken}`,
+              Authorization: `Bearer ${sessionGithubToken}`,
               "User-Agent": "Optio",
               Accept: "application/vnd.github.v3+json",
             };

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -17,7 +17,7 @@ import { eq, sql } from "drizzle-orm";
 import * as taskService from "../services/task-service.js";
 import * as repoPool from "../services/repo-pool-service.js";
 import { publishEvent } from "../services/event-bus.js";
-import { resolveSecretsForTask, retrieveSecret } from "../services/secret-service.js";
+import { resolveSecretsForTask, retrieveSecretWithFallback } from "../services/secret-service.js";
 import { getPromptTemplate } from "../services/prompt-template-service.js";
 import { logger } from "../logger.js";
 
@@ -115,7 +115,8 @@ export function startTaskWorker() {
         // events per cycle that repeat every 10s ("event storm") and
         // preventing ANY task from ever running.
         const { getRepoByUrl } = await import("../services/repo-service.js");
-        const repoConfig = await getRepoByUrl(currentTask.repoUrl);
+        const taskWorkspaceId = (currentTask as any).workspaceId ?? null;
+        const repoConfig = await getRepoByUrl(currentTask.repoUrl, taskWorkspaceId);
 
         // Compute effective concurrency: maxAgentsPerPod * maxPodInstances
         const maxAgentsPerPod = repoConfig?.maxAgentsPerPod ?? 2;
@@ -177,7 +178,9 @@ export function startTaskWorker() {
         // Get agent adapter and build config
         const adapter = getAdapter(task.agentType);
         const claudeAuthMode =
-          ((await retrieveSecret("CLAUDE_AUTH_MODE").catch(() => null)) as any) ?? "api-key";
+          ((await retrieveSecretWithFallback("CLAUDE_AUTH_MODE", "global", taskWorkspaceId).catch(
+            () => null,
+          )) as any) ?? "api-key";
         const optioApiUrl = `http://${process.env.API_HOST ?? "host.docker.internal"}:${process.env.API_PORT ?? "4000"}`;
 
         // Load and render prompt template
@@ -235,7 +238,6 @@ export function startTaskWorker() {
         const { getSkillsForTask, buildSkillSetupFiles } =
           await import("../services/skill-service.js");
 
-        const taskWorkspaceId = (task as any).workspaceId ?? null;
         const mcpServers = await getMcpServersForTask(task.repoUrl, taskWorkspaceId);
         if (mcpServers.length > 0) {
           const mcpJsonContent = await buildMcpJsonContent(mcpServers, task.repoUrl);
@@ -270,10 +272,11 @@ export function startTaskWorker() {
           ).toString("base64");
         }
 
-        // Resolve secrets (repo-scoped secrets override global ones)
+        // Resolve secrets (workspace → repo-scoped → global fallback)
         const resolvedSecrets = await resolveSecretsForTask(
           agentConfig.requiredSecrets,
           task.repoUrl,
+          taskWorkspaceId,
         );
         const allEnv = { ...agentConfig.env, ...resolvedSecrets };
 
@@ -306,7 +309,11 @@ export function startTaskWorker() {
 
         // For oauth-token mode, read the token from the secrets store
         if (claudeAuthMode === "oauth-token") {
-          const oauthToken = await retrieveSecret("CLAUDE_CODE_OAUTH_TOKEN").catch(() => null);
+          const oauthToken = await retrieveSecretWithFallback(
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "global",
+            taskWorkspaceId,
+          ).catch(() => null);
           if (oauthToken) {
             allEnv.CLAUDE_CODE_OAUTH_TOKEN = oauthToken as string;
             log.info("Injected CLAUDE_CODE_OAUTH_TOKEN from secrets store");


### PR DESCRIPTION
## Summary

- The task worker and PR watcher weren't passing `workspaceId` when resolving secrets, so all tasks used global secrets regardless of workspace
- Adds `retrieveSecretWithFallback()` for workspace-scoped secret lookup with global fallback
- Threads `workspaceId` through all secret and repo lookups in the task worker
- PR watcher now caches GitHub tokens per workspace instead of sharing one global token

## Test plan

- [ ] Create secrets in two different workspaces and verify tasks in each workspace use the correct secrets
- [ ] Verify global secrets still work as fallback when no workspace-scoped secret exists
- [ ] Verify PR watcher uses the correct GitHub token per workspace