### PR TITLE
fix: add unhandledRejection handler to API server

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -49,6 +49,12 @@ process.on("uncaughtException", (err) => {
   process.exit(1);
 });
 
+process.on("unhandledRejection", (reason, promise) => {
+  logger.error({ reason, promise }, "Unhandled promise rejection");
+  // Let it propagate to uncaughtException handler for clean shutdown
+  throw reason;
+});
+
 async function checkMetricsServer() {
   try {
     const { KubeConfig, CustomObjectsApi } = await import("@kubernetes/client-node");


### PR DESCRIPTION
## Summary
- Add `process.on("unhandledRejection")` handler to `apps/api/src/index.ts` alongside the existing `uncaughtException` handler
- Logs the rejection reason and promise, then re-throws so the `uncaughtException` handler performs a clean shutdown
- Prevents unhandled promise rejections from silently failing without any logging

## Test plan
- [x] Formatting passes (`pnpm format:check`)
- [x] Typechecking passes (`pnpm turbo typecheck`)
- [x] All 278 tests pass (`pnpm turbo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)