### PR TITLE
feat: initialize git submodules in repo-init.sh during pod setup

### DIFF
--- a/scripts/repo-init.sh
+++ b/scripts/repo-init.sh
@@ -33,6 +33,13 @@ echo "[optio] Cloning..."
 git clone --branch "${OPTIO_REPO_BRANCH}" "${OPTIO_REPO_URL}" repo 2>&1
 echo "[optio] Repo cloned"
 
+# Initialize submodules if any exist
+if [ -f /workspace/repo/.gitmodules ]; then
+  echo "[optio] Initializing submodules..."
+  cd /workspace/repo && git submodule update --init --recursive 2>&1
+  echo "[optio] Submodules initialized"
+fi
+
 # Create tasks directory for worktrees
 mkdir -p /workspace/tasks
 


### PR DESCRIPTION
## Summary

- Adds `git submodule update --init --recursive` to `repo-init.sh` after the clone step, gated on `.gitmodules` existence
- Prevents agents from wasting turns trying to manually clone/init submodules, which often fails due to worktree/module path conflicts
- Runs once per pod creation; submodule data in `.git/modules/` is available to worktrees created later

## Test plan

- [ ] Deploy a repo pod for a repo **with** submodules (e.g., one that vendors curl) — verify submodule directories are populated after pod init
- [ ] Deploy a repo pod for a repo **without** submodules — verify no errors and the "Initializing submodules" log line does not appear
- [ ] Create a worktree-based task on a repo with submodules — verify the agent can access submodule files without extra setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)