### PR TITLE
feat: Optio tool definitions and API auth passthrough

### DIFF
--- a/apps/api/src/routes/optio.ts
+++ b/apps/api/src/routes/optio.ts
@@ -1,0 +1,150 @@
+import type { FastifyInstance } from "fastify";
+import { sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { requireRole } from "../plugins/auth.js";
+
+/**
+ * Optio system routes — aggregate health and tool-related endpoints.
+ */
+export async function optioRoutes(app: FastifyInstance) {
+  /**
+   * GET /api/optio/system-status
+   *
+   * Returns an aggregate system health summary suitable for injection into
+   * an agent's system prompt as ambient context.
+   */
+  app.get("/api/optio/system-status", { preHandler: [requireRole("viewer")] }, async (req) => {
+    const workspaceId = req.user?.workspaceId || null;
+    const wsFilter = workspaceId ? sql`AND workspace_id = ${workspaceId}` : sql``;
+
+    // ── Task counts by state ──────────────────────────────────────────
+    const tasksByState = await db.execute<{
+      state: string;
+      count: string;
+    }>(sql`
+      SELECT state, COUNT(*)::text AS count
+      FROM tasks
+      WHERE 1=1 ${wsFilter}
+      GROUP BY state
+    `);
+
+    const stateMap: Record<string, number> = {};
+    for (const row of tasksByState) {
+      stateMap[row.state] = parseInt(row.count, 10) || 0;
+    }
+
+    // ── Failed today & completed today ────────────────────────────────
+    const [todayCounts] = await db.execute<{
+      failed_today: string;
+      completed_today: string;
+    }>(sql`
+      SELECT
+        COUNT(*) FILTER (WHERE state = 'failed' AND updated_at >= CURRENT_DATE)::text AS failed_today,
+        COUNT(*) FILTER (WHERE state = 'completed' AND updated_at >= CURRENT_DATE)::text AS completed_today
+      FROM tasks
+      WHERE 1=1 ${wsFilter}
+    `);
+
+    // ── Queue depth (pending + queued + waiting_on_deps) ──────────────
+    const queueDepth =
+      (stateMap["pending"] ?? 0) + (stateMap["queued"] ?? 0) + (stateMap["waiting_on_deps"] ?? 0);
+
+    // ── Pod health summary ────────────────────────────────────────────
+    const podSummary = await db.execute<{
+      total: string;
+      ready: string;
+      error: string;
+      provisioning: string;
+    }>(sql`
+      SELECT
+        COUNT(*)::text AS total,
+        COUNT(*) FILTER (WHERE state = 'ready')::text AS ready,
+        COUNT(*) FILTER (WHERE state = 'error')::text AS error,
+        COUNT(*) FILTER (WHERE state = 'provisioning')::text AS provisioning
+      FROM repo_pods
+      WHERE 1=1 ${wsFilter}
+    `);
+
+    const podStats = podSummary[0] ?? { total: "0", ready: "0", error: "0", provisioning: "0" };
+
+    // ── Cost today ────────────────────────────────────────────────────
+    const [costToday] = await db.execute<{ cost: string }>(sql`
+      SELECT COALESCE(SUM(CAST(cost_usd AS NUMERIC)), 0)::text AS cost
+      FROM tasks
+      WHERE cost_usd IS NOT NULL
+        AND created_at >= CURRENT_DATE
+        ${wsFilter}
+    `);
+
+    // ── Active alerts ─────────────────────────────────────────────────
+    // Recent OOM kills and crashes in the last hour
+    const recentHealthEvents = await db.execute<{
+      event_type: string;
+      pod_name: string;
+      message: string;
+      created_at: string;
+    }>(sql`
+      SELECT event_type, pod_name, message, created_at::text
+      FROM pod_health_events
+      WHERE event_type IN ('crashed', 'oom_killed')
+        AND created_at >= NOW() - INTERVAL '1 hour'
+      ORDER BY created_at DESC
+      LIMIT 10
+    `);
+
+    // Recent auth errors from failed tasks in the last hour
+    const recentAuthErrors = await db.execute<{
+      id: string;
+      title: string;
+      error_message: string;
+    }>(sql`
+      SELECT id, title, error_message
+      FROM tasks
+      WHERE state = 'failed'
+        AND error_message ILIKE '%auth%'
+        AND updated_at >= NOW() - INTERVAL '1 hour'
+        ${wsFilter}
+      LIMIT 5
+    `);
+
+    const alerts: Array<{ type: string; message: string; timestamp?: string }> = [];
+
+    for (const event of recentHealthEvents) {
+      alerts.push({
+        type: event.event_type,
+        message: `Pod ${event.pod_name}: ${event.message ?? event.event_type}`,
+        timestamp: event.created_at,
+      });
+    }
+
+    for (const task of recentAuthErrors) {
+      alerts.push({
+        type: "auth_error",
+        message: `Task "${task.title}" (${task.id}): ${task.error_message}`,
+      });
+    }
+
+    return {
+      tasks: {
+        running: stateMap["running"] ?? 0,
+        provisioning: stateMap["provisioning"] ?? 0,
+        queued: stateMap["queued"] ?? 0,
+        pending: stateMap["pending"] ?? 0,
+        waitingOnDeps: stateMap["waiting_on_deps"] ?? 0,
+        needsAttention: stateMap["needs_attention"] ?? 0,
+        prOpened: stateMap["pr_opened"] ?? 0,
+        failedToday: parseInt(todayCounts?.failed_today ?? "0", 10),
+        completedToday: parseInt(todayCounts?.completed_today ?? "0", 10),
+      },
+      pods: {
+        total: parseInt(podStats.total, 10),
+        ready: parseInt(podStats.ready, 10),
+        error: parseInt(podStats.error, 10),
+        provisioning: parseInt(podStats.provisioning, 10),
+      },
+      queueDepth,
+      costToday: costToday?.cost ?? "0",
+      alerts,
+    };
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -28,6 +28,7 @@ import { dependencyRoutes } from "./routes/dependencies.js";
 import { workflowRoutes } from "./routes/workflows.js";
 import { mcpServerRoutes } from "./routes/mcp-servers.js";
 import { skillRoutes } from "./routes/skills.js";
+import { optioRoutes } from "./routes/optio.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import { sessionTerminalWs } from "./ws/session-terminal.js";
@@ -91,6 +92,7 @@ export async function buildServer() {
   await app.register(workflowRoutes);
   await app.register(mcpServerRoutes);
   await app.register(skillRoutes);
+  await app.register(optioRoutes);
 
   // WebSocket routes
   await app.register(logStreamWs);

--- a/apps/api/src/ws/session-chat.ts
+++ b/apps/api/src/ws/session-chat.ts
@@ -9,6 +9,8 @@ import { parseClaudeEvent } from "../services/agent-event-parser.js";
 import { publishSessionEvent } from "../services/event-bus.js";
 import type { ExecSession } from "@optio/shared";
 
+const SESSION_COOKIE_NAME = "optio_session";
+
 /**
  * Session chat WebSocket handler.
  *
@@ -30,6 +32,10 @@ export async function sessionChatWs(app: FastifyInstance) {
   app.get("/ws/sessions/:sessionId/chat", { websocket: true }, async (socket, req) => {
     const { sessionId } = req.params as { sessionId: string };
     const log = logger.child({ sessionId, ws: "session-chat" });
+
+    // Extract the user's session token for auth passthrough.
+    // The agent can use this token to make API calls as the requesting user.
+    const userSessionToken = extractSessionToken(req);
 
     const session = await getSession(sessionId);
     if (!session) {
@@ -73,6 +79,17 @@ export async function sessionChatWs(app: FastifyInstance) {
 
     // Resolve auth env vars for the claude process
     const authEnv = await buildAuthEnv(log);
+
+    // Auth passthrough: inject the user's session token so the agent's HTTP
+    // calls to the Optio API are attributed to the requesting user.
+    if (userSessionToken) {
+      authEnv.OPTIO_SESSION_TOKEN = userSessionToken;
+    }
+    // Provide the API base URL so the agent knows where to send requests
+    const apiPublicUrl = process.env.API_PUBLIC_URL ?? process.env.OPTIO_API_URL;
+    if (apiPublicUrl) {
+      authEnv.OPTIO_API_URL = apiPublicUrl;
+    }
 
     const send = (msg: Record<string, unknown>) => {
       if (socket.readyState === 1) {
@@ -247,6 +264,34 @@ export async function sessionChatWs(app: FastifyInstance) {
       }
     });
   });
+}
+
+/**
+ * Extract the user's session token from the WebSocket upgrade request.
+ * Checks Bearer header, session cookie, and query param (in that order).
+ */
+function extractSessionToken(req: {
+  headers: Record<string, string | string[] | undefined>;
+  query: unknown;
+}): string | undefined {
+  // Bearer header
+  const authHeader = req.headers.authorization;
+  if (typeof authHeader === "string" && authHeader.startsWith("Bearer ")) {
+    return authHeader.slice(7);
+  }
+
+  // Session cookie
+  const cookieHeader = typeof req.headers.cookie === "string" ? req.headers.cookie : undefined;
+  if (cookieHeader) {
+    const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${SESSION_COOKIE_NAME}=([^;]*)`));
+    if (match) return decodeURIComponent(match[1]);
+  }
+
+  // Query param (WebSocket connections)
+  const token = (req.query as Record<string, string>)?.token;
+  if (token) return token;
+
+  return undefined;
 }
 
 /** Build auth environment variables for the claude process in the pod. */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,3 +17,4 @@ export * from "./error-classifier.js";
 export * from "./types/session.js";
 export * from "./types/mcp.js";
 export * from "./utils/off-peak.js";
+export * from "./optio-tools.js";

--- a/packages/shared/src/optio-tools.test.ts
+++ b/packages/shared/src/optio-tools.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import {
+  OPTIO_TOOLS,
+  getOptioToolDefinitions,
+  getOptioToolsByCategory,
+  toFunctionCallingFormat,
+  WATCH_TERMINAL_STATES,
+  LOG_ENTRY_MAX_LENGTH,
+} from "./optio-tools.js";
+
+describe("OPTIO_TOOLS", () => {
+  it("contains 18 tool definitions", () => {
+    expect(Object.keys(OPTIO_TOOLS)).toHaveLength(18);
+  });
+
+  it("has unique tool names", () => {
+    const names = Object.keys(OPTIO_TOOLS);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("all tools have required fields", () => {
+    for (const [name, tool] of Object.entries(OPTIO_TOOLS)) {
+      expect(tool.name, `${name} should have name`).toBe(name);
+      expect(tool.description, `${name} should have description`).toBeTruthy();
+      expect(tool.category, `${name} should have category`).toBeTruthy();
+      expect(tool.parameters.type, `${name} should have object params`).toBe("object");
+      expect(tool.endpoint.method, `${name} should have method`).toBeTruthy();
+      expect(tool.endpoint.path, `${name} should have path`).toBeTruthy();
+    }
+  });
+
+  it("all endpoints have valid HTTP methods", () => {
+    const validMethods = new Set(["GET", "POST", "PATCH", "DELETE"]);
+    for (const tool of Object.values(OPTIO_TOOLS)) {
+      expect(validMethods.has(tool.endpoint.method), `${tool.name}: ${tool.endpoint.method}`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("all endpoint paths start with /api/", () => {
+    for (const tool of Object.values(OPTIO_TOOLS)) {
+      expect(tool.endpoint.path.startsWith("/api/"), `${tool.name}: ${tool.endpoint.path}`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("tools with required parameters list them correctly", () => {
+    const toolsWithRequired = Object.values(OPTIO_TOOLS).filter(
+      (t) => t.parameters.required && t.parameters.required.length > 0,
+    );
+    for (const tool of toolsWithRequired) {
+      for (const req of tool.parameters.required!) {
+        expect(
+          tool.parameters.properties[req],
+          `${tool.name}: required param "${req}" missing from properties`,
+        ).toBeDefined();
+      }
+    }
+  });
+
+  it("only watch_task is a polling tool", () => {
+    const pollingTools = Object.values(OPTIO_TOOLS).filter((t) => t.isPolling);
+    expect(pollingTools).toHaveLength(1);
+    expect(pollingTools[0].name).toBe("watch_task");
+  });
+});
+
+describe("getOptioToolDefinitions", () => {
+  it("returns all tools as an array", () => {
+    const tools = getOptioToolDefinitions();
+    expect(tools).toHaveLength(18);
+    expect(Array.isArray(tools)).toBe(true);
+  });
+});
+
+describe("getOptioToolsByCategory", () => {
+  it("returns tasks category tools", () => {
+    const taskTools = getOptioToolsByCategory("tasks");
+    expect(taskTools.length).toBeGreaterThanOrEqual(7);
+    expect(taskTools.every((t) => t.category === "tasks")).toBe(true);
+  });
+
+  it("returns repos category tools", () => {
+    const repoTools = getOptioToolsByCategory("repos");
+    expect(repoTools).toHaveLength(3);
+    expect(repoTools.every((t) => t.category === "repos")).toBe(true);
+  });
+
+  it("returns issues category tools", () => {
+    const issueTools = getOptioToolsByCategory("issues");
+    expect(issueTools).toHaveLength(2);
+    expect(issueTools.every((t) => t.category === "issues")).toBe(true);
+  });
+
+  it("returns pods category tools", () => {
+    const podTools = getOptioToolsByCategory("pods");
+    expect(podTools).toHaveLength(2);
+  });
+
+  it("returns system category tools", () => {
+    const systemTools = getOptioToolsByCategory("system");
+    expect(systemTools).toHaveLength(1);
+    expect(systemTools[0].name).toBe("get_system_status");
+  });
+
+  it("returns watch category tools", () => {
+    const watchTools = getOptioToolsByCategory("watch");
+    expect(watchTools).toHaveLength(1);
+    expect(watchTools[0].name).toBe("watch_task");
+  });
+
+  it("returns costs category tools", () => {
+    const costTools = getOptioToolsByCategory("costs");
+    expect(costTools).toHaveLength(1);
+    expect(costTools[0].name).toBe("get_cost_analytics");
+  });
+});
+
+describe("toFunctionCallingFormat", () => {
+  it("strips Optio-specific fields", () => {
+    const tools = getOptioToolDefinitions();
+    const formatted = toFunctionCallingFormat(tools);
+
+    for (const tool of formatted) {
+      expect(tool).toHaveProperty("name");
+      expect(tool).toHaveProperty("description");
+      expect(tool).toHaveProperty("parameters");
+      // Should NOT have Optio-specific fields
+      expect(tool).not.toHaveProperty("endpoint");
+      expect(tool).not.toHaveProperty("isPolling");
+      expect(tool).not.toHaveProperty("category");
+    }
+  });
+
+  it("preserves tool names and descriptions", () => {
+    const tools = getOptioToolDefinitions();
+    const formatted = toFunctionCallingFormat(tools);
+
+    for (let i = 0; i < tools.length; i++) {
+      expect(formatted[i].name).toBe(tools[i].name);
+      expect(formatted[i].description).toBe(tools[i].description);
+    }
+  });
+
+  it("preserves parameter schemas", () => {
+    const formatted = toFunctionCallingFormat([OPTIO_TOOLS.create_task]);
+    expect(formatted[0].parameters.required).toContain("title");
+    expect(formatted[0].parameters.required).toContain("prompt");
+    expect(formatted[0].parameters.properties.priority).toBeDefined();
+  });
+});
+
+describe("constants", () => {
+  it("WATCH_TERMINAL_STATES contains expected states", () => {
+    expect(WATCH_TERMINAL_STATES.has("completed")).toBe(true);
+    expect(WATCH_TERMINAL_STATES.has("failed")).toBe(true);
+    expect(WATCH_TERMINAL_STATES.has("cancelled")).toBe(true);
+    expect(WATCH_TERMINAL_STATES.has("pr_opened")).toBe(true);
+    expect(WATCH_TERMINAL_STATES.has("running")).toBe(false);
+    expect(WATCH_TERMINAL_STATES.has("queued")).toBe(false);
+  });
+
+  it("LOG_ENTRY_MAX_LENGTH is a reasonable value", () => {
+    expect(LOG_ENTRY_MAX_LENGTH).toBeGreaterThan(0);
+    expect(LOG_ENTRY_MAX_LENGTH).toBeLessThanOrEqual(10000);
+  });
+});
+
+describe("tool schema validation", () => {
+  it("get_task_logs has tail parameter with correct defaults", () => {
+    const tool = OPTIO_TOOLS.get_task_logs;
+    expect(tool.parameters.properties.tail).toBeDefined();
+    expect(tool.parameters.properties.tail.default).toBe(100);
+    expect(tool.parameters.properties.tail.type).toBe("number");
+  });
+
+  it("create_task has all required params", () => {
+    const tool = OPTIO_TOOLS.create_task;
+    expect(tool.parameters.required).toEqual(
+      expect.arrayContaining(["title", "prompt", "repoUrl", "agentType"]),
+    );
+  });
+
+  it("watch_task has timeout and poll interval defaults", () => {
+    const tool = OPTIO_TOOLS.watch_task;
+    expect(tool.parameters.properties.timeoutSeconds.default).toBe(600);
+    expect(tool.parameters.properties.pollIntervalSeconds.default).toBe(10);
+  });
+
+  it("list_tasks state enum matches TaskState values", () => {
+    const tool = OPTIO_TOOLS.list_tasks;
+    const stateEnum = tool.parameters.properties.state.enum!;
+    expect(stateEnum).toContain("running");
+    expect(stateEnum).toContain("failed");
+    expect(stateEnum).toContain("completed");
+    expect(stateEnum).toContain("queued");
+    expect(stateEnum).toContain("pr_opened");
+    expect(stateEnum).toContain("pending");
+  });
+
+  it("get_system_status targets the correct endpoint", () => {
+    const tool = OPTIO_TOOLS.get_system_status;
+    expect(tool.endpoint.method).toBe("GET");
+    expect(tool.endpoint.path).toBe("/api/optio/system-status");
+  });
+});

--- a/packages/shared/src/optio-tools.ts
+++ b/packages/shared/src/optio-tools.ts
@@ -1,0 +1,588 @@
+/**
+ * Optio tool definitions for AI agents.
+ *
+ * Each tool maps to one or more Optio API endpoints. These schemas are
+ * compatible with both Claude and OpenAI function-calling formats.
+ *
+ * The agent makes direct HTTP calls to the API server using these definitions.
+ * Auth is handled via passthrough — the requesting user's session token is
+ * injected as a cookie/header on every call.
+ */
+
+export interface OptioToolParameter {
+  type: string;
+  description: string;
+  enum?: string[];
+  default?: unknown;
+  minimum?: number;
+  maximum?: number;
+  items?: { type: string };
+}
+
+export interface OptioToolDefinition {
+  name: string;
+  description: string;
+  category: "tasks" | "repos" | "issues" | "pods" | "costs" | "system" | "watch";
+  parameters: {
+    type: "object";
+    properties: Record<string, OptioToolParameter>;
+    required?: string[];
+  };
+  /** The HTTP method and path template for the primary API call. */
+  endpoint: {
+    method: "GET" | "POST" | "PATCH" | "DELETE";
+    path: string;
+  };
+  /** If true, this tool uses polling rather than a single API call. */
+  isPolling?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Task tools
+// ---------------------------------------------------------------------------
+
+const listTasks: OptioToolDefinition = {
+  name: "list_tasks",
+  description:
+    "List tasks with optional filters. Returns tasks sorted by creation date (newest first). " +
+    "Use the state filter to find running, failed, queued, or completed tasks.",
+  category: "tasks",
+  parameters: {
+    type: "object",
+    properties: {
+      state: {
+        type: "string",
+        description: "Filter by task state",
+        enum: [
+          "pending",
+          "waiting_on_deps",
+          "queued",
+          "provisioning",
+          "running",
+          "needs_attention",
+          "pr_opened",
+          "completed",
+          "failed",
+          "cancelled",
+        ],
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of tasks to return (1-1000)",
+        default: 50,
+        minimum: 1,
+        maximum: 1000,
+      },
+      offset: {
+        type: "number",
+        description: "Number of tasks to skip for pagination",
+        default: 0,
+        minimum: 0,
+      },
+    },
+  },
+  endpoint: { method: "GET", path: "/api/tasks" },
+};
+
+const getTask: OptioToolDefinition = {
+  name: "get_task",
+  description:
+    "Get detailed information about a specific task including PR status, error info, " +
+    "retry count, cost, and pipeline progress.",
+  category: "tasks",
+  parameters: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The task UUID",
+      },
+    },
+    required: ["id"],
+  },
+  endpoint: { method: "GET", path: "/api/tasks/:id" },
+};
+
+const createTask: OptioToolDefinition = {
+  name: "create_task",
+  description:
+    "Create a new task. The task will be queued and picked up by an available agent pod. " +
+    "Requires a title, prompt (the instructions for the agent), repository URL, and agent type.",
+  category: "tasks",
+  parameters: {
+    type: "object",
+    properties: {
+      title: {
+        type: "string",
+        description: "Short title for the task",
+      },
+      prompt: {
+        type: "string",
+        description: "Detailed instructions for the agent to execute",
+      },
+      repoUrl: {
+        type: "string",
+        description: "The repository URL (e.g. https://github.com/owner/repo)",
+      },
+      repoBranch: {
+        type: "string",
+        description: "Target branch (defaults to repo default branch)",
+      },
+      agentType: {
+        type: "string",
+        description: "The agent runtime to use",
+        enum: ["claude-code", "codex"],
+      },
+      priority: {
+        type: "number",
+        description: "Priority (lower = higher priority, 1-1000)",
+        minimum: 1,
+        maximum: 1000,
+      },
+      maxRetries: {
+        type: "number",
+        description: "Maximum number of automatic retries on failure (0-10)",
+        minimum: 0,
+        maximum: 10,
+      },
+    },
+    required: ["title", "prompt", "repoUrl", "agentType"],
+  },
+  endpoint: { method: "POST", path: "/api/tasks" },
+};
+
+const retryTask: OptioToolDefinition = {
+  name: "retry_task",
+  description:
+    "Retry a failed or cancelled task. The task will be re-queued with a fresh agent session.",
+  category: "tasks",
+  parameters: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The task UUID to retry",
+      },
+    },
+    required: ["id"],
+  },
+  endpoint: { method: "POST", path: "/api/tasks/:id/retry" },
+};
+
+const cancelTask: OptioToolDefinition = {
+  name: "cancel_task",
+  description: "Cancel a running or queued task. The agent process will be terminated.",
+  category: "tasks",
+  parameters: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The task UUID to cancel",
+      },
+    },
+    required: ["id"],
+  },
+  endpoint: { method: "POST", path: "/api/tasks/:id/cancel" },
+};
+
+const bulkRetryFailed: OptioToolDefinition = {
+  name: "bulk_retry_failed",
+  description:
+    "Retry all failed tasks in the workspace. Returns the count of tasks that were re-queued.",
+  category: "tasks",
+  parameters: {
+    type: "object",
+    properties: {},
+  },
+  endpoint: { method: "POST", path: "/api/tasks/bulk/retry-failed" },
+};
+
+const bulkCancelActive: OptioToolDefinition = {
+  name: "bulk_cancel_active",
+  description:
+    "Cancel all running and queued tasks in the workspace. Returns the count of tasks cancelled.",
+  category: "tasks",
+  parameters: {
+    type: "object",
+    properties: {},
+  },
+  endpoint: { method: "POST", path: "/api/tasks/bulk/cancel-active" },
+};
+
+const getTaskLogs: OptioToolDefinition = {
+  name: "get_task_logs",
+  description:
+    "Get logs for a specific task. Logs can be large — use the tail parameter to get " +
+    "only the most recent entries, and logType to filter by category. " +
+    "Returns a summary line showing how many total logs exist.",
+  category: "tasks",
+  parameters: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The task UUID",
+      },
+      tail: {
+        type: "number",
+        description: "Number of most recent log entries to return (default: 100)",
+        default: 100,
+        minimum: 1,
+        maximum: 1000,
+      },
+      logType: {
+        type: "string",
+        description: "Filter by log type",
+        enum: ["text", "tool_use", "tool_result", "thinking", "system", "error", "info"],
+      },
+      search: {
+        type: "string",
+        description: "Search string to filter log content",
+      },
+    },
+    required: ["id"],
+  },
+  endpoint: { method: "GET", path: "/api/tasks/:id/logs" },
+};
+
+// ---------------------------------------------------------------------------
+// Repo tools
+// ---------------------------------------------------------------------------
+
+const listRepos: OptioToolDefinition = {
+  name: "list_repos",
+  description: "List all configured repositories in the workspace with their settings and status.",
+  category: "repos",
+  parameters: {
+    type: "object",
+    properties: {},
+  },
+  endpoint: { method: "GET", path: "/api/repos" },
+};
+
+const getRepo: OptioToolDefinition = {
+  name: "get_repo",
+  description:
+    "Get detailed information about a repository including its settings, " +
+    "pod status, concurrency limits, model configuration, and review settings.",
+  category: "repos",
+  parameters: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The repository UUID",
+      },
+    },
+    required: ["id"],
+  },
+  endpoint: { method: "GET", path: "/api/repos/:id" },
+};
+
+const updateRepoSettings: OptioToolDefinition = {
+  name: "update_repo_settings",
+  description:
+    "Update repository settings such as concurrency limits, model, review configuration, " +
+    "auto-merge, and more. Only include the fields you want to change.",
+  category: "repos",
+  parameters: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The repository UUID",
+      },
+      maxConcurrentTasks: {
+        type: "number",
+        description: "Maximum concurrent tasks for this repo (1-50)",
+        minimum: 1,
+        maximum: 50,
+      },
+      maxPodInstances: {
+        type: "number",
+        description: "Maximum pod replicas for this repo (1-20)",
+        minimum: 1,
+        maximum: 20,
+      },
+      maxAgentsPerPod: {
+        type: "number",
+        description: "Maximum concurrent agents per pod (1-50)",
+        minimum: 1,
+        maximum: 50,
+      },
+      claudeModel: {
+        type: "string",
+        description: "Claude model to use (e.g. sonnet, opus, haiku)",
+      },
+      claudeContextWindow: {
+        type: "string",
+        description: "Context window size",
+        enum: ["default", "1m"],
+      },
+      claudeThinking: {
+        type: "boolean",
+        description: "Enable extended thinking mode",
+      },
+      claudeEffort: {
+        type: "string",
+        description: "Effort level for the agent",
+        enum: ["low", "medium", "high"],
+      },
+      autoMerge: {
+        type: "boolean",
+        description: "Auto-merge PRs when CI passes and reviews approved",
+      },
+      reviewEnabled: {
+        type: "boolean",
+        description: "Enable automatic code review agent",
+      },
+      reviewTrigger: {
+        type: "string",
+        description: "When to trigger the review agent",
+        enum: ["on_ci_pass", "on_pr"],
+      },
+      autoResume: {
+        type: "boolean",
+        description: "Auto-resume agent when reviewer requests changes",
+      },
+    },
+    required: ["id"],
+  },
+  endpoint: { method: "PATCH", path: "/api/repos/:id" },
+};
+
+// ---------------------------------------------------------------------------
+// Issue tools
+// ---------------------------------------------------------------------------
+
+const listIssues: OptioToolDefinition = {
+  name: "list_issues",
+  description:
+    "List GitHub Issues across configured repositories. Useful for finding work to assign to agents.",
+  category: "issues",
+  parameters: {
+    type: "object",
+    properties: {
+      repoUrl: {
+        type: "string",
+        description: "Filter by repository URL",
+      },
+    },
+  },
+  endpoint: { method: "GET", path: "/api/issues" },
+};
+
+const assignIssue: OptioToolDefinition = {
+  name: "assign_issue",
+  description:
+    "Assign a GitHub Issue to Optio, creating a task from it. The issue title and body " +
+    "become the task prompt.",
+  category: "issues",
+  parameters: {
+    type: "object",
+    properties: {
+      repoUrl: {
+        type: "string",
+        description: "The repository URL containing the issue",
+      },
+      issueNumber: {
+        type: "number",
+        description: "The GitHub Issue number",
+      },
+    },
+    required: ["repoUrl", "issueNumber"],
+  },
+  endpoint: { method: "POST", path: "/api/issues/assign" },
+};
+
+// ---------------------------------------------------------------------------
+// Pod tools
+// ---------------------------------------------------------------------------
+
+const listPods: OptioToolDefinition = {
+  name: "list_pods",
+  description:
+    "List all repo pods in the cluster with their status, active task count, " +
+    "and resource usage. Requires admin role.",
+  category: "pods",
+  parameters: {
+    type: "object",
+    properties: {},
+  },
+  endpoint: { method: "GET", path: "/api/cluster/pods" },
+};
+
+const getPodHealth: OptioToolDefinition = {
+  name: "get_pod_health",
+  description:
+    "Get detailed health information for a specific pod including recent health events, " +
+    "K8s status, resource usage, and associated tasks. Requires admin role.",
+  category: "pods",
+  parameters: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The repo pod UUID",
+      },
+    },
+    required: ["id"],
+  },
+  endpoint: { method: "GET", path: "/api/cluster/pods/:id" },
+};
+
+// ---------------------------------------------------------------------------
+// Cost tools
+// ---------------------------------------------------------------------------
+
+const getCostAnalytics: OptioToolDefinition = {
+  name: "get_cost_analytics",
+  description:
+    "Get cost analytics including total spend, daily breakdown, cost by repo, " +
+    "cost by task type, top expensive tasks, and trend compared to previous period.",
+  category: "costs",
+  parameters: {
+    type: "object",
+    properties: {
+      days: {
+        type: "number",
+        description: "Number of days to analyze (1-365, default: 30)",
+        default: 30,
+        minimum: 1,
+        maximum: 365,
+      },
+      repoUrl: {
+        type: "string",
+        description: "Filter to a specific repository",
+      },
+    },
+  },
+  endpoint: { method: "GET", path: "/api/analytics/costs" },
+};
+
+// ---------------------------------------------------------------------------
+// System tools
+// ---------------------------------------------------------------------------
+
+const getSystemStatus: OptioToolDefinition = {
+  name: "get_system_status",
+  description:
+    "Get an aggregate system health summary including task counts by state, " +
+    "pod health, queue depth, today's cost, and any active alerts " +
+    "(recent OOM kills, auth errors, etc.).",
+  category: "system",
+  parameters: {
+    type: "object",
+    properties: {},
+  },
+  endpoint: { method: "GET", path: "/api/optio/system-status" },
+};
+
+// ---------------------------------------------------------------------------
+// Watch tools
+// ---------------------------------------------------------------------------
+
+const watchTask: OptioToolDefinition = {
+  name: "watch_task",
+  description:
+    "Poll a task until it reaches a terminal state (completed, failed, cancelled, pr_opened). " +
+    "Reports the final status. Useful for waiting on a task you just created or retried. " +
+    "This is a polling operation — the agent will check the task status at regular intervals.",
+  category: "watch",
+  isPolling: true,
+  parameters: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The task UUID to watch",
+      },
+      timeoutSeconds: {
+        type: "number",
+        description: "Maximum time to wait in seconds (default: 600 = 10 minutes)",
+        default: 600,
+        minimum: 10,
+        maximum: 3600,
+      },
+      pollIntervalSeconds: {
+        type: "number",
+        description: "How often to check status in seconds (default: 10)",
+        default: 10,
+        minimum: 5,
+        maximum: 60,
+      },
+    },
+    required: ["id"],
+  },
+  endpoint: { method: "GET", path: "/api/tasks/:id" },
+};
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/**
+ * All Optio tool definitions, keyed by tool name.
+ */
+export const OPTIO_TOOLS: Record<string, OptioToolDefinition> = {
+  list_tasks: listTasks,
+  get_task: getTask,
+  create_task: createTask,
+  retry_task: retryTask,
+  cancel_task: cancelTask,
+  bulk_retry_failed: bulkRetryFailed,
+  bulk_cancel_active: bulkCancelActive,
+  get_task_logs: getTaskLogs,
+  list_repos: listRepos,
+  get_repo: getRepo,
+  update_repo_settings: updateRepoSettings,
+  list_issues: listIssues,
+  assign_issue: assignIssue,
+  list_pods: listPods,
+  get_pod_health: getPodHealth,
+  get_cost_analytics: getCostAnalytics,
+  get_system_status: getSystemStatus,
+  watch_task: watchTask,
+};
+
+/**
+ * Get all tool definitions as an array, suitable for injecting into an
+ * agent's system prompt or function-calling config.
+ */
+export function getOptioToolDefinitions(): OptioToolDefinition[] {
+  return Object.values(OPTIO_TOOLS);
+}
+
+/**
+ * Get tool definitions for a specific category.
+ */
+export function getOptioToolsByCategory(
+  category: OptioToolDefinition["category"],
+): OptioToolDefinition[] {
+  return Object.values(OPTIO_TOOLS).filter((t) => t.category === category);
+}
+
+/**
+ * Convert Optio tool definitions to the Claude/OpenAI function-calling format.
+ * Strips Optio-specific fields (endpoint, isPolling, category) and returns
+ * the standard { name, description, parameters } shape.
+ */
+export function toFunctionCallingFormat(
+  tools: OptioToolDefinition[],
+): Array<{ name: string; description: string; parameters: OptioToolDefinition["parameters"] }> {
+  return tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    parameters: t.parameters,
+  }));
+}
+
+/** Terminal states where watch_task stops polling. */
+export const WATCH_TERMINAL_STATES = new Set(["completed", "failed", "cancelled", "pr_opened"]);
+
+/**
+ * Maximum length for individual log entry content when returned via
+ * the get_task_logs tool. Longer entries are truncated with a suffix.
+ */
+export const LOG_ENTRY_MAX_LENGTH = 2000;


### PR DESCRIPTION
## Summary

Implements #185 — defines the set of tools the Optio agent can use to interact with the system, adds a system-status endpoint for ambient awareness, and wires up user auth passthrough so all agent actions are attributed to the requesting user.

- **Tool definitions** (`packages/shared/src/optio-tools.ts`): 18 JSON tool schemas organized by category (tasks, repos, issues, pods, costs, system, watch) compatible with both Claude and OpenAI function-calling formats. Includes `toFunctionCallingFormat()` helper to strip Optio-specific fields for injection into agent prompts.
- **System status endpoint** (`GET /api/optio/system-status`): Aggregate health summary returning task counts by state, pod health, queue depth, today's cost, and active alerts (OOM kills, auth errors). Designed to be injected into the agent's system prompt for ambient awareness.
- **Auth passthrough** (`apps/api/src/ws/session-chat.ts`): Extracts the user's session token from the WebSocket upgrade request (Bearer header, cookie, or query param) and injects it as `OPTIO_SESSION_TOKEN` + `OPTIO_API_URL` env vars into the pod. The agent includes this token in API calls so actions go through normal auth middleware and are attributed to the correct user.
- **Tests** (`packages/shared/src/optio-tools.test.ts`): Comprehensive test coverage for tool registry, categories, format conversion, schema validation, and constants.

Closes #185

## Test plan

- [x] All 741 existing tests pass
- [x] New tool definition tests pass (schema validation, categories, format conversion)
- [x] Typecheck passes across all 6 packages
- [x] Prettier formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)