### PR TITLE
feat: Optio agent pod infrastructure

### DIFF
--- a/Dockerfile.optio
+++ b/Dockerfile.optio
@@ -1,0 +1,29 @@
+# Optio operations assistant pod.
+# Lightweight image: Claude Code + HTTP tools. No repo/language tooling needed.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Minimal system packages — only what an ops agent needs
+RUN apt-get update && apt-get install -y \
+    curl wget jq ca-certificates gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (needed for Claude Code)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Claude Code
+RUN npm install -g @anthropic-ai/claude-code
+
+# Non-root user
+RUN useradd -m -s /bin/bash optio \
+    && mkdir -p /home/optio/.claude \
+    && chown -R optio:optio /home/optio
+
+USER optio
+WORKDIR /home/optio
+
+# The pod runs sleep infinity — the API server execs into it for chat sessions
+CMD ["sleep", "infinity"]

--- a/apps/api/src/routes/optio.test.ts
+++ b/apps/api/src/routes/optio.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+
+// ─── Mocks ───
+
+const mockListNamespacedPod = vi.fn();
+
+vi.mock("@kubernetes/client-node", () => {
+  return {
+    KubeConfig: vi.fn().mockImplementation(() => ({
+      loadFromDefault: vi.fn(),
+      makeApiClient: vi.fn(() => ({
+        listNamespacedPod: mockListNamespacedPod,
+      })),
+    })),
+    CoreV1Api: vi.fn(),
+  };
+});
+
+import { optioRoutes } from "./optio.js";
+
+// ─── Helpers ───
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await optioRoutes(app);
+  await app.ready();
+  return app;
+}
+
+describe("GET /api/optio/status", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns ready:true when optio pod is running", async () => {
+    mockListNamespacedPod.mockResolvedValue({
+      items: [
+        {
+          metadata: { name: "optio-optio-abc123" },
+          status: {
+            containerStatuses: [
+              {
+                state: { running: { startedAt: "2026-01-01T00:00:00Z" } },
+                ready: true,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const res = await app.inject({ method: "GET", url: "/api/optio/status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ready).toBe(true);
+    expect(body.podName).toBe("optio-optio-abc123");
+  });
+
+  it("returns ready:false when no pods found", async () => {
+    mockListNamespacedPod.mockResolvedValue({ items: [] });
+
+    const res = await app.inject({ method: "GET", url: "/api/optio/status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ready).toBe(false);
+    expect(body.podName).toBeNull();
+  });
+
+  it("returns ready:false when pod is not ready", async () => {
+    mockListNamespacedPod.mockResolvedValue({
+      items: [
+        {
+          metadata: { name: "optio-optio-abc123" },
+          status: {
+            containerStatuses: [
+              {
+                state: { waiting: { reason: "ContainerCreating" } },
+                ready: false,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const res = await app.inject({ method: "GET", url: "/api/optio/status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ready).toBe(false);
+    expect(body.podName).toBe("optio-optio-abc123");
+  });
+
+  it("returns ready:false when K8s API fails", async () => {
+    mockListNamespacedPod.mockRejectedValue(new Error("connection refused"));
+
+    const res = await app.inject({ method: "GET", url: "/api/optio/status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ready).toBe(false);
+    expect(body.podName).toBeNull();
+  });
+});

--- a/apps/api/src/routes/optio.ts
+++ b/apps/api/src/routes/optio.ts
@@ -1,0 +1,41 @@
+import type { FastifyInstance } from "fastify";
+import { KubeConfig, CoreV1Api } from "@kubernetes/client-node";
+
+const NAMESPACE = "optio";
+const POD_ROLE_LABEL = "optio.pod-role=optio";
+
+function getK8sApi() {
+  const kc = new KubeConfig();
+  kc.loadFromDefault();
+  return kc.makeApiClient(CoreV1Api);
+}
+
+export async function optioRoutes(app: FastifyInstance) {
+  app.get("/api/optio/status", async (_req, reply) => {
+    try {
+      const api = getK8sApi();
+      const podList = await api.listNamespacedPod({
+        namespace: NAMESPACE,
+        labelSelector: POD_ROLE_LABEL,
+      });
+
+      const pods = podList.items ?? [];
+      if (pods.length === 0) {
+        return reply.send({ ready: false, podName: null });
+      }
+
+      const pod = pods[0];
+      const podName = pod.metadata?.name ?? null;
+      const containerStatus = pod.status?.containerStatuses?.[0];
+      const isRunning = !!containerStatus?.state?.running;
+      const isReady = containerStatus?.ready ?? false;
+
+      reply.send({
+        ready: isRunning && isReady,
+        podName,
+      });
+    } catch {
+      reply.send({ ready: false, podName: null });
+    }
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -28,6 +28,7 @@ import { dependencyRoutes } from "./routes/dependencies.js";
 import { workflowRoutes } from "./routes/workflows.js";
 import { mcpServerRoutes } from "./routes/mcp-servers.js";
 import { skillRoutes } from "./routes/skills.js";
+import { optioRoutes } from "./routes/optio.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import { sessionTerminalWs } from "./ws/session-terminal.js";
@@ -91,6 +92,7 @@ export async function buildServer() {
   await app.register(workflowRoutes);
   await app.register(mcpServerRoutes);
   await app.register(skillRoutes);
+  await app.register(optioRoutes);
 
   // WebSocket routes
   await app.register(logStreamWs);

--- a/helm/optio/templates/optio-deployment.yaml
+++ b/helm/optio/templates/optio-deployment.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.optio.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-optio
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: optio-assistant
+    {{- include "optio.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: optio-assistant
+  template:
+    metadata:
+      labels:
+        app: optio-assistant
+        optio.pod-role: optio
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: optio
+          image: "{{ .Values.optio.image.repository }}:{{ .Values.optio.image.tag }}"
+          imagePullPolicy: {{ .Values.optio.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: OPTIO_API_URL
+              value: "http://{{ .Release.Name }}-api:{{ .Values.api.port }}"
+            - name: OPTIO_POD_ROLE
+              value: "optio"
+          resources:
+            {{- toYaml .Values.optio.resources | nindent 12 }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "pgrep -f 'sleep infinity' > /dev/null"
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "pgrep -f 'sleep infinity' > /dev/null"
+            initialDelaySeconds: 3
+            periodSeconds: 10
+{{- end }}

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -87,6 +87,25 @@ web:
     targetMemoryUtilizationPercentage: ""
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Optio Operations Assistant Pod
+# A single always-on pod running the Optio conversational assistant.
+# It makes API calls on behalf of users — no repo checkout needed.
+# ──────────────────────────────────────────────────────────────────────────────
+optio:
+  enabled: true
+  image:
+    repository: optio-optio
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Agent containers
 # ──────────────────────────────────────────────────────────────────────────────
 agent:

--- a/images/build.sh
+++ b/images/build.sh
@@ -7,28 +7,31 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 echo "=== Building Optio Agent Images ==="
 
 # Base image (all others depend on this)
-echo "[1/7] Building optio-base..."
+echo "[1/8] Building optio-base..."
 docker build -t optio-base:latest -f "$SCRIPT_DIR/base.Dockerfile" "$ROOT_DIR"
 
 # Language-specific images (can be built in parallel)
-echo "[2/7] Building optio-node..."
+echo "[2/8] Building optio-node..."
 docker build -t optio-node:latest -f "$SCRIPT_DIR/node.Dockerfile" "$ROOT_DIR" &
 
-echo "[3/7] Building optio-python..."
+echo "[3/8] Building optio-python..."
 docker build -t optio-python:latest -f "$SCRIPT_DIR/python.Dockerfile" "$ROOT_DIR" &
 
-echo "[4/7] Building optio-go..."
+echo "[4/8] Building optio-go..."
 docker build -t optio-go:latest -f "$SCRIPT_DIR/go.Dockerfile" "$ROOT_DIR" &
 
-echo "[5/7] Building optio-rust..."
+echo "[5/8] Building optio-rust..."
 docker build -t optio-rust:latest -f "$SCRIPT_DIR/rust.Dockerfile" "$ROOT_DIR" &
 
-echo "[6/7] Building optio-dind..."
+echo "[6/8] Building optio-dind..."
 docker build -t optio-dind:latest -f "$SCRIPT_DIR/dind.Dockerfile" "$ROOT_DIR" &
+
+echo "[7/8] Building optio-optio (operations assistant)..."
+docker build -t optio-optio:latest -f "$ROOT_DIR/Dockerfile.optio" "$ROOT_DIR" &
 
 wait
 
-echo "[7/7] Building optio-full..."
+echo "[8/8] Building optio-full..."
 docker build -t optio-full:latest -f "$SCRIPT_DIR/full.Dockerfile" "$ROOT_DIR"
 
 # Tag optio-base as the default

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -41,6 +41,9 @@ echo "   Building optio-full..."
 docker build -t optio-full:latest -f images/full.Dockerfile . -q
 echo "   All agent images built."
 
+echo "   Building optio-optio (operations assistant)..."
+docker build -t optio-optio:latest -f Dockerfile.optio . -q
+
 echo "[3/6] Building API and Web images..."
 docker build -t optio-api:latest -f Dockerfile.api . -q
 docker build -t optio-web:latest -f Dockerfile.web . -q
@@ -71,6 +74,7 @@ if helm status optio -n optio &>/dev/null; then
     --set agent.image.repository=optio-base \
     --set agent.image.tag=latest \
     --set agent.imagePullPolicy=Never \
+    --set optio.image.pullPolicy=Never \
     --set auth.disabled=true \
     --set api.service.type=NodePort \
     --set api.service.nodePort=30400 \
@@ -86,6 +90,7 @@ else
     --set agent.image.repository=optio-base \
     --set agent.image.tag=latest \
     --set agent.imagePullPolicy=Never \
+    --set optio.image.pullPolicy=Never \
     --set auth.disabled=true \
     --set api.service.type=NodePort \
     --set api.service.nodePort=30400 \
@@ -99,6 +104,7 @@ echo "   Helm deployment complete."
 echo "[6/6] Verifying deployment..."
 kubectl wait --namespace optio --for=condition=available deployment/optio-api --timeout=60s 2>/dev/null || true
 kubectl wait --namespace optio --for=condition=available deployment/optio-web --timeout=60s 2>/dev/null || true
+kubectl wait --namespace optio --for=condition=available deployment/optio-optio --timeout=60s 2>/dev/null || true
 
 echo ""
 echo "=== Setup Complete ==="


### PR DESCRIPTION
## Summary

- Add dedicated always-on K8s pod for the Optio operations assistant — a conversational AI that makes API calls on behalf of users (no repo checkout needed)
- New `Dockerfile.optio`: lightweight image with Claude Code + HTTP tools (curl/wget/jq), no language runtimes
- Helm deployment template with liveness/readiness probes, `OPTIO_API_URL` and `OPTIO_POD_ROLE` env vars, and appropriate resource limits
- API endpoint `GET /api/optio/status` → `{ ready: boolean, podName: string }` for the chat UI to detect pod readiness
- Updated `images/build.sh` and `scripts/setup-local.sh` to build and deploy the optio image

Closes #184

## Test plan

- [x] Typecheck passes (`turbo typecheck`)
- [x] All 745 tests pass (`turbo test`), including 4 new tests for the `/api/optio/status` endpoint
- [x] Formatting clean (`prettier --check`)
- [ ] Deploy locally with `setup-local.sh` and verify the optio pod starts
- [ ] Verify `GET /api/optio/status` returns `{ ready: true, podName: "..." }` when pod is running
- [ ] Verify status endpoint returns `{ ready: false }` when pod is not present
- [ ] Helm lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)