### PR TITLE
feat: Optio tool definitions, system-status endpoint, and auth passthrough

### DIFF
--- a/apps/api/src/routes/optio.test.ts
+++ b/apps/api/src/routes/optio.test.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from "fastify";
 // ─── Mocks ───
 
 const mockListNamespacedPod = vi.fn();
+const mockExecute = vi.fn();
 
 vi.mock("@kubernetes/client-node", () => {
   return {
@@ -18,12 +19,30 @@ vi.mock("@kubernetes/client-node", () => {
   };
 });
 
+vi.mock("../db/client.js", () => ({
+  db: {
+    execute: (...args: unknown[]) => mockExecute(...args),
+  },
+}));
+
 import { optioRoutes, _resetCache } from "./optio.js";
 
 // ─── Helpers ───
 
 async function buildTestApp(): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
+  await optioRoutes(app);
+  await app.ready();
+  return app;
+}
+
+async function buildTestAppWithAuth(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.decorateRequest("user", undefined as any);
+  app.addHook("preHandler", (req, _reply, done) => {
+    (req as any).user = { workspaceId: "ws-1", workspaceRole: "admin" };
+    done();
+  });
   await optioRoutes(app);
   await app.ready();
   return app;
@@ -123,5 +142,96 @@ describe("GET /api/optio/status", () => {
     const body = res.json();
     expect(body.ready).toBe(false);
     expect(body.podName).toBeNull();
+  });
+});
+
+describe("GET /api/optio/system-status", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestAppWithAuth();
+  });
+
+  it("returns aggregate system status", async () => {
+    mockExecute
+      // 1. Task counts by state
+      .mockResolvedValueOnce([
+        { state: "running", count: "3" },
+        { state: "queued", count: "5" },
+        { state: "needs_attention", count: "1" },
+        { state: "pr_opened", count: "2" },
+      ])
+      // 2. Failed/completed today
+      .mockResolvedValueOnce([{ failed_today: "2", completed_today: "7" }])
+      // 3. Pod health
+      .mockResolvedValueOnce([
+        { state: "ready", count: "4" },
+        { state: "error", count: "1" },
+        { state: "provisioning", count: "1" },
+      ])
+      // 4. Cost today
+      .mockResolvedValueOnce([{ cost_today: "3.5000" }])
+      // 5. Alerts
+      .mockResolvedValueOnce([
+        {
+          event_type: "oom_killed",
+          message: "Pod ran out of memory",
+          created_at: "2026-03-28T10:00:00Z",
+          pod_name: "optio-repo-abc",
+        },
+      ]);
+
+    const res = await app.inject({ method: "GET", url: "/api/optio/system-status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.tasks.running).toBe(3);
+    expect(body.tasks.queued).toBe(5);
+    expect(body.tasks.needsAttention).toBe(1);
+    expect(body.tasks.prOpened).toBe(2);
+    expect(body.tasks.failedToday).toBe(2);
+    expect(body.tasks.completedToday).toBe(7);
+
+    expect(body.pods.total).toBe(6);
+    expect(body.pods.healthy).toBe(4);
+    expect(body.pods.unhealthy).toBe(1);
+
+    expect(body.queueDepth).toBe(5);
+    expect(body.costToday).toBe(3.5);
+
+    expect(body.alerts).toHaveLength(1);
+    expect(body.alerts[0].type).toBe("oom_killed");
+  });
+
+  it("returns zeros when no data exists", async () => {
+    mockExecute
+      .mockResolvedValueOnce([]) // task counts
+      .mockResolvedValueOnce([{ failed_today: "0", completed_today: "0" }]) // today counts
+      .mockResolvedValueOnce([]) // pod health
+      .mockResolvedValueOnce([{ cost_today: "0" }]) // cost
+      .mockResolvedValueOnce([]); // alerts
+
+    const res = await app.inject({ method: "GET", url: "/api/optio/system-status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.tasks.running).toBe(0);
+    expect(body.tasks.queued).toBe(0);
+    expect(body.pods.total).toBe(0);
+    expect(body.queueDepth).toBe(0);
+    expect(body.costToday).toBe(0);
+    expect(body.alerts).toHaveLength(0);
+  });
+
+  it("returns 500 when DB fails", async () => {
+    mockExecute.mockRejectedValueOnce(new Error("connection error"));
+
+    const res = await app.inject({ method: "GET", url: "/api/optio/system-status" });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json().error).toBe("Failed to fetch system status");
   });
 });

--- a/apps/api/src/routes/optio.ts
+++ b/apps/api/src/routes/optio.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { KubeConfig, CoreV1Api } from "@kubernetes/client-node";
+import { sql } from "drizzle-orm";
+import { db } from "../db/client.js";
 
 const NAMESPACE = "optio";
 const POD_ROLE_LABEL = "optio.pod-role=optio";
@@ -61,6 +63,31 @@ async function getOptioPodStatus(): Promise<{
   }
 }
 
+/** Response shape for GET /api/optio/system-status */
+export interface SystemStatusResponse {
+  tasks: {
+    running: number;
+    queued: number;
+    provisioning: number;
+    failedToday: number;
+    completedToday: number;
+    needsAttention: number;
+    prOpened: number;
+  };
+  pods: {
+    total: number;
+    healthy: number;
+    unhealthy: number;
+  };
+  queueDepth: number;
+  costToday: number;
+  alerts: Array<{
+    type: string;
+    message: string;
+    timestamp: string;
+  }>;
+}
+
 export async function optioRoutes(app: FastifyInstance) {
   app.get("/api/optio/status", async (_req, reply) => {
     const enabled = process.env.OPTIO_POD_ENABLED === "true";
@@ -70,5 +97,124 @@ export async function optioRoutes(app: FastifyInstance) {
 
     const status = await getOptioPodStatus();
     return reply.send({ ...status, enabled: true });
+  });
+
+  app.get("/api/optio/system-status", async (req, reply) => {
+    const workspaceId = req.user?.workspaceId || null;
+    const wsFilter = workspaceId ? sql`AND workspace_id = ${workspaceId}` : sql``;
+
+    try {
+      // Task counts by state
+      const taskCounts = await db.execute<{
+        state: string;
+        count: string;
+      }>(sql`
+        SELECT state, COUNT(*)::text AS count
+        FROM tasks
+        WHERE 1=1 ${wsFilter}
+          AND state IN ('running', 'queued', 'provisioning', 'needs_attention', 'pr_opened')
+        GROUP BY state
+      `);
+
+      const taskCountMap: Record<string, number> = {};
+      for (const row of taskCounts) {
+        taskCountMap[row.state] = parseInt(row.count, 10);
+      }
+
+      // Failed and completed today
+      const [todayCounts] = await db.execute<{
+        failed_today: string;
+        completed_today: string;
+      }>(sql`
+        SELECT
+          COUNT(*) FILTER (WHERE state = 'failed' AND updated_at >= CURRENT_DATE)::text AS failed_today,
+          COUNT(*) FILTER (WHERE state = 'completed' AND updated_at >= CURRENT_DATE)::text AS completed_today
+        FROM tasks
+        WHERE 1=1 ${wsFilter}
+      `);
+
+      // Pod health from repo_pods table
+      const podRows = await db.execute<{
+        state: string;
+        count: string;
+      }>(sql`
+        SELECT state, COUNT(*)::text AS count
+        FROM repo_pods
+        WHERE 1=1
+          ${workspaceId ? sql`AND workspace_id = ${workspaceId}` : sql``}
+        GROUP BY state
+      `);
+
+      let totalPods = 0;
+      let healthyPods = 0;
+      let unhealthyPods = 0;
+      for (const row of podRows) {
+        const n = parseInt(row.count, 10);
+        totalPods += n;
+        if (row.state === "ready") {
+          healthyPods += n;
+        } else if (row.state === "error") {
+          unhealthyPods += n;
+        }
+      }
+
+      // Queue depth: tasks in queued + provisioning state
+      const queueDepth = (taskCountMap["queued"] ?? 0) + (taskCountMap["provisioning"] ?? 0);
+
+      // Cost today
+      const [costRow] = await db.execute<{ cost_today: string }>(sql`
+        SELECT COALESCE(SUM(CAST(cost_usd AS NUMERIC)), 0)::text AS cost_today
+        FROM tasks
+        WHERE cost_usd IS NOT NULL
+          AND created_at >= CURRENT_DATE
+          ${wsFilter}
+      `);
+
+      // Recent alerts: OOM kills and crashes in the last 24 hours
+      const alertRows = await db.execute<{
+        event_type: string;
+        message: string;
+        created_at: string;
+        pod_name: string;
+      }>(sql`
+        SELECT event_type, message, created_at::text, pod_name
+        FROM pod_health_events
+        WHERE created_at >= NOW() - INTERVAL '24 hours'
+          AND event_type IN ('crashed', 'oom_killed')
+        ORDER BY created_at DESC
+        LIMIT 10
+      `);
+
+      const alerts = alertRows.map((row) => ({
+        type: row.event_type,
+        message: row.message || `Pod ${row.pod_name} ${row.event_type.replace("_", " ")}`,
+        timestamp: row.created_at,
+      }));
+
+      const response: SystemStatusResponse = {
+        tasks: {
+          running: taskCountMap["running"] ?? 0,
+          queued: taskCountMap["queued"] ?? 0,
+          provisioning: taskCountMap["provisioning"] ?? 0,
+          failedToday: parseInt(todayCounts?.failed_today ?? "0", 10),
+          completedToday: parseInt(todayCounts?.completed_today ?? "0", 10),
+          needsAttention: taskCountMap["needs_attention"] ?? 0,
+          prOpened: taskCountMap["pr_opened"] ?? 0,
+        },
+        pods: {
+          total: totalPods,
+          healthy: healthyPods,
+          unhealthy: unhealthyPods,
+        },
+        queueDepth,
+        costToday: parseFloat(costRow?.cost_today ?? "0"),
+        alerts,
+      };
+
+      return reply.send(response);
+    } catch (err) {
+      app.log.error(err, "Failed to fetch system status");
+      return reply.status(500).send({ error: "Failed to fetch system status" });
+    }
   });
 }

--- a/apps/api/src/ws/session-chat.ts
+++ b/apps/api/src/ws/session-chat.ts
@@ -8,6 +8,7 @@ import { logger } from "../logger.js";
 import { parseClaudeEvent } from "../services/agent-event-parser.js";
 import { publishSessionEvent } from "../services/event-bus.js";
 import type { ExecSession } from "@optio/shared";
+import { extractSessionToken } from "./ws-auth.js";
 
 /**
  * Session chat WebSocket handler.
@@ -30,6 +31,11 @@ export async function sessionChatWs(app: FastifyInstance) {
   app.get("/ws/sessions/:sessionId/chat", { websocket: true }, async (socket, req) => {
     const { sessionId } = req.params as { sessionId: string };
     const log = logger.child({ sessionId, ws: "session-chat" });
+
+    // Extract the user's raw session token for auth passthrough.
+    // This token will be injected into the pod environment so that API calls
+    // made by the agent carry the user's identity.
+    const userSessionToken = extractSessionToken(req);
 
     const session = await getSession(sessionId);
     if (!session) {
@@ -106,14 +112,29 @@ export async function sessionChatWs(app: FastifyInstance) {
       const escapedPrompt = prompt.replace(/'/g, "'\\''");
       const modelFlag = currentModel ? `--model ${currentModel}` : "";
 
+      // Build auth passthrough env vars so the agent can make
+      // authenticated API calls on behalf of the requesting user.
+      const passthroughEnv: Record<string, string> = {};
+      if (userSessionToken) {
+        passthroughEnv.OPTIO_SESSION_TOKEN = userSessionToken;
+      }
+      const apiUrl = process.env.API_PUBLIC_URL || process.env.OPTIO_API_URL || "";
+      if (apiUrl) {
+        passthroughEnv.OPTIO_API_URL = apiUrl;
+      }
+
       const script = [
         "set -e",
         // Wait for repo to be ready
         "for i in $(seq 1 30); do [ -f /workspace/.ready ] && break; sleep 1; done",
         '[ -f /workspace/.ready ] || { echo "Repo not ready"; exit 1; }',
         `cd "${worktreePath}"`,
-        // Set auth env vars
+        // Set auth env vars for the Claude process
         ...Object.entries(authEnv).map(([k, v]) => `export ${k}='${v.replace(/'/g, "'\\''")}'`),
+        // Set auth passthrough env vars for Optio API calls
+        ...Object.entries(passthroughEnv).map(
+          ([k, v]) => `export ${k}='${v.replace(/'/g, "'\\''")}'`,
+        ),
         // Run claude in one-shot prompt mode with streaming JSON output
         `claude -p '${escapedPrompt}' ${modelFlag} --output-format stream-json --verbose --dangerously-skip-permissions 2>&1 || true`,
       ].join("\n");

--- a/apps/api/src/ws/ws-auth.test.ts
+++ b/apps/api/src/ws/ws-auth.test.ts
@@ -12,7 +12,7 @@ vi.mock("../services/oauth/index.js", () => ({
   isAuthDisabled: () => authDisabled,
 }));
 
-import { authenticateWs } from "./ws-auth.js";
+import { authenticateWs, extractSessionToken } from "./ws-auth.js";
 import type { FastifyRequest } from "fastify";
 
 function createMockSocket() {
@@ -132,5 +132,37 @@ describe("authenticateWs", () => {
 
     expect(user).toBeNull();
     expect(socket.close).toHaveBeenCalledWith(4401, "Invalid or expired session");
+  });
+});
+
+describe("extractSessionToken", () => {
+  beforeEach(() => {
+    authDisabled = false;
+  });
+
+  it("returns undefined when auth is disabled", () => {
+    authDisabled = true;
+    const req = createMockRequest({ cookie: "optio_session=abc123" });
+    expect(extractSessionToken(req)).toBeUndefined();
+  });
+
+  it("extracts token from cookie", () => {
+    const req = createMockRequest({ cookie: "optio_session=my-token" });
+    expect(extractSessionToken(req)).toBe("my-token");
+  });
+
+  it("extracts token from query param", () => {
+    const req = createMockRequest({ token: "query-token" });
+    expect(extractSessionToken(req)).toBe("query-token");
+  });
+
+  it("prefers cookie over query param", () => {
+    const req = createMockRequest({ cookie: "optio_session=cookie-token", token: "query-token" });
+    expect(extractSessionToken(req)).toBe("cookie-token");
+  });
+
+  it("returns undefined when no token is present", () => {
+    const req = createMockRequest();
+    expect(extractSessionToken(req)).toBeUndefined();
   });
 });

--- a/apps/api/src/ws/ws-auth.ts
+++ b/apps/api/src/ws/ws-auth.ts
@@ -53,3 +53,17 @@ export async function authenticateWs(
 
   return user;
 }
+
+/**
+ * Extract the raw session token from a Fastify request (cookie or query param).
+ * Used for auth passthrough — the raw token is forwarded to agent pods so they
+ * can make authenticated API calls on behalf of the user.
+ * Returns undefined if no token is found or auth is disabled.
+ */
+export function extractSessionToken(req: FastifyRequest): string | undefined {
+  if (isAuthDisabled()) return undefined;
+  return (
+    parseCookie(req.headers.cookie, SESSION_COOKIE_NAME) ??
+    (req.query as Record<string, string>)?.token
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,3 +18,4 @@ export * from "./types/session.js";
 export * from "./types/mcp.js";
 export * from "./utils/off-peak.js";
 export * from "./types/optio-settings.js";
+export * from "./optio-tools.js";

--- a/packages/shared/src/optio-tools.test.ts
+++ b/packages/shared/src/optio-tools.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  OPTIO_TOOL_SCHEMAS,
+  OPTIO_TOOL_MAP,
+  OPTIO_TOOL_NAMES,
+  getToolsByCategory,
+  getEnabledToolSchemas,
+  TERMINAL_TASK_STATES,
+  LOG_ENTRY_MAX_LENGTH,
+  LOG_TAIL_DEFAULT,
+} from "./optio-tools.js";
+
+describe("OPTIO_TOOL_SCHEMAS", () => {
+  it("contains 18 tool definitions", () => {
+    expect(OPTIO_TOOL_SCHEMAS).toHaveLength(18);
+  });
+
+  it("every tool has required fields", () => {
+    for (const tool of OPTIO_TOOL_SCHEMAS) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+      expect(tool.category).toBeTruthy();
+      expect(tool.endpoint).toBeTruthy();
+      expect(["GET", "POST", "PATCH", "DELETE"]).toContain(tool.method);
+      expect(tool.input_schema.type).toBe("object");
+      expect(tool.input_schema.properties).toBeDefined();
+    }
+  });
+
+  it("tool names are unique", () => {
+    const names = OPTIO_TOOL_SCHEMAS.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("every tool with required fields has those fields in properties", () => {
+    for (const tool of OPTIO_TOOL_SCHEMAS) {
+      if (tool.input_schema.required) {
+        for (const req of tool.input_schema.required) {
+          expect(tool.input_schema.properties).toHaveProperty(req);
+        }
+      }
+    }
+  });
+});
+
+describe("OPTIO_TOOL_MAP", () => {
+  it("has an entry for every tool", () => {
+    expect(Object.keys(OPTIO_TOOL_MAP)).toHaveLength(OPTIO_TOOL_SCHEMAS.length);
+  });
+
+  it("maps name to the correct tool", () => {
+    expect(OPTIO_TOOL_MAP["list_tasks"].endpoint).toBe("GET /api/tasks");
+    expect(OPTIO_TOOL_MAP["create_task"].method).toBe("POST");
+    expect(OPTIO_TOOL_MAP["get_system_status"].endpoint).toBe("GET /api/optio/system-status");
+  });
+});
+
+describe("OPTIO_TOOL_NAMES", () => {
+  it("matches schema names", () => {
+    expect(OPTIO_TOOL_NAMES).toEqual(OPTIO_TOOL_SCHEMAS.map((t) => t.name));
+  });
+});
+
+describe("getToolsByCategory", () => {
+  it("groups tools by category", () => {
+    const grouped = getToolsByCategory();
+    expect(grouped["Tasks"]).toBeDefined();
+    expect(grouped["Repos"]).toBeDefined();
+    expect(grouped["Issues"]).toBeDefined();
+    expect(grouped["Pods"]).toBeDefined();
+    expect(grouped["Costs"]).toBeDefined();
+    expect(grouped["System"]).toBeDefined();
+  });
+
+  it("Tasks category has 9 tools (including watch_task)", () => {
+    const grouped = getToolsByCategory();
+    expect(grouped["Tasks"]).toHaveLength(9);
+  });
+
+  it("Repos category has 3 tools", () => {
+    const grouped = getToolsByCategory();
+    expect(grouped["Repos"]).toHaveLength(3);
+  });
+});
+
+describe("getEnabledToolSchemas", () => {
+  it("filters to only enabled tools", () => {
+    const enabled = getEnabledToolSchemas(["list_tasks", "create_task"]);
+    expect(enabled).toHaveLength(2);
+    expect(enabled.map((t) => t.name)).toEqual(["list_tasks", "create_task"]);
+  });
+
+  it("returns empty array for no matches", () => {
+    const enabled = getEnabledToolSchemas(["nonexistent_tool"]);
+    expect(enabled).toHaveLength(0);
+  });
+
+  it("returns all tools when all names provided", () => {
+    const enabled = getEnabledToolSchemas(OPTIO_TOOL_NAMES);
+    expect(enabled).toHaveLength(OPTIO_TOOL_SCHEMAS.length);
+  });
+});
+
+describe("constants", () => {
+  it("TERMINAL_TASK_STATES contains expected values", () => {
+    expect(TERMINAL_TASK_STATES).toEqual(["completed", "failed", "cancelled"]);
+  });
+
+  it("LOG_ENTRY_MAX_LENGTH is 2000", () => {
+    expect(LOG_ENTRY_MAX_LENGTH).toBe(2000);
+  });
+
+  it("LOG_TAIL_DEFAULT is 100", () => {
+    expect(LOG_TAIL_DEFAULT).toBe(100);
+  });
+});
+
+describe("tool schema compatibility", () => {
+  it("all schemas have valid JSON Schema input_schema", () => {
+    for (const tool of OPTIO_TOOL_SCHEMAS) {
+      // Claude function calling requires type: "object" at top level
+      expect(tool.input_schema.type).toBe("object");
+      // Properties must be an object
+      expect(typeof tool.input_schema.properties).toBe("object");
+    }
+  });
+
+  it("watch_task has polling parameters", () => {
+    const watch = OPTIO_TOOL_MAP["watch_task"];
+    expect(watch.input_schema.properties).toHaveProperty("pollIntervalSeconds");
+    expect(watch.input_schema.properties).toHaveProperty("timeoutMinutes");
+    expect(watch.input_schema.required).toContain("id");
+  });
+
+  it("get_task_logs has tail and logType parameters", () => {
+    const logs = OPTIO_TOOL_MAP["get_task_logs"];
+    expect(logs.input_schema.properties).toHaveProperty("tail");
+    expect(logs.input_schema.properties).toHaveProperty("logType");
+    expect(logs.input_schema.properties.logType.enum).toBeDefined();
+  });
+});

--- a/packages/shared/src/optio-tools.ts
+++ b/packages/shared/src/optio-tools.ts
@@ -1,0 +1,557 @@
+/**
+ * Optio tool definitions for AI agent function calling.
+ *
+ * Each tool maps to one or more Optio API endpoints. The schemas are
+ * compatible with both Claude and OpenAI/Codex function-calling formats.
+ *
+ * The agent makes direct HTTP calls to the API server — no MCP wrapping.
+ */
+
+/** JSON Schema representation of a tool parameter. */
+export interface ToolParameterSchema {
+  type: string;
+  description?: string;
+  enum?: string[];
+  default?: unknown;
+  minimum?: number;
+  maximum?: number;
+  items?: ToolParameterSchema;
+}
+
+/** Standard tool definition compatible with Claude and Codex function calling. */
+export interface OptioToolSchema {
+  name: string;
+  description: string;
+  category: string;
+  /** The API endpoint(s) this tool maps to. */
+  endpoint: string;
+  /** HTTP method for the primary endpoint. */
+  method: "GET" | "POST" | "PATCH" | "DELETE";
+  input_schema: {
+    type: "object";
+    properties: Record<string, ToolParameterSchema>;
+    required?: string[];
+  };
+}
+
+// ─── Task Tools ─────────────────────────────────────────────────────────────
+
+const list_tasks: OptioToolSchema = {
+  name: "list_tasks",
+  description:
+    "List tasks with optional filters. Returns tasks sorted by most recent first. " +
+    "Supports filtering by state, repository, and date range.",
+  category: "Tasks",
+  endpoint: "GET /api/tasks",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {
+      state: {
+        type: "string",
+        description: "Filter by task state",
+        enum: [
+          "pending",
+          "waiting_on_deps",
+          "queued",
+          "provisioning",
+          "running",
+          "needs_attention",
+          "pr_opened",
+          "completed",
+          "failed",
+          "cancelled",
+        ],
+      },
+      repoUrl: {
+        type: "string",
+        description: "Filter by repository URL",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of tasks to return",
+        default: 20,
+        minimum: 1,
+        maximum: 100,
+      },
+      offset: {
+        type: "number",
+        description: "Number of tasks to skip for pagination",
+        default: 0,
+        minimum: 0,
+      },
+    },
+  },
+};
+
+const get_task: OptioToolSchema = {
+  name: "get_task",
+  description:
+    "Get detailed information about a specific task including its current state, " +
+    "PR status, error information, cost, and model used.",
+  category: "Tasks",
+  endpoint: "GET /api/tasks/:id",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The task UUID",
+      },
+    },
+    required: ["id"],
+  },
+};
+
+const create_task: OptioToolSchema = {
+  name: "create_task",
+  description:
+    "Create a new coding task. The task will be queued and assigned to an agent pod. " +
+    "Requires a title, repository URL, and prompt describing what to do.",
+  category: "Tasks",
+  endpoint: "POST /api/tasks",
+  method: "POST",
+  input_schema: {
+    type: "object",
+    properties: {
+      title: {
+        type: "string",
+        description: "Short title describing the task",
+      },
+      repoUrl: {
+        type: "string",
+        description: "Repository URL (e.g., https://github.com/owner/repo)",
+      },
+      prompt: {
+        type: "string",
+        description: "Detailed prompt/instructions for the agent",
+      },
+      priority: {
+        type: "number",
+        description: "Priority (lower = higher priority). Default is 100.",
+        default: 100,
+        minimum: 1,
+      },
+      repoBranch: {
+        type: "string",
+        description: "Base branch to work from. Defaults to repo's default branch.",
+      },
+    },
+    required: ["title", "repoUrl", "prompt"],
+  },
+};
+
+const retry_task: OptioToolSchema = {
+  name: "retry_task",
+  description:
+    "Retry a failed or cancelled task. Resets the task state and re-queues it for execution.",
+  category: "Tasks",
+  endpoint: "POST /api/tasks/:id/retry",
+  method: "POST",
+  input_schema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The task UUID to retry",
+      },
+    },
+    required: ["id"],
+  },
+};
+
+const cancel_task: OptioToolSchema = {
+  name: "cancel_task",
+  description: "Cancel a running, queued, or provisioning task.",
+  category: "Tasks",
+  endpoint: "POST /api/tasks/:id/cancel",
+  method: "POST",
+  input_schema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The task UUID to cancel",
+      },
+    },
+    required: ["id"],
+  },
+};
+
+const bulk_retry_failed: OptioToolSchema = {
+  name: "bulk_retry_failed",
+  description: "Retry all tasks that are currently in the failed state.",
+  category: "Tasks",
+  endpoint: "POST /api/tasks/bulk/retry-failed",
+  method: "POST",
+  input_schema: {
+    type: "object",
+    properties: {},
+  },
+};
+
+const bulk_cancel_active: OptioToolSchema = {
+  name: "bulk_cancel_active",
+  description: "Cancel all tasks that are currently running or queued.",
+  category: "Tasks",
+  endpoint: "POST /api/tasks/bulk/cancel-active",
+  method: "POST",
+  input_schema: {
+    type: "object",
+    properties: {},
+  },
+};
+
+const get_task_logs: OptioToolSchema = {
+  name: "get_task_logs",
+  description:
+    "Get logs for a specific task. Returns a summary line and the most recent log entries. " +
+    "Supports filtering by log type and limiting the number of entries returned. " +
+    "Individual log entries are truncated if they exceed 2000 characters.",
+  category: "Tasks",
+  endpoint: "GET /api/tasks/:id/logs",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The task UUID",
+      },
+      tail: {
+        type: "number",
+        description: "Number of most recent log entries to return",
+        default: 100,
+        minimum: 1,
+        maximum: 500,
+      },
+      logType: {
+        type: "string",
+        description: "Filter by log type",
+        enum: ["text", "tool_use", "tool_result", "thinking", "system", "error", "info"],
+      },
+    },
+    required: ["id"],
+  },
+};
+
+// ─── Repo Tools ─────────────────────────────────────────────────────────────
+
+const list_repos: OptioToolSchema = {
+  name: "list_repos",
+  description:
+    "List all configured repositories with their settings, including concurrency limits, " +
+    "model configuration, and review settings.",
+  category: "Repos",
+  endpoint: "GET /api/repos",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {},
+  },
+};
+
+const get_repo: OptioToolSchema = {
+  name: "get_repo",
+  description:
+    "Get detailed information about a specific repository including its settings, " +
+    "pod status, and configuration.",
+  category: "Repos",
+  endpoint: "GET /api/repos/:id",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The repository UUID",
+      },
+    },
+    required: ["id"],
+  },
+};
+
+const update_repo_settings: OptioToolSchema = {
+  name: "update_repo_settings",
+  description:
+    "Update settings for a repository. Can modify concurrency limits, model configuration, " +
+    "review settings, auto-merge, and more.",
+  category: "Repos",
+  endpoint: "PATCH /api/repos/:id",
+  method: "PATCH",
+  input_schema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The repository UUID",
+      },
+      maxConcurrentTasks: {
+        type: "number",
+        description: "Maximum concurrent tasks for this repo",
+        minimum: 1,
+        maximum: 50,
+      },
+      maxPodInstances: {
+        type: "number",
+        description: "Maximum pod replicas for this repo",
+        minimum: 1,
+        maximum: 20,
+      },
+      maxAgentsPerPod: {
+        type: "number",
+        description: "Maximum concurrent agents per pod",
+        minimum: 1,
+        maximum: 50,
+      },
+      claudeModel: {
+        type: "string",
+        description: "Claude model to use for coding tasks",
+        enum: ["opus", "sonnet", "haiku"],
+      },
+      reviewEnabled: {
+        type: "boolean",
+        description: "Enable automatic code review",
+      },
+      autoMerge: {
+        type: "boolean",
+        description: "Enable auto-merge when CI passes and review is approved",
+      },
+      autoResume: {
+        type: "boolean",
+        description: "Enable auto-resume when reviewer requests changes",
+      },
+    },
+    required: ["id"],
+  },
+};
+
+// ─── Issue Tools ────────────────────────────────────────────────────────────
+
+const list_issues: OptioToolSchema = {
+  name: "list_issues",
+  description: "List GitHub issues across configured repositories. Can filter by repository URL.",
+  category: "Issues",
+  endpoint: "GET /api/issues",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {
+      repoUrl: {
+        type: "string",
+        description: "Filter issues by repository URL",
+      },
+    },
+  },
+};
+
+const assign_issue: OptioToolSchema = {
+  name: "assign_issue",
+  description:
+    "Assign a GitHub issue to Optio, creating a task from it. The issue title and body " +
+    "become the task title and prompt.",
+  category: "Issues",
+  endpoint: "POST /api/issues/assign",
+  method: "POST",
+  input_schema: {
+    type: "object",
+    properties: {
+      repoUrl: {
+        type: "string",
+        description: "Repository URL the issue belongs to",
+      },
+      issueNumber: {
+        type: "number",
+        description: "The GitHub issue number",
+      },
+    },
+    required: ["repoUrl", "issueNumber"],
+  },
+};
+
+// ─── Pod / Cluster Tools ────────────────────────────────────────────────────
+
+const list_pods: OptioToolSchema = {
+  name: "list_pods",
+  description:
+    "List all active repo pods with their status, active task count, and health information.",
+  category: "Pods",
+  endpoint: "GET /api/cluster",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {},
+  },
+};
+
+const get_pod_health: OptioToolSchema = {
+  name: "get_pod_health",
+  description:
+    "Get detailed health information for a specific pod including recent health events, " +
+    "resource usage, and running tasks.",
+  category: "Pods",
+  endpoint: "GET /api/cluster/:id",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The pod UUID (from repo_pods table)",
+      },
+    },
+    required: ["id"],
+  },
+};
+
+// ─── Cost Tools ─────────────────────────────────────────────────────────────
+
+const get_cost_analytics: OptioToolSchema = {
+  name: "get_cost_analytics",
+  description:
+    "Get cost analytics including total spend, daily breakdown, cost by repo, " +
+    "cost by task type, and top expensive tasks.",
+  category: "Costs",
+  endpoint: "GET /api/analytics/costs",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {
+      days: {
+        type: "number",
+        description: "Number of days to look back",
+        default: 30,
+        minimum: 1,
+        maximum: 365,
+      },
+      repoUrl: {
+        type: "string",
+        description: "Filter costs by repository URL",
+      },
+    },
+  },
+};
+
+// ─── System Tools ───────────────────────────────────────────────────────────
+
+const get_system_status: OptioToolSchema = {
+  name: "get_system_status",
+  description:
+    "Get an aggregate system health summary including task counts by state, " +
+    "pod health, queue depth, today's cost, and any active alerts " +
+    "(recent OOM kills, auth errors, etc.).",
+  category: "System",
+  endpoint: "GET /api/optio/system-status",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {},
+  },
+};
+
+// ─── Watch Tool ─────────────────────────────────────────────────────────────
+
+const watch_task: OptioToolSchema = {
+  name: "watch_task",
+  description:
+    "Watch a task until it reaches a terminal state (completed, failed, cancelled). " +
+    "Polls the task status at a configurable interval and returns the final state. " +
+    "This is a long-running operation with a configurable timeout.",
+  category: "Tasks",
+  endpoint: "GET /api/tasks/:id",
+  method: "GET",
+  input_schema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The task UUID to watch",
+      },
+      pollIntervalSeconds: {
+        type: "number",
+        description: "Seconds between status checks",
+        default: 10,
+        minimum: 5,
+        maximum: 60,
+      },
+      timeoutMinutes: {
+        type: "number",
+        description: "Maximum minutes to watch before giving up",
+        default: 10,
+        minimum: 1,
+        maximum: 60,
+      },
+    },
+    required: ["id"],
+  },
+};
+
+// ─── Exports ────────────────────────────────────────────────────────────────
+
+/** All 18 Optio tool definitions. */
+export const OPTIO_TOOL_SCHEMAS: OptioToolSchema[] = [
+  // Tasks (8)
+  list_tasks,
+  get_task,
+  create_task,
+  retry_task,
+  cancel_task,
+  bulk_retry_failed,
+  bulk_cancel_active,
+  get_task_logs,
+  // Repos (3)
+  list_repos,
+  get_repo,
+  update_repo_settings,
+  // Issues (2)
+  list_issues,
+  assign_issue,
+  // Pods (2)
+  list_pods,
+  get_pod_health,
+  // Costs (1)
+  get_cost_analytics,
+  // System (1)
+  get_system_status,
+  // Watch (1)
+  watch_task,
+];
+
+/** Map of tool name to schema for quick lookup. */
+export const OPTIO_TOOL_MAP: Record<string, OptioToolSchema> = Object.fromEntries(
+  OPTIO_TOOL_SCHEMAS.map((t) => [t.name, t]),
+);
+
+/** All tool names as a flat array. */
+export const OPTIO_TOOL_NAMES: string[] = OPTIO_TOOL_SCHEMAS.map((t) => t.name);
+
+/** Tool schemas grouped by category. */
+export function getToolsByCategory(): Record<string, OptioToolSchema[]> {
+  const grouped: Record<string, OptioToolSchema[]> = {};
+  for (const tool of OPTIO_TOOL_SCHEMAS) {
+    if (!grouped[tool.category]) {
+      grouped[tool.category] = [];
+    }
+    grouped[tool.category].push(tool);
+  }
+  return grouped;
+}
+
+/**
+ * Get tool schemas for a specific set of enabled tools.
+ * Used to build the agent's tool configuration from the enabledTools setting.
+ */
+export function getEnabledToolSchemas(enabledToolNames: string[]): OptioToolSchema[] {
+  const set = new Set(enabledToolNames);
+  return OPTIO_TOOL_SCHEMAS.filter((t) => set.has(t.name));
+}
+
+/** Terminal task states for the watch_task tool. */
+export const TERMINAL_TASK_STATES = ["completed", "failed", "cancelled"] as const;
+
+/** Maximum character length for individual log entries in get_task_logs. */
+export const LOG_ENTRY_MAX_LENGTH = 2000;
+
+/** Default tail count for get_task_logs. */
+export const LOG_TAIL_DEFAULT = 100;


### PR DESCRIPTION
## Summary

- **18 tool definitions** (`packages/shared/src/optio-tools.ts`) — Claude/Codex-compatible function calling schemas covering Tasks, Repos, Issues, Pods, Costs, System, and Watch categories
- **`GET /api/optio/system-status` endpoint** — aggregate system health summary: task counts by state, pod health, queue depth, today's cost, and recent alerts (OOM kills, crashes)
- **Auth passthrough** — session-chat WebSocket extracts the user's raw session token and injects `OPTIO_SESSION_TOKEN` + `OPTIO_API_URL` into the agent pod environment so API calls are attributed to the requesting user

## Details

### Tool definitions
Each tool maps to one or more existing API endpoints with full JSON Schema `input_schema`. Includes helper functions: `getToolsByCategory()`, `getEnabledToolSchemas()`, and `OPTIO_TOOL_MAP` for quick lookups. Constants for log handling (`LOG_ENTRY_MAX_LENGTH`, `LOG_TAIL_DEFAULT`) and terminal states for the `watch_task` polling tool.

### System status endpoint
Queries tasks, repo_pods, and pod_health_events tables to build a real-time health dashboard. Workspace-scoped via `req.user.workspaceId`. Returns structured JSON ready for injection into the Optio agent's system prompt.

### Auth passthrough
Added `extractSessionToken()` to `ws-auth.ts`. The session-chat handler now extracts the token from the WebSocket upgrade request and passes it through as environment variables in the exec script, alongside `OPTIO_API_URL` from server config.

## Test plan
- [x] 19 new tests for tool definitions (schema validation, grouping, filtering, compatibility)
- [x] 3 new tests for system-status endpoint (happy path, empty data, DB error)
- [x] 5 new tests for `extractSessionToken()` (cookie, query param, preference, disabled, missing)
- [x] All 754+ existing tests continue to pass
- [x] Typecheck clean across all packages
- [x] Prettier formatting clean

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)