### PR TITLE
feat: add codex CLI app-server support for ChatGPT subscription auth

### DIFF
--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -26,7 +26,17 @@ export async function setupRoutes(app: FastifyInstance) {
       }
     } catch {}
 
-    const hasAnyAgentKey = hasAnthropicKey || hasOpenAIKey || usingSubscription || hasOauthToken;
+    // Check if using Codex app-server mode (no API key needed)
+    let hasCodexAppServer = false;
+    try {
+      const codexAuthMode = await retrieveSecret("CODEX_AUTH_MODE").catch(() => null);
+      if (codexAuthMode === "app-server") {
+        hasCodexAppServer = secretNames.includes("CODEX_APP_SERVER_URL");
+      }
+    } catch {}
+
+    const hasAnyAgentKey =
+      hasAnthropicKey || hasOpenAIKey || usingSubscription || hasOauthToken || hasCodexAppServer;
 
     let runtimeHealthy = false;
     try {
@@ -42,6 +52,7 @@ export async function setupRoutes(app: FastifyInstance) {
         githubToken: { done: hasGithubToken, label: "GitHub token" },
         anthropicKey: { done: hasAnthropicKey, label: "Anthropic API key" },
         openaiKey: { done: hasOpenAIKey, label: "OpenAI API key" },
+        codexAppServer: { done: hasCodexAppServer, label: "Codex app-server" },
         anyAgentKey: { done: hasAnyAgentKey, label: "At least one agent API key" },
       },
     });

--- a/apps/api/src/workers/task-worker.test.ts
+++ b/apps/api/src/workers/task-worker.test.ts
@@ -92,6 +92,39 @@ describe("buildAgentCommand", () => {
       expect(cmds.some((c) => c.includes("--full-auto"))).toBe(true);
       expect(cmds.some((c) => c.includes("--json"))).toBe(true);
     });
+
+    it("does not include --app-server flag in api-key mode", () => {
+      const env = { OPTIO_PROMPT: "Build feature", OPTIO_CODEX_AUTH_MODE: "api-key" };
+      const cmds = buildAgentCommand("codex", env);
+      expect(cmds.some((c) => c.includes("--app-server"))).toBe(false);
+    });
+
+    it("includes --app-server flag with URL in app-server mode", () => {
+      const env = {
+        OPTIO_PROMPT: "Build feature",
+        OPTIO_CODEX_AUTH_MODE: "app-server",
+        OPTIO_CODEX_APP_SERVER_URL: "ws://localhost:3900/v1/connect",
+      };
+      const cmds = buildAgentCommand("codex", env);
+      expect(cmds.some((c) => c.includes("--app-server"))).toBe(true);
+      expect(cmds.some((c) => c.includes("ws://localhost:3900/v1/connect"))).toBe(true);
+    });
+
+    it("includes app-server label in echo when in app-server mode", () => {
+      const env = {
+        OPTIO_PROMPT: "Build feature",
+        OPTIO_CODEX_AUTH_MODE: "app-server",
+        OPTIO_CODEX_APP_SERVER_URL: "ws://localhost:3900/v1/connect",
+      };
+      const cmds = buildAgentCommand("codex", env);
+      expect(cmds.some((c) => c.includes("(app-server)"))).toBe(true);
+    });
+
+    it("does not include --app-server flag when auth mode is app-server but URL is missing", () => {
+      const env = { OPTIO_PROMPT: "Build feature", OPTIO_CODEX_AUTH_MODE: "app-server" };
+      const cmds = buildAgentCommand("codex", env);
+      expect(cmds.some((c) => c.includes("--app-server"))).toBe(false);
+    });
   });
 
   describe("unknown agent", () => {

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -182,6 +182,18 @@ export function startTaskWorker() {
           ((await retrieveSecretWithFallback("CLAUDE_AUTH_MODE", "global", taskWorkspaceId).catch(
             () => null,
           )) as any) ?? "api-key";
+        const codexAuthMode =
+          ((await retrieveSecretWithFallback("CODEX_AUTH_MODE", "global", taskWorkspaceId).catch(
+            () => null,
+          )) as any) ?? "api-key";
+        const codexAppServerUrl =
+          codexAuthMode === "app-server"
+            ? (((await retrieveSecretWithFallback(
+                "CODEX_APP_SERVER_URL",
+                "global",
+                taskWorkspaceId,
+              ).catch(() => null)) as any) ?? undefined)
+            : undefined;
         const optioApiUrl = `http://${process.env.API_HOST ?? "host.docker.internal"}:${process.env.API_PORT ?? "4000"}`;
 
         // Load and render prompt template
@@ -224,6 +236,8 @@ export function startTaskWorker() {
           repoUrl: task.repoUrl,
           repoBranch: task.repoBranch,
           claudeAuthMode,
+          codexAuthMode,
+          codexAppServerUrl,
           optioApiUrl,
           renderedPrompt: finalRenderedPrompt,
           taskFileContent: finalTaskFileContent,
@@ -831,11 +845,16 @@ export function buildAgentCommand(
         `  ${resumeFlag}`.trim(),
       ];
     }
-    case "codex":
+    case "codex": {
+      const appServerFlag =
+        env.OPTIO_CODEX_AUTH_MODE === "app-server" && env.OPTIO_CODEX_APP_SERVER_URL
+          ? ` --app-server ${JSON.stringify(env.OPTIO_CODEX_APP_SERVER_URL)}`
+          : "";
       return [
-        `echo "[optio] Running OpenAI Codex..."`,
-        `codex exec --full-auto ${JSON.stringify(prompt)} --json`,
+        `echo "[optio] Running OpenAI Codex${appServerFlag ? " (app-server)" : ""}..."`,
+        `codex exec --full-auto ${JSON.stringify(prompt)}${appServerFlag} --json`,
       ];
+    }
     default:
       return [`echo "Unknown agent type: ${agentType}" && exit 1`];
   }

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -69,6 +69,10 @@ export default function SetupPage() {
   const [oauthChecking, setOauthChecking] = useState(false);
   const [showManualPaste, setShowManualPaste] = useState(false);
 
+  // Step 3: Codex auth mode
+  const [codexAuthMode, setCodexAuthMode] = useState<"api-key" | "app-server">("api-key");
+  const [codexAppServerUrl, setCodexAppServerUrl] = useState("");
+
   // Step 4: Repos
   const [repos, setRepos] = useState<RepoEntry[]>([]);
   const [suggestedRepos, setSuggestedRepos] = useState<
@@ -137,6 +141,9 @@ export default function SetupPage() {
     claudeAuthMode === "oauth-token"
       ? oauthTokenDetected || oauthToken.trim().length > 0
       : anthropicValidated;
+
+  const codexReady =
+    codexAuthMode === "app-server" ? codexAppServerUrl.trim().length > 0 : openaiValidated;
 
   const currentStep = STEPS[step];
 
@@ -263,7 +270,12 @@ export default function SetupPage() {
       if (claudeAuthMode === "oauth-token" && oauthToken.trim()) {
         await api.createSecret({ name: "CLAUDE_CODE_OAUTH_TOKEN", value: oauthToken });
       }
-      if (openaiKey.trim() && openaiValidated) {
+      // Save Codex auth mode and credentials
+      if (codexAuthMode === "app-server" && codexAppServerUrl.trim()) {
+        await api.createSecret({ name: "CODEX_AUTH_MODE", value: "app-server" });
+        await api.createSecret({ name: "CODEX_APP_SERVER_URL", value: codexAppServerUrl.trim() });
+      } else if (openaiKey.trim() && openaiValidated) {
+        await api.createSecret({ name: "CODEX_AUTH_MODE", value: "api-key" });
         await api.createSecret({ name: "OPENAI_API_KEY", value: openaiKey });
       }
       goNext();
@@ -704,53 +716,146 @@ export default function SetupPage() {
                 </div>
               </div>
 
-              {/* OpenAI (unchanged) */}
-              <div className="p-4 rounded-md bg-bg border border-border space-y-3">
+              {/* OpenAI Codex */}
+              <div className="p-4 rounded-md bg-bg border border-border space-y-4">
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium">
                     Codex (OpenAI) <span className="text-text-muted font-normal">— optional</span>
                   </span>
-                  {openaiValidated && (
+                  {codexReady && (
                     <span className="text-success text-xs flex items-center gap-1">
-                      <CheckCircle className="w-3 h-3" /> Valid
+                      <CheckCircle className="w-3 h-3" /> Ready
                     </span>
                   )}
                 </div>
-                <div className="flex gap-2">
-                  <input
-                    type="password"
-                    value={openaiKey}
-                    onChange={(e) => {
-                      setOpenaiKey(e.target.value);
-                      setOpenaiValidated(false);
-                      setOpenaiError("");
-                    }}
-                    onPaste={(e) => {
-                      e.preventDefault();
-                      const pasted = e.clipboardData.getData("text").trim();
-                      if (pasted) {
-                        setOpenaiKey(pasted);
-                        setOpenaiValidated(false);
-                        setOpenaiError("");
-                        setTimeout(() => validateOpenai(pasted), 50);
-                      }
-                    }}
-                    placeholder="sk-..."
-                    className="flex-1 px-3 py-2 rounded-md bg-bg-card border border-border text-sm focus:outline-none focus:border-primary"
-                  />
-                  <button
-                    onClick={() => validateOpenai()}
-                    disabled={loading || !openaiKey.trim() || openaiValidated}
-                    className="px-3 py-2 rounded-md bg-bg-hover text-sm hover:bg-border disabled:opacity-50"
+
+                {/* Codex auth mode selector */}
+                <div className="space-y-2">
+                  <label
+                    className={cn(
+                      "flex items-start gap-3 p-3 rounded-md border cursor-pointer transition-colors",
+                      codexAuthMode === "app-server"
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-text-muted",
+                    )}
                   >
-                    {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Validate"}
-                  </button>
+                    <input
+                      type="radio"
+                      name="codex-auth"
+                      checked={codexAuthMode === "app-server"}
+                      onChange={() => setCodexAuthMode("app-server")}
+                      className="mt-0.5"
+                    />
+                    <div className="flex-1">
+                      <span className="text-sm font-medium">
+                        Use ChatGPT subscription (app-server)
+                      </span>
+                      <p className="text-xs text-text-muted mt-0.5">
+                        Run Codex CLI with your ChatGPT Plus/Pro plan — no API key costs. Start the
+                        Codex desktop app or run{" "}
+                        <code className="px-1 py-0.5 bg-bg-card rounded text-primary text-[11px]">
+                          codex --app-server
+                        </code>{" "}
+                        locally, then provide the WebSocket endpoint below.
+                      </p>
+                      {codexAuthMode === "app-server" && (
+                        <div className="mt-3 space-y-2">
+                          <div>
+                            <p className="text-xs text-text-muted mb-1.5">
+                              App-server WebSocket endpoint:
+                            </p>
+                            <input
+                              type="text"
+                              value={codexAppServerUrl}
+                              onChange={(e) => setCodexAppServerUrl(e.target.value)}
+                              onPaste={(e) => {
+                                e.preventDefault();
+                                const pasted = e.clipboardData.getData("text").trim();
+                                if (pasted) {
+                                  setCodexAppServerUrl(pasted);
+                                }
+                              }}
+                              placeholder="ws://localhost:3900/v1/connect"
+                              className="w-full px-3 py-2 rounded-md bg-bg-card border border-border text-sm focus:outline-none focus:border-primary font-mono"
+                            />
+                          </div>
+                          {codexAppServerUrl.trim().length > 0 && (
+                            <span className="text-xs text-success flex items-center gap-1">
+                              <Check className="w-3 h-3" /> Endpoint configured
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </label>
+
+                  <label
+                    className={cn(
+                      "flex items-start gap-3 p-3 rounded-md border cursor-pointer transition-colors",
+                      codexAuthMode === "api-key"
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-text-muted",
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name="codex-auth"
+                      checked={codexAuthMode === "api-key"}
+                      onChange={() => setCodexAuthMode("api-key")}
+                      className="mt-0.5"
+                    />
+                    <div className="flex-1">
+                      <span className="text-sm font-medium">Use API key</span>
+                      <p className="text-xs text-text-muted mt-0.5">
+                        Pay-per-use via the OpenAI API. Get a key from platform.openai.com.
+                      </p>
+                      {codexAuthMode === "api-key" && (
+                        <div className="mt-2 space-y-2">
+                          <div className="flex gap-2">
+                            <input
+                              type="password"
+                              value={openaiKey}
+                              onChange={(e) => {
+                                setOpenaiKey(e.target.value);
+                                setOpenaiValidated(false);
+                                setOpenaiError("");
+                              }}
+                              onPaste={(e) => {
+                                e.preventDefault();
+                                const pasted = e.clipboardData.getData("text").trim();
+                                if (pasted) {
+                                  setOpenaiKey(pasted);
+                                  setOpenaiValidated(false);
+                                  setOpenaiError("");
+                                  setTimeout(() => validateOpenai(pasted), 50);
+                                }
+                              }}
+                              placeholder="sk-..."
+                              className="flex-1 px-3 py-2 rounded-md bg-bg-card border border-border text-sm focus:outline-none focus:border-primary"
+                            />
+                            <button
+                              onClick={() => validateOpenai()}
+                              disabled={loading || !openaiKey.trim() || openaiValidated}
+                              className="px-3 py-2 rounded-md bg-bg-hover text-sm hover:bg-border disabled:opacity-50"
+                            >
+                              {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Validate"}
+                            </button>
+                          </div>
+                          {openaiError && (
+                            <p className="text-error text-xs flex items-center gap-1">
+                              <AlertCircle className="w-3 h-3" /> {openaiError}
+                            </p>
+                          )}
+                          {openaiValidated && (
+                            <p className="text-success text-xs flex items-center gap-1">
+                              <CheckCircle className="w-3 h-3" /> API key valid
+                            </p>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </label>
                 </div>
-                {openaiError && (
-                  <p className="text-error text-xs flex items-center gap-1">
-                    <AlertCircle className="w-3 h-3" /> {openaiError}
-                  </p>
-                )}
               </div>
 
               <div className="flex items-center justify-between">
@@ -762,7 +867,7 @@ export default function SetupPage() {
                 </button>
                 <button
                   onClick={saveAgentKeysStep}
-                  disabled={(!claudeReady && !openaiValidated) || loading}
+                  disabled={(!claudeReady && !codexReady) || loading}
                   className="flex items-center gap-2 px-5 py-2 rounded-md bg-primary text-white text-sm hover:bg-primary-hover disabled:opacity-50"
                 >
                   {loading ? (

--- a/packages/agent-adapters/src/codex.test.ts
+++ b/packages/agent-adapters/src/codex.test.ts
@@ -36,7 +36,25 @@ describe("CodexAdapter", () => {
     it("reports both missing when empty", () => {
       const result = adapter.validateSecrets([]);
       expect(result.valid).toBe(false);
-      expect(result.missing).toEqual(["OPENAI_API_KEY", "GITHUB_TOKEN"]);
+      expect(result.missing).toEqual(["GITHUB_TOKEN", "OPENAI_API_KEY"]);
+    });
+
+    it("does not require OPENAI_API_KEY in app-server mode", () => {
+      const result = adapter.validateSecrets(["GITHUB_TOKEN"], "app-server");
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+
+    it("still requires GITHUB_TOKEN in app-server mode", () => {
+      const result = adapter.validateSecrets([], "app-server");
+      expect(result.valid).toBe(false);
+      expect(result.missing).toEqual(["GITHUB_TOKEN"]);
+    });
+
+    it("requires OPENAI_API_KEY in api-key mode", () => {
+      const result = adapter.validateSecrets(["GITHUB_TOKEN"], "api-key");
+      expect(result.valid).toBe(false);
+      expect(result.missing).toContain("OPENAI_API_KEY");
     });
   });
 
@@ -94,9 +112,35 @@ describe("CodexAdapter", () => {
       expect(config.env.OPTIO_BRANCH_NAME).toBe("optio/task-test-123");
     });
 
-    it("requires correct secrets", () => {
+    it("requires correct secrets in api-key mode", () => {
       const config = adapter.buildContainerConfig(baseInput);
-      expect(config.requiredSecrets).toEqual(["OPENAI_API_KEY", "GITHUB_TOKEN"]);
+      expect(config.requiredSecrets).toContain("OPENAI_API_KEY");
+      expect(config.requiredSecrets).toContain("GITHUB_TOKEN");
+    });
+
+    it("does not require OPENAI_API_KEY in app-server mode", () => {
+      const config = adapter.buildContainerConfig({
+        ...baseInput,
+        codexAuthMode: "app-server",
+        codexAppServerUrl: "ws://localhost:3900/v1/connect",
+      });
+      expect(config.requiredSecrets).toContain("GITHUB_TOKEN");
+      expect(config.requiredSecrets).not.toContain("OPENAI_API_KEY");
+    });
+
+    it("sets OPTIO_CODEX_AUTH_MODE and OPTIO_CODEX_APP_SERVER_URL in app-server mode", () => {
+      const config = adapter.buildContainerConfig({
+        ...baseInput,
+        codexAuthMode: "app-server",
+        codexAppServerUrl: "ws://localhost:3900/v1/connect",
+      });
+      expect(config.env.OPTIO_CODEX_AUTH_MODE).toBe("app-server");
+      expect(config.env.OPTIO_CODEX_APP_SERVER_URL).toBe("ws://localhost:3900/v1/connect");
+    });
+
+    it("sets OPTIO_CODEX_AUTH_MODE to api-key by default", () => {
+      const config = adapter.buildContainerConfig(baseInput);
+      expect(config.env.OPTIO_CODEX_AUTH_MODE).toBe("api-key");
     });
   });
 

--- a/packages/agent-adapters/src/codex.ts
+++ b/packages/agent-adapters/src/codex.ts
@@ -1,4 +1,9 @@
-import type { AgentTaskInput, AgentContainerConfig, AgentResult } from "@optio/shared";
+import type {
+  AgentTaskInput,
+  AgentContainerConfig,
+  AgentResult,
+  CodexAuthMode,
+} from "@optio/shared";
 import { TASK_BRANCH_PREFIX } from "@optio/shared";
 import type { AgentAdapter } from "./types.js";
 
@@ -33,8 +38,16 @@ export class CodexAdapter implements AgentAdapter {
   readonly type = "codex";
   readonly displayName = "OpenAI Codex";
 
-  validateSecrets(availableSecrets: string[]): { valid: boolean; missing: string[] } {
-    const required = ["OPENAI_API_KEY", "GITHUB_TOKEN"];
+  validateSecrets(
+    availableSecrets: string[],
+    codexAuthMode?: CodexAuthMode,
+  ): { valid: boolean; missing: string[] } {
+    const required: string[] = ["GITHUB_TOKEN"];
+    // In app-server mode, no OpenAI API key is needed — the CLI connects to
+    // a local app-server endpoint that handles auth via the user's ChatGPT plan.
+    if (codexAuthMode !== "app-server") {
+      required.push("OPENAI_API_KEY");
+    }
     const missing = required.filter((s) => !availableSecrets.includes(s));
     return { valid: missing.length === 0, missing };
   }
@@ -52,7 +65,18 @@ export class CodexAdapter implements AgentAdapter {
       OPTIO_BRANCH_NAME: `${TASK_BRANCH_PREFIX}${input.taskId}`,
     };
 
-    const requiredSecrets = ["OPENAI_API_KEY", "GITHUB_TOKEN"];
+    const requiredSecrets: string[] = ["GITHUB_TOKEN"];
+
+    if (input.codexAuthMode === "app-server") {
+      env.OPTIO_CODEX_AUTH_MODE = "app-server";
+      if (input.codexAppServerUrl) {
+        env.OPTIO_CODEX_APP_SERVER_URL = input.codexAppServerUrl;
+      }
+    } else {
+      env.OPTIO_CODEX_AUTH_MODE = "api-key";
+      requiredSecrets.push("OPENAI_API_KEY");
+    }
+
     const setupFiles: AgentContainerConfig["setupFiles"] = [];
 
     // Write the task file into the worktree

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1,4 +1,5 @@
 export type ClaudeAuthMode = "api-key" | "max-subscription";
+export type CodexAuthMode = "api-key" | "app-server";
 
 export interface AgentTaskInput {
   taskId: string;
@@ -7,6 +8,9 @@ export interface AgentTaskInput {
   repoBranch: string;
   additionalContext?: string;
   claudeAuthMode?: ClaudeAuthMode;
+  codexAuthMode?: CodexAuthMode;
+  /** The app-server WebSocket URL for Codex CLI (used when codexAuthMode is "app-server") */
+  codexAppServerUrl?: string;
   optioApiUrl?: string; // for apiKeyHelper callback
   /** The rendered system prompt (from the prompt template) */
   renderedPrompt?: string;


### PR DESCRIPTION
## Summary
- Add support for Codex CLI's `--app-server` flag, allowing users to run Codex agents using their ChatGPT Plus/Pro subscription without an OpenAI API key
- Users configure a WebSocket endpoint during setup that connects to a locally running Codex app-server instance
- Mirrors the existing Claude auth mode pattern (api-key vs subscription-based) for consistency

## Changes
- **`packages/shared/src/types/agent.ts`**: Add `CodexAuthMode` type (`"api-key" | "app-server"`) and `codexAuthMode`/`codexAppServerUrl` fields to `AgentTaskInput`
- **`packages/agent-adapters/src/codex.ts`**: Update `validateSecrets()` to skip `OPENAI_API_KEY` requirement in app-server mode; update `buildContainerConfig()` to set `OPTIO_CODEX_AUTH_MODE` and `OPTIO_CODEX_APP_SERVER_URL` env vars
- **`apps/api/src/workers/task-worker.ts`**: Read `CODEX_AUTH_MODE` and `CODEX_APP_SERVER_URL` secrets; pass `--app-server <url>` flag to codex CLI command when configured
- **`apps/api/src/routes/setup.ts`**: Recognize `CODEX_AUTH_MODE=app-server` + `CODEX_APP_SERVER_URL` as a valid agent configuration in setup status
- **`apps/web/src/app/setup/page.tsx`**: Add codex auth mode selector with radio buttons (app-server vs api-key), including endpoint URL input for app-server mode
- **Tests**: Comprehensive test coverage for adapter secret validation, container config, and CLI command generation in both auth modes

## Test plan
- [x] `pnpm turbo typecheck` passes across all 6 packages
- [x] `pnpm turbo test` passes (388 tests across all packages)
- [x] `pnpm format:check` passes
- [x] Pre-commit hooks pass (lint-staged + format + typecheck)
- [ ] Manual: verify setup wizard renders codex auth mode selector correctly
- [ ] Manual: verify app-server mode task execution with a running codex app-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)