### PR TITLE
chore: optimize Dockerfiles with multi-stage builds and security hardening

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -34,7 +34,7 @@ RUN chmod +x /opt/optio/entrypoint.sh /opt/optio/repo-init.sh
 
 RUN useradd -m -s /bin/bash agent \
     && chown -R agent:agent /workspace \
-    && echo "agent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    && echo "agent ALL=(ALL) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt" >> /etc/sudoers
 USER agent
 WORKDIR /workspace
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,5 @@
-FROM node:22-slim
+# ---- Dependencies stage ----
+FROM node:22-slim AS deps
 
 RUN corepack enable && corepack prepare pnpm@10 --activate
 
@@ -14,8 +15,20 @@ COPY packages/container-runtime/package.json packages/container-runtime/tsconfig
 COPY packages/agent-adapters/package.json packages/agent-adapters/tsconfig.json packages/agent-adapters/
 COPY packages/ticket-providers/package.json packages/ticket-providers/tsconfig.json packages/ticket-providers/
 
-# Install dependencies (production only to avoid vitest/vite type issues)
-RUN pnpm install --frozen-lockfile --prod=false
+# Install production dependencies only
+RUN pnpm install --frozen-lockfile --prod
+
+# ---- Runtime stage ----
+FROM node:22-slim
+
+# Install tsx globally for TypeScript execution at runtime
+# (workspace packages export .ts source, so the API runs via tsx)
+RUN npm install -g tsx
+
+WORKDIR /app
+
+# Copy production dependencies from deps stage
+COPY --from=deps /app/ ./
 
 # Copy source
 COPY packages/ packages/
@@ -23,5 +36,10 @@ COPY apps/api/ apps/api/
 
 EXPOSE 4000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://localhost:4000/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+
+USER node
+
 WORKDIR /app/apps/api
-CMD ["./node_modules/.bin/tsx", "src/index.ts"]
+CMD ["tsx", "src/index.ts"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,4 +1,5 @@
-FROM node:22-slim
+# ---- Dependencies stage ----
+FROM node:22-slim AS deps
 
 RUN corepack enable && corepack prepare pnpm@10 --activate
 
@@ -11,8 +12,11 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.base.js
 COPY apps/web/package.json apps/web/tsconfig.json apps/web/
 COPY packages/shared/package.json packages/shared/tsconfig.json packages/shared/
 
-# Install dependencies
+# Install all dependencies (dev deps needed for build)
 RUN pnpm install --frozen-lockfile --prod=false
+
+# ---- Builder stage ----
+FROM deps AS builder
 
 # Copy source
 COPY packages/shared/ packages/shared/
@@ -32,8 +36,24 @@ ENV NEXT_PUBLIC_AUTH_DISABLED=$NEXT_PUBLIC_AUTH_DISABLED
 RUN pnpm turbo build --filter=@optio/shared
 RUN cd apps/web && npx next build
 
-WORKDIR /app/apps/web
+# ---- Runtime stage ----
+FROM node:22-slim
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Copy standalone output (preserves monorepo directory structure)
+COPY --from=builder /app/apps/web/.next/standalone ./
+COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder /app/apps/web/public ./apps/web/public
 
 EXPOSE 3000
 
-CMD ["npx", "next", "start", "-p", "3000"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://localhost:3000').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+
+USER node
+
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   transpilePackages: ["@optio/shared"],
   webpack: (config) => {
     // Resolve .js imports to .ts files in workspace packages


### PR DESCRIPTION
## Summary

- **Dockerfile.api**: Multi-stage build separating dependency installation (prod-only) from the runtime stage. Installs `tsx` globally instead of via devDependencies. Adds `USER node` and `HEALTHCHECK` directives.
- **Dockerfile.web**: Multi-stage build with Next.js `standalone` output — dependencies and build tooling are confined to the builder stage, while the runtime image only contains the traced standalone output. Adds `USER node` and `HEALTHCHECK`.
- **Dockerfile.agent**: Scopes the `NOPASSWD` sudo rule from unrestricted `ALL` down to `/usr/bin/apt-get` and `/usr/bin/apt` only, since that's all that `repo-init.sh` needs for `OPTIO_EXTRA_PACKAGES`.
- **next.config.ts**: Adds `output: "standalone"` to enable the optimized standalone build.

## Test plan

- [x] `pnpm turbo typecheck` — all packages pass
- [x] `pnpm turbo test` — all 278 tests pass
- [x] `pnpm format:check` — clean
- [ ] Verify `docker build -f Dockerfile.api .` produces a working image
- [ ] Verify `docker build -f Dockerfile.web .` produces a working image with standalone server
- [ ] Verify `docker build -f Dockerfile.agent .` still allows `sudo apt-get install` but blocks `sudo rm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)