### PR TITLE
test: add tests for untested API services

### DIFF
--- a/apps/api/src/services/container-service.test.ts
+++ b/apps/api/src/services/container-service.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockRuntime = {
+  create: vi.fn(),
+  status: vi.fn(),
+  logs: vi.fn(),
+  destroy: vi.fn(),
+  ping: vi.fn(),
+};
+
+vi.mock("@optio/container-runtime", () => ({
+  createRuntime: vi.fn(() => mockRuntime),
+}));
+
+vi.mock("@optio/shared", async () => {
+  const actual = await vi.importActual("@optio/shared");
+  return {
+    ...actual,
+    DEFAULT_AGENT_IMAGE: "optio-agent:latest",
+  };
+});
+
+import {
+  getRuntime,
+  launchAgentContainer,
+  getContainerStatus,
+  streamContainerLogs,
+  destroyAgentContainer,
+  checkRuntimeHealth,
+} from "./container-service.js";
+
+describe("container-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getRuntime", () => {
+    it("creates and caches runtime", () => {
+      const runtime = getRuntime();
+      expect(runtime).toBeDefined();
+      // Calling again returns same instance
+      const runtime2 = getRuntime();
+      expect(runtime2).toBe(runtime);
+    });
+  });
+
+  describe("launchAgentContainer", () => {
+    it("creates container with correct spec", async () => {
+      const handle = { containerId: "c-1" };
+      mockRuntime.create.mockResolvedValue(handle);
+
+      const result = await launchAgentContainer({
+        taskId: "task-1",
+        agentType: "claude-code",
+        command: ["claude", "-p", "do stuff"],
+        env: { KEY: "value" },
+      });
+
+      expect(result).toEqual(handle);
+      expect(mockRuntime.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image: "optio-agent:latest",
+          workDir: "/workspace",
+          labels: {
+            "optio.task-id": "task-1",
+            "optio.agent-type": "claude-code",
+            "managed-by": "optio",
+          },
+        }),
+      );
+    });
+
+    it("uses custom image when provided", async () => {
+      mockRuntime.create.mockResolvedValue({ containerId: "c-2" });
+
+      await launchAgentContainer({
+        taskId: "task-1",
+        agentType: "claude-code",
+        command: ["echo"],
+        env: {},
+        image: "custom-image:v1",
+      });
+
+      expect(mockRuntime.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image: "custom-image:v1",
+        }),
+      );
+    });
+  });
+
+  describe("getContainerStatus", () => {
+    it("delegates to runtime", async () => {
+      const status = { state: "running" };
+      mockRuntime.status.mockResolvedValue(status);
+
+      const result = await getContainerStatus({ containerId: "c-1" } as any);
+      expect(result).toEqual(status);
+    });
+  });
+
+  describe("streamContainerLogs", () => {
+    it("delegates to runtime", () => {
+      const logs = (async function* () {
+        yield "line 1";
+      })();
+      mockRuntime.logs.mockReturnValue(logs);
+
+      const result = streamContainerLogs({ containerId: "c-1" } as any, { follow: true });
+      expect(result).toBe(logs);
+    });
+  });
+
+  describe("destroyAgentContainer", () => {
+    it("delegates to runtime", async () => {
+      mockRuntime.destroy.mockResolvedValue(undefined);
+
+      await destroyAgentContainer({ containerId: "c-1" } as any);
+      expect(mockRuntime.destroy).toHaveBeenCalled();
+    });
+  });
+
+  describe("checkRuntimeHealth", () => {
+    it("returns true when healthy", async () => {
+      mockRuntime.ping.mockResolvedValue(true);
+
+      const result = await checkRuntimeHealth();
+      expect(result).toBe(true);
+    });
+
+    it("returns false when unhealthy", async () => {
+      mockRuntime.ping.mockResolvedValue(false);
+
+      const result = await checkRuntimeHealth();
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/services/dependency-service.test.ts
+++ b/apps/api/src/services/dependency-service.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  taskDependencies: {
+    id: "task_dependencies.id",
+    taskId: "task_dependencies.task_id",
+    dependsOnTaskId: "task_dependencies.depends_on_task_id",
+  },
+  tasks: {
+    id: "tasks.id",
+    title: "tasks.title",
+    state: "tasks.state",
+    repoUrl: "tasks.repo_url",
+    workspaceId: "tasks.workspace_id",
+    parentTaskId: "tasks.parent_task_id",
+    taskType: "tasks.task_type",
+    ignoreOffPeak: "tasks.ignore_off_peak",
+  },
+  repos: {
+    repoUrl: "repos.repo_url",
+    workspaceId: "repos.workspace_id",
+  },
+  workspaces: {
+    id: "workspaces.id",
+    slug: "workspaces.slug",
+  },
+}));
+
+vi.mock("./task-service.js", () => ({
+  getTask: vi.fn(),
+  createTask: vi.fn(),
+  transitionTask: vi.fn(),
+  listTasks: vi.fn(),
+}));
+
+vi.mock("../workers/task-worker.js", () => ({
+  taskQueue: {
+    add: vi.fn(),
+  },
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnValue({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+import { db } from "../db/client.js";
+import * as taskService from "./task-service.js";
+import { taskQueue } from "../workers/task-worker.js";
+import {
+  addDependencies,
+  getDependencies,
+  getDependents,
+  areDependenciesMet,
+  onDependencyComplete,
+  cascadeFailure,
+  removeDependency,
+  computePendingReason,
+} from "./dependency-service.js";
+
+describe("dependency-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("addDependencies", () => {
+    it("does nothing with empty array", async () => {
+      await addDependencies("task-1", []);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it("throws on self-dependency", async () => {
+      await expect(addDependencies("task-1", ["task-1"])).rejects.toThrow(
+        "A task cannot depend on itself",
+      );
+    });
+
+    it("throws when dependency tasks not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      await expect(addDependencies("task-1", ["task-2"])).rejects.toThrow(
+        "Dependency tasks not found: task-2",
+      );
+    });
+
+    it("throws on circular dependency", async () => {
+      // Mock: dependency tasks exist
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockImplementation(() => {
+          selectCallCount++;
+          if (selectCallCount === 1) {
+            // Validate dep tasks exist (uses inArray/where)
+            return {
+              where: vi.fn().mockResolvedValue([{ id: "task-2" }]),
+            };
+          }
+          // getAllEdges: db.select().from(taskDependencies) — no where, returns directly
+          return Promise.resolve([{ taskId: "task-2", dependsOnTaskId: "task-1" }]);
+        }),
+      }));
+
+      await expect(addDependencies("task-1", ["task-2"])).rejects.toThrow(/[Cc]ircular dependency/);
+    });
+
+    it("inserts dependency rows on success", async () => {
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockImplementation(() => {
+          selectCallCount++;
+          if (selectCallCount === 1) {
+            // Validate dep tasks exist (uses where)
+            return {
+              where: vi.fn().mockResolvedValue([{ id: "task-2" }, { id: "task-3" }]),
+            };
+          }
+          // getAllEdges: returns directly from from()
+          return Promise.resolve([]);
+        }),
+      }));
+
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await addDependencies("task-1", ["task-2", "task-3"]);
+
+      expect(db.insert).toHaveBeenCalled();
+    });
+  });
+
+  describe("getDependencies", () => {
+    it("returns tasks that taskId depends on", async () => {
+      const deps = [{ id: "dep-1", title: "Dep 1", state: "completed", dependencyId: "d-1" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(deps),
+          }),
+        }),
+      });
+
+      const result = await getDependencies("task-1");
+      expect(result).toEqual(deps);
+    });
+  });
+
+  describe("getDependents", () => {
+    it("returns tasks that depend on taskId", async () => {
+      const dependents = [
+        { id: "t-2", title: "Task 2", state: "waiting_on_deps", dependencyId: "d-1" },
+      ];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(dependents),
+          }),
+        }),
+      });
+
+      const result = await getDependents("task-1");
+      expect(result).toEqual(dependents);
+    });
+  });
+
+  describe("areDependenciesMet", () => {
+    it("returns true when no dependencies", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const result = await areDependenciesMet("task-1");
+      expect(result).toBe(true);
+    });
+
+    it("returns true when all deps completed or pr_opened", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: "d-1", state: "completed" },
+              { id: "d-2", state: "pr_opened" },
+            ]),
+          }),
+        }),
+      });
+
+      const result = await areDependenciesMet("task-1");
+      expect(result).toBe(true);
+    });
+
+    it("returns false when some deps are still running", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { id: "d-1", state: "completed" },
+              { id: "d-2", state: "running" },
+            ]),
+          }),
+        }),
+      });
+
+      const result = await areDependenciesMet("task-1");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("onDependencyComplete", () => {
+    it("queues dependents whose deps are now all met", async () => {
+      let innerJoinCallCount = 0;
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              innerJoinCallCount++;
+              if (innerJoinCallCount === 1) {
+                // getDependents returns one dependent in waiting_on_deps
+                return Promise.resolve([
+                  { id: "t-2", title: "Task 2", state: "waiting_on_deps", dependencyId: "d-1" },
+                ]);
+              }
+              // areDependenciesMet / getDependencies — all completed
+              return Promise.resolve([
+                { id: "t-1", title: "Task 1", state: "completed", dependencyId: "d-1" },
+              ]);
+            }),
+          }),
+        }),
+      });
+
+      await onDependencyComplete("t-1");
+
+      expect(taskService.transitionTask).toHaveBeenCalledWith("t-2", "queued", "dependencies_met");
+      expect(taskQueue.add).toHaveBeenCalledWith(
+        "process-task",
+        { taskId: "t-2" },
+        expect.objectContaining({ priority: 100 }),
+      );
+    });
+
+    it("skips dependents not in waiting_on_deps state", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi
+              .fn()
+              .mockResolvedValue([
+                { id: "t-2", title: "Task 2", state: "running", dependencyId: "d-1" },
+              ]),
+          }),
+        }),
+      });
+
+      await onDependencyComplete("t-1");
+
+      expect(taskService.transitionTask).not.toHaveBeenCalled();
+    });
+
+    it("handles transition errors gracefully", async () => {
+      // getDependents
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi
+              .fn()
+              .mockResolvedValue([
+                { id: "t-2", title: "Task 2", state: "waiting_on_deps", dependencyId: "d-1" },
+              ]),
+          }),
+        }),
+      });
+
+      vi.mocked(taskService.transitionTask).mockRejectedValue(new Error("state race"));
+
+      // Should not throw
+      await onDependencyComplete("t-1");
+    });
+  });
+
+  describe("cascadeFailure", () => {
+    it("fails dependents in waiting_on_deps recursively", async () => {
+      let callCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              callCount++;
+              if (callCount === 1) {
+                return Promise.resolve([
+                  { id: "t-2", title: "Task 2", state: "waiting_on_deps", dependencyId: "d-1" },
+                ]);
+              }
+              // Recursive call for t-2's dependents
+              return Promise.resolve([]);
+            }),
+          }),
+        }),
+      }));
+
+      await cascadeFailure("t-1");
+
+      expect(taskService.transitionTask).toHaveBeenCalledWith(
+        "t-2",
+        "failed",
+        "dependency_failed",
+        "Dependency t-1 failed",
+      );
+    });
+
+    it("skips dependents not in waiting_on_deps", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi
+              .fn()
+              .mockResolvedValue([
+                { id: "t-2", title: "Task 2", state: "completed", dependencyId: "d-1" },
+              ]),
+          }),
+        }),
+      });
+
+      await cascadeFailure("t-1");
+
+      expect(taskService.transitionTask).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removeDependency", () => {
+    it("returns true when dependency removed", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "d-1" }]),
+        }),
+      });
+
+      const result = await removeDependency("task-1", "task-2");
+      expect(result).toBe(true);
+    });
+
+    it("returns false when dependency not found", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await removeDependency("task-1", "task-2");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("computePendingReason", () => {
+    it("returns null when task not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            then: vi.fn().mockImplementation((cb: any) => cb([])),
+          }),
+        }),
+      });
+
+      const result = await computePendingReason("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("returns blocked-by message for unsatisfied deps", async () => {
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              // Task lookup
+              return {
+                then: vi
+                  .fn()
+                  .mockImplementation((cb: any) => cb([{ id: "t-1", state: "waiting_on_deps" }])),
+              };
+            }
+            // getDependencies (innerJoin path)
+            return Promise.resolve([{ id: "d-1", title: "Build", state: "running" }]);
+          }),
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ id: "d-1", title: "Build", state: "running" }]),
+          }),
+        }),
+      }));
+
+      const result = await computePendingReason("t-1");
+      expect(result).toContain("Blocked by");
+      expect(result).toContain("Build");
+    });
+  });
+});

--- a/apps/api/src/services/event-bus.test.ts
+++ b/apps/api/src/services/event-bus.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPublish = vi.fn().mockResolvedValue(1);
+const mockRedisInstance = {
+  publish: mockPublish,
+};
+
+vi.mock("ioredis", () => ({
+  Redis: vi.fn(() => mockRedisInstance),
+}));
+
+import { publishEvent, publishSessionEvent, createSubscriber } from "./event-bus.js";
+
+describe("event-bus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("publishEvent", () => {
+    it("publishes to the global events channel", async () => {
+      await publishEvent({ type: "task:updated", taskId: "t-1" } as any);
+
+      expect(mockPublish).toHaveBeenCalledWith(
+        "optio:events",
+        expect.stringContaining('"type":"task:updated"'),
+      );
+    });
+
+    it("also publishes to task-specific channel when taskId present", async () => {
+      await publishEvent({ type: "task:updated", taskId: "t-1" } as any);
+
+      expect(mockPublish).toHaveBeenCalledWith(
+        "optio:task:t-1",
+        expect.stringContaining('"taskId":"t-1"'),
+      );
+      expect(mockPublish).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not publish to task channel when no taskId", async () => {
+      await publishEvent({ type: "session:created" } as any);
+
+      expect(mockPublish).toHaveBeenCalledTimes(1);
+      expect(mockPublish).toHaveBeenCalledWith("optio:events", expect.any(String));
+    });
+  });
+
+  describe("publishSessionEvent", () => {
+    it("publishes to session-specific channel", async () => {
+      await publishSessionEvent("sess-1", { type: "session:ended" } as any);
+
+      expect(mockPublish).toHaveBeenCalledWith(
+        "optio:session:sess-1",
+        expect.stringContaining('"type":"session:ended"'),
+      );
+    });
+  });
+
+  describe("createSubscriber", () => {
+    it("creates a new Redis instance", () => {
+      const subscriber = createSubscriber();
+      expect(subscriber).toBeDefined();
+    });
+  });
+});

--- a/apps/api/src/services/interactive-session-service.test.ts
+++ b/apps/api/src/services/interactive-session-service.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  interactiveSessions: {
+    id: "interactive_sessions.id",
+    repoUrl: "interactive_sessions.repo_url",
+    state: "interactive_sessions.state",
+    createdAt: "interactive_sessions.created_at",
+  },
+  sessionPrs: {
+    id: "session_prs.id",
+    sessionId: "session_prs.session_id",
+    createdAt: "session_prs.created_at",
+  },
+  repos: {
+    repoUrl: "repos.repo_url",
+  },
+  repoPods: {
+    id: "repo_pods.id",
+  },
+}));
+
+vi.mock("./event-bus.js", () => ({
+  publishEvent: vi.fn(),
+  publishSessionEvent: vi.fn(),
+}));
+
+vi.mock("./repo-pool-service.js", () => ({
+  getOrCreateRepoPod: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnValue({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+import { db } from "../db/client.js";
+import { publishEvent, publishSessionEvent } from "./event-bus.js";
+import { getOrCreateRepoPod } from "./repo-pool-service.js";
+import {
+  createSession,
+  getSession,
+  listSessions,
+  endSession,
+  getSessionPrs,
+  addSessionPr,
+  updateSessionPr,
+  getActiveSessionCount,
+} from "./interactive-session-service.js";
+
+describe("interactive-session-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createSession", () => {
+    it("creates a session with repo pod", async () => {
+      // Mock repo config lookup
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              defaultBranch: "main",
+              imagePreset: "node",
+              maxAgentsPerPod: 2,
+              maxPodInstances: 1,
+              networkPolicy: "unrestricted",
+              cpuRequest: null,
+              cpuLimit: null,
+              memoryRequest: null,
+              memoryLimit: null,
+            },
+          ]),
+        }),
+      });
+
+      vi.mocked(getOrCreateRepoPod).mockResolvedValue({
+        id: "pod-1",
+        podName: "optio-repo-pod-1",
+      } as any);
+
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            {
+              id: "session-1",
+              repoUrl: "https://github.com/owner/repo",
+              state: "active",
+              podId: "pod-1",
+            },
+          ]),
+        }),
+      });
+
+      const result = await createSession({
+        repoUrl: "https://github.com/owner/repo",
+        userId: "user-1",
+      });
+
+      expect(result.id).toBe("session-1");
+      expect(result.podName).toBe("optio-repo-pod-1");
+      expect(publishEvent).toHaveBeenCalled();
+      expect(publishSessionEvent).toHaveBeenCalled();
+    });
+
+    it("uses default branch when no repo config", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      vi.mocked(getOrCreateRepoPod).mockResolvedValue({
+        id: "pod-1",
+        podName: "pod-1",
+      } as any);
+
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi
+            .fn()
+            .mockResolvedValue([{ id: "session-1", state: "active", podId: "pod-1" }]),
+        }),
+      });
+
+      await createSession({ repoUrl: "https://github.com/o/r" });
+
+      expect(getOrCreateRepoPod).toHaveBeenCalledWith(
+        "https://github.com/o/r",
+        "main",
+        expect.any(Object),
+        undefined,
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("getSession", () => {
+    it("returns session with pod info", async () => {
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([{ id: "session-1", state: "active", podId: "pod-1" }]);
+            }
+            // Pod lookup
+            return Promise.resolve([{ podName: "optio-pod-1" }]);
+          }),
+        }),
+      }));
+
+      const result = await getSession("session-1");
+      expect(result).not.toBeNull();
+      expect(result!.podName).toBe("optio-pod-1");
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getSession("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("returns null podName when no pod", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "session-1", state: "active", podId: null }]),
+        }),
+      });
+
+      const result = await getSession("session-1");
+      expect(result!.podName).toBeNull();
+    });
+  });
+
+  describe("listSessions", () => {
+    it("lists sessions with default options", async () => {
+      const sessions = [{ id: "s-1" }, { id: "s-2" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockResolvedValue(sessions),
+              }),
+            }),
+          }),
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockResolvedValue(sessions),
+            }),
+          }),
+        }),
+      });
+
+      const result = await listSessions();
+      expect(result).toEqual(sessions);
+    });
+
+    it("filters by repoUrl and state", async () => {
+      const sessions = [{ id: "s-1" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockResolvedValue(sessions),
+              }),
+            }),
+          }),
+        }),
+      });
+
+      const result = await listSessions({
+        repoUrl: "https://github.com/o/r",
+        state: "active",
+      });
+      expect(result).toEqual(sessions);
+    });
+  });
+
+  describe("endSession", () => {
+    it("ends an active session", async () => {
+      // getSession mock
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([{ id: "session-1", state: "active", podId: "pod-1" }]);
+            }
+            if (selectCallCount === 2) {
+              return Promise.resolve([{ podName: "pod-1" }]);
+            }
+            return Promise.resolve([]);
+          }),
+        }),
+      }));
+
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: "session-1", state: "ended" }]),
+          }),
+        }),
+      });
+
+      const result = await endSession("session-1");
+      expect(result.state).toBe("ended");
+      expect(publishEvent).toHaveBeenCalled();
+      expect(publishSessionEvent).toHaveBeenCalled();
+    });
+
+    it("throws when session not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      await expect(endSession("nonexistent")).rejects.toThrow("Session not found");
+    });
+
+    it("throws when session already ended", async () => {
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([{ id: "session-1", state: "ended", podId: null }]);
+            }
+            return Promise.resolve([]);
+          }),
+        }),
+      }));
+
+      await expect(endSession("session-1")).rejects.toThrow("Session already ended");
+    });
+  });
+
+  describe("getSessionPrs", () => {
+    it("returns PRs for a session", async () => {
+      const prs = [{ id: "pr-1", prNumber: 42 }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue(prs),
+          }),
+        }),
+      });
+
+      const result = await getSessionPrs("session-1");
+      expect(result).toEqual(prs);
+    });
+  });
+
+  describe("addSessionPr", () => {
+    it("adds a PR to a session", async () => {
+      const pr = {
+        id: "pr-1",
+        sessionId: "s-1",
+        prUrl: "https://github.com/o/r/pull/1",
+        prNumber: 1,
+      };
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([pr]),
+        }),
+      });
+
+      const result = await addSessionPr("s-1", "https://github.com/o/r/pull/1", 1);
+      expect(result).toEqual(pr);
+    });
+  });
+
+  describe("updateSessionPr", () => {
+    it("updates PR fields", async () => {
+      const updated = { id: "pr-1", prState: "merged" };
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([updated]),
+          }),
+        }),
+      });
+
+      const result = await updateSessionPr("pr-1", { prState: "merged" });
+      expect(result.prState).toBe("merged");
+    });
+  });
+
+  describe("getActiveSessionCount", () => {
+    it("returns count of active sessions", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: 5 }]),
+        }),
+      });
+
+      const result = await getActiveSessionCount();
+      expect(result).toBe(5);
+    });
+
+    it("filters by repoUrl when provided", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: 2 }]),
+        }),
+      });
+
+      const result = await getActiveSessionCount("https://github.com/o/r");
+      expect(result).toBe(2);
+    });
+  });
+});

--- a/apps/api/src/services/mcp-server-service.test.ts
+++ b/apps/api/src/services/mcp-server-service.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  mcpServers: {
+    id: "mcp_servers.id",
+    scope: "mcp_servers.scope",
+    workspaceId: "mcp_servers.workspace_id",
+    enabled: "mcp_servers.enabled",
+  },
+}));
+
+vi.mock("./secret-service.js", () => ({
+  retrieveSecret: vi.fn(),
+}));
+
+import { db } from "../db/client.js";
+import { retrieveSecret } from "./secret-service.js";
+import {
+  listMcpServers,
+  getMcpServer,
+  createMcpServer,
+  updateMcpServer,
+  deleteMcpServer,
+  getMcpServersForTask,
+  resolveSecretRefs,
+  buildMcpJsonContent,
+} from "./mcp-server-service.js";
+
+const makeRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: "mcp-1",
+  name: "test-server",
+  command: "npx",
+  args: ["@test/mcp"],
+  env: null,
+  installCommand: null,
+  scope: "global",
+  repoUrl: null,
+  workspaceId: null,
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe("mcp-server-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listMcpServers", () => {
+    it("lists all servers with no filters", async () => {
+      const rows = [makeRow()];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockResolvedValue(rows),
+      });
+
+      const result = await listMcpServers();
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("test-server");
+    });
+
+    it("filters by scope and workspaceId", async () => {
+      const rows = [makeRow()];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows),
+        }),
+      });
+
+      const result = await listMcpServers("global", "ws-1");
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("getMcpServer", () => {
+    it("returns server when found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([makeRow()]),
+        }),
+      });
+
+      const result = await getMcpServer("mcp-1");
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("test-server");
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getMcpServer("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("createMcpServer", () => {
+    it("creates a server with defaults", async () => {
+      const row = makeRow();
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([row]),
+        }),
+      });
+
+      const result = await createMcpServer({
+        name: "test-server",
+        command: "npx",
+        args: ["@test/mcp"],
+      });
+
+      expect(result.name).toBe("test-server");
+      expect(result.command).toBe("npx");
+    });
+
+    it("creates a repo-scoped server", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return {
+            returning: vi
+              .fn()
+              .mockResolvedValue([
+                makeRow({ scope: "https://github.com/o/r", repoUrl: "https://github.com/o/r" }),
+              ]),
+          };
+        }),
+      });
+
+      await createMcpServer({
+        name: "repo-server",
+        command: "node",
+        repoUrl: "https://github.com/o/r",
+      });
+
+      expect(capturedValues.scope).toBe("https://github.com/o/r");
+      expect(capturedValues.repoUrl).toBe("https://github.com/o/r");
+    });
+  });
+
+  describe("updateMcpServer", () => {
+    it("updates specified fields", async () => {
+      let capturedSet: any;
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          capturedSet = vals;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([makeRow({ name: "updated" })]),
+            }),
+          };
+        }),
+      });
+
+      const result = await updateMcpServer("mcp-1", { name: "updated" });
+
+      expect(capturedSet.name).toBe("updated");
+      expect(capturedSet.updatedAt).toBeInstanceOf(Date);
+      expect(result.name).toBe("updated");
+    });
+
+    it("only includes provided fields", async () => {
+      let capturedSet: any;
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          capturedSet = vals;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([makeRow()]),
+            }),
+          };
+        }),
+      });
+
+      await updateMcpServer("mcp-1", { enabled: false });
+
+      expect(capturedSet.enabled).toBe(false);
+      expect(capturedSet.name).toBeUndefined();
+    });
+  });
+
+  describe("deleteMcpServer", () => {
+    it("deletes a server", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await deleteMcpServer("mcp-1");
+      expect(db.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe("getMcpServersForTask", () => {
+    it("returns enabled servers for repo, overriding globals", async () => {
+      const globalRow = makeRow({ id: "mcp-g", name: "shared", scope: "global" });
+      const repoRow = makeRow({
+        id: "mcp-r",
+        name: "shared",
+        scope: "https://github.com/o/r",
+      });
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([globalRow, repoRow]),
+        }),
+      });
+
+      const result = await getMcpServersForTask("https://github.com/o/r");
+      expect(result).toHaveLength(1);
+      expect(result[0].scope).toBe("https://github.com/o/r");
+    });
+
+    it("keeps global server when no repo override exists", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([makeRow({ scope: "global" })]),
+        }),
+      });
+
+      const result = await getMcpServersForTask("https://github.com/o/r");
+      expect(result).toHaveLength(1);
+      expect(result[0].scope).toBe("global");
+    });
+  });
+
+  describe("resolveSecretRefs", () => {
+    it("resolves ${{SECRET}} patterns in env vars", async () => {
+      vi.mocked(retrieveSecret).mockResolvedValue("secret-value");
+
+      const result = await resolveSecretRefs(
+        { API_KEY: "${{MY_SECRET}}" },
+        "https://github.com/o/r",
+      );
+
+      expect(result.API_KEY).toBe("secret-value");
+    });
+
+    it("falls back to global scope when repo scope fails", async () => {
+      vi.mocked(retrieveSecret)
+        .mockRejectedValueOnce(new Error("not found"))
+        .mockResolvedValueOnce("global-value");
+
+      const result = await resolveSecretRefs({ KEY: "${{MY_SECRET}}" }, "https://github.com/o/r");
+
+      expect(result.KEY).toBe("global-value");
+      expect(retrieveSecret).toHaveBeenCalledTimes(2);
+    });
+
+    it("leaves reference as-is when secret not found at all", async () => {
+      vi.mocked(retrieveSecret).mockRejectedValue(new Error("not found"));
+
+      const result = await resolveSecretRefs({ KEY: "${{MISSING}}" }, "https://github.com/o/r");
+
+      expect(result.KEY).toBe("${{MISSING}}");
+    });
+
+    it("passes through values without secret refs", async () => {
+      const result = await resolveSecretRefs({ PLAIN: "hello" }, "https://github.com/o/r");
+
+      expect(result.PLAIN).toBe("hello");
+      expect(retrieveSecret).not.toHaveBeenCalled();
+    });
+
+    it("resolves multiple refs in a single value", async () => {
+      vi.mocked(retrieveSecret).mockResolvedValue("val");
+
+      const result = await resolveSecretRefs(
+        { COMBINED: "${{A}}:${{B}}" },
+        "https://github.com/o/r",
+      );
+
+      expect(result.COMBINED).toBe("val:val");
+    });
+  });
+
+  describe("buildMcpJsonContent", () => {
+    it("builds valid .mcp.json content", async () => {
+      vi.mocked(retrieveSecret).mockResolvedValue("resolved");
+
+      const servers = [
+        {
+          id: "s-1",
+          name: "my-server",
+          command: "node",
+          args: ["server.js"],
+          env: { KEY: "${{SECRET}}" },
+          installCommand: null,
+          scope: "global",
+          repoUrl: null,
+          workspaceId: null,
+          enabled: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const result = await buildMcpJsonContent(servers, "https://github.com/o/r");
+      const parsed = JSON.parse(result);
+
+      expect(parsed.mcpServers["my-server"]).toBeDefined();
+      expect(parsed.mcpServers["my-server"].command).toBe("node");
+      expect(parsed.mcpServers["my-server"].args).toEqual(["server.js"]);
+      expect(parsed.mcpServers["my-server"].env.KEY).toBe("resolved");
+    });
+
+    it("omits env when no env vars", async () => {
+      const servers = [
+        {
+          id: "s-1",
+          name: "simple",
+          command: "npx",
+          args: ["server"],
+          env: null,
+          installCommand: null,
+          scope: "global",
+          repoUrl: null,
+          workspaceId: null,
+          enabled: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const result = await buildMcpJsonContent(servers, "https://github.com/o/r");
+      const parsed = JSON.parse(result);
+
+      expect(parsed.mcpServers["simple"].env).toBeUndefined();
+    });
+
+    it("resolves secret refs in args", async () => {
+      vi.mocked(retrieveSecret).mockResolvedValue("token123");
+
+      const servers = [
+        {
+          id: "s-1",
+          name: "auth-server",
+          command: "node",
+          args: ["--token", "${{API_TOKEN}}"],
+          env: null,
+          installCommand: null,
+          scope: "global",
+          repoUrl: null,
+          workspaceId: null,
+          enabled: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const result = await buildMcpJsonContent(servers, "https://github.com/o/r");
+      const parsed = JSON.parse(result);
+
+      expect(parsed.mcpServers["auth-server"].args).toEqual(["--token", "token123"]);
+    });
+  });
+});

--- a/apps/api/src/services/prompt-template-service.test.ts
+++ b/apps/api/src/services/prompt-template-service.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  promptTemplates: {
+    id: "prompt_templates.id",
+    isDefault: "prompt_templates.is_default",
+    repoUrl: "prompt_templates.repo_url",
+  },
+  repos: {
+    id: "repos.id",
+    repoUrl: "repos.repo_url",
+  },
+}));
+
+import { db } from "../db/client.js";
+import {
+  getPromptTemplate,
+  saveDefaultPromptTemplate,
+  saveRepoPromptTemplate,
+  listPromptTemplates,
+} from "./prompt-template-service.js";
+
+describe("prompt-template-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getPromptTemplate", () => {
+    it("returns repo-level override when available", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              id: "repo-1",
+              promptTemplateOverride: "Custom prompt",
+              autoMerge: true,
+            },
+          ]),
+        }),
+      });
+
+      const result = await getPromptTemplate("https://github.com/o/r");
+      expect(result.template).toBe("Custom prompt");
+      expect(result.autoMerge).toBe(true);
+    });
+
+    it("falls back to global default when no repo override", async () => {
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              // Repo lookup — no override
+              return Promise.resolve([
+                { id: "repo-1", promptTemplateOverride: null, autoMerge: true },
+              ]);
+            }
+            // Global default lookup
+            return Promise.resolve([{ id: "pt-1", template: "Global template", autoMerge: false }]);
+          }),
+        }),
+      }));
+
+      const result = await getPromptTemplate("https://github.com/o/r");
+      expect(result.template).toBe("Global template");
+      expect(result.autoMerge).toBe(true); // Uses repo's autoMerge
+    });
+
+    it("falls back to hardcoded default when no global template", async () => {
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            // All lookups return empty
+            return Promise.resolve([]);
+          }),
+        }),
+      }));
+
+      const result = await getPromptTemplate("https://github.com/o/r");
+      expect(result.id).toBe("builtin");
+      expect(result.template).toBeDefined();
+      expect(result.autoMerge).toBe(false);
+    });
+
+    it("returns global default when no repoUrl provided", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "pt-1", template: "Default", autoMerge: false }]),
+        }),
+      });
+
+      const result = await getPromptTemplate();
+      expect(result.template).toBe("Default");
+    });
+  });
+
+  describe("saveDefaultPromptTemplate", () => {
+    it("updates existing default template", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "pt-1" }]),
+        }),
+      });
+
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await saveDefaultPromptTemplate("New template", true);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it("inserts new default template when none exists", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await saveDefaultPromptTemplate("New template", false);
+      expect(db.insert).toHaveBeenCalled();
+    });
+  });
+
+  describe("saveRepoPromptTemplate", () => {
+    it("updates existing repo template", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "pt-1" }]),
+        }),
+      });
+
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await saveRepoPromptTemplate("https://github.com/o/r", "Template", true);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it("inserts new repo template when none exists", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return Promise.resolve(undefined);
+        }),
+      });
+
+      await saveRepoPromptTemplate("https://github.com/o/r.git", "Template", false);
+
+      expect(db.insert).toHaveBeenCalled();
+      // URL should be normalized
+      expect(capturedValues.repoUrl).toBe("https://github.com/o/r");
+    });
+  });
+
+  describe("listPromptTemplates", () => {
+    it("returns all prompt templates", async () => {
+      const templates = [{ id: "pt-1" }, { id: "pt-2" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockResolvedValue(templates),
+      });
+
+      const result = await listPromptTemplates();
+      expect(result).toEqual(templates);
+    });
+  });
+});

--- a/apps/api/src/services/repo-detect-service.test.ts
+++ b/apps/api/src/services/repo-detect-service.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { detectRepoConfig } from "./repo-detect-service.js";
+
+describe("repo-detect-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns base preset for non-GitHub URLs", async () => {
+    const result = await detectRepoConfig("https://gitlab.com/o/r", "token");
+    expect(result).toEqual({ imagePreset: "base", languages: [] });
+  });
+
+  it("returns base preset when API call fails", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result).toEqual({ imagePreset: "base", languages: [] });
+  });
+
+  it("detects node project", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { name: "package.json", type: "file" },
+          { name: "README.md", type: "file" },
+        ]),
+    });
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result.imagePreset).toBe("node");
+    expect(result.languages).toContain("node");
+    expect(result.testCommand).toBe("npm test");
+  });
+
+  it("detects rust project", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ name: "Cargo.toml", type: "file" }]),
+    });
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result.imagePreset).toBe("rust");
+    expect(result.languages).toContain("rust");
+    expect(result.testCommand).toBe("cargo test");
+  });
+
+  it("detects go project", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ name: "go.mod", type: "file" }]),
+    });
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result.imagePreset).toBe("go");
+    expect(result.languages).toContain("go");
+    expect(result.testCommand).toBe("go test ./...");
+  });
+
+  it("detects python project from pyproject.toml", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ name: "pyproject.toml", type: "file" }]),
+    });
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result.imagePreset).toBe("python");
+    expect(result.languages).toContain("python");
+    expect(result.testCommand).toBe("pytest");
+  });
+
+  it("detects python project from requirements.txt", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ name: "requirements.txt", type: "file" }]),
+    });
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result.imagePreset).toBe("python");
+  });
+
+  it("uses full preset for multi-language projects", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { name: "package.json", type: "file" },
+          { name: "Cargo.toml", type: "file" },
+        ]),
+    });
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result.imagePreset).toBe("full");
+    expect(result.languages).toContain("node");
+    expect(result.languages).toContain("rust");
+  });
+
+  it("sets first detected test command as the test command", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { name: "Cargo.toml", type: "file" },
+          { name: "package.json", type: "file" },
+        ]),
+    });
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result.testCommand).toBe("cargo test"); // Cargo.toml checked first
+  });
+
+  it("handles fetch exceptions gracefully", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result).toEqual({ imagePreset: "base", languages: [] });
+  });
+
+  it("sends correct authorization header", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+    globalThis.fetch = mockFetch;
+
+    await detectRepoConfig("https://github.com/owner/repo", "my-token");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/owner/repo/contents/",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer my-token",
+        }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/services/repo-service.test.ts
+++ b/apps/api/src/services/repo-service.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  repos: {
+    id: "repos.id",
+    repoUrl: "repos.repo_url",
+    workspaceId: "repos.workspace_id",
+  },
+  workspaces: {
+    id: "workspaces.id",
+    slug: "workspaces.slug",
+  },
+}));
+
+import { db } from "../db/client.js";
+import {
+  listRepos,
+  getRepo,
+  getRepoByUrl,
+  createRepo,
+  updateRepo,
+  deleteRepo,
+} from "./repo-service.js";
+
+describe("repo-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listRepos", () => {
+    it("lists all repos without filter", async () => {
+      const repos = [{ id: "r-1", repoUrl: "https://github.com/o/r" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockResolvedValue(repos),
+      });
+
+      const result = await listRepos();
+      expect(result).toEqual(repos);
+    });
+
+    it("filters by workspaceId", async () => {
+      const repos = [{ id: "r-1" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(repos),
+        }),
+      });
+
+      const result = await listRepos("ws-1");
+      expect(result).toEqual(repos);
+    });
+  });
+
+  describe("getRepo", () => {
+    it("returns repo when found", async () => {
+      const repo = { id: "r-1", repoUrl: "https://github.com/o/r" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([repo]),
+        }),
+      });
+
+      const result = await getRepo("r-1");
+      expect(result).toEqual(repo);
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getRepo("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getRepoByUrl", () => {
+    it("finds repo by normalized URL with workspaceId", async () => {
+      const repo = { id: "r-1", repoUrl: "https://github.com/o/r" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([repo]),
+        }),
+      });
+
+      const result = await getRepoByUrl("https://github.com/o/r.git", "ws-1");
+      expect(result).toEqual(repo);
+    });
+
+    it("returns null when not found", async () => {
+      // Default workspace lookup
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              // getDefaultWorkspaceId
+              return Promise.resolve([]);
+            }
+            // isNull fallback
+            return Promise.resolve([]);
+          }),
+        }),
+      }));
+
+      const result = await getRepoByUrl("https://github.com/o/nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("createRepo", () => {
+    it("creates a repo with normalized URL", async () => {
+      let capturedValues: any;
+      // getDefaultWorkspaceId
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "default-ws" }]),
+        }),
+      });
+
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return {
+            onConflictDoUpdate: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: "r-1", ...vals }]),
+            }),
+          };
+        }),
+      });
+
+      const result = await createRepo({
+        repoUrl: "https://github.com/Owner/Repo.git",
+        fullName: "Owner/Repo",
+      });
+
+      expect(capturedValues.repoUrl).toBe("https://github.com/owner/repo");
+      expect(capturedValues.defaultBranch).toBe("main");
+    });
+
+    it("uses provided workspaceId", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return {
+            onConflictDoUpdate: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: "r-1" }]),
+            }),
+          };
+        }),
+      });
+
+      await createRepo({
+        repoUrl: "https://github.com/o/r",
+        fullName: "o/r",
+        workspaceId: "ws-custom",
+      });
+
+      expect(capturedValues.workspaceId).toBe("ws-custom");
+    });
+  });
+
+  describe("updateRepo", () => {
+    it("updates repo fields", async () => {
+      const updated = { id: "r-1", autoMerge: true };
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([updated]),
+          }),
+        }),
+      });
+
+      const result = await updateRepo("r-1", { autoMerge: true });
+      expect(result!.autoMerge).toBe(true);
+    });
+
+    it("returns null when repo not found", async () => {
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const result = await updateRepo("nonexistent", { autoMerge: true });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteRepo", () => {
+    it("deletes a repo", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await deleteRepo("r-1");
+      expect(db.delete).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/services/schedule-service.test.ts
+++ b/apps/api/src/services/schedule-service.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  schedules: {
+    id: "schedules.id",
+    enabled: "schedules.enabled",
+    nextRunAt: "schedules.next_run_at",
+    createdAt: "schedules.created_at",
+  },
+  scheduleRuns: {
+    id: "schedule_runs.id",
+    scheduleId: "schedule_runs.schedule_id",
+    triggeredAt: "schedule_runs.triggered_at",
+  },
+}));
+
+import { db } from "../db/client.js";
+import {
+  createSchedule,
+  listSchedules,
+  getSchedule,
+  updateSchedule,
+  deleteSchedule,
+  recordRun,
+  getScheduleRuns,
+  getDueSchedules,
+  markScheduleRan,
+  validateCronExpression,
+} from "./schedule-service.js";
+
+describe("schedule-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createSchedule", () => {
+    it("creates a schedule with computed nextRunAt", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([{ id: "sched-1", ...vals }]) };
+        }),
+      });
+
+      const result = await createSchedule({
+        name: "Daily Build",
+        cronExpression: "0 0 * * *",
+        taskConfig: {
+          title: "Build",
+          prompt: "Build the app",
+          repoUrl: "https://github.com/o/r",
+          agentType: "claude-code",
+        },
+      });
+
+      expect(capturedValues.name).toBe("Daily Build");
+      expect(capturedValues.enabled).toBe(true);
+      expect(capturedValues.nextRunAt).toBeInstanceOf(Date);
+    });
+
+    it("sets nextRunAt to null when disabled", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([{ id: "sched-1", ...vals }]) };
+        }),
+      });
+
+      await createSchedule({
+        name: "Disabled",
+        cronExpression: "0 0 * * *",
+        enabled: false,
+        taskConfig: {
+          title: "Build",
+          prompt: "...",
+          repoUrl: "https://github.com/o/r",
+          agentType: "claude-code",
+        },
+      });
+
+      expect(capturedValues.nextRunAt).toBeNull();
+    });
+
+    it("passes createdBy to values", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([{ id: "sched-1" }]) };
+        }),
+      });
+
+      await createSchedule(
+        {
+          name: "Test",
+          cronExpression: "0 0 * * *",
+          taskConfig: {
+            title: "T",
+            prompt: "P",
+            repoUrl: "https://github.com/o/r",
+            agentType: "claude-code",
+          },
+        },
+        "user-1",
+      );
+
+      expect(capturedValues.createdBy).toBe("user-1");
+    });
+  });
+
+  describe("listSchedules", () => {
+    it("returns all schedules ordered by createdAt", async () => {
+      const schedules = [{ id: "s-1" }, { id: "s-2" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockResolvedValue(schedules),
+        }),
+      });
+
+      const result = await listSchedules();
+      expect(result).toEqual(schedules);
+    });
+  });
+
+  describe("getSchedule", () => {
+    it("returns schedule when found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "s-1", name: "Daily" }]),
+        }),
+      });
+
+      const result = await getSchedule("s-1");
+      expect(result).toEqual({ id: "s-1", name: "Daily" });
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getSchedule("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("updateSchedule", () => {
+    it("updates schedule and recomputes nextRunAt", async () => {
+      // getSchedule mock
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi
+            .fn()
+            .mockResolvedValue([{ id: "s-1", cronExpression: "0 0 * * *", enabled: true }]),
+        }),
+      });
+
+      let capturedSet: any;
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          capturedSet = vals;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: "s-1", name: "Updated" }]),
+            }),
+          };
+        }),
+      });
+
+      const result = await updateSchedule("s-1", { name: "Updated" });
+      expect(result!.name).toBe("Updated");
+      expect(capturedSet.nextRunAt).toBeInstanceOf(Date);
+    });
+
+    it("sets nextRunAt to null when disabling", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi
+            .fn()
+            .mockResolvedValue([{ id: "s-1", cronExpression: "0 0 * * *", enabled: true }]),
+        }),
+      });
+
+      let capturedSet: any;
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          capturedSet = vals;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: "s-1" }]),
+            }),
+          };
+        }),
+      });
+
+      await updateSchedule("s-1", { enabled: false });
+      expect(capturedSet.nextRunAt).toBeNull();
+    });
+
+    it("returns null when schedule not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await updateSchedule("nonexistent", { name: "X" });
+      expect(result).toBeNull();
+    });
+
+    it("updates cronExpression and recomputes", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi
+            .fn()
+            .mockResolvedValue([{ id: "s-1", cronExpression: "0 0 * * *", enabled: true }]),
+        }),
+      });
+
+      let capturedSet: any;
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          capturedSet = vals;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: "s-1" }]),
+            }),
+          };
+        }),
+      });
+
+      await updateSchedule("s-1", { cronExpression: "*/5 * * * *" });
+      expect(capturedSet.cronExpression).toBe("*/5 * * * *");
+      expect(capturedSet.nextRunAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("deleteSchedule", () => {
+    it("returns true when deleted", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "s-1" }]),
+        }),
+      });
+
+      const result = await deleteSchedule("s-1");
+      expect(result).toBe(true);
+    });
+
+    it("returns false when not found", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await deleteSchedule("nonexistent");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("recordRun", () => {
+    it("records a successful run", async () => {
+      const run = { id: "run-1", scheduleId: "s-1", taskId: "t-1", status: "success" };
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([run]),
+        }),
+      });
+
+      const result = await recordRun("s-1", "t-1", "success");
+      expect(result).toEqual(run);
+    });
+
+    it("records a failed run with error", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([{ id: "run-1" }]) };
+        }),
+      });
+
+      await recordRun("s-1", null, "failed", "Something went wrong");
+      expect(capturedValues.error).toBe("Something went wrong");
+      expect(capturedValues.taskId).toBeNull();
+    });
+  });
+
+  describe("getScheduleRuns", () => {
+    it("returns runs for a schedule", async () => {
+      const runs = [{ id: "r-1" }, { id: "r-2" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue(runs),
+            }),
+          }),
+        }),
+      });
+
+      const result = await getScheduleRuns("s-1");
+      expect(result).toEqual(runs);
+    });
+  });
+
+  describe("getDueSchedules", () => {
+    it("returns enabled schedules past their nextRunAt", async () => {
+      const due = [{ id: "s-1", enabled: true }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(due),
+        }),
+      });
+
+      const result = await getDueSchedules();
+      expect(result).toEqual(due);
+    });
+  });
+
+  describe("markScheduleRan", () => {
+    it("updates lastRunAt and computes new nextRunAt", async () => {
+      let capturedSet: any;
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          capturedSet = vals;
+          return { where: vi.fn().mockResolvedValue(undefined) };
+        }),
+      });
+
+      await markScheduleRan("s-1", "0 0 * * *");
+
+      expect(capturedSet.lastRunAt).toBeInstanceOf(Date);
+      expect(capturedSet.nextRunAt).toBeInstanceOf(Date);
+      expect(capturedSet.nextRunAt.getTime()).toBeGreaterThan(capturedSet.lastRunAt.getTime());
+    });
+  });
+
+  describe("validateCronExpression", () => {
+    it("returns valid for a correct expression", () => {
+      const result = validateCronExpression("0 0 * * *");
+      expect(result.valid).toBe(true);
+      expect(result.nextRun).toBeDefined();
+      expect(result.description).toBe("Every day at midnight");
+    });
+
+    it("returns invalid for a bad expression", () => {
+      const result = validateCronExpression("not a cron");
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it("describes common cron patterns", () => {
+      expect(validateCronExpression("0 9 * * *").description).toBe("Every day at 9:00");
+      expect(validateCronExpression("0 0 1 * *").description).toBe(
+        "First of every month at midnight",
+      );
+      expect(validateCronExpression("0 0 * * 1").description).toBe("Every Monday at midnight");
+      expect(validateCronExpression("*/5 * * * *").description).toBe("Every hour at minute */5");
+      expect(validateCronExpression("0 */2 * * *").description).toBe("Every day at */2:00");
+    });
+
+    it("returns raw expression for non-standard patterns", () => {
+      const result = validateCronExpression("15 14 1 * 3");
+      expect(result.valid).toBe(true);
+      expect(result.description).toBe("15 14 1 * 3");
+    });
+  });
+});

--- a/apps/api/src/services/session-service.test.ts
+++ b/apps/api/src/services/session-service.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  users: {
+    id: "users.id",
+    provider: "users.provider",
+    externalId: "users.external_id",
+    email: "users.email",
+    displayName: "users.display_name",
+    avatarUrl: "users.avatar_url",
+    defaultWorkspaceId: "users.default_workspace_id",
+  },
+  sessions: {
+    id: "sessions.id",
+    userId: "sessions.user_id",
+    tokenHash: "sessions.token_hash",
+    expiresAt: "sessions.expires_at",
+    createdAt: "sessions.created_at",
+  },
+}));
+
+import { db } from "../db/client.js";
+import {
+  createSession,
+  validateSession,
+  revokeSession,
+  revokeAllUserSessions,
+  createWsToken,
+  cleanupExpiredSessions,
+} from "./session-service.js";
+
+describe("session-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createSession", () => {
+    it("creates new user and session when user not found", async () => {
+      // User lookup returns empty
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      // Insert user
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            {
+              id: "user-1",
+              provider: "github",
+              externalId: "ext-1",
+              email: "test@test.com",
+              displayName: "Test User",
+              avatarUrl: null,
+              defaultWorkspaceId: null,
+            },
+          ]),
+        }),
+      });
+
+      const result = await createSession("github", {
+        externalId: "ext-1",
+        email: "test@test.com",
+        displayName: "Test User",
+      });
+
+      expect(result.user.email).toBe("test@test.com");
+      expect(result.user.provider).toBe("github");
+      expect(result.token).toBeDefined();
+      expect(result.token.length).toBe(64); // 32 bytes hex
+    });
+
+    it("updates existing user on login", async () => {
+      // User lookup returns existing
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                id: "user-1",
+                provider: "github",
+                externalId: "ext-1",
+                email: "old@test.com",
+                displayName: "Old Name",
+              },
+            ]),
+          }),
+        }),
+      });
+
+      // Update user
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([
+              {
+                id: "user-1",
+                provider: "github",
+                externalId: "ext-1",
+                email: "new@test.com",
+                displayName: "New Name",
+                avatarUrl: null,
+                defaultWorkspaceId: "ws-1",
+              },
+            ]),
+          }),
+        }),
+      });
+
+      // Insert session
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const result = await createSession("github", {
+        externalId: "ext-1",
+        email: "new@test.com",
+        displayName: "New Name",
+      });
+
+      expect(result.user.email).toBe("new@test.com");
+      expect(result.user.workspaceId).toBe("ws-1");
+    });
+  });
+
+  describe("validateSession", () => {
+    it("returns user for valid session", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([
+                {
+                  sessionId: "sess-1",
+                  userId: "user-1",
+                  provider: "github",
+                  email: "test@test.com",
+                  displayName: "Test",
+                  avatarUrl: null,
+                  defaultWorkspaceId: "ws-1",
+                },
+              ]),
+            }),
+          }),
+        }),
+      });
+
+      const result = await validateSession("some-token");
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("user-1");
+      expect(result!.email).toBe("test@test.com");
+    });
+
+    it("returns null for invalid or expired session", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      });
+
+      const result = await validateSession("bad-token");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("revokeSession", () => {
+    it("deletes session by token hash", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await revokeSession("some-token");
+      expect(db.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe("revokeAllUserSessions", () => {
+    it("deletes all sessions for a user", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await revokeAllUserSessions("user-1");
+      expect(db.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe("createWsToken", () => {
+    it("creates a short-lived WebSocket token", async () => {
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const token = await createWsToken("user-1");
+      expect(token).toBeDefined();
+      expect(token.length).toBe(64); // 32 bytes hex
+    });
+  });
+
+  describe("cleanupExpiredSessions", () => {
+    it("deletes expired sessions and returns count", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "s-1" }, { id: "s-2" }]),
+        }),
+      });
+
+      const count = await cleanupExpiredSessions();
+      expect(count).toBe(2);
+    });
+
+    it("returns 0 when no expired sessions", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const count = await cleanupExpiredSessions();
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/services/skill-service.test.ts
+++ b/apps/api/src/services/skill-service.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  customSkills: {
+    id: "custom_skills.id",
+    scope: "custom_skills.scope",
+    workspaceId: "custom_skills.workspace_id",
+    enabled: "custom_skills.enabled",
+  },
+}));
+
+import { db } from "../db/client.js";
+import {
+  listSkills,
+  getSkill,
+  createSkill,
+  updateSkill,
+  deleteSkill,
+  getSkillsForTask,
+  buildSkillSetupFiles,
+} from "./skill-service.js";
+
+const makeRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "skill-1",
+  name: "test-skill",
+  description: "A test skill",
+  prompt: "Do the thing",
+  scope: "global",
+  repoUrl: null,
+  workspaceId: null,
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe("skill-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listSkills", () => {
+    it("lists all skills with no filters", async () => {
+      const rows = [makeRow()];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockResolvedValue(rows),
+      });
+
+      const result = await listSkills();
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("test-skill");
+    });
+
+    it("filters by scope and workspaceId", async () => {
+      const rows = [makeRow()];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows),
+        }),
+      });
+
+      const result = await listSkills("global", "ws-1");
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("getSkill", () => {
+    it("returns skill when found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([makeRow()]),
+        }),
+      });
+
+      const result = await getSkill("skill-1");
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("test-skill");
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getSkill("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("createSkill", () => {
+    it("creates a global skill with defaults", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([makeRow()]) };
+        }),
+      });
+
+      const result = await createSkill({
+        name: "test-skill",
+        prompt: "Do the thing",
+      });
+
+      expect(capturedValues.scope).toBe("global");
+      expect(capturedValues.enabled).toBe(true);
+      expect(result.name).toBe("test-skill");
+    });
+
+    it("creates a repo-scoped skill", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return {
+            returning: vi
+              .fn()
+              .mockResolvedValue([
+                makeRow({ scope: "https://github.com/o/r", repoUrl: "https://github.com/o/r" }),
+              ]),
+          };
+        }),
+      });
+
+      await createSkill({
+        name: "repo-skill",
+        prompt: "Do it",
+        repoUrl: "https://github.com/o/r",
+      });
+
+      expect(capturedValues.scope).toBe("https://github.com/o/r");
+      expect(capturedValues.repoUrl).toBe("https://github.com/o/r");
+    });
+  });
+
+  describe("updateSkill", () => {
+    it("updates specified fields", async () => {
+      let capturedSet: any;
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          capturedSet = vals;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([makeRow({ name: "updated" })]),
+            }),
+          };
+        }),
+      });
+
+      const result = await updateSkill("skill-1", { name: "updated" });
+      expect(capturedSet.name).toBe("updated");
+      expect(capturedSet.updatedAt).toBeInstanceOf(Date);
+      expect(result.name).toBe("updated");
+    });
+
+    it("does not include undefined fields", async () => {
+      let capturedSet: any;
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          capturedSet = vals;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([makeRow()]),
+            }),
+          };
+        }),
+      });
+
+      await updateSkill("skill-1", { enabled: false });
+      expect(capturedSet.enabled).toBe(false);
+      expect(capturedSet.name).toBeUndefined();
+      expect(capturedSet.prompt).toBeUndefined();
+    });
+  });
+
+  describe("deleteSkill", () => {
+    it("deletes a skill", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await deleteSkill("skill-1");
+      expect(db.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe("getSkillsForTask", () => {
+    it("returns enabled skills with repo overrides", async () => {
+      const globalRow = makeRow({ id: "s-g", name: "deploy", scope: "global" });
+      const repoRow = makeRow({
+        id: "s-r",
+        name: "deploy",
+        scope: "https://github.com/o/r",
+      });
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([globalRow, repoRow]),
+        }),
+      });
+
+      const result = await getSkillsForTask("https://github.com/o/r");
+      expect(result).toHaveLength(1);
+      expect(result[0].scope).toBe("https://github.com/o/r");
+    });
+
+    it("keeps global skills when no repo override", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([makeRow({ scope: "global" })]),
+        }),
+      });
+
+      const result = await getSkillsForTask("https://github.com/o/r");
+      expect(result).toHaveLength(1);
+      expect(result[0].scope).toBe("global");
+    });
+
+    it("returns multiple skills with different names", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi
+            .fn()
+            .mockResolvedValue([
+              makeRow({ id: "s-1", name: "deploy", scope: "global" }),
+              makeRow({ id: "s-2", name: "test", scope: "global" }),
+            ]),
+        }),
+      });
+
+      const result = await getSkillsForTask("https://github.com/o/r");
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("buildSkillSetupFiles", () => {
+    it("creates .claude/commands/ files for each skill", () => {
+      const skills = [
+        {
+          id: "s-1",
+          name: "deploy",
+          description: null,
+          prompt: "Deploy the app",
+          scope: "global",
+          repoUrl: null,
+          workspaceId: null,
+          enabled: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: "s-2",
+          name: "test",
+          description: null,
+          prompt: "Run tests",
+          scope: "global",
+          repoUrl: null,
+          workspaceId: null,
+          enabled: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const files = buildSkillSetupFiles(skills);
+
+      expect(files).toHaveLength(2);
+      expect(files[0].path).toBe(".claude/commands/deploy.md");
+      expect(files[0].content).toBe("Deploy the app");
+      expect(files[1].path).toBe(".claude/commands/test.md");
+      expect(files[1].content).toBe("Run tests");
+    });
+
+    it("returns empty array for no skills", () => {
+      const files = buildSkillSetupFiles([]);
+      expect(files).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/services/task-template-service.test.ts
+++ b/apps/api/src/services/task-template-service.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  taskTemplates: {
+    id: "task_templates.id",
+    repoUrl: "task_templates.repo_url",
+  },
+}));
+
+import { db } from "../db/client.js";
+import {
+  listTaskTemplates,
+  getTaskTemplate,
+  createTaskTemplate,
+  updateTaskTemplate,
+  deleteTaskTemplate,
+} from "./task-template-service.js";
+
+describe("task-template-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listTaskTemplates", () => {
+    it("lists all templates without filter", async () => {
+      const templates = [{ id: "tt-1", name: "Build" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockResolvedValue(templates),
+      });
+
+      const result = await listTaskTemplates();
+      expect(result).toEqual(templates);
+    });
+
+    it("filters by repoUrl", async () => {
+      const templates = [{ id: "tt-1" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(templates),
+        }),
+      });
+
+      const result = await listTaskTemplates("https://github.com/o/r");
+      expect(result).toEqual(templates);
+    });
+  });
+
+  describe("getTaskTemplate", () => {
+    it("returns template when found", async () => {
+      const template = { id: "tt-1", name: "Build" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([template]),
+        }),
+      });
+
+      const result = await getTaskTemplate("tt-1");
+      expect(result).toEqual(template);
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getTaskTemplate("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("createTaskTemplate", () => {
+    it("creates template with defaults", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([{ id: "tt-1", ...vals }]) };
+        }),
+      });
+
+      const result = await createTaskTemplate({
+        name: "Build",
+        prompt: "Build the app",
+      });
+
+      expect(capturedValues.agentType).toBe("claude-code");
+      expect(capturedValues.priority).toBe(100);
+      expect(capturedValues.repoUrl).toBeNull();
+    });
+
+    it("uses provided values", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([{ id: "tt-1" }]) };
+        }),
+      });
+
+      await createTaskTemplate({
+        name: "Test",
+        prompt: "Run tests",
+        agentType: "codex",
+        priority: 50,
+        repoUrl: "https://github.com/o/r",
+        metadata: { key: "value" },
+      });
+
+      expect(capturedValues.agentType).toBe("codex");
+      expect(capturedValues.priority).toBe(50);
+      expect(capturedValues.repoUrl).toBe("https://github.com/o/r");
+      expect(capturedValues.metadata).toEqual({ key: "value" });
+    });
+  });
+
+  describe("updateTaskTemplate", () => {
+    it("updates template fields", async () => {
+      const updated = { id: "tt-1", name: "Updated" };
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([updated]),
+          }),
+        }),
+      });
+
+      const result = await updateTaskTemplate("tt-1", { name: "Updated" });
+      expect(result!.name).toBe("Updated");
+    });
+
+    it("returns null when not found", async () => {
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const result = await updateTaskTemplate("nonexistent", { name: "X" });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteTaskTemplate", () => {
+    it("deletes a template", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await deleteTaskTemplate("tt-1");
+      expect(db.delete).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/services/ticket-sync-service.test.ts
+++ b/apps/api/src/services/ticket-sync-service.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  ticketProviders: {
+    enabled: "ticket_providers.enabled",
+  },
+}));
+
+vi.mock("@optio/ticket-providers", () => ({
+  getTicketProvider: vi.fn(),
+}));
+
+vi.mock("./task-service.js", () => ({
+  createTask: vi.fn(),
+  transitionTask: vi.fn(),
+  listTasks: vi.fn(),
+}));
+
+vi.mock("../workers/task-worker.js", () => ({
+  taskQueue: {
+    add: vi.fn(),
+  },
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { db } from "../db/client.js";
+import { getTicketProvider } from "@optio/ticket-providers";
+import * as taskService from "./task-service.js";
+import { taskQueue } from "../workers/task-worker.js";
+import { syncAllTickets } from "./ticket-sync-service.js";
+
+describe("ticket-sync-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("syncs new tickets and creates tasks", async () => {
+    // Provider config from DB
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi
+          .fn()
+          .mockResolvedValue([
+            { source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
+          ]),
+      }),
+    });
+
+    const mockProvider = {
+      fetchActionableTickets: vi.fn().mockResolvedValue([
+        {
+          title: "Fix bug",
+          body: "Description",
+          source: "github",
+          externalId: "123",
+          url: "https://github.com/o/r/issues/123",
+          labels: [],
+          repo: null,
+        },
+      ]),
+      addComment: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(getTicketProvider).mockReturnValue(mockProvider as any);
+
+    // No existing tasks
+    vi.mocked(taskService.listTasks).mockResolvedValue([] as any);
+
+    vi.mocked(taskService.createTask).mockResolvedValue({
+      id: "task-1",
+      maxRetries: 3,
+    } as any);
+
+    const count = await syncAllTickets();
+
+    expect(count).toBe(1);
+    expect(taskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Fix bug",
+        repoUrl: "https://github.com/o/r",
+        agentType: "claude-code",
+        ticketSource: "github",
+        ticketExternalId: "123",
+      }),
+    );
+    expect(taskService.transitionTask).toHaveBeenCalledWith("task-1", "queued", "ticket_sync");
+    expect(taskQueue.add).toHaveBeenCalled();
+    expect(mockProvider.addComment).toHaveBeenCalled();
+  });
+
+  it("skips tickets that already have tasks", async () => {
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi
+          .fn()
+          .mockResolvedValue([
+            { source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
+          ]),
+      }),
+    });
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([
+        {
+          title: "Existing",
+          body: "",
+          source: "github",
+          externalId: "123",
+          url: "",
+          labels: [],
+          repo: null,
+        },
+      ]),
+      addComment: vi.fn(),
+    } as any);
+
+    // Existing task matches
+    vi.mocked(taskService.listTasks).mockResolvedValue([
+      { ticketSource: "github", ticketExternalId: "123" },
+    ] as any);
+
+    const count = await syncAllTickets();
+    expect(count).toBe(0);
+    expect(taskService.createTask).not.toHaveBeenCalled();
+  });
+
+  it("uses codex agent type when ticket has codex label", async () => {
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi
+          .fn()
+          .mockResolvedValue([
+            { source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
+          ]),
+      }),
+    });
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([
+        {
+          title: "Codex task",
+          body: "",
+          source: "github",
+          externalId: "456",
+          url: "",
+          labels: ["codex"],
+          repo: null,
+        },
+      ]),
+      addComment: vi.fn(),
+    } as any);
+
+    vi.mocked(taskService.listTasks).mockResolvedValue([] as any);
+    vi.mocked(taskService.createTask).mockResolvedValue({ id: "t-1", maxRetries: 3 } as any);
+
+    await syncAllTickets();
+
+    expect(taskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ agentType: "codex" }),
+    );
+  });
+
+  it("uses ticket repo URL when available", async () => {
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            source: "github",
+            config: { repoUrl: "https://github.com/fallback/repo" },
+            enabled: true,
+          },
+        ]),
+      }),
+    });
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([
+        {
+          title: "Task",
+          body: "",
+          source: "github",
+          externalId: "789",
+          url: "",
+          labels: [],
+          repo: "owner/specific-repo",
+        },
+      ]),
+      addComment: vi.fn(),
+    } as any);
+
+    vi.mocked(taskService.listTasks).mockResolvedValue([] as any);
+    vi.mocked(taskService.createTask).mockResolvedValue({ id: "t-1", maxRetries: 3 } as any);
+
+    await syncAllTickets();
+
+    expect(taskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoUrl: "https://github.com/owner/specific-repo.git",
+      }),
+    );
+  });
+
+  it("skips tickets without repo URL", async () => {
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ source: "github", config: {}, enabled: true }]),
+      }),
+    });
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([
+        {
+          title: "No repo",
+          body: "",
+          source: "github",
+          externalId: "999",
+          url: "",
+          labels: [],
+          repo: null,
+        },
+      ]),
+      addComment: vi.fn(),
+    } as any);
+
+    vi.mocked(taskService.listTasks).mockResolvedValue([] as any);
+
+    const count = await syncAllTickets();
+    expect(count).toBe(0);
+    expect(taskService.createTask).not.toHaveBeenCalled();
+  });
+
+  it("handles provider errors gracefully", async () => {
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ source: "github", config: {}, enabled: true }]),
+      }),
+    });
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockRejectedValue(new Error("API error")),
+    } as any);
+
+    const count = await syncAllTickets();
+    expect(count).toBe(0);
+  });
+
+  it("continues syncing when comment fails", async () => {
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi
+          .fn()
+          .mockResolvedValue([
+            { source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
+          ]),
+      }),
+    });
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([
+        {
+          title: "Task",
+          body: "",
+          source: "github",
+          externalId: "111",
+          url: "",
+          labels: [],
+          repo: null,
+        },
+      ]),
+      addComment: vi.fn().mockRejectedValue(new Error("comment failed")),
+    } as any);
+
+    vi.mocked(taskService.listTasks).mockResolvedValue([] as any);
+    vi.mocked(taskService.createTask).mockResolvedValue({ id: "t-1", maxRetries: 3 } as any);
+
+    const count = await syncAllTickets();
+    expect(count).toBe(1); // Task still synced despite comment failure
+  });
+});

--- a/apps/api/src/services/webhook-service.test.ts
+++ b/apps/api/src/services/webhook-service.test.ts
@@ -1,6 +1,47 @@
 import crypto from "node:crypto";
-import { describe, it, expect } from "vitest";
-import { signPayload, VALID_EVENTS } from "./webhook-service.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  webhooks: {
+    id: "webhooks.id",
+    active: "webhooks.active",
+    createdAt: "webhooks.created_at",
+  },
+  webhookDeliveries: {
+    id: "webhook_deliveries.id",
+    webhookId: "webhook_deliveries.webhook_id",
+    deliveredAt: "webhook_deliveries.delivered_at",
+  },
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { db } from "../db/client.js";
+import {
+  signPayload,
+  VALID_EVENTS,
+  createWebhook,
+  listWebhooks,
+  getWebhook,
+  deleteWebhook,
+  getWebhookDeliveries,
+  deliverWebhook,
+  getWebhooksForEvent,
+} from "./webhook-service.js";
 
 describe("signPayload", () => {
   it("produces a valid HMAC-SHA256 hex signature", () => {
@@ -8,7 +49,6 @@ describe("signPayload", () => {
     const secret = "test-secret-key";
     const signature = signPayload(payload, secret);
 
-    // Verify it matches what Node's crypto would produce
     const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
     expect(signature).toBe(expected);
   });
@@ -41,5 +81,304 @@ describe("VALID_EVENTS", () => {
     expect(VALID_EVENTS).toContain("task.pr_opened");
     expect(VALID_EVENTS).toContain("review.completed");
     expect(VALID_EVENTS).toHaveLength(5);
+  });
+});
+
+describe("webhook CRUD", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createWebhook", () => {
+    it("creates a webhook with defaults", async () => {
+      const webhook = { id: "wh-1", url: "https://example.com/hook" };
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([webhook]),
+        }),
+      });
+
+      const result = await createWebhook({
+        url: "https://example.com/hook",
+        events: ["task.completed"],
+      });
+
+      expect(result).toEqual(webhook);
+    });
+
+    it("passes createdBy when provided", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([{ id: "wh-1" }]) };
+        }),
+      });
+
+      await createWebhook({ url: "https://example.com", events: ["task.completed"] }, "user-1");
+
+      expect(capturedValues.createdBy).toBe("user-1");
+    });
+  });
+
+  describe("listWebhooks", () => {
+    it("returns all webhooks ordered by createdAt", async () => {
+      const hooks = [{ id: "wh-1" }, { id: "wh-2" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockResolvedValue(hooks),
+        }),
+      });
+
+      const result = await listWebhooks();
+      expect(result).toEqual(hooks);
+    });
+  });
+
+  describe("getWebhook", () => {
+    it("returns webhook when found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "wh-1", url: "https://example.com" }]),
+        }),
+      });
+
+      const result = await getWebhook("wh-1");
+      expect(result!.url).toBe("https://example.com");
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getWebhook("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteWebhook", () => {
+    it("returns true when deleted", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "wh-1" }]),
+        }),
+      });
+
+      const result = await deleteWebhook("wh-1");
+      expect(result).toBe(true);
+    });
+
+    it("returns false when not found", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await deleteWebhook("nonexistent");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getWebhookDeliveries", () => {
+    it("returns deliveries for a webhook", async () => {
+      const deliveries = [{ id: "d-1" }, { id: "d-2" }];
+      const mockLimit = vi.fn().mockResolvedValue(deliveries);
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: mockLimit,
+            }),
+          }),
+        }),
+      });
+
+      const result = await getWebhookDeliveries("wh-1", { limit: 10 });
+      expect(result).toEqual(deliveries);
+    });
+  });
+});
+
+describe("deliverWebhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("delivers a standard webhook with signature", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve("OK"),
+    });
+    globalThis.fetch = mockFetch;
+
+    (db.insert as any) = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "d-1", success: true }]),
+      }),
+    });
+
+    const webhook = {
+      id: "wh-1",
+      url: "https://example.com/hook",
+      secret: "my-secret",
+      events: ["task.completed"],
+      active: true,
+    };
+
+    const result = await deliverWebhook(webhook as any, "task.completed", {
+      taskId: "t-1",
+      taskTitle: "Test",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/hook",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-Optio-Event": "task.completed",
+          "X-Optio-Signature": expect.any(String),
+        }),
+      }),
+    );
+  });
+
+  it("delivers a Slack-formatted webhook", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve("ok"),
+    });
+    globalThis.fetch = mockFetch;
+
+    (db.insert as any) = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "d-1", success: true }]),
+      }),
+    });
+
+    const webhook = {
+      id: "wh-1",
+      url: "https://hooks.slack.com/services/T00/B00/xxx",
+      secret: null,
+      events: ["task.completed"],
+      active: true,
+    };
+
+    await deliverWebhook(webhook as any, "task.completed", { taskId: "t-1", taskTitle: "My Task" });
+
+    const callArgs = mockFetch.mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+    // Slack payload should have blocks and text
+    expect(body.text).toContain("My Task");
+    expect(body.blocks).toBeDefined();
+    expect(body.blocks[0].type).toBe("header");
+  });
+
+  it("records failed delivery", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+
+    let capturedValues: any;
+    (db.insert as any) = vi.fn().mockReturnValue({
+      values: vi.fn().mockImplementation((vals: any) => {
+        capturedValues = vals;
+        return { returning: vi.fn().mockResolvedValue([{ id: "d-1", success: false }]) };
+      }),
+    });
+
+    await deliverWebhook(
+      { id: "wh-1", url: "https://example.com", secret: null, events: [], active: true } as any,
+      "task.failed",
+      { taskId: "t-1" },
+    );
+
+    expect(capturedValues.success).toBe(false);
+    expect(capturedValues.error).toContain("HTTP 500");
+  });
+
+  it("handles fetch exceptions", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("Connection refused"));
+
+    let capturedValues: any;
+    (db.insert as any) = vi.fn().mockReturnValue({
+      values: vi.fn().mockImplementation((vals: any) => {
+        capturedValues = vals;
+        return { returning: vi.fn().mockResolvedValue([{ id: "d-1" }]) };
+      }),
+    });
+
+    await deliverWebhook(
+      { id: "wh-1", url: "https://example.com", secret: null, events: [], active: true } as any,
+      "task.failed",
+      {},
+    );
+
+    expect(capturedValues.success).toBe(false);
+    expect(capturedValues.error).toBe("Connection refused");
+  });
+
+  it("skips signature header when no secret", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve("OK"),
+    });
+    globalThis.fetch = mockFetch;
+
+    (db.insert as any) = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "d-1" }]),
+      }),
+    });
+
+    await deliverWebhook(
+      { id: "wh-1", url: "https://example.com", secret: null, events: [], active: true } as any,
+      "task.completed",
+      {},
+    );
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers["X-Optio-Signature"]).toBeUndefined();
+  });
+});
+
+describe("getWebhooksForEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns active webhooks subscribed to the event", async () => {
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          { id: "wh-1", events: ["task.completed", "task.failed"], active: true },
+          { id: "wh-2", events: ["task.failed"], active: true },
+        ]),
+      }),
+    });
+
+    const result = await getWebhooksForEvent("task.completed");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("wh-1");
+  });
+
+  it("returns empty array when no webhooks match", async () => {
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: "wh-1", events: ["task.failed"], active: true }]),
+      }),
+    });
+
+    const result = await getWebhooksForEvent("task.completed");
+    expect(result).toHaveLength(0);
   });
 });

--- a/apps/api/src/services/workflow-service.test.ts
+++ b/apps/api/src/services/workflow-service.test.ts
@@ -1,0 +1,501 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  workflowTemplates: {
+    id: "workflow_templates.id",
+    workspaceId: "workflow_templates.workspace_id",
+    createdAt: "workflow_templates.created_at",
+  },
+  workflowRuns: {
+    id: "workflow_runs.id",
+    workflowTemplateId: "workflow_runs.workflow_template_id",
+    createdAt: "workflow_runs.created_at",
+  },
+  tasks: {
+    id: "tasks.id",
+    workflowRunId: "tasks.workflow_run_id",
+  },
+}));
+
+vi.mock("./task-service.js", () => ({
+  getTask: vi.fn(),
+  createTask: vi.fn(),
+  transitionTask: vi.fn(),
+}));
+
+vi.mock("./dependency-service.js", () => ({
+  addDependencies: vi.fn(),
+}));
+
+vi.mock("../workers/task-worker.js", () => ({
+  taskQueue: {
+    add: vi.fn(),
+  },
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnValue({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+// Must mock @optio/shared detectCycle
+vi.mock("@optio/shared", async () => {
+  const actual = await vi.importActual("@optio/shared");
+  return {
+    ...actual,
+  };
+});
+
+import { db } from "../db/client.js";
+import * as taskService from "./task-service.js";
+import * as dependencyService from "./dependency-service.js";
+import { taskQueue } from "../workers/task-worker.js";
+import {
+  listWorkflowTemplates,
+  getWorkflowTemplate,
+  createWorkflowTemplate,
+  updateWorkflowTemplate,
+  deleteWorkflowTemplate,
+  listWorkflowRuns,
+  getWorkflowRun,
+  runWorkflow,
+  checkWorkflowRunCompletion,
+} from "./workflow-service.js";
+
+describe("workflow-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listWorkflowTemplates", () => {
+    it("lists all templates ordered by createdAt", async () => {
+      const templates = [{ id: "wt-1", name: "Deploy" }];
+      const mockWhere = vi.fn().mockResolvedValue(templates);
+      const mockOrderBy = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      (db.select as any) = vi.fn().mockReturnValue({ from: mockFrom });
+
+      // Without workspaceId, should not call where
+      mockOrderBy.mockResolvedValue(templates);
+      const result = await listWorkflowTemplates();
+      expect(result).toEqual(templates);
+    });
+
+    it("filters by workspaceId when provided", async () => {
+      const templates = [{ id: "wt-1", name: "Deploy" }];
+      const mockWhere = vi.fn().mockResolvedValue(templates);
+      const mockOrderBy = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      (db.select as any) = vi.fn().mockReturnValue({ from: mockFrom });
+
+      const result = await listWorkflowTemplates("ws-1");
+      expect(mockWhere).toHaveBeenCalled();
+    });
+  });
+
+  describe("getWorkflowTemplate", () => {
+    it("returns template when found", async () => {
+      const template = { id: "wt-1", name: "Deploy" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([template]),
+        }),
+      });
+
+      const result = await getWorkflowTemplate("wt-1");
+      expect(result).toEqual(template);
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getWorkflowTemplate("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("createWorkflowTemplate", () => {
+    it("creates a template with valid DAG", async () => {
+      const created = { id: "wt-1", name: "Pipeline", steps: [] };
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([created]),
+        }),
+      });
+
+      const result = await createWorkflowTemplate({
+        name: "Pipeline",
+        steps: [
+          { id: "step-a", title: "Build", prompt: "Build the app" },
+          { id: "step-b", title: "Test", prompt: "Run tests", dependsOn: ["step-a"] },
+        ],
+      });
+
+      expect(result).toEqual(created);
+    });
+
+    it("throws on circular dependency", async () => {
+      await expect(
+        createWorkflowTemplate({
+          name: "Bad",
+          steps: [
+            { id: "a", title: "A", prompt: "...", dependsOn: ["b"] },
+            { id: "b", title: "B", prompt: "...", dependsOn: ["a"] },
+          ],
+        }),
+      ).rejects.toThrow(/[Cc]ircular dependency/);
+    });
+
+    it("throws on unknown step reference", async () => {
+      await expect(
+        createWorkflowTemplate({
+          name: "Bad",
+          steps: [{ id: "a", title: "A", prompt: "...", dependsOn: ["nonexistent"] }],
+        }),
+      ).rejects.toThrow(/unknown step/);
+    });
+
+    it("uses default status 'draft' when not specified", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([{ id: "wt-1", ...vals }]) };
+        }),
+      });
+
+      await createWorkflowTemplate({
+        name: "Test",
+        steps: [{ id: "a", title: "A", prompt: "Do it" }],
+      });
+
+      expect(capturedValues.status).toBe("draft");
+    });
+  });
+
+  describe("updateWorkflowTemplate", () => {
+    it("updates template fields", async () => {
+      const updated = { id: "wt-1", name: "Updated" };
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([updated]),
+          }),
+        }),
+      });
+
+      const result = await updateWorkflowTemplate("wt-1", { name: "Updated" });
+      expect(result).toEqual(updated);
+    });
+
+    it("validates DAG when steps are updated", async () => {
+      await expect(
+        updateWorkflowTemplate("wt-1", {
+          steps: [
+            { id: "a", title: "A", prompt: "...", dependsOn: ["b"] },
+            { id: "b", title: "B", prompt: "...", dependsOn: ["a"] },
+          ],
+        }),
+      ).rejects.toThrow(/[Cc]ircular dependency/);
+    });
+
+    it("returns null when template not found", async () => {
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const result = await updateWorkflowTemplate("nonexistent", { name: "X" });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteWorkflowTemplate", () => {
+    it("returns true when template is deleted", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "wt-1" }]),
+        }),
+      });
+
+      const result = await deleteWorkflowTemplate("wt-1");
+      expect(result).toBe(true);
+    });
+
+    it("returns false when template not found", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await deleteWorkflowTemplate("nonexistent");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("listWorkflowRuns", () => {
+    it("lists runs for a template", async () => {
+      const runs = [{ id: "wr-1" }, { id: "wr-2" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue(runs),
+          }),
+        }),
+      });
+
+      const result = await listWorkflowRuns("wt-1");
+      expect(result).toEqual(runs);
+    });
+  });
+
+  describe("getWorkflowRun", () => {
+    it("returns run when found", async () => {
+      const run = { id: "wr-1", status: "running" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([run]),
+        }),
+      });
+
+      const result = await getWorkflowRun("wr-1");
+      expect(result).toEqual(run);
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getWorkflowRun("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("runWorkflow", () => {
+    it("creates tasks and wires dependencies for a workflow", async () => {
+      // Mock getWorkflowTemplate
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              id: "wt-1",
+              status: "active",
+              steps: [
+                {
+                  id: "build",
+                  title: "Build",
+                  prompt: "Build it",
+                  repoUrl: "https://github.com/o/r",
+                },
+                {
+                  id: "test",
+                  title: "Test",
+                  prompt: "Test it",
+                  repoUrl: "https://github.com/o/r",
+                  dependsOn: ["build"],
+                },
+              ],
+            },
+          ]),
+        }),
+      });
+
+      // Mock insert for workflow run
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "wr-1", taskMapping: {} }]),
+        }),
+      });
+
+      // Mock update for tasks and workflow run
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      let taskCount = 0;
+      vi.mocked(taskService.createTask).mockImplementation(async () => {
+        taskCount++;
+        return { id: `task-${taskCount}`, maxRetries: 3 } as any;
+      });
+
+      const result = await runWorkflow("wt-1");
+
+      expect(taskService.createTask).toHaveBeenCalledTimes(2);
+      expect(dependencyService.addDependencies).toHaveBeenCalledWith("task-2", ["task-1"]);
+      // Build step has no deps → queued
+      expect(taskService.transitionTask).toHaveBeenCalledWith("task-1", "queued", "workflow_start");
+      // Test step has deps → waiting_on_deps
+      expect(taskService.transitionTask).toHaveBeenCalledWith(
+        "task-2",
+        "waiting_on_deps",
+        "workflow_start",
+      );
+      expect(taskQueue.add).toHaveBeenCalledTimes(1); // Only root task queued
+    });
+
+    it("throws when template not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      await expect(runWorkflow("nonexistent")).rejects.toThrow("Workflow template not found");
+    });
+
+    it("throws when template is archived", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "wt-1", status: "archived", steps: [] }]),
+        }),
+      });
+
+      await expect(runWorkflow("wt-1")).rejects.toThrow("Cannot run an archived workflow");
+    });
+
+    it("throws when step has no repoUrl and no override", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              id: "wt-1",
+              status: "active",
+              steps: [{ id: "s1", title: "S1", prompt: "..." }],
+            },
+          ]),
+        }),
+      });
+
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "wr-1", taskMapping: {} }]),
+        }),
+      });
+
+      await expect(runWorkflow("wt-1")).rejects.toThrow(/no repoUrl/);
+    });
+  });
+
+  describe("checkWorkflowRunCompletion", () => {
+    it("marks run as completed when all tasks completed", async () => {
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              return Promise.resolve([
+                { id: "wr-1", status: "running", taskMapping: { a: "t-1", b: "t-2" } },
+              ]);
+            }
+            return Promise.resolve([]);
+          }),
+        }),
+      }));
+
+      vi.mocked(taskService.getTask)
+        .mockResolvedValueOnce({ id: "t-1", state: "completed" } as any)
+        .mockResolvedValueOnce({ id: "t-2", state: "completed" } as any);
+
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await checkWorkflowRunCompletion("wr-1");
+
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it("marks run as failed when all terminal but some failed", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi
+            .fn()
+            .mockResolvedValue([
+              { id: "wr-1", status: "running", taskMapping: { a: "t-1", b: "t-2" } },
+            ]),
+        }),
+      });
+
+      vi.mocked(taskService.getTask)
+        .mockResolvedValueOnce({ id: "t-1", state: "completed" } as any)
+        .mockResolvedValueOnce({ id: "t-2", state: "failed" } as any);
+
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await checkWorkflowRunCompletion("wr-1");
+
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it("does nothing when run is not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      await checkWorkflowRunCompletion("nonexistent");
+
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when tasks are still running", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi
+            .fn()
+            .mockResolvedValue([
+              { id: "wr-1", status: "running", taskMapping: { a: "t-1", b: "t-2" } },
+            ]),
+        }),
+      });
+
+      vi.mocked(taskService.getTask)
+        .mockResolvedValueOnce({ id: "t-1", state: "completed" } as any)
+        .mockResolvedValueOnce({ id: "t-2", state: "running" } as any);
+
+      (db.update as any) = vi.fn();
+
+      await checkWorkflowRunCompletion("wr-1");
+
+      expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/services/workspace-service.test.ts
+++ b/apps/api/src/services/workspace-service.test.ts
@@ -1,0 +1,402 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  workspaces: {
+    id: "workspaces.id",
+    slug: "workspaces.slug",
+  },
+  workspaceMembers: {
+    id: "workspace_members.id",
+    workspaceId: "workspace_members.workspace_id",
+    userId: "workspace_members.user_id",
+    role: "workspace_members.role",
+    createdAt: "workspace_members.created_at",
+  },
+  users: {
+    id: "users.id",
+    email: "users.email",
+    displayName: "users.display_name",
+    avatarUrl: "users.avatar_url",
+    defaultWorkspaceId: "users.default_workspace_id",
+  },
+}));
+
+import { db } from "../db/client.js";
+import {
+  createWorkspace,
+  getWorkspace,
+  getWorkspaceBySlug,
+  updateWorkspace,
+  deleteWorkspace,
+  listUserWorkspaces,
+  getUserRole,
+  listMembers,
+  addMember,
+  updateMemberRole,
+  removeMember,
+  ensureUserHasWorkspace,
+  switchWorkspace,
+} from "./workspace-service.js";
+
+describe("workspace-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createWorkspace", () => {
+    it("creates workspace and adds creator as admin", async () => {
+      const ws = { id: "ws-1", name: "Test", slug: "test" };
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([ws]),
+          onConflictDoUpdate: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([ws]),
+          }),
+        }),
+      });
+
+      // Mock user lookup for setting default workspace
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "user-1", defaultWorkspaceId: null }]),
+        }),
+      });
+
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      const result = await createWorkspace({ name: "Test", slug: "test" }, "user-1");
+      expect(result).toEqual(ws);
+      // Should have inserted workspace member
+      expect(db.insert).toHaveBeenCalledTimes(2); // workspace + member
+    });
+
+    it("sanitizes slug to lowercase with dashes", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([{ id: "ws-1", ...vals }]) };
+        }),
+      });
+
+      await createWorkspace({ name: "Test", slug: "My Workspace!" });
+
+      expect(capturedValues.slug).toBe("my-workspace-");
+    });
+
+    it("skips admin setup when no createdBy", async () => {
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "ws-1" }]),
+        }),
+      });
+
+      await createWorkspace({ name: "Test", slug: "test" });
+
+      // Only one insert (workspace), not two
+      expect(db.insert).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getWorkspace", () => {
+    it("returns workspace when found", async () => {
+      const ws = { id: "ws-1", name: "Test" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([ws]),
+        }),
+      });
+
+      const result = await getWorkspace("ws-1");
+      expect(result).toEqual(ws);
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getWorkspace("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getWorkspaceBySlug", () => {
+    it("returns workspace by slug", async () => {
+      const ws = { id: "ws-1", slug: "my-ws" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([ws]),
+        }),
+      });
+
+      const result = await getWorkspaceBySlug("my-ws");
+      expect(result).toEqual(ws);
+    });
+  });
+
+  describe("updateWorkspace", () => {
+    it("updates workspace fields", async () => {
+      let capturedSet: any;
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          capturedSet = vals;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: "ws-1", name: "Updated" }]),
+            }),
+          };
+        }),
+      });
+
+      const result = await updateWorkspace("ws-1", { name: "Updated" });
+      expect(result!.name).toBe("Updated");
+      expect(capturedSet.name).toBe("Updated");
+      expect(capturedSet.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it("sanitizes slug on update", async () => {
+      let capturedSet: any;
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((vals: any) => {
+          capturedSet = vals;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: "ws-1" }]),
+            }),
+          };
+        }),
+      });
+
+      await updateWorkspace("ws-1", { slug: "My Slug!" });
+      expect(capturedSet.slug).toBe("my-slug-");
+    });
+
+    it("returns null when workspace not found", async () => {
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const result = await updateWorkspace("nonexistent", { name: "X" });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteWorkspace", () => {
+    it("deletes a workspace", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await deleteWorkspace("ws-1");
+      expect(db.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe("listUserWorkspaces", () => {
+    it("returns workspaces user belongs to with roles", async () => {
+      const rows = [{ id: "ws-1", name: "Test", slug: "test", role: "admin" }];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(rows),
+          }),
+        }),
+      });
+
+      const result = await listUserWorkspaces("user-1");
+      expect(result).toEqual(rows);
+    });
+  });
+
+  describe("getUserRole", () => {
+    it("returns role when user is a member", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ role: "admin" }]),
+        }),
+      });
+
+      const result = await getUserRole("ws-1", "user-1");
+      expect(result).toBe("admin");
+    });
+
+    it("returns null when user is not a member", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getUserRole("ws-1", "user-1");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("listMembers", () => {
+    it("returns members with user info", async () => {
+      const members = [
+        { id: "m-1", userId: "u-1", role: "admin", email: "a@b.com", displayName: "User" },
+      ];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(members),
+          }),
+        }),
+      });
+
+      const result = await listMembers("ws-1");
+      expect(result).toEqual(members);
+    });
+  });
+
+  describe("addMember", () => {
+    it("validates user exists and adds member", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "user-1" }]),
+        }),
+      });
+
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await addMember("ws-1", "user-1", "member");
+      expect(db.insert).toHaveBeenCalled();
+    });
+
+    it("throws when user not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      await expect(addMember("ws-1", "nonexistent")).rejects.toThrow("User not found");
+    });
+  });
+
+  describe("updateMemberRole", () => {
+    it("updates the member role", async () => {
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await updateMemberRole("ws-1", "user-1", "admin");
+      expect(db.update).toHaveBeenCalled();
+    });
+  });
+
+  describe("removeMember", () => {
+    it("removes a member from workspace", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await removeMember("ws-1", "user-1");
+      expect(db.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe("ensureUserHasWorkspace", () => {
+    it("returns existing default workspace", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "user-1", defaultWorkspaceId: "ws-1" }]),
+        }),
+      });
+
+      const result = await ensureUserHasWorkspace("user-1");
+      expect(result).toBe("ws-1");
+    });
+
+    it("sets first membership workspace as default when no default", async () => {
+      let selectCallCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              // User lookup: no default workspace
+              return Promise.resolve([{ id: "user-1", defaultWorkspaceId: null }]);
+            }
+            // listUserWorkspaces
+            return Promise.resolve([]);
+          }),
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi
+              .fn()
+              .mockResolvedValue([
+                { id: "ws-existing", name: "Existing", slug: "existing", role: "member" },
+              ]),
+          }),
+        }),
+      }));
+
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      const result = await ensureUserHasWorkspace("user-1");
+      expect(result).toBe("ws-existing");
+    });
+  });
+
+  describe("switchWorkspace", () => {
+    it("switches workspace when user is a member", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ role: "member" }]),
+        }),
+      });
+
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await switchWorkspace("user-1", "ws-2");
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it("throws when user is not a member", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      await expect(switchWorkspace("user-1", "ws-2")).rejects.toThrow(
+        "Not a member of this workspace",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive test suites for 15 previously untested API services, following the existing mocking patterns from `subtask-service.test.ts`
- Expand `webhook-service.test.ts` from 45 lines to full coverage of CRUD, delivery (standard + Slack), signatures, and event filtering
- All 496 tests pass (33 test files, up from 12)

## Services covered

**High priority:** workflow-service, dependency-service, mcp-server-service, workspace-service, interactive-session-service

**Medium priority:** schedule-service, repo-service, session-service, skill-service, prompt-template-service

**Lower priority:** repo-detect-service, ticket-sync-service, container-service, task-template-service, event-bus

## Test plan
- [x] All 496 tests pass (`npx turbo test`)
- [x] Pre-commit hooks pass (format, typecheck)
- [ ] CI validates all tests pass on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)