### PR TITLE
feat: Optio chat backend (WebSocket relay + agent execution)

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -32,6 +32,7 @@ import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import { sessionTerminalWs } from "./ws/session-terminal.js";
 import { sessionChatWs } from "./ws/session-chat.js";
+import { optioChatWs } from "./ws/optio-chat.js";
 import authPlugin from "./plugins/auth.js";
 
 const loggerConfig =
@@ -97,6 +98,7 @@ export async function buildServer() {
   await app.register(eventsWs);
   await app.register(sessionTerminalWs);
   await app.register(sessionChatWs);
+  await app.register(optioChatWs);
 
   // Global error handler for Zod validation
   app.setErrorHandler((error: FastifyError | Error, _req, reply) => {

--- a/apps/api/src/services/optio-chat-service.test.ts
+++ b/apps/api/src/services/optio-chat-service.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  parseActionProposals,
+  buildSystemPrompt,
+  isUserActive,
+  setUserActive,
+  isWriteTool,
+  isReadTool,
+  OPTIO_TOOLS,
+  type SystemStatus,
+} from "./optio-chat-service.js";
+
+describe("parseActionProposals", () => {
+  it("extracts a single action proposal", () => {
+    const text = `I'll retry the failed tasks.
+
+<optio_action_proposal>
+[{ "description": "Retry 3 failed tasks", "details": "POST /api/tasks/bulk/retry-failed" }]
+</optio_action_proposal>
+
+Let me know if you want to proceed.`;
+
+    const { proposals, cleanText } = parseActionProposals(text);
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].description).toBe("Retry 3 failed tasks");
+    expect(proposals[0].details).toBe("POST /api/tasks/bulk/retry-failed");
+    expect(cleanText).not.toContain("optio_action_proposal");
+    expect(cleanText).toContain("retry the failed tasks");
+  });
+
+  it("extracts multiple action proposals in one block", () => {
+    const text = `<optio_action_proposal>
+[
+  { "description": "Cancel task #abc", "details": "POST /api/tasks/abc/cancel" },
+  { "description": "Cancel task #def", "details": "POST /api/tasks/def/cancel" }
+]
+</optio_action_proposal>`;
+
+    const { proposals } = parseActionProposals(text);
+    expect(proposals).toHaveLength(2);
+    expect(proposals[0].description).toBe("Cancel task #abc");
+    expect(proposals[1].description).toBe("Cancel task #def");
+  });
+
+  it("handles a single object (not array)", () => {
+    const text = `<optio_action_proposal>
+{ "description": "Create a task", "details": "POST /api/tasks" }
+</optio_action_proposal>`;
+
+    const { proposals } = parseActionProposals(text);
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].description).toBe("Create a task");
+  });
+
+  it("returns empty proposals when no markers found", () => {
+    const text = "Just a regular response with no proposals.";
+    const { proposals, cleanText } = parseActionProposals(text);
+    expect(proposals).toHaveLength(0);
+    expect(cleanText).toBe(text);
+  });
+
+  it("handles malformed JSON gracefully", () => {
+    const text = `<optio_action_proposal>
+this is not json at all
+</optio_action_proposal>`;
+
+    const { proposals } = parseActionProposals(text);
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].description).toBe("this is not json at all");
+    expect(proposals[0].details).toBe("");
+  });
+
+  it("handles unclosed proposal tag", () => {
+    const text = `Some text <optio_action_proposal> [{"description": "test"}] but no end tag`;
+    const { proposals, cleanText } = parseActionProposals(text);
+    expect(proposals).toHaveLength(0);
+    expect(cleanText).toBe(text);
+  });
+
+  it("extracts multiple separate proposal blocks", () => {
+    const text = `First: <optio_action_proposal>
+[{ "description": "Action A", "details": "detail A" }]
+</optio_action_proposal>
+Then: <optio_action_proposal>
+[{ "description": "Action B", "details": "detail B" }]
+</optio_action_proposal>`;
+
+    const { proposals } = parseActionProposals(text);
+    expect(proposals).toHaveLength(2);
+    expect(proposals[0].description).toBe("Action A");
+    expect(proposals[1].description).toBe("Action B");
+  });
+});
+
+describe("buildSystemPrompt", () => {
+  const mockStatus: SystemStatus = {
+    tasks: { running: 2, queued: 3, failed: 1, prOpened: 4, completed: 50, total: 60 },
+    recentFailures: [
+      {
+        id: "task-1",
+        title: "Fix auth bug",
+        repoUrl: "https://github.com/org/repo",
+        errorMessage: "OOM",
+        failedAt: "2026-03-28T10:00:00Z",
+      },
+    ],
+    repos: [{ repoUrl: "https://github.com/org/repo", fullName: "org/repo", activeTasks: 2 }],
+    pods: [
+      {
+        podName: "optio-pod-abc",
+        repoUrl: "https://github.com/org/repo",
+        state: "ready",
+        activeTaskCount: 2,
+      },
+    ],
+    maxConcurrent: 5,
+  };
+
+  it("includes tool definitions", () => {
+    const prompt = buildSystemPrompt(mockStatus, "http://localhost:4000");
+    expect(prompt).toContain("list_tasks");
+    expect(prompt).toContain("retry_task");
+    expect(prompt).toContain("REQUIRES CONFIRMATION");
+    expect(prompt).toContain("read-only");
+  });
+
+  it("includes system status", () => {
+    const prompt = buildSystemPrompt(mockStatus, "http://localhost:4000");
+    expect(prompt).toContain('"running": 2');
+    expect(prompt).toContain('"failed": 1');
+    expect(prompt).toContain("Fix auth bug");
+    expect(prompt).toContain("OOM");
+  });
+
+  it("includes API base URL", () => {
+    const prompt = buildSystemPrompt(mockStatus, "http://api:4000");
+    expect(prompt).toContain("http://api:4000");
+    expect(prompt).toContain("curl -s http://api:4000/api/tasks");
+  });
+
+  it("includes action proposal format instructions", () => {
+    const prompt = buildSystemPrompt(mockStatus, "http://localhost:4000");
+    expect(prompt).toContain("<optio_action_proposal>");
+    expect(prompt).toContain("</optio_action_proposal>");
+    expect(prompt).toContain("Do NOT execute write operations");
+  });
+});
+
+describe("concurrency tracking", () => {
+  beforeEach(() => {
+    // Reset state
+    setUserActive("user-1", false);
+    setUserActive("user-2", false);
+  });
+
+  it("tracks active users", () => {
+    expect(isUserActive("user-1")).toBe(false);
+    setUserActive("user-1", true);
+    expect(isUserActive("user-1")).toBe(true);
+  });
+
+  it("removes user on deactivate", () => {
+    setUserActive("user-1", true);
+    setUserActive("user-1", false);
+    expect(isUserActive("user-1")).toBe(false);
+  });
+
+  it("tracks multiple users independently", () => {
+    setUserActive("user-1", true);
+    setUserActive("user-2", true);
+    expect(isUserActive("user-1")).toBe(true);
+    expect(isUserActive("user-2")).toBe(true);
+
+    setUserActive("user-1", false);
+    expect(isUserActive("user-1")).toBe(false);
+    expect(isUserActive("user-2")).toBe(true);
+  });
+});
+
+describe("tool classification", () => {
+  it("classifies read tools correctly", () => {
+    expect(isReadTool("list_tasks")).toBe(true);
+    expect(isReadTool("get_task")).toBe(true);
+    expect(isReadTool("get_task_logs")).toBe(true);
+    expect(isReadTool("list_repos")).toBe(true);
+    expect(isReadTool("get_analytics")).toBe(true);
+  });
+
+  it("classifies write tools correctly", () => {
+    expect(isWriteTool("create_task")).toBe(true);
+    expect(isWriteTool("retry_task")).toBe(true);
+    expect(isWriteTool("cancel_task")).toBe(true);
+    expect(isWriteTool("bulk_retry_failed")).toBe(true);
+    expect(isWriteTool("bulk_cancel_active")).toBe(true);
+    expect(isWriteTool("assign_issue")).toBe(true);
+  });
+
+  it("read tools are not write tools", () => {
+    expect(isWriteTool("list_tasks")).toBe(false);
+    expect(isReadTool("create_task")).toBe(false);
+  });
+
+  it("unknown tools are neither", () => {
+    expect(isReadTool("unknown_tool")).toBe(false);
+    expect(isWriteTool("unknown_tool")).toBe(false);
+  });
+
+  it("all tools are classified", () => {
+    for (const tool of OPTIO_TOOLS) {
+      if (tool.requiresConfirmation) {
+        expect(isWriteTool(tool.name)).toBe(true);
+      } else {
+        expect(isReadTool(tool.name)).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/api/src/services/optio-chat-service.ts
+++ b/apps/api/src/services/optio-chat-service.ts
@@ -1,0 +1,334 @@
+import { db } from "../db/client.js";
+import { tasks, repos, repoPods } from "../db/schema.js";
+import { eq, sql, and, gte, desc } from "drizzle-orm";
+
+// ── Tool definitions with confirmation flags ──────────────────────────────────
+
+export interface OptioChatTool {
+  name: string;
+  description: string;
+  requiresConfirmation: boolean;
+}
+
+export const OPTIO_TOOLS: OptioChatTool[] = [
+  // Read-only — no confirmation
+  {
+    name: "list_tasks",
+    description: "List tasks, optionally filtered by state or repo",
+    requiresConfirmation: false,
+  },
+  {
+    name: "get_task",
+    description: "Get details of a specific task by ID",
+    requiresConfirmation: false,
+  },
+  {
+    name: "get_task_logs",
+    description: "Get logs for a specific task",
+    requiresConfirmation: false,
+  },
+  {
+    name: "list_repos",
+    description: "List all configured repositories",
+    requiresConfirmation: false,
+  },
+  {
+    name: "get_repo",
+    description: "Get details of a specific repository",
+    requiresConfirmation: false,
+  },
+  {
+    name: "get_cluster_status",
+    description: "Get cluster pod/node status",
+    requiresConfirmation: false,
+  },
+  {
+    name: "get_analytics",
+    description: "Get cost analytics and usage data",
+    requiresConfirmation: false,
+  },
+  { name: "list_sessions", description: "List interactive sessions", requiresConfirmation: false },
+
+  // Write operations — require confirmation
+  {
+    name: "create_task",
+    description: "Create a new task for a repository",
+    requiresConfirmation: true,
+  },
+  {
+    name: "retry_task",
+    description: "Retry a failed or cancelled task",
+    requiresConfirmation: true,
+  },
+  {
+    name: "cancel_task",
+    description: "Cancel a running or queued task",
+    requiresConfirmation: true,
+  },
+  { name: "bulk_retry_failed", description: "Retry all failed tasks", requiresConfirmation: true },
+  {
+    name: "bulk_cancel_active",
+    description: "Cancel all running and queued tasks",
+    requiresConfirmation: true,
+  },
+  {
+    name: "assign_issue",
+    description: "Assign a GitHub issue to Optio",
+    requiresConfirmation: true,
+  },
+  {
+    name: "update_repo_settings",
+    description: "Update repository configuration",
+    requiresConfirmation: true,
+  },
+];
+
+const READ_TOOLS = OPTIO_TOOLS.filter((t) => !t.requiresConfirmation).map((t) => t.name);
+const WRITE_TOOLS = OPTIO_TOOLS.filter((t) => t.requiresConfirmation).map((t) => t.name);
+
+// ── Action proposal parsing ──────────────────────────────────────────────────
+
+export interface ActionProposal {
+  description: string;
+  details: string;
+}
+
+const PROPOSAL_START = "<optio_action_proposal>";
+const PROPOSAL_END = "</optio_action_proposal>";
+
+/**
+ * Parse action proposals from agent text output.
+ * Returns extracted proposals and the text with proposals removed.
+ */
+export function parseActionProposals(text: string): {
+  proposals: ActionProposal[];
+  cleanText: string;
+} {
+  const proposals: ActionProposal[] = [];
+  let cleanText = text;
+
+  let startIdx = cleanText.indexOf(PROPOSAL_START);
+  while (startIdx !== -1) {
+    const endIdx = cleanText.indexOf(PROPOSAL_END, startIdx);
+    if (endIdx === -1) break;
+
+    const jsonStr = cleanText.slice(startIdx + PROPOSAL_START.length, endIdx).trim();
+    try {
+      const parsed = JSON.parse(jsonStr);
+      const items = Array.isArray(parsed) ? parsed : [parsed];
+      for (const item of items) {
+        proposals.push({
+          description: item.description ?? "Unknown action",
+          details: item.details ?? "",
+        });
+      }
+    } catch {
+      // If JSON parsing fails, treat the whole block as a single proposal
+      proposals.push({ description: jsonStr.slice(0, 200), details: "" });
+    }
+
+    cleanText = cleanText.slice(0, startIdx) + cleanText.slice(endIdx + PROPOSAL_END.length);
+    startIdx = cleanText.indexOf(PROPOSAL_START);
+  }
+
+  return { proposals, cleanText: cleanText.trim() };
+}
+
+// ── System status ─────────────────────────────────────────────────────────────
+
+export interface SystemStatus {
+  tasks: {
+    running: number;
+    queued: number;
+    failed: number;
+    prOpened: number;
+    completed: number;
+    total: number;
+  };
+  recentFailures: {
+    id: string;
+    title: string;
+    repoUrl: string;
+    errorMessage: string | null;
+    failedAt: string;
+  }[];
+  repos: { repoUrl: string; fullName: string; activeTasks: number }[];
+  pods: { podName: string | null; repoUrl: string; state: string; activeTaskCount: number }[];
+  maxConcurrent: number;
+}
+
+/**
+ * Fetch live system status from the database.
+ * This is included in the system prompt for each agent invocation.
+ */
+export async function getSystemStatus(): Promise<SystemStatus> {
+  // Task counts by state
+  const stateCounts = await db
+    .select({
+      state: tasks.state,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(tasks)
+    .groupBy(tasks.state);
+
+  const countMap: Record<string, number> = {};
+  let total = 0;
+  for (const row of stateCounts) {
+    countMap[row.state] = row.count;
+    total += row.count;
+  }
+
+  // Recent failures (last 24h, max 10)
+  const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const recentFailures = await db
+    .select({
+      id: tasks.id,
+      title: tasks.title,
+      repoUrl: tasks.repoUrl,
+      errorMessage: tasks.errorMessage,
+      updatedAt: tasks.updatedAt,
+    })
+    .from(tasks)
+    .where(and(eq(tasks.state, "failed"), gte(tasks.updatedAt, oneDayAgo)))
+    .orderBy(desc(tasks.updatedAt))
+    .limit(10);
+
+  // Active repos with task counts
+  const activeRepos = await db
+    .select({
+      repoUrl: repos.repoUrl,
+      fullName: repos.fullName,
+      activeTasks: sql<number>`(
+        SELECT count(*)::int FROM tasks
+        WHERE tasks.repo_url = repos.repo_url
+        AND tasks.state IN ('running', 'queued', 'provisioning')
+      )`,
+    })
+    .from(repos)
+    .limit(20);
+
+  // Pod status
+  const podStatus = await db
+    .select({
+      podName: repoPods.podName,
+      repoUrl: repoPods.repoUrl,
+      state: repoPods.state,
+      activeTaskCount: repoPods.activeTaskCount,
+    })
+    .from(repoPods)
+    .limit(20);
+
+  const maxConcurrent = parseInt(process.env.OPTIO_MAX_CONCURRENT ?? "5", 10);
+
+  return {
+    tasks: {
+      running: countMap["running"] ?? 0,
+      queued: countMap["queued"] ?? 0,
+      failed: countMap["failed"] ?? 0,
+      prOpened: countMap["pr_opened"] ?? 0,
+      completed: countMap["completed"] ?? 0,
+      total,
+    },
+    recentFailures: recentFailures.map((f) => ({
+      id: f.id,
+      title: f.title,
+      repoUrl: f.repoUrl,
+      errorMessage: f.errorMessage,
+      failedAt: f.updatedAt.toISOString(),
+    })),
+    repos: activeRepos.map((r) => ({
+      repoUrl: r.repoUrl,
+      fullName: r.fullName,
+      activeTasks: r.activeTasks,
+    })),
+    pods: podStatus.map((p) => ({
+      podName: p.podName,
+      repoUrl: p.repoUrl,
+      state: p.state,
+      activeTaskCount: p.activeTaskCount,
+    })),
+    maxConcurrent,
+  };
+}
+
+// ── System prompt builder ─────────────────────────────────────────────────────
+
+/**
+ * Build the system prompt for the Optio chat agent.
+ * Includes persona, tool definitions, live system status, and action formatting rules.
+ */
+export function buildSystemPrompt(status: SystemStatus, apiBaseUrl: string): string {
+  const toolList = OPTIO_TOOLS.map(
+    (t) =>
+      `- ${t.name}: ${t.description} [${t.requiresConfirmation ? "REQUIRES CONFIRMATION" : "read-only"}]`,
+  ).join("\n");
+
+  const statusJson = JSON.stringify(status, null, 2);
+
+  return `You are Optio, an AI assistant that helps users manage AI coding tasks and workflows.
+You have access to the Optio API at ${apiBaseUrl} and can perform operations on behalf of the user.
+
+## Available Actions
+
+${toolList}
+
+## Current System Status
+
+\`\`\`json
+${statusJson}
+\`\`\`
+
+## How to Perform Actions
+
+### Read Operations
+For read-only operations (list_tasks, get_task, get_task_logs, list_repos, etc.), use your Bash tool to call the Optio API directly. The API is available at ${apiBaseUrl}. Examples:
+- \`curl -s ${apiBaseUrl}/api/tasks?state=failed | jq .\`
+- \`curl -s ${apiBaseUrl}/api/tasks/TASK_ID | jq .\`
+- \`curl -s ${apiBaseUrl}/api/analytics/costs?days=7 | jq .\`
+
+### Write Operations
+For write operations (create_task, retry_task, cancel_task, bulk operations, etc.), you MUST propose them first. Output your proposal in this exact format:
+
+${PROPOSAL_START}
+[
+  { "description": "Short human-readable description", "details": "Technical details of the API call" }
+]
+${PROPOSAL_END}
+
+Do NOT execute write operations until the user explicitly approves. After approval, execute the operation using curl.
+
+## Guidelines
+- Be concise and helpful
+- Use the system status above to answer questions without making API calls when possible
+- When listing tasks or showing data, format it clearly
+- For failures, examine error messages and suggest specific remedies
+- When proposing actions, be specific about what will happen (e.g., "Retry 3 failed tasks: #abc, #def, #ghi")
+- If you need more data than what's in the system status, use curl to fetch it`;
+}
+
+// ── Concurrency tracking ──────────────────────────────────────────────────────
+
+/** Track active conversations per user (in-memory, resets on restart). */
+const activeConversations = new Map<string, boolean>();
+
+export function isUserActive(userId: string): boolean {
+  return activeConversations.get(userId) === true;
+}
+
+export function setUserActive(userId: string, active: boolean): void {
+  if (active) {
+    activeConversations.set(userId, true);
+  } else {
+    activeConversations.delete(userId);
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+export function isWriteTool(toolName: string): boolean {
+  return WRITE_TOOLS.includes(toolName);
+}
+
+export function isReadTool(toolName: string): boolean {
+  return READ_TOOLS.includes(toolName);
+}

--- a/apps/api/src/ws/optio-chat.ts
+++ b/apps/api/src/ws/optio-chat.ts
@@ -1,0 +1,402 @@
+import type { FastifyInstance } from "fastify";
+import { spawn, type ChildProcess } from "child_process";
+import { authenticateWs } from "./ws-auth.js";
+import { logger } from "../logger.js";
+import { parseClaudeEvent } from "../services/agent-event-parser.js";
+import {
+  buildSystemPrompt,
+  getSystemStatus,
+  isUserActive,
+  setUserActive,
+  parseActionProposals,
+} from "../services/optio-chat-service.js";
+
+/**
+ * Optio chat WebSocket handler.
+ *
+ * Provides a conversational interface to the Optio system. Each user message
+ * spawns a new `claude -p` invocation with conversation context. Write operations
+ * require explicit user approval via an action proposal flow.
+ *
+ * Route: WS /ws/optio/chat
+ *
+ * Client → Server messages:
+ *   { type: "message", content: string, conversationContext?: ConversationMessage[] }
+ *   { type: "approve" }   — approve a pending action proposal
+ *   { type: "decline" }   — decline a pending action proposal
+ *   { type: "interrupt" } — cancel the current agent invocation
+ *
+ * Server → Client messages:
+ *   { type: "text", content: string }
+ *   { type: "action_proposal", actions: ActionProposal[] }
+ *   { type: "action_result", success: boolean, summary: string }
+ *   { type: "error", message: string }
+ *   { type: "status", status: "thinking" | "executing" | "waiting_for_approval" }
+ */
+export async function optioChatWs(app: FastifyInstance) {
+  app.get("/ws/optio/chat", { websocket: true }, async (socket, req) => {
+    const log = logger.child({ ws: "optio-chat" });
+
+    // Authenticate
+    const user = await authenticateWs(socket, req);
+    if (!user) return;
+
+    const userId = user.id;
+    log.info({ userId }, "Optio chat connected");
+
+    // Enforce one active conversation per user
+    if (isUserActive(userId)) {
+      send({
+        type: "error",
+        message: "You already have an active Optio conversation. Close the other one first.",
+      });
+      socket.close(4409, "Concurrent conversation");
+      return;
+    }
+
+    setUserActive(userId, true);
+
+    let childProc: ChildProcess | null = null;
+    let isProcessing = false;
+    let outputBuffer = "";
+    let pendingProposal: {
+      actions: { description: string; details: string }[];
+      context: ConversationMessage[];
+    } | null = null;
+
+    function send(msg: Record<string, unknown>) {
+      if (socket.readyState === 1) {
+        socket.send(JSON.stringify(msg));
+      }
+    }
+
+    // Resolve auth env vars for the claude process
+    const authEnv = await buildAuthEnv(log);
+
+    // Resolve the internal API base URL for agent curl calls
+    const apiPort = process.env.PORT ?? process.env.API_PORT ?? "4000";
+    const apiBaseUrl = `http://localhost:${apiPort}`;
+
+    send({ type: "status", status: "ready" as string });
+
+    /**
+     * Execute a single claude prompt. Each user message (or approval) triggers
+     * a new invocation — there is no persistent agent process.
+     */
+    async function runPrompt(prompt: string, conversationContext: ConversationMessage[]) {
+      if (isProcessing) {
+        send({ type: "error", message: "Agent is already processing a request" });
+        return;
+      }
+
+      isProcessing = true;
+      send({ type: "status", status: "thinking" });
+
+      try {
+        // Fetch live system status for the prompt
+        const status = await getSystemStatus();
+        const systemPrompt = buildSystemPrompt(status, apiBaseUrl);
+
+        // Build the full prompt with conversation context
+        const fullPrompt = buildFullPrompt(systemPrompt, conversationContext, prompt);
+
+        const args = [
+          "-p",
+          fullPrompt,
+          "--output-format",
+          "stream-json",
+          "--verbose",
+          "--dangerously-skip-permissions",
+          "--max-turns",
+          "20",
+        ];
+
+        const env: Record<string, string> = {
+          ...(process.env as Record<string, string>),
+          ...authEnv,
+          // Suppress interactive prompts
+          CI: "true",
+        };
+
+        childProc = spawn("claude", args, {
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        let accumulatedText = "";
+
+        childProc.stdout!.on("data", (chunk: Buffer) => {
+          outputBuffer += chunk.toString("utf-8");
+
+          const lines = outputBuffer.split("\n");
+          outputBuffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            if (!line.trim()) continue;
+
+            const { entries } = parseClaudeEvent(line, "optio-chat");
+
+            for (const entry of entries) {
+              if (entry.type === "text") {
+                accumulatedText += entry.content;
+              }
+              // Forward all events as chat_event for full transparency
+              send({ type: "chat_event", event: entry });
+            }
+          }
+        });
+
+        childProc.stderr!.on("data", (chunk: Buffer) => {
+          const text = chunk.toString("utf-8").trim();
+          if (text) {
+            log.warn({ stderr: text }, "Claude stderr");
+          }
+        });
+
+        // Wait for process to exit
+        await new Promise<void>((resolve) => {
+          childProc!.on("close", () => {
+            // Process remaining buffer
+            if (outputBuffer.trim()) {
+              const { entries } = parseClaudeEvent(outputBuffer, "optio-chat");
+              for (const entry of entries) {
+                if (entry.type === "text") {
+                  accumulatedText += entry.content;
+                }
+                send({ type: "chat_event", event: entry });
+              }
+              outputBuffer = "";
+            }
+            resolve();
+          });
+        });
+
+        // Check for action proposals in accumulated text
+        const { proposals, cleanText } = parseActionProposals(accumulatedText);
+        if (proposals.length > 0) {
+          // Store the pending proposal for approve/decline flow
+          pendingProposal = { actions: proposals, context: conversationContext };
+
+          // Send the clean text first (if any)
+          if (cleanText.trim()) {
+            send({ type: "text", content: cleanText });
+          }
+
+          // Send the action proposal
+          send({ type: "action_proposal", actions: proposals });
+          send({ type: "status", status: "waiting_for_approval" });
+        } else {
+          // No proposals — send final text if we haven't been streaming it
+          if (accumulatedText.trim()) {
+            send({ type: "text", content: accumulatedText });
+          }
+        }
+      } catch (err) {
+        log.error({ err }, "Failed to run Optio chat prompt");
+        const message =
+          err instanceof Error && err.message.includes("ENOENT")
+            ? "Optio is starting up — the claude CLI is not available. Try again in a moment."
+            : "Failed to execute agent prompt";
+        send({ type: "error", message });
+      } finally {
+        isProcessing = false;
+        childProc = null;
+        if (!pendingProposal) {
+          send({ type: "status", status: "idle" as string });
+        }
+      }
+    }
+
+    // Handle incoming messages
+    socket.on("message", (data: Buffer | string) => {
+      const str = typeof data === "string" ? data : data.toString("utf-8");
+
+      let msg: {
+        type: string;
+        content?: string;
+        conversationContext?: ConversationMessage[];
+      };
+      try {
+        msg = JSON.parse(str);
+      } catch {
+        send({ type: "error", message: "Invalid JSON message" });
+        return;
+      }
+
+      switch (msg.type) {
+        case "message": {
+          if (!msg.content?.trim()) {
+            send({ type: "error", message: "Empty message" });
+            return;
+          }
+          // Clear any pending proposal when new message arrives
+          pendingProposal = null;
+          const ctx = (msg.conversationContext ?? []).slice(-20); // cap at 20 exchanges
+          runPrompt(msg.content, ctx).catch((err) => {
+            log.error({ err }, "Prompt execution failed");
+            send({ type: "error", message: "Prompt failed" });
+          });
+          break;
+        }
+
+        case "approve": {
+          if (!pendingProposal) {
+            send({ type: "error", message: "No pending action to approve" });
+            return;
+          }
+          const proposal = pendingProposal;
+          pendingProposal = null;
+          send({ type: "status", status: "executing" });
+
+          const actionSummary = proposal.actions
+            .map((a) => `- ${a.description}: ${a.details}`)
+            .join("\n");
+
+          // Build a new conversation context with the approval
+          const approvalContext: ConversationMessage[] = [
+            ...proposal.context,
+            {
+              role: "assistant",
+              content: `I proposed these actions:\n${actionSummary}`,
+            },
+            { role: "user", content: "Approved. Please execute these actions now." },
+          ];
+
+          runPrompt(
+            "The user approved the proposed actions. Execute them now using curl against the API.",
+            approvalContext,
+          ).catch((err) => {
+            log.error({ err }, "Approval execution failed");
+            send({ type: "error", message: "Failed to execute approved actions" });
+          });
+          break;
+        }
+
+        case "decline": {
+          if (!pendingProposal) {
+            send({ type: "error", message: "No pending action to decline" });
+            return;
+          }
+          const proposal = pendingProposal;
+          pendingProposal = null;
+
+          const declinedSummary = proposal.actions.map((a) => `- ${a.description}`).join("\n");
+
+          const declineContext: ConversationMessage[] = [
+            ...proposal.context,
+            {
+              role: "assistant",
+              content: `I proposed these actions:\n${declinedSummary}`,
+            },
+            {
+              role: "user",
+              content: "I declined these actions. What would you like to change?",
+            },
+          ];
+
+          runPrompt(
+            "The user declined the proposed actions. Ask what they would like to change.",
+            declineContext,
+          ).catch((err) => {
+            log.error({ err }, "Decline follow-up failed");
+            send({ type: "error", message: "Failed to handle decline" });
+          });
+          break;
+        }
+
+        case "interrupt": {
+          if (childProc) {
+            log.info("Interrupting Optio chat agent");
+            childProc.kill("SIGTERM");
+            childProc = null;
+            isProcessing = false;
+            outputBuffer = "";
+            pendingProposal = null;
+            send({ type: "status", status: "idle" as string });
+          }
+          break;
+        }
+
+        default:
+          send({ type: "error", message: `Unknown message type: ${msg.type}` });
+      }
+    });
+
+    socket.on("close", () => {
+      log.info({ userId }, "Optio chat disconnected");
+      setUserActive(userId, false);
+      if (childProc) {
+        childProc.kill("SIGTERM");
+        childProc = null;
+      }
+    });
+  });
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+interface ConversationMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/**
+ * Build the full prompt string from system prompt, conversation history, and
+ * the current user message.
+ */
+function buildFullPrompt(
+  systemPrompt: string,
+  conversationContext: ConversationMessage[],
+  currentMessage: string,
+): string {
+  const parts: string[] = [systemPrompt];
+
+  if (conversationContext.length > 0) {
+    parts.push("\n## Conversation History\n");
+    for (const msg of conversationContext) {
+      const role = msg.role === "user" ? "User" : "Assistant";
+      parts.push(`${role}: ${msg.content}`);
+    }
+  }
+
+  parts.push(`\n## Current Request\n\nUser: ${currentMessage}`);
+
+  return parts.join("\n");
+}
+
+/**
+ * Build auth environment variables for the claude process.
+ * Reuses the same logic as session-chat.ts.
+ */
+async function buildAuthEnv(log: {
+  warn: (obj: any, msg: string) => void;
+}): Promise<Record<string, string>> {
+  const env: Record<string, string> = {};
+
+  try {
+    const { retrieveSecret } = await import("../services/secret-service.js");
+    const authMode = (await retrieveSecret("CLAUDE_AUTH_MODE").catch(() => null)) as string | null;
+
+    if (authMode === "api-key") {
+      const apiKey = await retrieveSecret("ANTHROPIC_API_KEY").catch(() => null);
+      if (apiKey) {
+        env.ANTHROPIC_API_KEY = apiKey as string;
+      }
+    } else if (authMode === "max-subscription") {
+      const { getClaudeAuthToken } = await import("../services/auth-service.js");
+      const result = getClaudeAuthToken();
+      if (result.available && result.token) {
+        env.CLAUDE_CODE_OAUTH_TOKEN = result.token;
+      }
+    } else if (authMode === "oauth-token") {
+      const token = await retrieveSecret("CLAUDE_CODE_OAUTH_TOKEN").catch(() => null);
+      if (token) {
+        env.CLAUDE_CODE_OAUTH_TOKEN = token as string;
+      }
+    }
+  } catch (err) {
+    log.warn({ err }, "Failed to build auth env for Optio chat");
+  }
+
+  return env;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,4 +16,5 @@ export * from "./types/image.js";
 export * from "./error-classifier.js";
 export * from "./types/session.js";
 export * from "./types/mcp.js";
+export * from "./types/optio-chat.js";
 export * from "./utils/off-peak.js";

--- a/packages/shared/src/types/optio-chat.ts
+++ b/packages/shared/src/types/optio-chat.ts
@@ -1,0 +1,45 @@
+/** Action proposal from the Optio chat agent */
+export interface OptioChatActionProposal {
+  description: string;
+  details: string;
+}
+
+/** Conversation message sent as context with each request */
+export interface OptioChatConversationMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/** Client → Server messages for the Optio chat WebSocket */
+export type OptioChatClientMessage =
+  | { type: "message"; content: string; conversationContext?: OptioChatConversationMessage[] }
+  | { type: "approve" }
+  | { type: "decline" }
+  | { type: "interrupt" };
+
+/** Server → Client messages for the Optio chat WebSocket */
+export type OptioChatServerMessage =
+  | { type: "text"; content: string }
+  | { type: "chat_event"; event: OptioChatEvent }
+  | { type: "action_proposal"; actions: OptioChatActionProposal[] }
+  | { type: "action_result"; success: boolean; summary: string }
+  | { type: "error"; message: string }
+  | { type: "status"; status: OptioChatStatus };
+
+export type OptioChatStatus = "ready" | "thinking" | "executing" | "waiting_for_approval" | "idle";
+
+export interface OptioChatEvent {
+  taskId: string;
+  timestamp: string;
+  sessionId?: string;
+  type: "text" | "tool_use" | "tool_result" | "thinking" | "system" | "error" | "info";
+  content: string;
+  metadata?: {
+    toolName?: string;
+    toolInput?: Record<string, unknown>;
+    cost?: number;
+    turns?: number;
+    durationMs?: number;
+    [key: string]: unknown;
+  };
+}


### PR DESCRIPTION
## Summary

Implements the backend for the Optio conversational chat interface (#186). Users send messages via WebSocket, the API spawns a `claude -p` invocation with conversation context and live system status, and streams the response back.

- **`WS /ws/optio/chat`** — new WebSocket endpoint with session-based auth
- **Per-request `claude -p` invocation** — each message triggers a new agent call with NDJSON streaming; conversation context (last 20 exchanges) is sent with each request
- **Action confirmation flow** — write operations (create, retry, cancel, bulk ops) require user approval via `action_proposal` → `approve`/`decline` messages; read operations execute without confirmation
- **Per-user concurrency** — one active Optio conversation per user; rejects additional connections
- **System status injection** — live task counts, recent failures, pod status, and repo info injected into each agent prompt
- **Shared types** — `OptioChatClientMessage`, `OptioChatServerMessage`, and related types exported from `@optio/shared`

### New files
| File | Purpose |
|------|---------|
| `apps/api/src/ws/optio-chat.ts` | WebSocket handler — auth, message routing, `claude` process spawning, streaming, action proposal flow |
| `apps/api/src/services/optio-chat-service.ts` | Service layer — system status queries, system prompt builder, action proposal parsing, tool definitions, concurrency tracking |
| `apps/api/src/services/optio-chat-service.test.ts` | 19 unit tests for service layer |
| `packages/shared/src/types/optio-chat.ts` | Shared TypeScript types for the chat protocol |

### Modified files
| File | Change |
|------|--------|
| `apps/api/src/server.ts` | Register the `optioChatWs` handler |
| `packages/shared/src/index.ts` | Export `optio-chat` types |

## Test plan
- [x] 19 unit tests pass (action proposal parsing, prompt building, tool classification, concurrency tracking)
- [x] Full typecheck passes across all 6 packages
- [x] Format check passes
- [ ] Manual: connect to `ws://localhost:30400/ws/optio/chat` with auth token, send `{"type":"message","content":"list all tasks"}`
- [ ] Manual: verify action proposals for write operations (retry, cancel)
- [ ] Manual: verify approve/decline flow triggers follow-up prompts

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)