### PR TITLE
perf: add missing database indexes for workspace-scoped queries

### DIFF
--- a/apps/api/src/db/migrations/0031_workspace_scoped_indexes.sql
+++ b/apps/api/src/db/migrations/0031_workspace_scoped_indexes.sql
@@ -1,0 +1,7 @@
+-- Add missing indexes for workspace-scoped queries
+CREATE INDEX IF NOT EXISTS "tasks_workspace_state_idx" ON "tasks" ("workspace_id", "state");
+CREATE INDEX IF NOT EXISTS "tasks_workspace_updated_idx" ON "tasks" ("workspace_id", "updated_at");
+CREATE INDEX IF NOT EXISTS "secrets_workspace_id_idx" ON "secrets" ("workspace_id");
+CREATE INDEX IF NOT EXISTS "repos_workspace_id_idx" ON "repos" ("workspace_id");
+CREATE INDEX IF NOT EXISTS "webhooks_workspace_id_idx" ON "webhooks" ("workspace_id");
+CREATE INDEX IF NOT EXISTS "repo_pods_workspace_id_idx" ON "repo_pods" ("workspace_id");

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1775577600000,
       "tag": "0030_secret_proxy",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1775664000000,
+      "tag": "0031_workspace_scoped_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -129,6 +129,8 @@ export const tasks = pgTable(
     index("tasks_parent_task_id_idx").on(table.parentTaskId),
     index("tasks_created_at_idx").on(table.createdAt.desc()),
     index("tasks_workspace_id_idx").on(table.workspaceId),
+    index("tasks_workspace_state_idx").on(table.workspaceId, table.state),
+    index("tasks_workspace_updated_idx").on(table.workspaceId, table.updatedAt),
   ],
 );
 
@@ -184,7 +186,10 @@ export const secrets = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [unique("secrets_name_scope_ws_key").on(table.name, table.scope, table.workspaceId)],
+  (table) => [
+    unique("secrets_name_scope_ws_key").on(table.name, table.scope, table.workspaceId),
+    index("secrets_workspace_id_idx").on(table.workspaceId),
+  ],
 );
 
 export const repos = pgTable(
@@ -233,7 +238,10 @@ export const repos = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [unique("repos_url_workspace_key").on(table.repoUrl, table.workspaceId)],
+  (table) => [
+    unique("repos_url_workspace_key").on(table.repoUrl, table.workspaceId),
+    index("repos_workspace_id_idx").on(table.workspaceId),
+  ],
 );
 
 export const ticketProviders = pgTable("ticket_providers", {
@@ -269,7 +277,10 @@ export const repoPods = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [index("repo_pods_repo_url_idx").on(table.repoUrl)],
+  (table) => [
+    index("repo_pods_repo_url_idx").on(table.repoUrl),
+    index("repo_pods_workspace_id_idx").on(table.workspaceId),
+  ],
 );
 
 export const podHealthEvents = pgTable("pod_health_events", {
@@ -300,18 +311,22 @@ export const webhookEventEnum = pgEnum("webhook_event", [
   "review.completed",
 ]);
 
-export const webhooks = pgTable("webhooks", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  url: text("url").notNull(),
-  workspaceId: uuid("workspace_id"), // nullable for backward compat
-  events: jsonb("events").$type<string[]>().notNull(), // array of webhook_event values
-  secret: text("secret"), // HMAC-SHA256 signing secret (plaintext; only used for outbound signing)
-  description: text("description"),
-  active: boolean("active").notNull().default(true),
-  createdBy: uuid("created_by"),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+export const webhooks = pgTable(
+  "webhooks",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    url: text("url").notNull(),
+    workspaceId: uuid("workspace_id"), // nullable for backward compat
+    events: jsonb("events").$type<string[]>().notNull(), // array of webhook_event values
+    secret: text("secret"), // HMAC-SHA256 signing secret (plaintext; only used for outbound signing)
+    description: text("description"),
+    active: boolean("active").notNull().default(true),
+    createdBy: uuid("created_by"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("webhooks_workspace_id_idx").on(table.workspaceId)],
+);
 
 export const webhookDeliveries = pgTable("webhook_deliveries", {
   id: uuid("id").primaryKey().defaultRandom(),


### PR DESCRIPTION
## Summary

- Adds 6 missing database indexes to improve performance of workspace-scoped queries at scale
- `tasks(workspace_id, state)` — most common query pattern for listing tasks by workspace filtered by state
- `tasks(workspace_id, updated_at)` — dashboard sorting by last updated
- `secrets(workspace_id)`, `repos(workspace_id)`, `webhooks(workspace_id)`, `repo_pods(workspace_id)` — workspace-scoped lookups
- Includes migration `0031_workspace_scoped_indexes.sql` using `CREATE INDEX IF NOT EXISTS` for safe idempotent application

## Test plan

- [x] TypeScript typechecks pass (`pnpm turbo typecheck`)
- [x] All 278 tests pass (`pnpm turbo test`)
- [x] Formatting checks pass (`pnpm format:check`)
- [ ] Migration applies cleanly on deployment (additive-only, no behavior changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)