### PR TITLE
fix: use GitHub issue number instead of task UUID in PR body

### DIFF
--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -196,6 +196,7 @@ export function startTaskWorker() {
           TASK_TITLE: task.title,
           REPO_NAME: repoName,
           AUTO_MERGE: String(promptConfig.autoMerge),
+          ISSUE_NUMBER: task.ticketExternalId ?? "",
         });
 
         const taskFileContent = renderTaskFile({

--- a/packages/shared/src/prompt-template.test.ts
+++ b/packages/shared/src/prompt-template.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { renderPromptTemplate, renderTaskFile, TASK_FILE_PATH } from "./prompt-template.js";
+import {
+  DEFAULT_PROMPT_TEMPLATE,
+  renderPromptTemplate,
+  renderTaskFile,
+  TASK_FILE_PATH,
+} from "./prompt-template.js";
 
 describe("renderPromptTemplate", () => {
   it("replaces simple variables", () => {
@@ -83,6 +88,36 @@ describe("renderTaskFile", () => {
     });
     expect(result).toContain("github");
     expect(result).toContain("https://github.com/org/repo/issues/42");
+  });
+});
+
+describe("DEFAULT_PROMPT_TEMPLATE", () => {
+  it("uses issue reference when ISSUE_NUMBER is provided", () => {
+    const result = renderPromptTemplate(DEFAULT_PROMPT_TEMPLATE, {
+      TASK_FILE: ".optio/task.md",
+      BRANCH_NAME: "optio/task-abc",
+      TASK_ID: "abc-123",
+      TASK_TITLE: "Fix login bug",
+      REPO_NAME: "org/repo",
+      AUTO_MERGE: "false",
+      ISSUE_NUMBER: "42",
+    });
+    expect(result).toContain('--body "Closes #42"');
+    expect(result).not.toContain("Implements task");
+  });
+
+  it("falls back to task ID when ISSUE_NUMBER is not provided", () => {
+    const result = renderPromptTemplate(DEFAULT_PROMPT_TEMPLATE, {
+      TASK_FILE: ".optio/task.md",
+      BRANCH_NAME: "optio/task-abc",
+      TASK_ID: "abc-123",
+      TASK_TITLE: "Fix login bug",
+      REPO_NAME: "org/repo",
+      AUTO_MERGE: "false",
+      ISSUE_NUMBER: "",
+    });
+    expect(result).toContain('--body "Implements task abc-123"');
+    expect(result).not.toContain("Closes #");
   });
 });
 

--- a/packages/shared/src/prompt-template.ts
+++ b/packages/shared/src/prompt-template.ts
@@ -17,7 +17,7 @@ no existing PR and no prior work. You must write the code, not review it.
 6. Commit your work to the current branch ({{BRANCH_NAME}}).
 7. Push and open a pull request using the \`gh\` CLI:
    \`\`\`
-   gh pr create --title "{{TASK_TITLE}}" --body "Implements task {{TASK_ID}}"
+{{#if ISSUE_NUMBER}}   gh pr create --title "{{TASK_TITLE}}" --body "Closes #{{ISSUE_NUMBER}}"{{else}}   gh pr create --title "{{TASK_TITLE}}" --body "Implements task {{TASK_ID}}"{{/if}}
    \`\`\`
 8. After opening the PR, you are done. Do NOT wait for CI checks or monitor them.
    The orchestration system handles CI monitoring and code review automatically.


### PR DESCRIPTION
## Summary

- When a task originates from a GitHub issue, the agent's PR body now uses `Closes #<issue-number>` instead of `Implements task <uuid>`
- Falls back to the task ID when no linked issue exists
- Passes `ISSUE_NUMBER` (from `task.ticketExternalId`) to the prompt template renderer

Fixes #138

## Test plan

- [x] Unit tests added for both cases (issue linked, no issue)
- [x] All 110 existing tests pass
- [ ] Create a task from a GitHub issue and verify the PR body references the issue number
- [ ] Create a manual task (no issue) and verify the PR body still shows the task ID