### PR TITLE
fix: add workspace scoping to dependencies and comments routes

### DIFF
--- a/apps/api/src/routes/comments.test.ts
+++ b/apps/api/src/routes/comments.test.ts
@@ -111,6 +111,7 @@ describe("PATCH /api/tasks/:taskId/comments/:commentId", () => {
   });
 
   it("updates a comment", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-1" });
     mockUpdateComment.mockResolvedValue({ id: "c-1", content: "Updated" });
 
     const res = await app.inject({
@@ -124,6 +125,7 @@ describe("PATCH /api/tasks/:taskId/comments/:commentId", () => {
   });
 
   it("returns 404 for nonexistent comment", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-1" });
     mockUpdateComment.mockRejectedValue(new Error("Comment not found"));
 
     const res = await app.inject({
@@ -136,6 +138,7 @@ describe("PATCH /api/tasks/:taskId/comments/:commentId", () => {
   });
 
   it("returns 403 for unauthorized edit", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-1" });
     mockUpdateComment.mockRejectedValue(new Error("Not authorized to edit"));
 
     const res = await app.inject({
@@ -157,6 +160,7 @@ describe("DELETE /api/tasks/:taskId/comments/:commentId", () => {
   });
 
   it("deletes a comment", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-1" });
     mockDeleteComment.mockResolvedValue(undefined);
 
     const res = await app.inject({ method: "DELETE", url: "/api/tasks/task-1/comments/c-1" });
@@ -166,6 +170,7 @@ describe("DELETE /api/tasks/:taskId/comments/:commentId", () => {
   });
 
   it("returns 404 for nonexistent comment", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-1" });
     mockDeleteComment.mockRejectedValue(new Error("Comment not found"));
 
     const res = await app.inject({
@@ -217,5 +222,39 @@ describe("GET /api/tasks/:id/activity", () => {
     // Sorted by createdAt: event first (09:00), then comment (10:00)
     expect(body.activity[0].type).toBe("event");
     expect(body.activity[1].type).toBe("comment");
+  });
+});
+
+describe("workspace scoping", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns 404 for PATCH comment on task in different workspace", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/tasks/task-1/comments/c-1",
+      payload: { content: "Updated" },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockUpdateComment).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for DELETE comment on task in different workspace", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/api/tasks/task-1/comments/c-1",
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockDeleteComment).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -33,7 +33,13 @@ export async function commentRoutes(app: FastifyInstance) {
 
   // Update a comment
   app.patch("/api/tasks/:taskId/comments/:commentId", async (req, reply) => {
-    const { commentId } = req.params as { taskId: string; commentId: string };
+    const { taskId, commentId } = req.params as { taskId: string; commentId: string };
+    const task = await taskService.getTask(taskId);
+    if (!task) return reply.status(404).send({ error: "Task not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && task.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Task not found" });
+    }
     const { content } = updateCommentSchema.parse(req.body);
     try {
       const comment = await commentService.updateComment(commentId, content, req.user?.id);
@@ -48,7 +54,13 @@ export async function commentRoutes(app: FastifyInstance) {
 
   // Delete a comment
   app.delete("/api/tasks/:taskId/comments/:commentId", async (req, reply) => {
-    const { commentId } = req.params as { taskId: string; commentId: string };
+    const { taskId, commentId } = req.params as { taskId: string; commentId: string };
+    const task = await taskService.getTask(taskId);
+    if (!task) return reply.status(404).send({ error: "Task not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && task.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Task not found" });
+    }
     try {
       await commentService.deleteComment(commentId, req.user?.id);
       reply.status(204).send();

--- a/apps/api/src/routes/dependencies.test.ts
+++ b/apps/api/src/routes/dependencies.test.ts
@@ -25,9 +25,15 @@ import { dependencyRoutes } from "./dependencies.js";
 
 // ─── Helpers ───
 
-async function buildTestApp(): Promise<FastifyInstance> {
+async function buildTestApp(user?: { id: string; workspaceId: string }): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
   app.decorateRequest("user", undefined as any);
+  if (user) {
+    app.addHook("preHandler", (req, _reply, done) => {
+      (req as any).user = user;
+      done();
+    });
+  }
   await dependencyRoutes(app);
   await app.ready();
   return app;
@@ -137,6 +143,7 @@ describe("DELETE /api/tasks/:id/dependencies/:depTaskId", () => {
   });
 
   it("removes a dependency", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1" });
     mockRemoveDependency.mockResolvedValue(true);
 
     const res = await app.inject({
@@ -148,6 +155,7 @@ describe("DELETE /api/tasks/:id/dependencies/:depTaskId", () => {
   });
 
   it("returns 404 for nonexistent dependency", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1" });
     mockRemoveDependency.mockResolvedValue(false);
 
     const res = await app.inject({
@@ -156,5 +164,66 @@ describe("DELETE /api/tasks/:id/dependencies/:depTaskId", () => {
     });
 
     expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("workspace scoping", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp({ id: "user-1", workspaceId: "ws-1" });
+  });
+
+  it("returns 404 for task in different workspace (GET dependencies)", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "GET", url: "/api/tasks/task-1/dependencies" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockGetDependencies).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for task in different workspace (GET dependents)", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "GET", url: "/api/tasks/task-1/dependents" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockGetDependents).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for task in different workspace (POST dependencies)", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/tasks/task-1/dependencies",
+      payload: { dependsOnIds: ["00000000-0000-0000-0000-000000000001"] },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockAddDependencies).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for task in different workspace (DELETE dependency)", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/api/tasks/task-1/dependencies/task-2",
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockRemoveDependency).not.toHaveBeenCalled();
+  });
+
+  it("allows access for task in same workspace", async () => {
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-1" });
+    mockGetDependencies.mockResolvedValue([]);
+
+    const res = await app.inject({ method: "GET", url: "/api/tasks/task-1/dependencies" });
+
+    expect(res.statusCode).toBe(200);
   });
 });

--- a/apps/api/src/routes/dependencies.ts
+++ b/apps/api/src/routes/dependencies.ts
@@ -9,6 +9,10 @@ export async function dependencyRoutes(app: FastifyInstance) {
     const { id } = req.params as { id: string };
     const task = await taskService.getTask(id);
     if (!task) return reply.status(404).send({ error: "Task not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && task.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Task not found" });
+    }
     const dependencies = await dependencyService.getDependencies(id);
     reply.send({ dependencies });
   });
@@ -18,6 +22,10 @@ export async function dependencyRoutes(app: FastifyInstance) {
     const { id } = req.params as { id: string };
     const task = await taskService.getTask(id);
     if (!task) return reply.status(404).send({ error: "Task not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && task.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Task not found" });
+    }
     const dependents = await dependencyService.getDependents(id);
     reply.send({ dependents });
   });
@@ -29,6 +37,10 @@ export async function dependencyRoutes(app: FastifyInstance) {
 
     const task = await taskService.getTask(id);
     if (!task) return reply.status(404).send({ error: "Task not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && task.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Task not found" });
+    }
 
     try {
       await dependencyService.addDependencies(id, body.dependsOnIds);
@@ -41,6 +53,12 @@ export async function dependencyRoutes(app: FastifyInstance) {
   // Remove a dependency
   app.delete("/api/tasks/:id/dependencies/:depTaskId", async (req, reply) => {
     const { id, depTaskId } = req.params as { id: string; depTaskId: string };
+    const task = await taskService.getTask(id);
+    if (!task) return reply.status(404).send({ error: "Task not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && task.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Task not found" });
+    }
     const removed = await dependencyService.removeDependency(id, depTaskId);
     if (!removed) return reply.status(404).send({ error: "Dependency not found" });
     reply.status(204).send();


### PR DESCRIPTION
## Summary
- Add workspace membership validation to all 4 dependency endpoints (`GET dependencies`, `GET dependents`, `POST dependencies`, `DELETE dependency`) — previously any authenticated user could view/inject/remove dependencies for tasks in other workspaces
- Add workspace membership validation to `PATCH` and `DELETE` comment endpoints — previously any authenticated user could update/delete comments on tasks in other workspaces
- Follow the existing pattern from `subtasks.ts`: check `req.user?.workspaceId` against `task.workspaceId`, return 404 if mismatched

## Test plan
- [x] Updated existing tests in `comments.test.ts` and `dependencies.test.ts` to mock `getTask` where newly required
- [x] Added workspace scoping tests verifying 404 is returned for cross-workspace access
- [x] All 741 tests pass, typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)