### PR TITLE
feat: Optio agent settings panel

### DIFF
--- a/apps/api/src/db/migrations/0032_optio_settings.sql
+++ b/apps/api/src/db/migrations/0032_optio_settings.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "optio_settings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"model" text DEFAULT 'sonnet' NOT NULL,
+	"system_prompt" text DEFAULT '' NOT NULL,
+	"enabled_tools" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"confirm_writes" boolean DEFAULT true NOT NULL,
+	"max_turns" integer DEFAULT 20 NOT NULL,
+	"workspace_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "optio_settings_workspace_id_idx" ON "optio_settings" USING btree ("workspace_id");

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1775664000000,
       "tag": "0031_workspace_scoped_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1775750400000,
+      "tag": "0032_optio_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -565,6 +565,24 @@ export const customSkills = pgTable(
   ],
 );
 
+// ── Optio Agent Settings (singleton per workspace) ────────────────────────────
+
+export const optioSettings = pgTable(
+  "optio_settings",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    model: text("model").notNull().default("sonnet"), // "opus" | "sonnet" | "haiku"
+    systemPrompt: text("system_prompt").notNull().default(""), // custom additions appended to base prompt
+    enabledTools: jsonb("enabled_tools").$type<string[]>().notNull().default([]), // empty = all enabled
+    confirmWrites: boolean("confirm_writes").notNull().default(true),
+    maxTurns: integer("max_turns").notNull().default(20),
+    workspaceId: uuid("workspace_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("optio_settings_workspace_id_idx").on(table.workspaceId)],
+);
+
 export const promptTemplates = pgTable("prompt_templates", {
   id: uuid("id").primaryKey().defaultRandom(),
   name: text("name").notNull().unique(),

--- a/apps/api/src/routes/optio-settings.ts
+++ b/apps/api/src/routes/optio-settings.ts
@@ -1,0 +1,28 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import * as optioSettingsService from "../services/optio-settings-service.js";
+
+const updateSettingsSchema = z.object({
+  model: z.enum(["opus", "sonnet", "haiku"]).optional(),
+  systemPrompt: z.string().optional(),
+  enabledTools: z.array(z.string()).min(1, "At least one tool must be enabled").optional(),
+  confirmWrites: z.boolean().optional(),
+  maxTurns: z.number().int().min(5).max(50).optional(),
+});
+
+export async function optioSettingsRoutes(app: FastifyInstance) {
+  // Get current settings
+  app.get("/api/optio/settings", async (req, reply) => {
+    const workspaceId = req.user?.workspaceId ?? null;
+    const settings = await optioSettingsService.getSettings(workspaceId);
+    reply.send({ settings });
+  });
+
+  // Update settings (upsert)
+  app.put("/api/optio/settings", async (req, reply) => {
+    const input = updateSettingsSchema.parse(req.body);
+    const workspaceId = req.user?.workspaceId ?? null;
+    const settings = await optioSettingsService.upsertSettings(input, workspaceId);
+    reply.send({ settings });
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -29,6 +29,7 @@ import { workflowRoutes } from "./routes/workflows.js";
 import { mcpServerRoutes } from "./routes/mcp-servers.js";
 import { skillRoutes } from "./routes/skills.js";
 import { optioRoutes } from "./routes/optio.js";
+import { optioSettingsRoutes } from "./routes/optio-settings.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import { sessionTerminalWs } from "./ws/session-terminal.js";
@@ -93,6 +94,7 @@ export async function buildServer() {
   await app.register(mcpServerRoutes);
   await app.register(skillRoutes);
   await app.register(optioRoutes);
+  await app.register(optioSettingsRoutes);
 
   // WebSocket routes
   await app.register(logStreamWs);

--- a/apps/api/src/services/optio-settings-service.ts
+++ b/apps/api/src/services/optio-settings-service.ts
@@ -1,0 +1,107 @@
+import { eq, and, or, isNull } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { optioSettings } from "../db/schema.js";
+import type { OptioSettings, UpdateOptioSettingsInput } from "@optio/shared";
+
+/**
+ * Get settings for a workspace. Returns the settings row or sensible defaults
+ * if none exists yet.
+ */
+export async function getSettings(workspaceId?: string | null): Promise<OptioSettings> {
+  const conditions = [];
+  if (workspaceId) {
+    conditions.push(
+      or(eq(optioSettings.workspaceId, workspaceId), isNull(optioSettings.workspaceId))!,
+    );
+  }
+
+  const rows = await (conditions.length > 0
+    ? db
+        .select()
+        .from(optioSettings)
+        .where(and(...conditions))
+    : db.select().from(optioSettings));
+
+  // Prefer workspace-specific row, fall back to global (null workspace) row
+  const wsRow = rows.find((r) => r.workspaceId === workspaceId);
+  const globalRow = rows.find((r) => r.workspaceId === null);
+  const row = wsRow ?? globalRow;
+
+  if (row) return mapRow(row);
+
+  // Return defaults (no row in DB yet)
+  return {
+    id: "",
+    model: "sonnet",
+    systemPrompt: "",
+    enabledTools: [],
+    confirmWrites: true,
+    maxTurns: 20,
+    workspaceId: workspaceId ?? null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+/**
+ * Upsert settings for a workspace. Creates if doesn't exist, updates if it does.
+ */
+export async function upsertSettings(
+  input: UpdateOptioSettingsInput,
+  workspaceId?: string | null,
+): Promise<OptioSettings> {
+  // Check for existing row
+  const conditions = workspaceId
+    ? [eq(optioSettings.workspaceId, workspaceId)]
+    : [isNull(optioSettings.workspaceId)];
+
+  const [existing] = await db
+    .select()
+    .from(optioSettings)
+    .where(and(...conditions));
+
+  if (existing) {
+    // Update existing row
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.model !== undefined) updates.model = input.model;
+    if (input.systemPrompt !== undefined) updates.systemPrompt = input.systemPrompt;
+    if (input.enabledTools !== undefined) updates.enabledTools = input.enabledTools;
+    if (input.confirmWrites !== undefined) updates.confirmWrites = input.confirmWrites;
+    if (input.maxTurns !== undefined) updates.maxTurns = input.maxTurns;
+
+    const [row] = await db
+      .update(optioSettings)
+      .set(updates)
+      .where(eq(optioSettings.id, existing.id))
+      .returning();
+    return mapRow(row);
+  } else {
+    // Create new row
+    const [row] = await db
+      .insert(optioSettings)
+      .values({
+        model: input.model ?? "sonnet",
+        systemPrompt: input.systemPrompt ?? "",
+        enabledTools: input.enabledTools ?? [],
+        confirmWrites: input.confirmWrites ?? true,
+        maxTurns: input.maxTurns ?? 20,
+        workspaceId: workspaceId ?? undefined,
+      })
+      .returning();
+    return mapRow(row);
+  }
+}
+
+function mapRow(row: typeof optioSettings.$inferSelect): OptioSettings {
+  return {
+    id: row.id,
+    model: row.model,
+    systemPrompt: row.systemPrompt,
+    enabledTools: row.enabledTools,
+    confirmWrites: row.confirmWrites,
+    maxTurns: row.maxTurns,
+    workspaceId: row.workspaceId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -15,7 +15,12 @@ import {
   Sparkles,
   Plus,
   X,
+  Bot,
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
 } from "lucide-react";
+import { OPTIO_TOOL_CATEGORIES, ALL_OPTIO_TOOL_NAMES } from "@optio/shared";
 
 function PromptTemplateEditor() {
   const [template, setTemplate] = useState("");
@@ -762,6 +767,228 @@ function AuthenticationSettings() {
   );
 }
 
+function OptioAgentSettings() {
+  const [model, setModel] = useState("sonnet");
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [enabledTools, setEnabledTools] = useState<string[]>([...ALL_OPTIO_TOOL_NAMES]);
+  const [confirmWrites, setConfirmWrites] = useState(true);
+  const [maxTurns, setMaxTurns] = useState(20);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [showBasePrompt, setShowBasePrompt] = useState(false);
+
+  useEffect(() => {
+    api
+      .getOptioSettings()
+      .then((res) => {
+        const s = res.settings;
+        setModel(s.model);
+        setSystemPrompt(s.systemPrompt);
+        // Empty array means "all enabled" (default state)
+        setEnabledTools(
+          s.enabledTools && s.enabledTools.length > 0 ? s.enabledTools : [...ALL_OPTIO_TOOL_NAMES],
+        );
+        setConfirmWrites(s.confirmWrites);
+        setMaxTurns(s.maxTurns);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleSave = async () => {
+    if (enabledTools.length === 0) {
+      toast.error("At least one tool must be enabled");
+      return;
+    }
+    setSaving(true);
+    try {
+      // If all tools are enabled, store empty array (meaning "all")
+      const toolsToSave = enabledTools.length === ALL_OPTIO_TOOL_NAMES.length ? [] : enabledTools;
+      await api.updateOptioSettings({
+        model,
+        systemPrompt,
+        enabledTools: toolsToSave.length === 0 ? ALL_OPTIO_TOOL_NAMES : toolsToSave,
+        confirmWrites,
+        maxTurns,
+      });
+      toast.success("Optio agent settings saved");
+    } catch (err) {
+      toast.error("Failed to save settings", {
+        description: err instanceof Error ? err.message : "Unknown error",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleTool = (toolName: string) => {
+    setEnabledTools((prev) =>
+      prev.includes(toolName) ? prev.filter((t) => t !== toolName) : [...prev, toolName],
+    );
+  };
+
+  const enableAll = () => setEnabledTools([...ALL_OPTIO_TOOL_NAMES]);
+  const disableAll = () => setEnabledTools([]);
+
+  if (loading) {
+    return (
+      <div className="p-5 rounded-xl border border-border/50 bg-bg-card text-center text-text-muted text-sm">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" /> Loading...
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-5 rounded-xl border border-border/50 bg-bg-card space-y-5">
+      {/* Model Selection */}
+      <div>
+        <label className="block text-xs font-medium text-text-muted mb-1">Model</label>
+        <select
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+        >
+          <option value="opus">Opus — most capable, highest cost</option>
+          <option value="sonnet">Sonnet — balanced capability and cost</option>
+          <option value="haiku">Haiku — fastest, lowest cost</option>
+        </select>
+      </div>
+
+      {/* System Prompt */}
+      <div>
+        <label className="block text-xs font-medium text-text-muted mb-1">
+          Custom System Prompt
+        </label>
+        <p className="text-xs text-text-muted mb-2">
+          These instructions are appended to Optio&apos;s base prompt. Use this to add context about
+          your team&apos;s workflows, naming conventions, or preferences.
+        </p>
+        <button
+          onClick={() => setShowBasePrompt(!showBasePrompt)}
+          className="flex items-center gap-1 text-xs text-primary hover:underline mb-2"
+        >
+          {showBasePrompt ? (
+            <ChevronDown className="w-3 h-3" />
+          ) : (
+            <ChevronRight className="w-3 h-3" />
+          )}
+          {showBasePrompt ? "Hide" : "Show"} base system prompt
+        </button>
+        {showBasePrompt && (
+          <div className="p-3 rounded-md bg-bg border border-border mb-2 max-h-48 overflow-y-auto">
+            <p className="text-xs text-text-muted font-mono whitespace-pre-wrap">
+              The base system prompt is defined in code and includes instructions for task
+              execution, PR creation, and tool usage. Your custom prompt below is appended after the
+              base prompt to provide additional context.
+            </p>
+          </div>
+        )}
+        <textarea
+          value={systemPrompt}
+          onChange={(e) => setSystemPrompt(e.target.value)}
+          rows={6}
+          placeholder="e.g., Always use conventional commits. Follow our coding style guide at docs/STYLE.md..."
+          className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-y leading-relaxed"
+        />
+      </div>
+
+      {/* Tool Enablement */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <label className="block text-xs font-medium text-text-muted">Enabled Tools</label>
+          <div className="flex gap-2">
+            <button onClick={enableAll} className="text-xs text-primary hover:underline">
+              Enable all
+            </button>
+            <span className="text-xs text-text-muted">|</span>
+            <button onClick={disableAll} className="text-xs text-primary hover:underline">
+              Disable all
+            </button>
+          </div>
+        </div>
+        <div className="space-y-3">
+          {OPTIO_TOOL_CATEGORIES.map((category) => (
+            <div key={category.name} className="p-3 rounded-md bg-bg border border-border">
+              <h4 className="text-xs font-medium mb-2">{category.name}</h4>
+              <div className="space-y-1.5">
+                {category.tools.map((tool) => (
+                  <label key={tool.name} className="flex items-center gap-2 text-xs cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={enabledTools.includes(tool.name)}
+                      onChange={() => toggleTool(tool.name)}
+                      className="w-3.5 h-3.5 rounded"
+                    />
+                    <span className="font-medium">{tool.name}</span>
+                    <span className="text-text-muted">— {tool.description}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        {enabledTools.length === 0 && (
+          <p className="text-xs text-error mt-1 flex items-center gap-1">
+            <AlertTriangle className="w-3 h-3" />
+            At least one tool must be enabled
+          </p>
+        )}
+      </div>
+
+      {/* Confirmation Behavior */}
+      <div>
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={confirmWrites}
+            onChange={(e) => setConfirmWrites(e.target.checked)}
+            className="w-4 h-4 rounded"
+          />
+          Require confirmation for write operations
+        </label>
+        {!confirmWrites && (
+          <p className="text-xs text-warning mt-1 flex items-center gap-1 ml-6">
+            <AlertTriangle className="w-3 h-3" />
+            Optio will execute actions immediately without asking for approval
+          </p>
+        )}
+      </div>
+
+      {/* Max Conversation Length */}
+      <div>
+        <label className="block text-xs font-medium text-text-muted mb-1">
+          Max Conversation Turns
+        </label>
+        <p className="text-xs text-text-muted mb-2">
+          Maximum back-and-forth exchanges per session (5–50).
+        </p>
+        <input
+          type="number"
+          value={maxTurns}
+          onChange={(e) => {
+            const v = parseInt(e.target.value, 10);
+            if (!isNaN(v)) setMaxTurns(Math.max(5, Math.min(50, v)));
+          }}
+          min={5}
+          max={50}
+          className="w-32 px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+        />
+      </div>
+
+      {/* Save Button */}
+      <div className="flex justify-end">
+        <button
+          onClick={handleSave}
+          disabled={saving || enabledTools.length === 0}
+          className="px-4 py-1.5 rounded-md bg-primary text-white text-xs hover:bg-primary-hover disabled:opacity-50"
+        >
+          {saving ? "Saving..." : "Save Settings"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function SettingsPage() {
   usePageTitle("Settings");
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
@@ -804,6 +1031,15 @@ export default function SettingsPage() {
   return (
     <div className="p-6 max-w-3xl mx-auto space-y-8">
       <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+
+      {/* Optio Agent Settings */}
+      <section>
+        <h2 className="text-sm font-medium text-text-muted mb-3 flex items-center gap-2">
+          <Bot className="w-4 h-4" />
+          Optio Agent Settings
+        </h2>
+        <OptioAgentSettings />
+      </section>
 
       {/* Authentication */}
       <section>

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -891,4 +891,19 @@ export const api = {
     }),
 
   deleteSkill: (id: string) => request<void>(`/api/skills/${id}`, { method: "DELETE" }),
+
+  // Optio Agent Settings
+  getOptioSettings: () => request<{ settings: any }>("/api/optio/settings"),
+
+  updateOptioSettings: (data: {
+    model?: string;
+    systemPrompt?: string;
+    enabledTools?: string[];
+    confirmWrites?: boolean;
+    maxTurns?: number;
+  }) =>
+    request<{ settings: any }>("/api/optio/settings", {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
 };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,3 +17,4 @@ export * from "./error-classifier.js";
 export * from "./types/session.js";
 export * from "./types/mcp.js";
 export * from "./utils/off-peak.js";
+export * from "./types/optio-settings.js";

--- a/packages/shared/src/types/optio-settings.ts
+++ b/packages/shared/src/types/optio-settings.ts
@@ -1,0 +1,87 @@
+export interface OptioSettings {
+  id: string;
+  model: string; // "opus" | "sonnet" | "haiku"
+  systemPrompt: string;
+  enabledTools: string[];
+  confirmWrites: boolean;
+  maxTurns: number;
+  workspaceId?: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface UpdateOptioSettingsInput {
+  model?: string;
+  systemPrompt?: string;
+  enabledTools?: string[];
+  confirmWrites?: boolean;
+  maxTurns?: number;
+}
+
+/** Tool category for UI grouping */
+export interface OptioToolCategory {
+  name: string;
+  tools: OptioToolDefinition[];
+}
+
+export interface OptioToolDefinition {
+  name: string;
+  description: string;
+  category: string;
+}
+
+/** All available Optio tools, grouped by category */
+export const OPTIO_TOOL_CATEGORIES: OptioToolCategory[] = [
+  {
+    name: "Tasks",
+    tools: [
+      { name: "list_tasks", description: "List and search tasks", category: "Tasks" },
+      { name: "create_task", description: "Create a new task", category: "Tasks" },
+      { name: "cancel_task", description: "Cancel a running task", category: "Tasks" },
+      { name: "retry_task", description: "Retry a failed task", category: "Tasks" },
+      { name: "get_task_details", description: "View task details and logs", category: "Tasks" },
+      { name: "resume_task", description: "Resume a paused task", category: "Tasks" },
+    ],
+  },
+  {
+    name: "Repos",
+    tools: [
+      { name: "list_repos", description: "List configured repositories", category: "Repos" },
+      { name: "add_repo", description: "Add a new repository", category: "Repos" },
+      { name: "update_repo", description: "Update repository settings", category: "Repos" },
+      { name: "delete_repo", description: "Remove a repository", category: "Repos" },
+    ],
+  },
+  {
+    name: "Issues",
+    tools: [
+      { name: "list_issues", description: "Browse GitHub issues", category: "Issues" },
+      { name: "assign_issue", description: "Assign an issue to Optio", category: "Issues" },
+    ],
+  },
+  {
+    name: "Pods",
+    tools: [
+      { name: "list_pods", description: "List running pods", category: "Pods" },
+      { name: "restart_pod", description: "Restart a pod", category: "Pods" },
+      { name: "get_cluster_status", description: "View cluster health", category: "Pods" },
+    ],
+  },
+  {
+    name: "Costs",
+    tools: [{ name: "get_cost_analytics", description: "View cost analytics", category: "Costs" }],
+  },
+  {
+    name: "System",
+    tools: [
+      { name: "manage_secrets", description: "Create or delete secrets", category: "System" },
+      { name: "manage_schedules", description: "Create or modify schedules", category: "System" },
+      { name: "manage_webhooks", description: "Configure webhooks", category: "System" },
+    ],
+  },
+];
+
+/** Flat list of all tool names */
+export const ALL_OPTIO_TOOL_NAMES: string[] = OPTIO_TOOL_CATEGORIES.flatMap((cat) =>
+  cat.tools.map((t) => t.name),
+);


### PR DESCRIPTION
## Summary

- Adds a new **Optio Agent Settings** panel to the `/settings` page for configuring the Optio agent
- New `optio_settings` database table (singleton per workspace) with Drizzle migration
- `GET /api/optio/settings` and `PUT /api/optio/settings` API endpoints with Zod validation and upsert semantics
- Settings UI includes:
  - **Model selection** dropdown (Opus/Sonnet/Haiku) with cost/capability hints
  - **Custom system prompt** textarea with expandable base prompt preview
  - **Tool enablement** checklist grouped by category (Tasks, Repos, Issues, Pods, Costs, System) with enable/disable all
  - **Confirmation behavior** toggle with warning when disabled
  - **Max conversation turns** number input (5–50)

Closes #189

## Test plan
- [x] All 1037 existing tests pass
- [x] TypeScript compiles across all 6 packages
- [x] Prettier formatting passes
- [ ] Verify settings load and save correctly via the UI
- [ ] Verify upsert creates a new row on first save, updates on subsequent saves
- [ ] Verify validation rejects invalid inputs (empty tools array, maxTurns out of range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)