### PR TITLE
refactor: remove unnecessary `as any` casts for workspaceId in workers

### DIFF
--- a/apps/api/src/workers/pr-watcher-worker.ts
+++ b/apps/api/src/workers/pr-watcher-worker.ts
@@ -176,7 +176,7 @@ export function startPrWatcherWorker() {
 
       if (openPrTasks.length > 0) {
         for (const task of openPrTasks) {
-          const taskWsId = (task as any).workspaceId ?? null;
+          const taskWsId = task.workspaceId ?? null;
           const githubToken = await getGithubToken(taskWsId);
           if (!githubToken) continue;
 

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -116,7 +116,7 @@ export function startTaskWorker() {
         // events per cycle that repeat every 10s ("event storm") and
         // preventing ANY task from ever running.
         const { getRepoByUrl } = await import("../services/repo-service.js");
-        const taskWorkspaceId = (currentTask as any).workspaceId ?? null;
+        const taskWorkspaceId = currentTask.workspaceId ?? null;
         const repoConfig = await getRepoByUrl(currentTask.repoUrl, taskWorkspaceId);
 
         // Compute effective concurrency: maxAgentsPerPod * maxPodInstances


### PR DESCRIPTION
## Summary
- Removes `(currentTask as any).workspaceId` cast in `task-worker.ts`
- Removes `(task as any).workspaceId` cast in `pr-watcher-worker.ts`
- Both queries already use `.select()` which returns all columns including `workspaceId`, so the casts were unnecessary

## Test plan
- [x] TypeScript typecheck passes without the `as any` casts
- [x] All 224 tests pass

Closes task 38129d0c-0c2e-4c90-86d1-7c516aaed4ca

🤖 Generated with [Claude Code](https://claude.com/claude-code)