### PR TITLE
fix: detect existing PRs on task restart to avoid duplicate work

### DIFF
--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -173,9 +173,12 @@ export async function taskRoutes(app: FastifyInstance) {
       undefined,
       req.user?.id,
     );
+    // If the task already has a PR, use restartFromBranch to reuse
+    // the existing branch instead of starting fresh
+    const hasPrBranch = !!existing.prUrl;
     await taskQueue.add(
       "process-task",
-      { taskId: id },
+      { taskId: id, ...(hasPrBranch && { restartFromBranch: true }) },
       {
         jobId: `${id}-retry-${Date.now()}`,
         attempts: 1,

--- a/apps/api/src/services/pr-detection-service.test.ts
+++ b/apps/api/src/services/pr-detection-service.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { parseOwnerRepo, checkExistingPr } from "./pr-detection-service.js";
+
+// Mock secret-service
+vi.mock("./secret-service.js", () => ({
+  retrieveSecretWithFallback: vi.fn(),
+}));
+
+// Mock logger
+vi.mock("../logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  },
+}));
+
+describe("parseOwnerRepo", () => {
+  it("parses HTTPS GitHub URL", () => {
+    expect(parseOwnerRepo("https://github.com/owner/repo")).toEqual({
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  it("parses lowercase normalized URL", () => {
+    expect(parseOwnerRepo("https://github.com/myorg/myrepo")).toEqual({
+      owner: "myorg",
+      repo: "myrepo",
+    });
+  });
+
+  it("returns null for non-GitHub URL", () => {
+    expect(parseOwnerRepo("https://gitlab.com/owner/repo")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseOwnerRepo("")).toBeNull();
+  });
+
+  it("handles URLs with trailing path segments", () => {
+    const result = parseOwnerRepo("https://github.com/owner/repo/tree/main");
+    expect(result).toEqual({ owner: "owner", repo: "repo" });
+  });
+});
+
+describe("checkExistingPr", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns PR when an open PR exists for the task branch", async () => {
+    const { retrieveSecretWithFallback } = await import("./secret-service.js");
+    vi.mocked(retrieveSecretWithFallback).mockResolvedValue("ghp_test_token");
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          html_url: "https://github.com/owner/repo/pull/42",
+          number: 42,
+          state: "open",
+        },
+      ],
+    });
+
+    const result = await checkExistingPr("https://github.com/owner/repo", "task-123", null);
+
+    expect(result).toEqual({
+      url: "https://github.com/owner/repo/pull/42",
+      number: 42,
+      state: "open",
+    });
+
+    // Verify the API call used the correct branch
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("head=owner:optio/task-task-123"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer ghp_test_token",
+        }),
+      }),
+    );
+  });
+
+  it("returns null when no PR exists", async () => {
+    const { retrieveSecretWithFallback } = await import("./secret-service.js");
+    vi.mocked(retrieveSecretWithFallback).mockResolvedValue("ghp_test_token");
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    const result = await checkExistingPr("https://github.com/owner/repo", "task-456", null);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when GITHUB_TOKEN is unavailable", async () => {
+    const { retrieveSecretWithFallback } = await import("./secret-service.js");
+    vi.mocked(retrieveSecretWithFallback).mockRejectedValue(new Error("No token"));
+
+    const result = await checkExistingPr("https://github.com/owner/repo", "task-789", null);
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when GitHub API returns an error", async () => {
+    const { retrieveSecretWithFallback } = await import("./secret-service.js");
+    vi.mocked(retrieveSecretWithFallback).mockResolvedValue("ghp_test_token");
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+
+    const result = await checkExistingPr("https://github.com/owner/repo", "task-err", null);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null for non-GitHub repo URLs", async () => {
+    const result = await checkExistingPr("https://gitlab.com/owner/repo", "task-gl", null);
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when fetch throws a network error", async () => {
+    const { retrieveSecretWithFallback } = await import("./secret-service.js");
+    vi.mocked(retrieveSecretWithFallback).mockResolvedValue("ghp_test_token");
+
+    mockFetch.mockRejectedValue(new Error("Network error"));
+
+    const result = await checkExistingPr("https://github.com/owner/repo", "task-net", null);
+
+    expect(result).toBeNull();
+  });
+
+  it("passes workspace ID to secret resolution", async () => {
+    const { retrieveSecretWithFallback } = await import("./secret-service.js");
+    vi.mocked(retrieveSecretWithFallback).mockResolvedValue("ghp_test_token");
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    await checkExistingPr("https://github.com/owner/repo", "task-ws", "workspace-42");
+
+    expect(retrieveSecretWithFallback).toHaveBeenCalledWith(
+      "GITHUB_TOKEN",
+      "global",
+      "workspace-42",
+    );
+  });
+});

--- a/apps/api/src/services/pr-detection-service.ts
+++ b/apps/api/src/services/pr-detection-service.ts
@@ -1,0 +1,88 @@
+import { TASK_BRANCH_PREFIX } from "@optio/shared";
+import { retrieveSecretWithFallback } from "./secret-service.js";
+import { logger } from "../logger.js";
+
+export interface ExistingPr {
+  url: string;
+  number: number;
+  state: string;
+}
+
+/**
+ * Extract owner and repo from a normalized repo URL.
+ * e.g. "https://github.com/owner/repo" → { owner: "owner", repo: "repo" }
+ */
+export function parseOwnerRepo(repoUrl: string): { owner: string; repo: string } | null {
+  const match = repoUrl.match(/github\.com\/([^/]+)\/([^/]+)/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2] };
+}
+
+/**
+ * Check if an open PR already exists for a task's branch.
+ *
+ * Uses the GitHub API: GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=open
+ * Branch naming is deterministic: `optio/task-{taskId}`
+ *
+ * Returns the PR info if found, or null if no PR exists.
+ */
+export async function checkExistingPr(
+  repoUrl: string,
+  taskId: string,
+  workspaceId: string | null,
+): Promise<ExistingPr | null> {
+  const parsed = parseOwnerRepo(repoUrl);
+  if (!parsed) {
+    logger.debug({ repoUrl }, "Cannot parse owner/repo from URL — skipping PR check");
+    return null;
+  }
+
+  let githubToken: string | null = null;
+  try {
+    githubToken = await retrieveSecretWithFallback("GITHUB_TOKEN", "global", workspaceId);
+  } catch {
+    logger.debug("No GITHUB_TOKEN available — skipping existing PR check");
+    return null;
+  }
+  if (!githubToken) return null;
+
+  const branch = `${TASK_BRANCH_PREFIX}${taskId}`;
+  const { owner, repo } = parsed;
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/pulls?head=${owner}:${branch}&state=open`,
+      {
+        headers: {
+          Authorization: `Bearer ${githubToken}`,
+          "User-Agent": "Optio",
+          Accept: "application/vnd.github.v3+json",
+        },
+      },
+    );
+
+    if (!res.ok) {
+      logger.debug({ status: res.status }, "GitHub API error checking for existing PR");
+      return null;
+    }
+
+    const pulls = (await res.json()) as Array<{
+      html_url: string;
+      number: number;
+      state: string;
+    }>;
+
+    if (pulls.length === 0) return null;
+
+    // Return the first (most relevant) open PR for this branch
+    const pr = pulls[0];
+    return {
+      url: pr.html_url,
+      number: pr.number,
+      state: pr.state,
+    };
+  } catch (err) {
+    logger.debug({ err }, "Failed to check for existing PR");
+    return null;
+  }
+}

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -12,6 +12,7 @@ import {
 import { getAdapter } from "@optio/agent-adapters";
 import { parseClaudeEvent } from "../services/agent-event-parser.js";
 import { parseCodexEvent } from "../services/codex-event-parser.js";
+import { checkExistingPr } from "../services/pr-detection-service.js";
 import { db } from "../db/client.js";
 import { tasks } from "../db/schema.js";
 import { eq, sql } from "drizzle-orm";
@@ -351,6 +352,30 @@ export function startTaskWorker() {
         await taskService.updateTaskContainer(taskId, pod.podName ?? pod.podId ?? pod.id);
         await taskService.transitionTask(taskId, TaskState.RUNNING, "worktree_created");
         log.info("Running agent in worktree");
+
+        // ── Check for existing PR before launching agent ───────────────
+        // If a previous run already opened a PR for this task's branch,
+        // skip the agent entirely and transition straight to pr_opened.
+        // This avoids wasting compute on tasks killed by restarts/reconcile.
+        const isReviewTask0 = !!reviewOverride || task.taskType === "review";
+        if (!restartFromBranch && !resumeSessionId && !isReviewTask0) {
+          const existingPr = await checkExistingPr(task.repoUrl, taskId, taskWorkspaceId);
+          if (existingPr) {
+            log.info(
+              { prUrl: existingPr.url, prNumber: existingPr.number },
+              "Existing PR found — skipping agent, transitioning to pr_opened",
+            );
+            await taskService.updateTaskPr(taskId, existingPr.url);
+            await repoPool.updateWorktreeState(taskId, "preserved");
+            await taskService.transitionTask(
+              taskId,
+              TaskState.PR_OPENED,
+              "existing_pr_detected",
+              existingPr.url,
+            );
+            return;
+          }
+        }
 
         // Build the agent command based on type
         const isReviewTask = !!reviewOverride || task.taskType === "review";
@@ -703,20 +728,68 @@ export async function reconcileOrphanedTasks() {
     .from(tasks)
     .where(eq(tasks.state, "running" as any));
 
-  // Provisioning/running tasks lost their exec session — fail then re-queue
+  // Provisioning/running tasks lost their exec session.
+  // Before failing and re-queuing, check if a PR was already opened —
+  // if so, transition directly to pr_opened to avoid redoing work.
   for (const task of [...orphanedProvisioning, ...orphanedRunning]) {
-    await taskService.transitionTask(
-      task.id,
-      TaskState.FAILED,
-      "startup_reconcile",
-      "Server restarted during execution",
-    );
-    await taskService.transitionTask(
-      task.id,
-      TaskState.QUEUED,
-      "startup_reconcile",
-      "Re-queued after server restart",
-    );
+    const taskWsId = (task as any).workspaceId ?? null;
+    const isReview = task.taskType === "review";
+    let existingPr = null;
+    if (!isReview) {
+      try {
+        existingPr = await checkExistingPr(task.repoUrl, task.id, taskWsId);
+      } catch {
+        // Non-fatal — fall through to fail + re-queue
+      }
+    }
+
+    if (existingPr && task.state === "running") {
+      // running → pr_opened is a valid transition
+      logger.info(
+        { taskId: task.id, prUrl: existingPr.url },
+        "Existing PR found during reconciliation — transitioning to pr_opened",
+      );
+      await taskService.updateTaskPr(task.id, existingPr.url);
+      await taskService.transitionTask(
+        task.id,
+        TaskState.PR_OPENED,
+        "startup_reconcile",
+        existingPr.url,
+      );
+    } else if (existingPr && task.state === "provisioning") {
+      // provisioning → pr_opened is NOT valid; fail → re-queue and
+      // the pre-agent PR check will short-circuit it to pr_opened
+      logger.info(
+        { taskId: task.id, prUrl: existingPr.url },
+        "Existing PR found during reconciliation (provisioning) — will detect on re-queue",
+      );
+      await taskService.updateTaskPr(task.id, existingPr.url);
+      await taskService.transitionTask(
+        task.id,
+        TaskState.FAILED,
+        "startup_reconcile",
+        "Server restarted during execution",
+      );
+      await taskService.transitionTask(
+        task.id,
+        TaskState.QUEUED,
+        "startup_reconcile",
+        "Re-queued after server restart (PR already exists)",
+      );
+    } else {
+      await taskService.transitionTask(
+        task.id,
+        TaskState.FAILED,
+        "startup_reconcile",
+        "Server restarted during execution",
+      );
+      await taskService.transitionTask(
+        task.id,
+        TaskState.QUEUED,
+        "startup_reconcile",
+        "Re-queued after server restart",
+      );
+    }
   }
 
   // Re-query queued tasks (provisioning/running were just transitioned to queued above)


### PR DESCRIPTION
## Summary

- Adds a **PR detection service** (`pr-detection-service.ts`) that queries the GitHub API to check if an open PR already exists for a task's deterministic branch (`optio/task-{id}`)
- **Task worker** checks for existing PRs before launching the agent — if found, skips the agent entirely and transitions straight to `pr_opened`, saving time and compute
- **Startup reconciliation** checks for existing PRs before blindly failing and re-queuing orphaned running tasks — running tasks with existing PRs go directly to `pr_opened` instead of being re-run from scratch
- **Retry route** passes `restartFromBranch: true` when the task already has a PR URL, so the agent reuses the existing branch instead of starting fresh

Fixes the issue where tasks killed by API redeployments (e.g. `startup_reconcile`) kept restarting from scratch even though a PR with hundreds of lines of changes was already open.

## Test plan

- [x] Added unit tests for `parseOwnerRepo` (5 tests) and `checkExistingPr` (7 tests) covering: PR found, no PR, no token, API error, non-GitHub URL, network error, workspace ID passthrough
- [x] All 236 existing tests pass
- [x] Typecheck passes across all packages
- [ ] Manual: create a task, let it open a PR, then restart the API — verify the task transitions to `pr_opened` instead of re-running the agent
- [ ] Manual: retry a task that has an existing PR — verify `restartFromBranch` is used

<!-- optio-task: 657cdd09-2296-49ab-9f9e-b5dd0e3301f5 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)