### PR TITLE
feat: enforce RBAC roles across API routes

### DIFF
--- a/apps/api/src/plugins/auth.test.ts
+++ b/apps/api/src/plugins/auth.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+
+// ─── Mocks ───
+
+let authDisabled = false;
+vi.mock("../services/oauth/index.js", () => ({
+  isAuthDisabled: () => authDisabled,
+  getEnabledProviders: () => [],
+  getOAuthProvider: () => undefined,
+}));
+
+vi.mock("../services/session-service.js", () => ({
+  validateSession: () => null,
+}));
+
+vi.mock("../services/workspace-service.js", () => ({
+  getUserRole: () => null,
+  ensureUserHasWorkspace: () => "ws-1",
+}));
+
+import { requireRole } from "./auth.js";
+
+// ─── Helpers ───
+
+function makeUser(role: string | null) {
+  return {
+    id: "user-1",
+    provider: "github",
+    email: "test@example.com",
+    displayName: "Test",
+    avatarUrl: null,
+    workspaceId: "ws-1",
+    workspaceRole: role,
+  };
+}
+
+/**
+ * Build a Fastify app with a test route protected by requireRole.
+ * The `userRole` param sets the workspace role on req.user before the guard runs.
+ * Pass `null` to simulate a user with no role.
+ * Pass `undefined` to simulate no user at all (auth disabled scenario).
+ */
+async function buildApp(
+  minimumRole: "admin" | "member" | "viewer",
+  userRole?: string | null,
+): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+
+  // Set req.user before the requireRole preHandler
+  if (userRole !== undefined) {
+    app.addHook("onRequest", async (req) => {
+      (req as any).user = makeUser(userRole);
+    });
+  }
+
+  app.get("/test", { preHandler: [requireRole(minimumRole)] }, async (_req, reply) => {
+    reply.send({ ok: true });
+  });
+
+  await app.ready();
+  return app;
+}
+
+function inject(app: FastifyInstance) {
+  return app.inject({ method: "GET", url: "/test" });
+}
+
+// ─── Tests ───
+
+describe("requireRole", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authDisabled = false;
+  });
+
+  describe("when auth is disabled", () => {
+    it("allows any request regardless of role", async () => {
+      authDisabled = true;
+      const app = await buildApp("admin"); // no user set
+      const res = await inject(app);
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ ok: true });
+    });
+  });
+
+  describe("requireRole('admin')", () => {
+    it("allows admin", async () => {
+      const res = await inject(await buildApp("admin", "admin"));
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("rejects member", async () => {
+      const res = await inject(await buildApp("admin", "member"));
+      expect(res.statusCode).toBe(403);
+      expect(res.json().error).toContain("admin");
+    });
+
+    it("rejects viewer", async () => {
+      const res = await inject(await buildApp("admin", "viewer"));
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("rejects null role", async () => {
+      const res = await inject(await buildApp("admin", null));
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe("requireRole('member')", () => {
+    it("allows admin", async () => {
+      const res = await inject(await buildApp("member", "admin"));
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("allows member", async () => {
+      const res = await inject(await buildApp("member", "member"));
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("rejects viewer", async () => {
+      const res = await inject(await buildApp("member", "viewer"));
+      expect(res.statusCode).toBe(403);
+      expect(res.json().error).toContain("member");
+    });
+
+    it("rejects null role", async () => {
+      const res = await inject(await buildApp("member", null));
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe("requireRole('viewer')", () => {
+    it("allows admin", async () => {
+      const res = await inject(await buildApp("viewer", "admin"));
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("allows member", async () => {
+      const res = await inject(await buildApp("viewer", "member"));
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("allows viewer", async () => {
+      const res = await inject(await buildApp("viewer", "viewer"));
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("rejects null role", async () => {
+      const res = await inject(await buildApp("viewer", null));
+      expect(res.statusCode).toBe(403);
+    });
+  });
+});

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -3,11 +3,39 @@ import fp from "fastify-plugin";
 import { validateSession, type SessionUser } from "../services/session-service.js";
 import { isAuthDisabled } from "../services/oauth/index.js";
 import { getUserRole, ensureUserHasWorkspace } from "../services/workspace-service.js";
+import type { WorkspaceRole } from "@optio/shared";
 
 declare module "fastify" {
   interface FastifyRequest {
     user?: SessionUser;
   }
+}
+
+/** Role hierarchy: admin > member > viewer. */
+const ROLE_LEVEL: Record<string, number> = { admin: 3, member: 2, viewer: 1 };
+
+/**
+ * Returns a Fastify preHandler that rejects requests from users whose
+ * workspace role is below `minimumRole`.
+ *
+ * When auth is disabled the check is skipped (local dev).
+ */
+export function requireRole(minimumRole: WorkspaceRole) {
+  const minLevel = ROLE_LEVEL[minimumRole] ?? 0;
+
+  return async (req: FastifyRequest, reply: FastifyReply) => {
+    // Auth disabled — allow everything (local dev)
+    if (isAuthDisabled()) return;
+
+    const role = req.user?.workspaceRole;
+    const level = role ? (ROLE_LEVEL[role] ?? 0) : 0;
+
+    if (level < minLevel) {
+      return reply.status(403).send({
+        error: `Forbidden: requires ${minimumRole} role`,
+      });
+    }
+  };
 }
 
 const SESSION_COOKIE_NAME = "optio_session";

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db/client.js";
+import { requireRole } from "../plugins/auth.js";
 
 const costsQuerySchema = z.object({
   days: z.coerce.number().int().min(1).max(365).optional().default(30),
@@ -9,8 +10,8 @@ const costsQuerySchema = z.object({
 });
 
 export async function analyticsRoutes(app: FastifyInstance) {
-  // Cost analytics — aggregated cost data for the dashboard
-  app.get("/api/analytics/costs", async (req, reply) => {
+  // Cost analytics — aggregated cost data for the dashboard (member+)
+  app.get("/api/analytics/costs", { preHandler: [requireRole("member")] }, async (req, reply) => {
     const query = costsQuerySchema.parse(req.query);
     const days = query.days;
     const repoUrl = query.repoUrl || null;

--- a/apps/api/src/routes/bulk.ts
+++ b/apps/api/src/routes/bulk.ts
@@ -5,67 +5,76 @@ import { tasks } from "../db/schema.js";
 import { TaskState } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
 import { taskQueue } from "../workers/task-worker.js";
+import { requireRole } from "../plugins/auth.js";
 
 export async function bulkRoutes(app: FastifyInstance) {
-  // Retry all failed tasks
-  app.post("/api/tasks/bulk/retry-failed", async (req, reply) => {
-    const workspaceId = req.user?.workspaceId;
-    const conditions = [eq(tasks.state, "failed" as any)];
-    if (workspaceId) conditions.push(eq(tasks.workspaceId, workspaceId));
-    const failedTasks = await db
-      .select({ id: tasks.id })
-      .from(tasks)
-      .where(and(...conditions));
+  // Retry all failed tasks — member+
+  app.post(
+    "/api/tasks/bulk/retry-failed",
+    { preHandler: [requireRole("member")] },
+    async (req, reply) => {
+      const workspaceId = req.user?.workspaceId;
+      const conditions = [eq(tasks.state, "failed" as any)];
+      if (workspaceId) conditions.push(eq(tasks.workspaceId, workspaceId));
+      const failedTasks = await db
+        .select({ id: tasks.id })
+        .from(tasks)
+        .where(and(...conditions));
 
-    let retried = 0;
-    for (const task of failedTasks) {
-      try {
-        await taskService.transitionTask(task.id, TaskState.QUEUED, "bulk_retry");
-        await taskQueue.add(
-          "process-task",
-          { taskId: task.id },
-          {
-            jobId: `${task.id}-retry-${Date.now()}`,
-            attempts: 1,
-          },
-        );
-        retried++;
-      } catch {
-        // Skip tasks that can't transition
+      let retried = 0;
+      for (const task of failedTasks) {
+        try {
+          await taskService.transitionTask(task.id, TaskState.QUEUED, "bulk_retry");
+          await taskQueue.add(
+            "process-task",
+            { taskId: task.id },
+            {
+              jobId: `${task.id}-retry-${Date.now()}`,
+              attempts: 1,
+            },
+          );
+          retried++;
+        } catch {
+          // Skip tasks that can't transition
+        }
       }
-    }
-    reply.send({ retried, total: failedTasks.length });
-  });
+      reply.send({ retried, total: failedTasks.length });
+    },
+  );
 
-  // Cancel all running/queued tasks
-  app.post("/api/tasks/bulk/cancel-active", async (req, reply) => {
-    const workspaceId = req.user?.workspaceId;
-    const runningConds = [eq(tasks.state, "running" as any)];
-    const queuedConds = [eq(tasks.state, "queued" as any)];
-    if (workspaceId) {
-      runningConds.push(eq(tasks.workspaceId, workspaceId));
-      queuedConds.push(eq(tasks.workspaceId, workspaceId));
-    }
-    const activeTasks = await db
-      .select({ id: tasks.id, state: tasks.state })
-      .from(tasks)
-      .where(and(...runningConds));
-
-    const queuedTasks = await db
-      .select({ id: tasks.id, state: tasks.state })
-      .from(tasks)
-      .where(and(...queuedConds));
-
-    const allActive = [...activeTasks, ...queuedTasks];
-    let cancelled = 0;
-    for (const task of allActive) {
-      try {
-        await taskService.transitionTask(task.id, TaskState.CANCELLED, "bulk_cancel");
-        cancelled++;
-      } catch {
-        // Skip tasks that can't transition
+  // Cancel all running/queued tasks — member+
+  app.post(
+    "/api/tasks/bulk/cancel-active",
+    { preHandler: [requireRole("member")] },
+    async (req, reply) => {
+      const workspaceId = req.user?.workspaceId;
+      const runningConds = [eq(tasks.state, "running" as any)];
+      const queuedConds = [eq(tasks.state, "queued" as any)];
+      if (workspaceId) {
+        runningConds.push(eq(tasks.workspaceId, workspaceId));
+        queuedConds.push(eq(tasks.workspaceId, workspaceId));
       }
-    }
-    reply.send({ cancelled, total: allActive.length });
-  });
+      const activeTasks = await db
+        .select({ id: tasks.id, state: tasks.state })
+        .from(tasks)
+        .where(and(...runningConds));
+
+      const queuedTasks = await db
+        .select({ id: tasks.id, state: tasks.state })
+        .from(tasks)
+        .where(and(...queuedConds));
+
+      const allActive = [...activeTasks, ...queuedTasks];
+      let cancelled = 0;
+      for (const task of allActive) {
+        try {
+          await taskService.transitionTask(task.id, TaskState.CANCELLED, "bulk_cancel");
+          cancelled++;
+        } catch {
+          // Skip tasks that can't transition
+        }
+      }
+      reply.send({ cancelled, total: allActive.length });
+    },
+  );
 }

--- a/apps/api/src/routes/cluster.ts
+++ b/apps/api/src/routes/cluster.ts
@@ -3,6 +3,7 @@ import { KubeConfig, CoreV1Api, CustomObjectsApi } from "@kubernetes/client-node
 import { db } from "../db/client.js";
 import { repoPods, tasks, podHealthEvents, repos } from "../db/schema.js";
 import { eq, desc, and, inArray, sql } from "drizzle-orm";
+import { requireRole } from "../plugins/auth.js";
 
 function getK8sConfig() {
   const kc = new KubeConfig();
@@ -87,8 +88,8 @@ function formatMemoryGi(ki: number): string {
 }
 
 export async function clusterRoutes(app: FastifyInstance) {
-  // Cluster overview: nodes, all pods, services, resource summary
-  app.get("/api/cluster/overview", async (req, reply) => {
+  // Cluster overview: nodes, all pods, services, resource summary — admin only
+  app.get("/api/cluster/overview", { preHandler: [requireRole("admin")] }, async (req, reply) => {
     try {
       const api = getK8sApi();
 
@@ -298,8 +299,8 @@ export async function clusterRoutes(app: FastifyInstance) {
     }
   });
 
-  // Keep the existing pod detail endpoints
-  app.get("/api/cluster/pods", async (req, reply) => {
+  // Keep the existing pod detail endpoints — admin only
+  app.get("/api/cluster/pods", { preHandler: [requireRole("admin")] }, async (req, reply) => {
     try {
       const workspaceId = req.user?.workspaceId;
       const pods = workspaceId
@@ -329,7 +330,7 @@ export async function clusterRoutes(app: FastifyInstance) {
     }
   });
 
-  app.get("/api/cluster/pods/:id", async (req, reply) => {
+  app.get("/api/cluster/pods/:id", { preHandler: [requireRole("admin")] }, async (req, reply) => {
     const { id } = req.params as { id: string };
     const [pod] = await db.select().from(repoPods).where(eq(repoPods.id, id));
     if (!pod) return reply.status(404).send({ error: "Pod not found" });
@@ -377,48 +378,56 @@ export async function clusterRoutes(app: FastifyInstance) {
     reply.send({ pod: { ...pod, activeTaskCount: liveActiveCount, tasks: podTasks, k8sPod } });
   });
 
-  // Pod health events
-  app.get("/api/cluster/health-events", async (req, reply) => {
-    const query = req.query as { limit?: string };
-    const limit = query.limit ? parseInt(query.limit, 10) : 50;
-    const events = await db
-      .select()
-      .from(podHealthEvents)
-      .orderBy(desc(podHealthEvents.createdAt))
-      .limit(limit);
-    reply.send({ events });
-  });
+  // Pod health events — admin only
+  app.get(
+    "/api/cluster/health-events",
+    { preHandler: [requireRole("admin")] },
+    async (req, reply) => {
+      const query = req.query as { limit?: string };
+      const limit = query.limit ? parseInt(query.limit, 10) : 50;
+      const events = await db
+        .select()
+        .from(podHealthEvents)
+        .orderBy(desc(podHealthEvents.createdAt))
+        .limit(limit);
+      reply.send({ events });
+    },
+  );
 
-  // Force restart a repo pod
-  app.post("/api/cluster/pods/:id/restart", async (req, reply) => {
-    const { id } = req.params as { id: string };
-    const [pod] = await db.select().from(repoPods).where(eq(repoPods.id, id));
-    if (!pod) return reply.status(404).send({ error: "Pod not found" });
-    const wsId = req.user?.workspaceId;
-    if (wsId && pod.workspaceId !== wsId) {
-      return reply.status(404).send({ error: "Pod not found" });
-    }
+  // Force restart a repo pod — admin only
+  app.post(
+    "/api/cluster/pods/:id/restart",
+    { preHandler: [requireRole("admin")] },
+    async (req, reply) => {
+      const { id } = req.params as { id: string };
+      const [pod] = await db.select().from(repoPods).where(eq(repoPods.id, id));
+      if (!pod) return reply.status(404).send({ error: "Pod not found" });
+      const wsId = req.user?.workspaceId;
+      if (wsId && pod.workspaceId !== wsId) {
+        return reply.status(404).send({ error: "Pod not found" });
+      }
 
-    // Destroy the pod
-    if (pod.podName) {
-      try {
-        const { getRuntime } = await import("../services/container-service.js");
-        const runtime = getRuntime();
-        await runtime.destroy({ id: pod.podId ?? pod.podName, name: pod.podName });
-      } catch {}
-    }
+      // Destroy the pod
+      if (pod.podName) {
+        try {
+          const { getRuntime } = await import("../services/container-service.js");
+          const runtime = getRuntime();
+          await runtime.destroy({ id: pod.podId ?? pod.podName, name: pod.podName });
+        } catch {}
+      }
 
-    // Clear the record — next task will recreate it
-    await db.delete(repoPods).where(eq(repoPods.id, id));
+      // Clear the record — next task will recreate it
+      await db.delete(repoPods).where(eq(repoPods.id, id));
 
-    await db.insert(podHealthEvents).values({
-      repoPodId: id,
-      repoUrl: pod.repoUrl,
-      eventType: "restarted",
-      podName: pod.podName,
-      message: "Manual restart via API",
-    });
+      await db.insert(podHealthEvents).values({
+        repoPodId: id,
+        repoUrl: pod.repoUrl,
+        eventType: "restarted",
+        podName: pod.podName,
+        message: "Manual restart via API",
+      });
 
-    reply.send({ ok: true });
-  });
+      reply.send({ ok: true });
+    },
+  );
 }

--- a/apps/api/src/routes/repos.ts
+++ b/apps/api/src/routes/repos.ts
@@ -8,6 +8,7 @@ import {
   parseCpuMillicores,
   parseMemoryMi,
 } from "@optio/shared";
+import { requireRole } from "../plugins/auth.js";
 
 const createRepoSchema = z.object({
   repoUrl: z.string().min(1),
@@ -74,7 +75,7 @@ export async function repoRoutes(app: FastifyInstance) {
     reply.send({ repo });
   });
 
-  app.post("/api/repos", async (req, reply) => {
+  app.post("/api/repos", { preHandler: [requireRole("admin")] }, async (req, reply) => {
     const body = createRepoSchema.parse(req.body);
     const workspaceId = req.user?.workspaceId ?? null;
 
@@ -108,7 +109,7 @@ export async function repoRoutes(app: FastifyInstance) {
     reply.status(201).send({ repo });
   });
 
-  app.patch("/api/repos/:id", async (req, reply) => {
+  app.patch("/api/repos/:id", { preHandler: [requireRole("admin")] }, async (req, reply) => {
     const { id } = req.params as { id: string };
     const existing = await repoService.getRepo(id);
     if (!existing) return reply.status(404).send({ error: "Repo not found" });
@@ -160,7 +161,7 @@ export async function repoRoutes(app: FastifyInstance) {
     reply.send({ repo });
   });
 
-  app.delete("/api/repos/:id", async (req, reply) => {
+  app.delete("/api/repos/:id", { preHandler: [requireRole("admin")] }, async (req, reply) => {
     const { id } = req.params as { id: string };
     const existing = await repoService.getRepo(id);
     if (!existing) return reply.status(404).send({ error: "Repo not found" });
@@ -172,8 +173,8 @@ export async function repoRoutes(app: FastifyInstance) {
     reply.status(204).send();
   });
 
-  // Auto-detect repo configuration
-  app.post("/api/repos/:id/detect", async (req, reply) => {
+  // Auto-detect repo configuration — admin only
+  app.post("/api/repos/:id/detect", { preHandler: [requireRole("admin")] }, async (req, reply) => {
     const { id } = req.params as { id: string };
     const repo = await repoService.getRepo(id);
     if (!repo) return reply.status(404).send({ error: "Repo not found" });

--- a/apps/api/src/routes/secrets.ts
+++ b/apps/api/src/routes/secrets.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import * as secretService from "../services/secret-service.js";
+import { requireRole } from "../plugins/auth.js";
 
 const createSecretSchema = z.object({
   name: z.string().min(1),
@@ -9,7 +10,7 @@ const createSecretSchema = z.object({
 });
 
 export async function secretRoutes(app: FastifyInstance) {
-  // List secrets (names only)
+  // List secrets (names only) — any workspace member can view
   app.get("/api/secrets", async (req, reply) => {
     const query = req.query as { scope?: string };
     const workspaceId = req.user?.workspaceId ?? null;
@@ -17,16 +18,16 @@ export async function secretRoutes(app: FastifyInstance) {
     reply.send({ secrets });
   });
 
-  // Create/update secret
-  app.post("/api/secrets", async (req, reply) => {
+  // Create/update secret — admin only
+  app.post("/api/secrets", { preHandler: [requireRole("admin")] }, async (req, reply) => {
     const input = createSecretSchema.parse(req.body);
     const workspaceId = req.user?.workspaceId ?? null;
     await secretService.storeSecret(input.name, input.value, input.scope, workspaceId);
     reply.status(201).send({ name: input.name, scope: input.scope ?? "global" });
   });
 
-  // Delete secret
-  app.delete("/api/secrets/:name", async (req, reply) => {
+  // Delete secret — admin only
+  app.delete("/api/secrets/:name", { preHandler: [requireRole("admin")] }, async (req, reply) => {
     const { name } = req.params as { name: string };
     const query = req.query as { scope?: string };
     const workspaceId = req.user?.workspaceId ?? null;

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -7,6 +7,7 @@ import * as dependencyService from "../services/dependency-service.js";
 import { taskQueue } from "../workers/task-worker.js";
 import { db } from "../db/client.js";
 import { tasks } from "../db/schema.js";
+import { requireRole } from "../plugins/auth.js";
 
 const createTaskSchema = z.object({
   title: z.string().min(1),
@@ -84,8 +85,8 @@ export async function taskRoutes(app: FastifyInstance) {
     reply.send({ task, pendingReason, pipelineProgress });
   });
 
-  // Create task
-  app.post("/api/tasks", async (req, reply) => {
+  // Create task — member+
+  app.post("/api/tasks", { preHandler: [requireRole("member")] }, async (req, reply) => {
     const input = createTaskSchema.parse(req.body);
     const { dependsOn, ...taskInput } = input;
     const task = await taskService.createTask({
@@ -138,8 +139,8 @@ export async function taskRoutes(app: FastifyInstance) {
     reply.status(201).send({ task });
   });
 
-  // Cancel task
-  app.post("/api/tasks/:id/cancel", async (req, reply) => {
+  // Cancel task — member+
+  app.post("/api/tasks/:id/cancel", { preHandler: [requireRole("member")] }, async (req, reply) => {
     const { id } = req.params as { id: string };
     const existing = await taskService.getTask(id);
     if (!existing) return reply.status(404).send({ error: "Task not found" });
@@ -157,8 +158,8 @@ export async function taskRoutes(app: FastifyInstance) {
     reply.send({ task });
   });
 
-  // Retry task
-  app.post("/api/tasks/:id/retry", async (req, reply) => {
+  // Retry task — member+
+  app.post("/api/tasks/:id/retry", { preHandler: [requireRole("member")] }, async (req, reply) => {
     const { id } = req.params as { id: string };
     const existing = await taskService.getTask(id);
     if (!existing) return reply.status(404).send({ error: "Task not found" });
@@ -187,35 +188,39 @@ export async function taskRoutes(app: FastifyInstance) {
     reply.send({ task });
   });
 
-  // Force redo task — reset everything and re-queue from any state
-  app.post("/api/tasks/:id/force-redo", async (req, reply) => {
-    const { id } = req.params as { id: string };
-    const existing = await taskService.getTask(id);
-    if (!existing) return reply.status(404).send({ error: "Task not found" });
-    const wsId = req.user?.workspaceId;
-    if (wsId && existing.workspaceId !== wsId) {
-      return reply.status(404).send({ error: "Task not found" });
-    }
-
-    // Remove any existing BullMQ jobs for this task (waiting/delayed) to prevent duplicates
-    const existingJobs = await taskQueue.getJobs(["waiting", "delayed", "prioritized"]);
-    for (const job of existingJobs) {
-      if (job.data?.taskId === id) {
-        await job.remove().catch(() => {});
+  // Force redo task — reset everything and re-queue from any state (member+)
+  app.post(
+    "/api/tasks/:id/force-redo",
+    { preHandler: [requireRole("member")] },
+    async (req, reply) => {
+      const { id } = req.params as { id: string };
+      const existing = await taskService.getTask(id);
+      if (!existing) return reply.status(404).send({ error: "Task not found" });
+      const wsId = req.user?.workspaceId;
+      if (wsId && existing.workspaceId !== wsId) {
+        return reply.status(404).send({ error: "Task not found" });
       }
-    }
 
-    const task = await taskService.forceRedoTask(id);
-    await taskQueue.add(
-      "process-task",
-      { taskId: id },
-      {
-        jobId: `${id}-redo-${Date.now()}`,
-        attempts: 1,
-      },
-    );
-    reply.send({ task });
-  });
+      // Remove any existing BullMQ jobs for this task (waiting/delayed) to prevent duplicates
+      const existingJobs = await taskQueue.getJobs(["waiting", "delayed", "prioritized"]);
+      for (const job of existingJobs) {
+        if (job.data?.taskId === id) {
+          await job.remove().catch(() => {});
+        }
+      }
+
+      const task = await taskService.forceRedoTask(id);
+      await taskQueue.add(
+        "process-task",
+        { taskId: id },
+        {
+          jobId: `${id}-redo-${Date.now()}`,
+          attempts: 1,
+        },
+      );
+      reply.send({ task });
+    },
+  );
 
   // Get task logs
   app.get("/api/tasks/:id/logs", async (req, reply) => {
@@ -359,8 +364,8 @@ export async function taskRoutes(app: FastifyInstance) {
     reply.send({ events });
   });
 
-  // Launch a review for a task
-  app.post("/api/tasks/:id/review", async (req, reply) => {
+  // Launch a review for a task — member+
+  app.post("/api/tasks/:id/review", { preHandler: [requireRole("member")] }, async (req, reply) => {
     const { id } = req.params as { id: string };
     const existing = await taskService.getTask(id);
     if (!existing) return reply.status(404).send({ error: "Task not found" });
@@ -377,47 +382,51 @@ export async function taskRoutes(app: FastifyInstance) {
     }
   });
 
-  // Run now — override off-peak hold for a queued task
-  app.post("/api/tasks/:id/run-now", async (req, reply) => {
-    const { id } = req.params as { id: string };
-    const existing = await taskService.getTask(id);
-    if (!existing) return reply.status(404).send({ error: "Task not found" });
-    const wsId = req.user?.workspaceId;
-    if (wsId && existing.workspaceId !== wsId) {
-      return reply.status(404).send({ error: "Task not found" });
-    }
-    if (existing.state !== "queued") {
-      return reply.status(400).send({ error: "Task is not in queued state" });
-    }
-
-    // Set ignoreOffPeak flag
-    await db
-      .update(tasks)
-      .set({ ignoreOffPeak: true, updatedAt: new Date() })
-      .where(eq(tasks.id, id));
-
-    // Remove existing delayed jobs for this task and re-queue immediately
-    const existingJobs = await taskQueue.getJobs(["waiting", "delayed", "prioritized"]);
-    for (const job of existingJobs) {
-      if (job.data?.taskId === id) {
-        await job.remove().catch(() => {});
+  // Run now — override off-peak hold for a queued task (member+)
+  app.post(
+    "/api/tasks/:id/run-now",
+    { preHandler: [requireRole("member")] },
+    async (req, reply) => {
+      const { id } = req.params as { id: string };
+      const existing = await taskService.getTask(id);
+      if (!existing) return reply.status(404).send({ error: "Task not found" });
+      const wsId = req.user?.workspaceId;
+      if (wsId && existing.workspaceId !== wsId) {
+        return reply.status(404).send({ error: "Task not found" });
       }
-    }
-    await taskQueue.add(
-      "process-task",
-      { taskId: id },
-      {
-        jobId: `${id}-runnow-${Date.now()}`,
-        priority: existing.priority ?? 100,
-      },
-    );
+      if (existing.state !== "queued") {
+        return reply.status(400).send({ error: "Task is not in queued state" });
+      }
 
-    const task = await taskService.getTask(id);
-    reply.send({ task });
-  });
+      // Set ignoreOffPeak flag
+      await db
+        .update(tasks)
+        .set({ ignoreOffPeak: true, updatedAt: new Date() })
+        .where(eq(tasks.id, id));
 
-  // Reorder tasks (update priorities)
-  app.post("/api/tasks/reorder", async (req, reply) => {
+      // Remove existing delayed jobs for this task and re-queue immediately
+      const existingJobs = await taskQueue.getJobs(["waiting", "delayed", "prioritized"]);
+      for (const job of existingJobs) {
+        if (job.data?.taskId === id) {
+          await job.remove().catch(() => {});
+        }
+      }
+      await taskQueue.add(
+        "process-task",
+        { taskId: id },
+        {
+          jobId: `${id}-runnow-${Date.now()}`,
+          priority: existing.priority ?? 100,
+        },
+      );
+
+      const task = await taskService.getTask(id);
+      reply.send({ task });
+    },
+  );
+
+  // Reorder tasks (update priorities) — member+
+  app.post("/api/tasks/reorder", { preHandler: [requireRole("member")] }, async (req, reply) => {
     const body = req.body as { taskIds: string[] };
     if (!Array.isArray(body.taskIds)) {
       return reply.status(400).send({ error: "taskIds array required" });


### PR DESCRIPTION
## Summary

- Adds `requireRole()` preHandler guard in the auth plugin that checks workspace role hierarchy (admin > member > viewer) and returns 403 when the user's role is insufficient
- Applies role-based access control to all priority routes:
  - **secrets** — admin-only for create/update/delete
  - **repos** — admin-only for create/update/delete/detect config
  - **analytics** — member+ for cost data access
  - **tasks** — member+ for create/cancel/retry/redo/review/reorder; viewer+ for read-only (list, get, logs, events)
  - **cluster** — admin-only for all endpoints (overview, pods, health events, restart)
  - **bulk** — member+ for retry-failed and cancel-active
- Auth-disabled mode (local dev) bypasses all role checks
- Includes 13 unit tests covering all role combinations and the auth-disabled bypass

## Test plan

- [x] All 291 tests pass (`npx turbo test`)
- [x] TypeScript compiles cleanly (`npx turbo typecheck`)
- [x] Pre-commit hooks pass (lint-staged, prettier, typecheck)
- [ ] Verify admin user can access all routes
- [ ] Verify member user is blocked from secrets CUD, repos config, and cluster routes
- [ ] Verify viewer user is blocked from task creation, analytics, and all admin routes
- [ ] Verify auth-disabled mode allows all operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)