### PR TITLE
fix: include Optio pod in update-local.sh and add cache test

### DIFF
--- a/apps/api/src/routes/optio.test.ts
+++ b/apps/api/src/routes/optio.test.ts
@@ -124,4 +124,28 @@ describe("GET /api/optio/status", () => {
     expect(body.ready).toBe(false);
     expect(body.podName).toBeNull();
   });
+
+  it("caches K8s API result for subsequent requests", async () => {
+    mockListNamespacedPod.mockResolvedValue({
+      items: [
+        {
+          metadata: { name: "optio-optio-abc123" },
+          status: {
+            phase: "Running",
+            conditions: [{ type: "Ready", status: "True" }],
+          },
+        },
+      ],
+    });
+
+    // First request hits the K8s API
+    const res1 = await app.inject({ method: "GET", url: "/api/optio/status" });
+    expect(res1.json().ready).toBe(true);
+    expect(mockListNamespacedPod).toHaveBeenCalledTimes(1);
+
+    // Second request within the TTL should use cache
+    const res2 = await app.inject({ method: "GET", url: "/api/optio/status" });
+    expect(res2.json().ready).toBe(true);
+    expect(mockListNamespacedPod).toHaveBeenCalledTimes(1);
+  });
 });

--- a/scripts/update-local.sh
+++ b/scripts/update-local.sh
@@ -42,14 +42,21 @@ if [ "$REBUILD_AGENTS" = true ]; then
   docker build -t optio-full:latest -f images/full.Dockerfile . -q
 fi
 
+# Rebuild the Optio operations assistant image if missing
+if ! docker image inspect "optio-optio:latest" &>/dev/null; then
+  echo "   Rebuilding optio-optio (operations assistant)..."
+  docker build -t optio-optio:latest -f Dockerfile.optio . -q
+fi
+
 echo "   Images built."
 
 # Rolling restart
 echo "[4/4] Restarting deployments..."
 helm upgrade optio helm/optio -n optio --reuse-values
-kubectl rollout restart deployment/optio-api deployment/optio-web -n optio
+kubectl rollout restart deployment/optio-api deployment/optio-web deployment/optio-optio -n optio
 kubectl rollout status deployment/optio-api -n optio --timeout=60s 2>/dev/null || true
 kubectl rollout status deployment/optio-web -n optio --timeout=60s 2>/dev/null || true
+kubectl rollout status deployment/optio-optio -n optio --timeout=60s 2>/dev/null || true
 
 echo ""
 echo "=== Update Complete ==="


### PR DESCRIPTION
## Summary
- **update-local.sh was missing Optio pod support**: When the Optio operations assistant pod was introduced (PRs #193/#194), the `update-local.sh` script wasn't updated to include the `optio-optio` image in its rebuild check or include `deployment/optio-optio` in the rolling restart
- **Added cache TTL test**: The `GET /api/optio/status` endpoint caches K8s API responses for 10 seconds to avoid excessive polling, but this behavior had no test coverage

## Changes
- `scripts/update-local.sh`: Add `optio-optio` image rebuild check and include the deployment in rolling restarts
- `apps/api/src/routes/optio.test.ts`: Add test verifying that the K8s API cache prevents duplicate calls within the TTL window

## Test plan
- [x] All 747 tests pass (59 test files)
- [x] New cache test verifies K8s API is called once for two rapid status requests
- [x] Typecheck passes across all 6 packages
- [x] Prettier formatting passes

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)