### PR TITLE
fix: add query parameter validation and bounds across routes

### DIFF
--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -12,9 +12,12 @@ const costsQuerySchema = z.object({
 export async function analyticsRoutes(app: FastifyInstance) {
   // Cost analytics — aggregated cost data for the dashboard (member+)
   app.get("/api/analytics/costs", { preHandler: [requireRole("member")] }, async (req, reply) => {
-    const query = costsQuerySchema.parse(req.query);
-    const days = query.days;
-    const repoUrl = query.repoUrl || null;
+    const parsed = costsQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0].message });
+    }
+    const days = parsed.data.days;
+    const repoUrl = parsed.data.repoUrl || null;
 
     const workspaceId = req.user?.workspaceId || null;
 

--- a/apps/api/src/routes/cluster.ts
+++ b/apps/api/src/routes/cluster.ts
@@ -1,9 +1,14 @@
 import type { FastifyInstance } from "fastify";
+import { z } from "zod";
 import { KubeConfig, CoreV1Api, CustomObjectsApi } from "@kubernetes/client-node";
 import { db } from "../db/client.js";
 import { repoPods, tasks, podHealthEvents, repos } from "../db/schema.js";
 import { eq, desc, and, inArray, sql } from "drizzle-orm";
 import { requireRole } from "../plugins/auth.js";
+
+const healthEventsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(1000).default(50),
+});
 
 function getK8sConfig() {
   const kc = new KubeConfig();
@@ -383,8 +388,11 @@ export async function clusterRoutes(app: FastifyInstance) {
     "/api/cluster/health-events",
     { preHandler: [requireRole("admin")] },
     async (req, reply) => {
-      const query = req.query as { limit?: string };
-      const limit = query.limit ? parseInt(query.limit, 10) : 50;
+      const parsed = healthEventsQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        return reply.status(400).send({ error: parsed.error.issues[0].message });
+      }
+      const limit = parsed.data.limit;
       const events = await db
         .select()
         .from(podHealthEvents)

--- a/apps/api/src/routes/query-validation.test.ts
+++ b/apps/api/src/routes/query-validation.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+
+// ─── Mocks ───
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    execute: vi.fn().mockResolvedValue([]),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+          groupBy: vi.fn().mockResolvedValue([]),
+        }),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    }),
+  },
+}));
+
+const mockListTasks = vi.fn().mockResolvedValue([]);
+const mockSearchTasks = vi.fn().mockResolvedValue({ tasks: [], cursor: null });
+const mockGetTask = vi.fn().mockResolvedValue({ id: "t1", state: "running", workspaceId: null });
+const mockGetTaskLogs = vi.fn().mockResolvedValue([]);
+
+vi.mock("../services/task-service.js", () => ({
+  listTasks: (...args: unknown[]) => mockListTasks(...args),
+  searchTasks: (...args: unknown[]) => mockSearchTasks(...args),
+  getTask: (...args: unknown[]) => mockGetTask(...args),
+  getTaskLogs: (...args: unknown[]) => mockGetTaskLogs(...args),
+  getTaskEvents: vi.fn().mockResolvedValue([]),
+  createTask: vi.fn(),
+  transitionTask: vi.fn(),
+  getAllTaskLogs: vi.fn().mockResolvedValue([]),
+  forceRedoTask: vi.fn(),
+}));
+
+vi.mock("../services/dependency-service.js", () => ({
+  addDependencies: vi.fn(),
+  computePendingReason: vi.fn(),
+}));
+
+vi.mock("../workers/task-worker.js", () => ({
+  taskQueue: {
+    add: vi.fn(),
+    getJobs: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  tasks: {},
+  repoPods: {},
+  podHealthEvents: {},
+  repos: {},
+}));
+
+const mockListSessions = vi.fn().mockResolvedValue([]);
+const mockGetActiveSessionCount = vi.fn().mockResolvedValue(0);
+
+vi.mock("../services/interactive-session-service.js", () => ({
+  listSessions: (...args: unknown[]) => mockListSessions(...args),
+  getActiveSessionCount: (...args: unknown[]) => mockGetActiveSessionCount(...args),
+  getSession: vi.fn(),
+  createSession: vi.fn(),
+  endSession: vi.fn(),
+}));
+
+import { taskRoutes } from "./tasks.js";
+import { sessionRoutes } from "./sessions.js";
+
+// ─── Helpers ───
+
+async function buildTaskApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  // Decorate with a fake user to satisfy workspace checks
+  app.decorateRequest("user", undefined);
+  app.addHook("preHandler", async (req) => {
+    (req as any).user = { id: "u1", workspaceId: null };
+  });
+  await taskRoutes(app);
+  await app.ready();
+  return app;
+}
+
+async function buildSessionApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.decorateRequest("user", undefined);
+  app.addHook("preHandler", async (req) => {
+    (req as any).user = { id: "u1", workspaceId: null };
+  });
+  await sessionRoutes(app);
+  await app.ready();
+  return app;
+}
+
+// ─── Tests ───
+
+describe("query parameter validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/tasks", () => {
+    it("accepts valid limit and offset", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks?limit=10&offset=5",
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mockListTasks).toHaveBeenCalledWith(expect.objectContaining({ limit: 10, offset: 5 }));
+    });
+
+    it("uses defaults when no params provided", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks",
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mockListTasks).toHaveBeenCalledWith(expect.objectContaining({ limit: 50, offset: 0 }));
+    });
+
+    it("rejects negative limit", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks?limit=-1",
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body)).toHaveProperty("error");
+    });
+
+    it("rejects limit exceeding max (1000)", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks?limit=5000",
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body)).toHaveProperty("error");
+    });
+
+    it("rejects negative offset", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks?offset=-10",
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body)).toHaveProperty("error");
+    });
+
+    it("rejects non-integer limit", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks?limit=3.5",
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body)).toHaveProperty("error");
+    });
+
+    it("rejects zero limit", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks?limit=0",
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body)).toHaveProperty("error");
+    });
+  });
+
+  describe("GET /api/tasks/search", () => {
+    it("accepts valid limit", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks/search?limit=25&q=test",
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mockSearchTasks).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 25, q: "test" }),
+      );
+    });
+
+    it("rejects limit over 1000", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks/search?limit=2000",
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe("GET /api/tasks/:id/logs", () => {
+    it("accepts valid limit and offset", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks/t1/logs?limit=100&offset=50",
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mockGetTaskLogs).toHaveBeenCalledWith(
+        "t1",
+        expect.objectContaining({ limit: 100, offset: 50 }),
+      );
+    });
+
+    it("uses default limit of 200", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks/t1/logs",
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mockGetTaskLogs).toHaveBeenCalledWith(
+        "t1",
+        expect.objectContaining({ limit: 200, offset: 0 }),
+      );
+    });
+
+    it("rejects negative limit", async () => {
+      const app = await buildTaskApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/tasks/t1/logs?limit=-5",
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe("GET /api/sessions", () => {
+    it("accepts valid limit and offset", async () => {
+      const app = await buildSessionApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/sessions?limit=20&offset=10",
+      });
+      expect(res.statusCode).toBe(200);
+      expect(mockListSessions).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 20, offset: 10 }),
+      );
+    });
+
+    it("rejects limit exceeding 1000", async () => {
+      const app = await buildSessionApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/sessions?limit=9999",
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("rejects negative offset", async () => {
+      const app = await buildSessionApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/sessions?offset=-1",
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+});

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -5,6 +5,13 @@ import * as sessionService from "../services/interactive-session-service.js";
 import { db } from "../db/client.js";
 import { repos } from "../db/schema.js";
 
+const listSessionsQuerySchema = z.object({
+  repoUrl: z.string().optional(),
+  state: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(1000).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
 const createSessionSchema = z.object({
   repoUrl: z.string().url(),
 });
@@ -12,19 +19,18 @@ const createSessionSchema = z.object({
 export async function sessionRoutes(app: FastifyInstance) {
   // List sessions
   app.get("/api/sessions", async (req, reply) => {
-    const query = req.query as {
-      repoUrl?: string;
-      state?: string;
-      limit?: string;
-      offset?: string;
-    };
+    const parsed = listSessionsQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0].message });
+    }
+    const { repoUrl, state, limit, offset } = parsed.data;
     const sessions = await sessionService.listSessions({
-      repoUrl: query.repoUrl,
-      state: query.state,
-      limit: query.limit ? parseInt(query.limit, 10) : 50,
-      offset: query.offset ? parseInt(query.offset, 10) : 0,
+      repoUrl,
+      state,
+      limit,
+      offset,
     });
-    const activeCount = await sessionService.getActiveSessionCount(query.repoUrl);
+    const activeCount = await sessionService.getActiveSessionCount(repoUrl);
     reply.send({ sessions, activeCount });
   });
 

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -9,6 +9,34 @@ import { db } from "../db/client.js";
 import { tasks } from "../db/schema.js";
 import { requireRole } from "../plugins/auth.js";
 
+const listQuerySchema = z.object({
+  state: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(1000).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+const searchQuerySchema = z.object({
+  q: z.string().optional(),
+  state: z.string().optional(),
+  repoUrl: z.string().optional(),
+  agentType: z.string().optional(),
+  taskType: z.string().optional(),
+  costMin: z.string().optional(),
+  costMax: z.string().optional(),
+  createdAfter: z.string().optional(),
+  createdBefore: z.string().optional(),
+  author: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+});
+
+const logsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(10000).default(200),
+  offset: z.coerce.number().int().min(0).default(0),
+  search: z.string().optional(),
+  logType: z.string().optional(),
+});
+
 const createTaskSchema = z.object({
   title: z.string().min(1),
   prompt: z.string().min(1),
@@ -26,12 +54,14 @@ const createTaskSchema = z.object({
 export async function taskRoutes(app: FastifyInstance) {
   // List tasks
   app.get("/api/tasks", async (req, reply) => {
-    const query = req.query as { state?: string; limit?: string; offset?: string };
-    const limit = query.limit ? parseInt(query.limit, 10) : 50;
-    const offset = query.offset ? parseInt(query.offset, 10) : 0;
+    const parsed = listQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0].message });
+    }
+    const { state, limit, offset } = parsed.data;
     const workspaceId = req.user?.workspaceId ?? null;
     const taskList = await taskService.listTasks({
-      state: query.state,
+      state,
       limit,
       offset,
       workspaceId,
@@ -41,7 +71,11 @@ export async function taskRoutes(app: FastifyInstance) {
 
   // Search tasks with advanced filtering and cursor-based pagination
   app.get("/api/tasks/search", async (req, reply) => {
-    const query = req.query as Record<string, string | undefined>;
+    const parsed = searchQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0].message });
+    }
+    const query = parsed.data;
     const result = await taskService.searchTasks({
       q: query.q,
       state: query.state,
@@ -54,7 +88,7 @@ export async function taskRoutes(app: FastifyInstance) {
       createdBefore: query.createdBefore,
       author: query.author,
       cursor: query.cursor,
-      limit: query.limit ? parseInt(query.limit, 10) : undefined,
+      limit: query.limit,
       workspaceId: req.user?.workspaceId ?? null,
     });
     reply.send(result);
@@ -231,17 +265,16 @@ export async function taskRoutes(app: FastifyInstance) {
     if (wsId && task.workspaceId !== wsId) {
       return reply.status(404).send({ error: "Task not found" });
     }
-    const query = req.query as {
-      limit?: string;
-      offset?: string;
-      search?: string;
-      logType?: string;
-    };
+    const logsParsed = logsQuerySchema.safeParse(req.query);
+    if (!logsParsed.success) {
+      return reply.status(400).send({ error: logsParsed.error.issues[0].message });
+    }
+    const logsQuery = logsParsed.data;
     const logs = await taskService.getTaskLogs(id, {
-      limit: query.limit ? parseInt(query.limit, 10) : 200,
-      offset: query.offset ? parseInt(query.offset, 10) : 0,
-      search: query.search || undefined,
-      logType: query.logType || undefined,
+      limit: logsQuery.limit,
+      offset: logsQuery.offset,
+      search: logsQuery.search || undefined,
+      logType: logsQuery.logType || undefined,
     });
     reply.send({ logs });
   });


### PR DESCRIPTION
## Summary
- Add Zod validation schemas for numeric query parameters (`limit`, `offset`, `days`) on all list/analytics endpoints
- Prevents unbounded result sets (e.g. `limit=999999`) and nonsensical values (e.g. `days=-5`)
- Returns 400 with a descriptive error message for invalid parameters

### Routes updated
| Route | Parameters | Bounds |
|---|---|---|
| `GET /api/analytics/costs` | `days` | 1–365, default 30 |
| `GET /api/tasks` | `limit`, `offset` | limit 1–1000 (default 50), offset ≥ 0 |
| `GET /api/tasks/search` | `limit` | 1–1000 |
| `GET /api/tasks/:id/logs` | `limit`, `offset` | limit 1–10000 (default 200), offset ≥ 0 |
| `GET /api/cluster/health-events` | `limit` | 1–1000, default 50 |
| `GET /api/sessions` | `limit`, `offset` | limit 1–1000 (default 50), offset ≥ 0 |

## Test plan
- [x] Added 15 new tests in `query-validation.test.ts` covering valid params, defaults, negative values, exceeding max, non-integers, and zero limit
- [x] All 293 tests pass (19 test files)
- [x] Typecheck passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)