### PR TITLE
feat: add feature-specific error boundaries to web app

### DIFF
--- a/apps/web/src/app/sessions/[id]/page.tsx
+++ b/apps/web/src/app/sessions/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
 import { SessionTerminal } from "@/components/session-terminal";
 import { SessionChat } from "@/components/session-chat";
 import { SplitPane } from "@/components/split-pane";
+import { ErrorBoundary } from "@/components/error-boundary";
 
 export default function SessionDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -276,15 +277,19 @@ export default function SessionDetailPage({ params }: { params: Promise<{ id: st
             leftLabel="Agent Chat"
             rightLabel="Terminal"
             left={
-              <SessionChat
-                sessionId={id}
-                onCostUpdate={handleCostUpdate}
-                onSendToAgent={handleSendToAgentRegister}
-              />
+              <ErrorBoundary label="Session chat">
+                <SessionChat
+                  sessionId={id}
+                  onCostUpdate={handleCostUpdate}
+                  onSendToAgent={handleSendToAgentRegister}
+                />
+              </ErrorBoundary>
             }
             right={
               <div className="h-full flex flex-col">
-                <SessionTerminal sessionId={id} />
+                <ErrorBoundary label="Terminal">
+                  <SessionTerminal sessionId={id} />
+                </ErrorBoundary>
                 {/* PR cards inline below terminal when present */}
                 {prs.length > 0 && (
                   <div className="shrink-0 border-t border-border bg-bg px-3 py-2">

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -9,6 +9,7 @@ import { PipelineTimeline } from "@/components/pipeline-timeline";
 import { ActivityFeed } from "@/components/activity-feed";
 import { StateBadge } from "@/components/state-badge";
 import { api } from "@/lib/api-client";
+import { ErrorBoundary } from "@/components/error-boundary";
 import { classifyError } from "@optio/shared";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import {
@@ -801,7 +802,9 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
 
           {/* Log content via LogViewer */}
           <div className="flex-1 overflow-hidden">
-            <LogViewer taskId={id} />
+            <ErrorBoundary label="Log viewer">
+              <LogViewer taskId={id} />
+            </ErrorBoundary>
           </div>
 
           {/* Resume / interact bar */}
@@ -882,9 +885,13 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
             </div>
             <div className="flex-1 overflow-auto p-3">
               {sidebarTab === "pipeline" ? (
-                <PipelineTimeline task={task} events={events} subtasks={subtasks} />
+                <ErrorBoundary label="Pipeline timeline">
+                  <PipelineTimeline task={task} events={events} subtasks={subtasks} />
+                </ErrorBoundary>
               ) : (
-                <ActivityFeed taskId={id} />
+                <ErrorBoundary label="Activity feed">
+                  <ActivityFeed taskId={id} />
+                </ErrorBoundary>
               )}
             </div>
           </div>

--- a/apps/web/src/components/error-boundary.tsx
+++ b/apps/web/src/components/error-boundary.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { AlertCircle, RotateCcw } from "lucide-react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Label describing the section, shown in the fallback UI */
+  label?: string;
+  /** Additional CSS classes for the fallback container */
+  className?: string;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(
+      JSON.stringify({
+        type: "error_boundary",
+        section: this.props.label ?? "unknown",
+        error: error.message,
+        stack: error.stack,
+        componentStack: errorInfo.componentStack,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          className={"flex items-center justify-center p-6 " + (this.props.className ?? "h-full")}
+        >
+          <div className="text-center space-y-3 max-w-sm">
+            <AlertCircle className="w-8 h-8 text-error/60 mx-auto" />
+            <div>
+              <p className="text-sm font-medium text-text">
+                {this.props.label
+                  ? `${this.props.label} failed to load`
+                  : "This section failed to load"}
+              </p>
+              <p className="text-xs text-text-muted mt-1">
+                An unexpected error occurred. Try again or reload the page.
+              </p>
+            </div>
+            {process.env.NODE_ENV === "development" && this.state.error && (
+              <pre className="text-[11px] text-error/70 bg-error/5 border border-error/20 rounded-md p-2 text-left overflow-auto max-h-32 whitespace-pre-wrap break-all">
+                {this.state.error.message}
+                {this.state.error.stack && `\n\n${this.state.error.stack}`}
+              </pre>
+            )}
+            <button
+              onClick={this.handleRetry}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-white text-xs hover:bg-primary-hover transition-colors"
+            >
+              <RotateCcw className="w-3 h-3" />
+              Try again
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a reusable `<ErrorBoundary>` class component with descriptive fallback UI, retry button, and error details in dev mode
- Wrap the log viewer, pipeline timeline, and activity feed on the task detail page so a crash in one section doesn't take down the whole page
- Wrap the session chat and session terminal on the session detail page with independent error boundaries
- Errors are logged in structured JSON format for future observability integration

## Test plan
- [ ] Verify task detail page renders normally with no regressions
- [ ] Verify session detail page renders normally with no regressions
- [ ] Simulate a rendering error in log viewer — confirm fallback UI appears with retry button, rest of page remains functional
- [ ] Confirm error details are shown in dev mode (`NODE_ENV=development`) but hidden in production
- [ ] Click "Try again" button — confirm component re-renders successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)