### PR TITLE
feat: Optio chat UI with action confirmation panel

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -440,6 +440,28 @@ html.light .recharts-custom-tooltip {
 }
 
 /* ──────────────────────────────────────
+   Optio Chat Panel
+   ────────────────────────────────────── */
+
+/* Backdrop fade */
+.optio-panel-backdrop {
+  animation: fade-in 0.2s ease both;
+}
+
+/* Markdown-like styling for chat responses */
+.optio-chat-markdown code {
+  font-family: var(--font-mono);
+  font-size: 0.8em;
+  padding: 0.15em 0.35em;
+  border-radius: 0.25rem;
+  background: var(--color-bg-hover);
+}
+
+.optio-chat-markdown strong {
+  font-weight: 600;
+}
+
+/* ──────────────────────────────────────
    Respect reduced motion preferences
    ────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { usePageTitle } from "@/hooks/use-page-title";
 import { useDashboardData } from "@/hooks/use-dashboard-data";
-import { RefreshCw } from "lucide-react";
+import { RefreshCw, MessageSquare } from "lucide-react";
 import {
   PipelineStatsBar,
   UsagePanel,
@@ -12,6 +12,7 @@ import {
   PodsList,
   WelcomeHero,
 } from "@/components/dashboard";
+import { useOptioChatStore } from "@/components/optio-chat/optio-chat-store.js";
 
 export default function OverviewPage() {
   usePageTitle("Overview");
@@ -106,6 +107,8 @@ export default function OverviewPage() {
 
       <PipelineStatsBar taskStats={taskStats} />
 
+      <DashboardOptioPrompt failedCount={taskStats?.failed ?? 0} />
+
       <UsagePanel usage={usage} />
 
       <ClusterSummary
@@ -127,5 +130,27 @@ export default function OverviewPage() {
         />
       </div>
     </div>
+  );
+}
+
+function DashboardOptioPrompt({ failedCount }: { failedCount: number }) {
+  const openWithPrefill = useOptioChatStore((s) => s.openWithPrefill);
+
+  if (failedCount === 0) return null;
+
+  return (
+    <button
+      onClick={() =>
+        openWithPrefill(
+          `${failedCount} task${failedCount === 1 ? "" : "s"} failed today. Can you help me understand what went wrong?`,
+        )
+      }
+      className="w-full rounded-md border border-warning/20 bg-warning/5 px-4 py-3 flex items-center gap-3 hover:bg-warning/10 transition-colors text-left group"
+    >
+      <MessageSquare className="w-4 h-4 text-warning/60 shrink-0 group-hover:text-warning transition-colors" />
+      <span className="text-sm text-warning/80 group-hover:text-warning transition-colors">
+        {failedCount} task{failedCount === 1 ? "" : "s"} failed today &mdash; ask Optio to help?
+      </span>
+    </button>
   );
 }

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -29,8 +29,10 @@ import {
   Key,
   Check,
   Copy,
+  MessageSquare,
 } from "lucide-react";
 import { toast } from "sonner";
+import { useOptioChatStore } from "@/components/optio-chat/optio-chat-store.js";
 
 export default function TaskDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -46,6 +48,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   const [tokenSaving, setTokenSaving] = useState(false);
   const [dependents, setDependents] = useState<any[]>([]);
   const [showCreateSubtask, setShowCreateSubtask] = useState(false);
+  const openWithPrefill = useOptioChatStore((s) => s.openWithPrefill);
   const [newSubtask, setNewSubtask] = useState({
     title: "",
     prompt: "",
@@ -256,6 +259,19 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
                 Attempt Resume
               </button>
             )}
+            <button
+              onClick={() => {
+                const ctx = task.errorMessage
+                  ? `Task "${task.title}" (${task.state}) failed with: ${task.errorMessage}`
+                  : `Task "${task.title}" is in state: ${task.state}`;
+                openWithPrefill(ctx);
+              }}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary/10 text-primary text-xs hover:bg-primary/20 transition-colors"
+              title="Ask Optio for help with this task"
+            >
+              <MessageSquare className="w-3 h-3" />
+              Ask Optio
+            </button>
             <button
               onClick={handleForceRedo}
               disabled={actionLoading}

--- a/apps/web/src/components/layout/layout-shell.tsx
+++ b/apps/web/src/components/layout/layout-shell.tsx
@@ -7,6 +7,7 @@ import { GlobalWebSocketProvider } from "./ws-provider";
 import { SetupCheck } from "./setup-check";
 import { ThemeProvider } from "./theme-provider";
 import { ThemedToaster } from "./themed-toaster";
+import { OptioChatPanel } from "@/components/optio-chat/optio-chat-panel.js";
 
 export function LayoutShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -51,6 +52,7 @@ export function LayoutShell({ children }: { children: React.ReactNode }) {
             </div>
             <main className="flex-1 overflow-auto">{children}</main>
           </div>
+          <OptioChatPanel />
         </div>
       )}
       <ThemedToaster />

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -17,9 +17,11 @@ import {
   Clock,
   FileText,
   GitBranch,
+  Bot,
 } from "lucide-react";
 import { UserMenu } from "./user-menu";
 import { WorkspaceSwitcher } from "./workspace-switcher";
+import { useOptioChatStore } from "@/components/optio-chat/optio-chat-store.js";
 
 const MAIN_NAV = [
   { href: "/", label: "Overview", icon: LayoutDashboard },
@@ -69,6 +71,40 @@ function NavLink({
   );
 }
 
+function OptioButton({ onClose }: { onClose?: () => void }) {
+  const { togglePanel, status } = useOptioChatStore();
+  const statusColor =
+    status === "unavailable" || status === "error"
+      ? "bg-error"
+      : status === "connecting"
+        ? "bg-warning"
+        : "bg-success";
+
+  return (
+    <button
+      onClick={() => {
+        togglePanel();
+        onClose?.();
+      }}
+      className={cn(
+        "w-full flex items-center gap-2.5 py-2 px-2.5 rounded-lg text-[13px] font-medium transition-all duration-150",
+        "text-text-muted hover:bg-primary/10 hover:text-text",
+      )}
+    >
+      <div className="relative">
+        <Bot className="w-4 h-4 shrink-0 text-primary" />
+        <span
+          className={cn(
+            "absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full border border-bg",
+            statusColor,
+          )}
+        />
+      </div>
+      Ask Optio
+    </button>
+  );
+}
+
 export function Sidebar({ open, onClose }: { open?: boolean; onClose?: () => void }) {
   const pathname = usePathname();
 
@@ -112,6 +148,9 @@ export function Sidebar({ open, onClose }: { open?: boolean; onClose?: () => voi
           ))}
         </div>
       </nav>
+      <div className="border-t border-border/50 px-2.5 py-2">
+        <OptioButton onClose={onClose} />
+      </div>
       <div className="border-t border-border/50 px-2.5 py-2.5">
         <UserMenu />
       </div>

--- a/apps/web/src/components/optio-chat/action-confirmation.tsx
+++ b/apps/web/src/components/optio-chat/action-confirmation.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { Check, X, MessageSquare } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ActionProposal } from "./optio-chat-store.js";
+
+interface ActionConfirmationProps {
+  proposal: ActionProposal;
+  onApprove: (id: string) => void;
+  onDeny: (id: string, feedback: string) => void;
+}
+
+export function ActionConfirmation({ proposal, onApprove, onDeny }: ActionConfirmationProps) {
+  const [showFeedback, setShowFeedback] = useState(false);
+  const [feedback, setFeedback] = useState("");
+
+  const isResolved = proposal.status !== "pending";
+
+  const handleDeny = () => {
+    if (showFeedback && feedback.trim()) {
+      onDeny(proposal.id, feedback.trim());
+    } else {
+      setShowFeedback(true);
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border-2 overflow-hidden",
+        isResolved
+          ? proposal.status === "approved"
+            ? "border-success/30 bg-success/5"
+            : "border-error/30 bg-error/5"
+          : "border-primary/30 bg-primary/5",
+      )}
+    >
+      <div className="px-4 py-3">
+        <p className="text-sm font-medium mb-2">{proposal.description}</p>
+        <ul className="space-y-1.5">
+          {proposal.actions.map((action, i) => (
+            <li key={i} className="flex items-start gap-2 text-sm text-text-muted">
+              <span className="text-primary mt-0.5 shrink-0">&bull;</span>
+              {action}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {!isResolved && (
+        <div className="border-t border-border/50 px-4 py-3 space-y-2">
+          {showFeedback && (
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={feedback}
+                onChange={(e) => setFeedback(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && feedback.trim()) {
+                    onDeny(proposal.id, feedback.trim());
+                  }
+                }}
+                placeholder="What should I change?"
+                className="flex-1 px-3 py-1.5 text-sm rounded-md border border-border bg-bg-card focus:outline-none focus:ring-1 focus:ring-primary/30 focus:border-primary/50"
+                autoFocus
+              />
+              <button
+                onClick={() => {
+                  if (feedback.trim()) onDeny(proposal.id, feedback.trim());
+                }}
+                disabled={!feedback.trim()}
+                className="px-3 py-1.5 rounded-md text-xs bg-text-muted/10 text-text-muted hover:bg-text-muted/20 transition-colors disabled:opacity-50"
+              >
+                <MessageSquare className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          )}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              onClick={handleDeny}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs bg-error/10 text-error hover:bg-error/20 transition-colors btn-press"
+            >
+              <X className="w-3.5 h-3.5" />
+              Deny
+            </button>
+            <button
+              onClick={() => onApprove(proposal.id)}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs bg-success/10 text-success hover:bg-success/20 transition-colors btn-press"
+            >
+              <Check className="w-3.5 h-3.5" />
+              Approve
+            </button>
+          </div>
+        </div>
+      )}
+
+      {isResolved && (
+        <div
+          className={cn(
+            "border-t px-4 py-2 text-xs",
+            proposal.status === "approved"
+              ? "border-success/20 text-success/70"
+              : "border-error/20 text-error/70",
+          )}
+        >
+          {proposal.status === "approved"
+            ? "Approved"
+            : `Denied${proposal.feedback ? `: ${proposal.feedback}` : ""}`}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/optio-chat/index.ts
+++ b/apps/web/src/components/optio-chat/index.ts
@@ -1,0 +1,9 @@
+export { OptioChatPanel } from "./optio-chat-panel.js";
+export { ActionConfirmation } from "./action-confirmation.js";
+export {
+  useOptioChatStore,
+  MAX_EXCHANGES,
+  type OptioChatMessage,
+  type OptioChatStatus,
+  type ActionProposal,
+} from "./optio-chat-store.js";

--- a/apps/web/src/components/optio-chat/optio-chat-panel.tsx
+++ b/apps/web/src/components/optio-chat/optio-chat-panel.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { X, Send, RotateCcw, Bot, User, Loader2, AlertTriangle, Info } from "lucide-react";
+import { ActionConfirmation } from "./action-confirmation.js";
+import { useOptioChatStore, MAX_EXCHANGES, type OptioChatMessage } from "./optio-chat-store.js";
+
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? "ws://localhost:4000";
+
+export function OptioChatPanel() {
+  const {
+    isOpen,
+    messages,
+    status,
+    prefill,
+    exchangeCount,
+    closePanel,
+    addMessage,
+    updateMessage,
+    setStatus,
+    setPrefill,
+    resetConversation,
+    incrementExchangeCount,
+  } = useOptioChatStore();
+
+  const [input, setInput] = useState("");
+  const wsRef = useRef<WebSocket | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const pathname = usePathname();
+  const prevPathname = useRef(pathname);
+
+  // Reset conversation on page navigation
+  useEffect(() => {
+    if (prevPathname.current !== pathname) {
+      resetConversation();
+      wsRef.current?.close();
+      wsRef.current = null;
+    }
+    prevPathname.current = pathname;
+  }, [pathname, resetConversation]);
+
+  // Apply prefill to input
+  useEffect(() => {
+    if (prefill) {
+      setInput(prefill);
+      setPrefill("");
+      inputRef.current?.focus();
+    }
+  }, [prefill, setPrefill]);
+
+  const scrollToBottom = useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  // Auto-scroll on new messages
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, scrollToBottom]);
+
+  // Focus input when panel opens
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 200);
+    }
+  }, [isOpen]);
+
+  // Connect to WebSocket
+  const ensureConnection = useCallback(() => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) return;
+    if (wsRef.current && wsRef.current.readyState === WebSocket.CONNECTING) return;
+
+    setStatus("connecting");
+    const ws = new WebSocket(`${WS_URL}/ws/optio/chat`);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      setStatus("ready");
+    };
+
+    ws.onmessage = (event) => {
+      let msg: any;
+      try {
+        msg = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+
+      switch (msg.type) {
+        case "status":
+          setStatus(msg.status);
+          break;
+
+        case "message": {
+          const assistantMsg: OptioChatMessage = {
+            id: `assistant-${Date.now()}`,
+            role: "assistant",
+            content: msg.content,
+            timestamp: new Date().toISOString(),
+            actionProposal: msg.actionProposal
+              ? {
+                  ...msg.actionProposal,
+                  id: msg.actionProposal.id ?? `proposal-${Date.now()}`,
+                  status: "pending",
+                }
+              : undefined,
+          };
+          addMessage(assistantMsg);
+          incrementExchangeCount();
+          setStatus("ready");
+          break;
+        }
+
+        case "action_result": {
+          const resultMsg: OptioChatMessage = {
+            id: `assistant-${Date.now()}`,
+            role: "assistant",
+            content: msg.content,
+            timestamp: new Date().toISOString(),
+          };
+          addMessage(resultMsg);
+          setStatus("ready");
+          break;
+        }
+
+        case "error":
+          setStatus("error");
+          const errorMsg: OptioChatMessage = {
+            id: `error-${Date.now()}`,
+            role: "assistant",
+            content: msg.message ?? "Something went wrong. Please try again.",
+            timestamp: new Date().toISOString(),
+          };
+          addMessage(errorMsg);
+          break;
+      }
+    };
+
+    ws.onclose = () => {
+      setStatus("ready");
+      wsRef.current = null;
+    };
+
+    ws.onerror = () => {
+      setStatus("unavailable");
+      wsRef.current = null;
+    };
+  }, [setStatus, addMessage, incrementExchangeCount]);
+
+  // Escape to close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        closePanel();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, closePanel]);
+
+  const handleSend = () => {
+    const text = input.trim();
+    if (!text || status === "thinking") return;
+
+    if (exchangeCount >= MAX_EXCHANGES) return;
+
+    ensureConnection();
+
+    const userMsg: OptioChatMessage = {
+      id: `user-${Date.now()}`,
+      role: "user",
+      content: text,
+      timestamp: new Date().toISOString(),
+    };
+    addMessage(userMsg);
+    incrementExchangeCount();
+    setStatus("thinking");
+
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: "message", content: text }));
+    }
+
+    setInput("");
+  };
+
+  const handleApprove = (proposalId: string) => {
+    // Update the proposal status in the message
+    const msg = messages.find((m) => m.actionProposal?.id === proposalId);
+    if (msg) {
+      updateMessage(msg.id, {
+        actionProposal: { ...msg.actionProposal!, status: "approved" },
+      });
+    }
+
+    setStatus("thinking");
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: "approve", proposalId }));
+    }
+  };
+
+  const handleDeny = (proposalId: string, feedback: string) => {
+    const msg = messages.find((m) => m.actionProposal?.id === proposalId);
+    if (msg) {
+      updateMessage(msg.id, {
+        actionProposal: { ...msg.actionProposal!, status: "denied", feedback },
+      });
+    }
+
+    setStatus("thinking");
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: "deny", proposalId, feedback }));
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const atLimit = exchangeCount >= MAX_EXCHANGES;
+
+  return (
+    <>
+      {/* Backdrop overlay */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/30 backdrop-blur-[2px] optio-panel-backdrop"
+          onClick={closePanel}
+        />
+      )}
+
+      {/* Slide-out panel */}
+      <div
+        className={cn(
+          "fixed top-0 right-0 z-50 h-full w-[420px] max-w-full flex flex-col",
+          "bg-bg border-l border-border shadow-2xl",
+          "transition-transform duration-300 ease-out",
+          isOpen ? "translate-x-0" : "translate-x-full",
+        )}
+      >
+        {/* Header */}
+        <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-border bg-bg-card">
+          <div className="flex items-center gap-2.5">
+            <div className="w-7 h-7 rounded-lg bg-primary/15 flex items-center justify-center">
+              <Bot className="w-4 h-4 text-primary" />
+            </div>
+            <div>
+              <span className="font-semibold text-sm">Optio</span>
+              <span className="ml-2 text-[10px] text-text-muted">
+                {status === "thinking"
+                  ? "Thinking..."
+                  : status === "unavailable"
+                    ? "Unavailable"
+                    : ""}
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={resetConversation}
+              className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted transition-colors"
+              title="Reset conversation"
+            >
+              <RotateCcw className="w-3.5 h-3.5" />
+            </button>
+            <button
+              onClick={closePanel}
+              className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted transition-colors"
+              title="Close (Esc)"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Session ephemeral indicator */}
+        <div className="shrink-0 px-4 py-1.5 bg-bg-subtle/50 border-b border-border/50 flex items-center gap-1.5">
+          <Info className="w-3 h-3 text-text-muted/50" />
+          <span className="text-[10px] text-text-muted/50">Session resets on page change</span>
+        </div>
+
+        {/* Unavailable state */}
+        {status === "unavailable" ? (
+          <div className="flex-1 flex items-center justify-center p-6">
+            <div className="text-center">
+              <AlertTriangle className="w-10 h-10 mx-auto mb-3 text-warning/60" />
+              <p className="text-sm font-medium text-text-muted">Optio is unavailable</p>
+              <p className="text-xs text-text-muted/60 mt-1 max-w-xs">
+                The Optio chat backend is not running. Check that the WebSocket endpoint is
+                configured.
+              </p>
+              <button
+                onClick={() => {
+                  setStatus("ready");
+                  ensureConnection();
+                }}
+                className="mt-4 px-3 py-1.5 rounded-md text-xs bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+              >
+                Retry connection
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* Messages */}
+            <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+              {messages.length === 0 && (
+                <div className="h-full flex items-center justify-center text-text-muted">
+                  <div className="text-center">
+                    <Bot className="w-8 h-8 mx-auto mb-3 opacity-30" />
+                    <p className="text-sm font-medium">Ask Optio anything</p>
+                    <p className="text-xs mt-1 max-w-[260px] text-text-muted/60">
+                      Retry failed tasks, update repo settings, check status, or get help debugging.
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {messages.map((msg) => (
+                <div
+                  key={msg.id}
+                  className={cn("flex gap-2.5", msg.role === "user" ? "justify-end" : "")}
+                >
+                  {msg.role === "assistant" && (
+                    <div className="shrink-0 mt-1">
+                      <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center">
+                        <Bot className="w-3.5 h-3.5 text-primary" />
+                      </div>
+                    </div>
+                  )}
+
+                  <div
+                    className={cn(
+                      "max-w-[85%]",
+                      msg.role === "user"
+                        ? "bg-primary/10 border border-primary/20 rounded-lg px-3.5 py-2"
+                        : "space-y-2 min-w-0",
+                    )}
+                  >
+                    {msg.actionProposal ? (
+                      <ActionConfirmation
+                        proposal={msg.actionProposal}
+                        onApprove={handleApprove}
+                        onDeny={handleDeny}
+                      />
+                    ) : (
+                      <div className="text-sm whitespace-pre-wrap leading-relaxed optio-chat-markdown">
+                        {msg.content}
+                      </div>
+                    )}
+                  </div>
+
+                  {msg.role === "user" && (
+                    <div className="shrink-0 mt-1">
+                      <div className="w-6 h-6 rounded-full bg-bg-card border border-border flex items-center justify-center">
+                        <User className="w-3.5 h-3.5 text-text-muted" />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+
+              {status === "thinking" && (
+                <div className="flex gap-2.5">
+                  <div className="shrink-0 mt-1">
+                    <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center">
+                      <Bot className="w-3.5 h-3.5 text-primary animate-pulse" />
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-text-muted">
+                    <Loader2 className="w-3 h-3 animate-spin" />
+                    Thinking...
+                  </div>
+                </div>
+              )}
+
+              {/* Exchange limit warning */}
+              {atLimit && (
+                <div className="text-center py-4 space-y-2">
+                  <p className="text-xs text-warning">
+                    This conversation is getting long. Start a fresh one?
+                  </p>
+                  <button
+                    onClick={resetConversation}
+                    className="px-3 py-1.5 rounded-md text-xs bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+                  >
+                    Reset conversation
+                  </button>
+                </div>
+              )}
+
+              <div ref={messagesEndRef} />
+            </div>
+
+            {/* Input */}
+            <div className="shrink-0 border-t border-border px-4 py-3">
+              <div className="flex items-end gap-2">
+                <div className="flex-1 relative">
+                  <textarea
+                    ref={inputRef}
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder={
+                      atLimit
+                        ? "Conversation limit reached"
+                        : status === "thinking"
+                          ? "Optio is thinking..."
+                          : "Ask Optio..."
+                    }
+                    disabled={atLimit}
+                    rows={1}
+                    className={cn(
+                      "w-full resize-none rounded-lg border border-border bg-bg-card px-3 py-2.5 text-sm",
+                      "placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-primary/30 focus:border-primary/50",
+                      "disabled:opacity-50 disabled:cursor-not-allowed",
+                      "min-h-[40px] max-h-[100px]",
+                    )}
+                    style={{ height: "auto" }}
+                    onInput={(e) => {
+                      const target = e.target as HTMLTextAreaElement;
+                      target.style.height = "auto";
+                      target.style.height = `${Math.min(target.scrollHeight, 100)}px`;
+                    }}
+                  />
+                </div>
+                <button
+                  onClick={handleSend}
+                  disabled={!input.trim() || status === "thinking" || atLimit}
+                  className={cn(
+                    "shrink-0 p-2.5 rounded-lg transition-colors",
+                    input.trim() && status !== "thinking"
+                      ? "bg-primary text-white hover:bg-primary/90"
+                      : "bg-bg-card text-text-muted border border-border",
+                    "disabled:opacity-50 disabled:cursor-not-allowed",
+                  )}
+                  title="Send (Enter)"
+                >
+                  <Send className="w-4 h-4" />
+                </button>
+              </div>
+              <div className="flex items-center justify-between mt-1.5">
+                <span className="text-[10px] text-text-muted/50">
+                  Enter to send, Shift+Enter for new line
+                </span>
+                <span className="text-[10px] text-text-muted/50">
+                  {exchangeCount}/{MAX_EXCHANGES}
+                </span>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/optio-chat/optio-chat-store.ts
+++ b/apps/web/src/components/optio-chat/optio-chat-store.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { create } from "zustand";
+
+export type OptioChatStatus =
+  | "idle"
+  | "connecting"
+  | "ready"
+  | "thinking"
+  | "error"
+  | "unavailable";
+
+export interface ActionProposal {
+  id: string;
+  description: string;
+  actions: string[];
+  status: "pending" | "approved" | "denied";
+  feedback?: string;
+}
+
+export interface OptioChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+  actionProposal?: ActionProposal;
+}
+
+interface OptioChatState {
+  isOpen: boolean;
+  messages: OptioChatMessage[];
+  status: OptioChatStatus;
+  prefill: string;
+  exchangeCount: number;
+
+  openPanel: () => void;
+  closePanel: () => void;
+  togglePanel: () => void;
+  openWithPrefill: (text: string) => void;
+  addMessage: (msg: OptioChatMessage) => void;
+  updateMessage: (id: string, updates: Partial<OptioChatMessage>) => void;
+  setStatus: (status: OptioChatStatus) => void;
+  setPrefill: (text: string) => void;
+  resetConversation: () => void;
+  incrementExchangeCount: () => void;
+}
+
+const MAX_EXCHANGES = 20;
+
+export const useOptioChatStore = create<OptioChatState>((set) => ({
+  isOpen: false,
+  messages: [],
+  status: "ready",
+  prefill: "",
+  exchangeCount: 0,
+
+  openPanel: () => set({ isOpen: true }),
+  closePanel: () => set({ isOpen: false }),
+  togglePanel: () => set((s) => ({ isOpen: !s.isOpen })),
+  openWithPrefill: (text: string) => set({ isOpen: true, prefill: text }),
+
+  addMessage: (msg) =>
+    set((s) => ({
+      messages: [...s.messages, msg],
+    })),
+
+  updateMessage: (id, updates) =>
+    set((s) => ({
+      messages: s.messages.map((m) => (m.id === id ? { ...m, ...updates } : m)),
+    })),
+
+  setStatus: (status) => set({ status }),
+  setPrefill: (prefill) => set({ prefill }),
+
+  resetConversation: () =>
+    set({
+      messages: [],
+      exchangeCount: 0,
+      prefill: "",
+      status: "ready",
+    }),
+
+  incrementExchangeCount: () => set((s) => ({ exchangeCount: s.exchangeCount + 1 })),
+}));
+
+export { MAX_EXCHANGES };

--- a/apps/web/src/components/task-card.tsx
+++ b/apps/web/src/components/task-card.tsx
@@ -7,8 +7,18 @@ import { StateBadge } from "./state-badge";
 import { classifyError } from "@optio/shared";
 import { api } from "@/lib/api-client";
 import { formatRelativeTime } from "@/lib/utils";
-import { ExternalLink, RotateCcw, Bot, Link2, Clock, Moon, Play } from "lucide-react";
+import {
+  ExternalLink,
+  RotateCcw,
+  Bot,
+  Link2,
+  Clock,
+  Moon,
+  Play,
+  MessageSquare,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useOptioChatStore } from "@/components/optio-chat/optio-chat-store.js";
 
 /** Map raw trigger/message strings to human-readable attention reasons. */
 function formatAttentionReason(reason: string): string {
@@ -42,6 +52,7 @@ interface TaskCardProps {
 
 export const TaskCard = React.memo(function TaskCard({ task, subtasks }: TaskCardProps) {
   const router = useRouter();
+  const openWithPrefill = useOptioChatStore((s) => s.openWithPrefill);
   const repoName = task.repoUrl.replace(/.*\/\/[^/]+\//, "").replace(/\.git$/, "");
   const [owner, repo] = repoName.includes("/") ? repoName.split("/") : ["", repoName];
   const prNumber = task.prUrl?.match(/\/pull\/(\d+)/)?.[1];
@@ -138,28 +149,42 @@ export const TaskCard = React.memo(function TaskCard({ task, subtasks }: TaskCar
             <span className="text-xs text-error/80 truncate">
               {classifyError(task.errorMessage).title}
             </span>
-            <button
-              onClick={async (e) => {
-                e.stopPropagation();
-                const btn = e.currentTarget;
-                btn.textContent = "Retrying...";
-                btn.setAttribute("disabled", "true");
-                try {
-                  await api.retryTask(task.id);
-                  window.location.href = window.location.href;
-                } catch {
-                  btn.textContent = "Failed";
-                  setTimeout(() => {
-                    btn.textContent = "Retry";
-                    btn.removeAttribute("disabled");
-                  }, 2000);
-                }
-              }}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs bg-primary/10 text-primary hover:bg-primary/20 transition-all shrink-0 btn-press"
-            >
-              <RotateCcw className="w-3 h-3" />
-              Retry
-            </button>
+            <div className="flex items-center gap-1.5 shrink-0">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openWithPrefill(
+                    `Task #${task.id.slice(0, 8)} failed with: ${classifyError(task.errorMessage!).title}`,
+                  );
+                }}
+                className="p-1 rounded-md text-xs bg-primary/10 text-primary hover:bg-primary/20 transition-all btn-press"
+                title="Ask Optio"
+              >
+                <MessageSquare className="w-3 h-3" />
+              </button>
+              <button
+                onClick={async (e) => {
+                  e.stopPropagation();
+                  const btn = e.currentTarget;
+                  btn.textContent = "Retrying...";
+                  btn.setAttribute("disabled", "true");
+                  try {
+                    await api.retryTask(task.id);
+                    window.location.href = window.location.href;
+                  } catch {
+                    btn.textContent = "Failed";
+                    setTimeout(() => {
+                      btn.textContent = "Retry";
+                      btn.removeAttribute("disabled");
+                    }, 2000);
+                  }
+                }}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs bg-primary/10 text-primary hover:bg-primary/20 transition-all btn-press"
+              >
+                <RotateCcw className="w-3 h-3" />
+                Retry
+              </button>
+            </div>
           </div>
         )}
         {task.state === "needs_attention" && task.errorMessage && (


### PR DESCRIPTION
## Summary

- Adds a slide-out chat panel accessible from the sidebar via an "Ask Optio" button with connection status indicator (green/yellow/red dot)
- Implements action confirmation UX with approve/deny buttons and feedback input for denied proposals
- Adds contextual entry points: failed task cards show an Optio button, task detail page has "Ask Optio" in the action bar, and the dashboard shows a failure prompt when tasks have failed
- Conversations are ephemeral (reset on page navigation or refresh) with a 20-exchange limit and reset prompt

Closes #187

## New files

- `apps/web/src/components/optio-chat/optio-chat-store.ts` — Zustand store for chat state (messages, status, prefill, exchange count)
- `apps/web/src/components/optio-chat/optio-chat-panel.tsx` — Main slide-out panel with chat interface, WebSocket connection to `/ws/optio/chat`, and message rendering
- `apps/web/src/components/optio-chat/action-confirmation.tsx` — Action proposal card with approve/deny/feedback UX
- `apps/web/src/components/optio-chat/index.ts` — Barrel export

## Modified files

- `apps/web/src/components/layout/sidebar.tsx` — Added OptioButton with status indicator dot
- `apps/web/src/components/layout/layout-shell.tsx` — Mounted OptioChatPanel in the layout
- `apps/web/src/components/task-card.tsx` — Added Optio icon button on failed task error sections
- `apps/web/src/app/tasks/[id]/page.tsx` — Added "Ask Optio" button in the task detail action bar
- `apps/web/src/app/page.tsx` — Added DashboardOptioPrompt when failed tasks exist
- `apps/web/src/app/globals.css` — Added CSS for panel backdrop and markdown styling

## Test plan

- [ ] Verify the "Ask Optio" button appears in the sidebar with a status dot
- [ ] Click the sidebar button to open the slide-out panel from the right
- [ ] Verify Escape key and backdrop click dismiss the panel
- [ ] Verify the panel header shows "Session resets on page change" indicator
- [ ] Navigate to a different page and verify conversation resets
- [ ] Test the "Reset conversation" button in the panel header
- [ ] On the dashboard, verify the failure prompt appears when tasks have failed
- [ ] On a failed task card, verify the Optio icon button opens the panel with prefilled context
- [ ] On the task detail page, verify "Ask Optio" button opens panel with task context
- [ ] Verify action confirmation cards render with Approve/Deny buttons
- [ ] Verify Deny shows a feedback input, and both buttons become disabled after selection
- [ ] Verify the exchange counter shows and the limit warning appears at 20 exchanges

🤖 Generated with [Claude Code](https://claude.com/claude-code)