### PR TITLE
fix: prevent duplicate repos when workspace_id is NULL

### DIFF
--- a/apps/api/src/db/migrations/0026_repos_null_workspace_unique.sql
+++ b/apps/api/src/db/migrations/0026_repos_null_workspace_unique.sql
@@ -1,0 +1,32 @@
+-- Fix: duplicate repos allowed when workspace_id is NULL
+-- PostgreSQL treats NULLs as distinct in unique constraints, so the existing
+-- repos_url_workspace_key constraint on (repo_url, workspace_id) does not
+-- prevent duplicate repos when workspace_id IS NULL.
+
+-- Step 1: Deduplicate any existing repos with NULL workspace_id.
+-- Keep the oldest entry (smallest created_at), delete newer duplicates.
+DELETE FROM repos
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id,
+           ROW_NUMBER() OVER (PARTITION BY repo_url ORDER BY created_at ASC) AS rn
+    FROM repos
+    WHERE workspace_id IS NULL
+  ) dupes
+  WHERE rn > 1
+);
+--> statement-breakpoint
+-- Step 2: Assign remaining NULL workspace_id repos to the default workspace.
+-- The default workspace was created in migration 0022 with slug 'default'.
+UPDATE repos
+SET workspace_id = (SELECT id FROM workspaces WHERE slug = 'default' LIMIT 1),
+    updated_at = NOW()
+WHERE workspace_id IS NULL
+  AND EXISTS (SELECT 1 FROM workspaces WHERE slug = 'default');
+--> statement-breakpoint
+-- Step 3: Create a partial unique index as a safety net.
+-- Even though we assign default workspaces above, this prevents future NULLs
+-- from creating duplicates if application code regresses.
+CREATE UNIQUE INDEX IF NOT EXISTS "repos_url_null_ws_idx"
+  ON repos (repo_url)
+  WHERE workspace_id IS NULL;

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1775145600000,
       "tag": "0025_network_policy",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1775232000000,
+      "tag": "0026_repos_null_workspace_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/services/repo-service.ts
+++ b/apps/api/src/services/repo-service.ts
@@ -1,6 +1,6 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNull } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { repos } from "../db/schema.js";
+import { repos, workspaces } from "../db/schema.js";
 import { normalizeRepoUrl } from "@optio/shared";
 
 export interface RepoRecord {
@@ -55,13 +55,35 @@ export async function getRepo(id: string): Promise<RepoRecord | null> {
   return (repo as RepoRecord) ?? null;
 }
 
+async function getDefaultWorkspaceId(): Promise<string | null> {
+  const [ws] = await db
+    .select({ id: workspaces.id })
+    .from(workspaces)
+    .where(eq(workspaces.slug, "default"));
+  return ws?.id ?? null;
+}
+
 export async function getRepoByUrl(
   repoUrl: string,
   workspaceId?: string | null,
 ): Promise<RepoRecord | null> {
   const normalized = normalizeRepoUrl(repoUrl);
   const conditions = [eq(repos.repoUrl, normalized)];
-  if (workspaceId) conditions.push(eq(repos.workspaceId, workspaceId));
+  if (workspaceId) {
+    conditions.push(eq(repos.workspaceId, workspaceId));
+  } else {
+    // When no workspace is specified, try the default workspace first,
+    // then fall back to any repo with a NULL workspace_id
+    const defaultWsId = await getDefaultWorkspaceId();
+    if (defaultWsId) {
+      const [repo] = await db
+        .select()
+        .from(repos)
+        .where(and(eq(repos.repoUrl, normalized), eq(repos.workspaceId, defaultWsId)));
+      if (repo) return repo as RepoRecord;
+    }
+    conditions.push(isNull(repos.workspaceId));
+  }
   const [repo] = await db
     .select()
     .from(repos)
@@ -76,6 +98,10 @@ export async function createRepo(data: {
   isPrivate?: boolean;
   workspaceId?: string | null;
 }): Promise<RepoRecord> {
+  // Ensure repos always have a workspace assigned — prevents NULL workspace_id
+  // rows which bypass the (repo_url, workspace_id) unique constraint
+  const workspaceId = data.workspaceId || (await getDefaultWorkspaceId()) || undefined;
+
   const [repo] = await db
     .insert(repos)
     .values({
@@ -83,7 +109,7 @@ export async function createRepo(data: {
       fullName: data.fullName,
       defaultBranch: data.defaultBranch ?? "main",
       isPrivate: data.isPrivate ?? false,
-      workspaceId: data.workspaceId ?? undefined,
+      workspaceId,
     })
     .onConflictDoUpdate({
       target: [repos.repoUrl, repos.workspaceId],

--- a/apps/api/src/services/review-service.test.ts
+++ b/apps/api/src/services/review-service.test.ts
@@ -16,7 +16,8 @@ vi.mock("../db/client.js", () => ({
 }));
 
 vi.mock("../db/schema.js", () => ({
-  repos: { repoUrl: "repoUrl" },
+  repos: { repoUrl: "repoUrl", workspaceId: "workspaceId" },
+  workspaces: { id: "id", slug: "slug" },
   tasks: {},
   taskEvents: {},
   taskLogs: {},
@@ -98,10 +99,12 @@ describe("launchReview", () => {
 
     mockGetTask.mockResolvedValueOnce(parentTask);
 
-    // Repo config query
-    vi.mocked(db.select().from(undefined as any).where as any).mockResolvedValueOnce([
-      { reviewPromptTemplate: null, testCommand: "npm test", reviewModel: "haiku" },
-    ]);
+    // Repo config query (first call is getDefaultWorkspaceId, second is the repo lookup)
+    vi.mocked(db.select().from(undefined as any).where as any)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { reviewPromptTemplate: null, testCommand: "npm test", reviewModel: "haiku" },
+      ]);
 
     const reviewSubtask = { id: "review-1", title: "Review: Implement feature X" };
     mockCreateSubtask.mockResolvedValueOnce(reviewSubtask);
@@ -154,8 +157,10 @@ describe("launchReview", () => {
 
     mockGetTask.mockResolvedValueOnce(parentTask);
 
-    // No repo config
-    vi.mocked(db.select().from(undefined as any).where as any).mockResolvedValueOnce([]);
+    // No repo config (first call is getDefaultWorkspaceId, second is the repo lookup)
+    vi.mocked(db.select().from(undefined as any).where as any)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
 
     mockCreateSubtask.mockResolvedValueOnce({ id: "review-2" });
     mockTransitionTask.mockResolvedValueOnce({ id: "review-2", state: "queued" });
@@ -184,7 +189,9 @@ describe("launchReview", () => {
     };
 
     mockGetTask.mockResolvedValueOnce(parentTask);
-    vi.mocked(db.select().from(undefined as any).where as any).mockResolvedValueOnce([]);
+    vi.mocked(db.select().from(undefined as any).where as any)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
 
     mockCreateSubtask.mockResolvedValueOnce({ id: "review-3" });
     mockTransitionTask.mockResolvedValueOnce({ id: "review-3" });

--- a/apps/api/src/services/subtask-service.test.ts
+++ b/apps/api/src/services/subtask-service.test.ts
@@ -22,6 +22,11 @@ vi.mock("../db/schema.js", () => ({
   },
   repos: {
     repoUrl: "repos.repo_url",
+    workspaceId: "repos.workspace_id",
+  },
+  workspaces: {
+    id: "workspaces.id",
+    slug: "workspaces.slug",
   },
 }));
 
@@ -468,7 +473,11 @@ describe("subtask-service", () => {
               return Promise.resolve([{ id: "review-1", state: "completed", taskType: "review" }]);
             }
             if (selectCallCount === 3) {
-              // repo config query
+              // getDefaultWorkspaceId — no default workspace in test
+              return Promise.resolve([]);
+            }
+            if (selectCallCount === 4) {
+              // getRepoByUrl isNull fallback — repo config query
               return Promise.resolve([{ autoMerge: true }]);
             }
             return Promise.resolve([]);
@@ -536,6 +545,11 @@ describe("subtask-service", () => {
               return Promise.resolve([{ id: "review-1", state: "completed", taskType: "review" }]);
             }
             if (selectCallCount === 3) {
+              // getDefaultWorkspaceId — no default workspace in test
+              return Promise.resolve([]);
+            }
+            if (selectCallCount === 4) {
+              // getRepoByUrl isNull fallback — repo config query
               return Promise.resolve([{ autoMerge: true }]);
             }
             return Promise.resolve([]);
@@ -586,7 +600,11 @@ describe("subtask-service", () => {
               return Promise.resolve([{ id: "review-1", state: "completed", taskType: "review" }]);
             }
             if (selectCallCount === 3) {
-              // autoMerge is false
+              // getDefaultWorkspaceId — no default workspace in test
+              return Promise.resolve([]);
+            }
+            if (selectCallCount === 4) {
+              // getRepoByUrl isNull fallback — autoMerge is false
               return Promise.resolve([{ autoMerge: false }]);
             }
             return Promise.resolve([]);


### PR DESCRIPTION
## Summary
- **Migration 0026**: Deduplicates existing repos with NULL `workspace_id`, assigns them to the default workspace, and creates a partial unique index (`repos_url_null_ws_idx`) as a database-level safety net
- **`repo-service.ts`**: `createRepo` now resolves the default workspace when no `workspaceId` is provided, preventing future NULL `workspace_id` rows that bypass the composite unique constraint
- **`getRepoByUrl`**: When called without workspace context, now checks the default workspace first before falling back to NULL workspace lookup

## Context
PostgreSQL treats NULLs as distinct in unique constraints, so `repos_url_workspace_key` on `(repo_url, workspace_id)` allowed duplicate repo entries when `workspace_id` was NULL. This caused duplicate repos and duplicate issues in the issues list.

## Test plan
- [x] All 224 existing tests pass
- [x] Typecheck passes across all 6 packages
- [x] Formatting checks pass
- [ ] Verify migration runs cleanly on a fresh database
- [ ] Verify migration handles existing duplicates on a production-like database
- [ ] Test repo creation in auth-disabled mode (no user/workspace context)

Closes #6c3d96db

🤖 Generated with [Claude Code](https://claude.com/claude-code)