### PR TITLE
feat: Optio audit trail for all agent actions

### DIFF
--- a/apps/api/src/db/migrations/0033_optio_actions.sql
+++ b/apps/api/src/db/migrations/0033_optio_actions.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "optio_actions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid,
+	"action" text NOT NULL,
+	"params" jsonb,
+	"result" jsonb,
+	"success" boolean NOT NULL,
+	"conversation_snippet" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "optio_actions" ADD CONSTRAINT "optio_actions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "optio_actions_user_id_idx" ON "optio_actions" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "optio_actions_action_idx" ON "optio_actions" USING btree ("action");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "optio_actions_created_at_idx" ON "optio_actions" USING btree ("created_at" DESC NULLS LAST);

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1775750400000,
       "tag": "0032_optio_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1775836800000,
+      "tag": "0033_optio_actions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -583,6 +583,27 @@ export const optioSettings = pgTable(
   (table) => [index("optio_settings_workspace_id_idx").on(table.workspaceId)],
 );
 
+// ── Optio Action Audit Trail ─────────────────────────────────────────────────
+
+export const optioActions = pgTable(
+  "optio_actions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id").references(() => users.id),
+    action: text("action").notNull(), // tool name e.g. "retry_task", "bulk_cancel_active"
+    params: jsonb("params").$type<Record<string, unknown>>(), // sanitized tool call parameters
+    result: jsonb("result").$type<Record<string, unknown>>(), // outcome: affected IDs, error, etc.
+    success: boolean("success").notNull(),
+    conversationSnippet: text("conversation_snippet"), // user message that triggered this
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("optio_actions_user_id_idx").on(table.userId),
+    index("optio_actions_action_idx").on(table.action),
+    index("optio_actions_created_at_idx").on(table.createdAt.desc()),
+  ],
+);
+
 export const promptTemplates = pgTable("prompt_templates", {
   id: uuid("id").primaryKey().defaultRandom(),
   name: text("name").notNull().unique(),

--- a/apps/api/src/routes/optio-actions.test.ts
+++ b/apps/api/src/routes/optio-actions.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+
+// ─── Mocks ───
+
+const mockListActions = vi.fn();
+
+const mockListNamespacedPod = vi.fn().mockResolvedValue({ items: [] });
+
+vi.mock("@kubernetes/client-node", () => ({
+  KubeConfig: vi.fn().mockImplementation(() => ({
+    loadFromDefault: vi.fn(),
+    makeApiClient: vi.fn(() => ({
+      listNamespacedPod: mockListNamespacedPod,
+    })),
+  })),
+  CoreV1Api: vi.fn(),
+}));
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    execute: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../services/optio-action-service.js", () => ({
+  listActions: (...args: unknown[]) => mockListActions(...args),
+}));
+
+import { optioRoutes } from "./optio.js";
+
+// ─── Helpers ───
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.decorateRequest("user", undefined as any);
+  app.addHook("preHandler", (req, _reply, done) => {
+    (req as any).user = { id: "user-1", workspaceId: "ws-1", workspaceRole: "admin" };
+    done();
+  });
+  await optioRoutes(app);
+  await app.ready();
+  return app;
+}
+
+describe("GET /api/optio/actions", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns paginated actions", async () => {
+    const actions = [
+      {
+        id: "a1",
+        userId: "u1",
+        action: "retry_task",
+        params: { id: "task-1" },
+        result: { retried: true },
+        success: true,
+        conversationSnippet: "retry task-1",
+        createdAt: "2026-03-28T10:00:00.000Z",
+        user: { id: "u1", displayName: "Alice", avatarUrl: null },
+      },
+    ];
+    mockListActions.mockResolvedValue({ actions, total: 1 });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/optio/actions",
+      query: { limit: "10", offset: "0" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.actions).toHaveLength(1);
+    expect(body.total).toBe(1);
+    expect(body.actions[0].action).toBe("retry_task");
+    expect(body.actions[0].user.displayName).toBe("Alice");
+  });
+
+  it("passes filters to the service", async () => {
+    mockListActions.mockResolvedValue({ actions: [], total: 0 });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/optio/actions",
+      query: {
+        userId: "550e8400-e29b-41d4-a716-446655440000",
+        action: "cancel_task",
+        success: "false",
+        limit: "25",
+        offset: "10",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockListActions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "550e8400-e29b-41d4-a716-446655440000",
+        action: "cancel_task",
+        success: false,
+        limit: 25,
+        offset: 10,
+      }),
+    );
+  });
+
+  it("applies default pagination values", async () => {
+    mockListActions.mockResolvedValue({ actions: [], total: 0 });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/optio/actions",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockListActions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 50,
+        offset: 0,
+      }),
+    );
+  });
+
+  it("returns 400 for invalid userId format", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/optio/actions",
+      query: { userId: "not-a-uuid" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBeDefined();
+  });
+
+  it("returns 500 when service throws", async () => {
+    mockListActions.mockRejectedValue(new Error("DB connection failed"));
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/optio/actions",
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json().error).toBe("Failed to fetch optio actions");
+  });
+
+  it("supports date range filtering", async () => {
+    mockListActions.mockResolvedValue({ actions: [], total: 0 });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/optio/actions",
+      query: {
+        after: "2026-03-01T00:00:00Z",
+        before: "2026-03-28T23:59:59Z",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const call = mockListActions.mock.calls[0][0];
+    expect(call.after).toBeInstanceOf(Date);
+    expect(call.before).toBeInstanceOf(Date);
+  });
+});

--- a/apps/api/src/routes/optio.ts
+++ b/apps/api/src/routes/optio.ts
@@ -1,7 +1,9 @@
 import type { FastifyInstance } from "fastify";
 import { KubeConfig, CoreV1Api } from "@kubernetes/client-node";
 import { sql } from "drizzle-orm";
+import { z } from "zod";
 import { db } from "../db/client.js";
+import * as optioActionService from "../services/optio-action-service.js";
 
 const NAMESPACE = "optio";
 const POD_ROLE_LABEL = "optio.pod-role=optio";
@@ -215,6 +217,44 @@ export async function optioRoutes(app: FastifyInstance) {
     } catch (err) {
       app.log.error(err, "Failed to fetch system status");
       return reply.status(500).send({ error: "Failed to fetch system status" });
+    }
+  });
+
+  // ── Optio Action Audit Trail ──────────────────────────────────────────────
+
+  const listActionsQuerySchema = z.object({
+    userId: z.string().uuid().optional(),
+    action: z.string().optional(),
+    success: z
+      .enum(["true", "false"])
+      .transform((v) => v === "true")
+      .optional(),
+    after: z
+      .string()
+      .datetime()
+      .transform((v) => new Date(v))
+      .optional(),
+    before: z
+      .string()
+      .datetime()
+      .transform((v) => new Date(v))
+      .optional(),
+    limit: z.coerce.number().int().min(1).max(500).default(50),
+    offset: z.coerce.number().int().min(0).default(0),
+  });
+
+  app.get("/api/optio/actions", async (req, reply) => {
+    const parsed = listActionsQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0].message });
+    }
+
+    try {
+      const { actions, total } = await optioActionService.listActions(parsed.data);
+      return reply.send({ actions, total });
+    } catch (err) {
+      app.log.error(err, "Failed to fetch optio actions");
+      return reply.status(500).send({ error: "Failed to fetch optio actions" });
     }
   });
 }

--- a/apps/api/src/services/optio-action-service.test.ts
+++ b/apps/api/src/services/optio-action-service.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  optioActions: {
+    id: "id",
+    userId: "user_id",
+    action: "action",
+    params: "params",
+    result: "result",
+    success: "success",
+    conversationSnippet: "conversation_snippet",
+    createdAt: { desc: vi.fn() },
+  },
+  users: {
+    id: "id",
+    displayName: "display_name",
+    avatarUrl: "avatar_url",
+  },
+}));
+
+import { db } from "../db/client.js";
+import { logAction, listActions } from "./optio-action-service.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("logAction", () => {
+  it("inserts an action and returns it", async () => {
+    const mockAction = {
+      id: "action-1",
+      userId: "user-1",
+      action: "retry_task",
+      params: { id: "task-1" },
+      result: { retried: true },
+      success: true,
+      conversationSnippet: "Please retry task-1",
+      createdAt: new Date(),
+    };
+    (db.insert as any).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([mockAction]),
+      }),
+    });
+
+    const result = await logAction({
+      userId: "user-1",
+      action: "retry_task",
+      params: { id: "task-1" },
+      result: { retried: true },
+      success: true,
+      conversationSnippet: "Please retry task-1",
+    });
+
+    expect(result).toEqual(mockAction);
+  });
+
+  it("sanitizes sensitive fields in params", async () => {
+    const mockAction = {
+      id: "action-2",
+      action: "create_task",
+      params: { title: "test", apiToken: "[REDACTED]" },
+      success: true,
+      createdAt: new Date(),
+    };
+    const mockReturning = vi.fn().mockResolvedValue([mockAction]);
+    const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+    (db.insert as any).mockReturnValue({ values: mockValues });
+
+    await logAction({
+      action: "create_task",
+      params: { title: "test", apiToken: "secret-value-123" },
+      success: true,
+    });
+
+    // Verify the values call had the sanitized params
+    const insertedValues = mockValues.mock.calls[0][0];
+    expect(insertedValues.params.apiToken).toBe("[REDACTED]");
+    expect(insertedValues.params.title).toBe("test");
+  });
+
+  it("sanitizes various sensitive key patterns", async () => {
+    const mockReturning = vi.fn().mockResolvedValue([{ id: "a" }]);
+    const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+    (db.insert as any).mockReturnValue({ values: mockValues });
+
+    await logAction({
+      action: "test",
+      params: {
+        password: "pass123",
+        SECRET_KEY: "key123",
+        authHeader: "Bearer xyz",
+        normalField: "keep-this",
+        credential: "cred",
+      },
+      success: true,
+    });
+
+    const insertedValues = mockValues.mock.calls[0][0];
+    expect(insertedValues.params.password).toBe("[REDACTED]");
+    expect(insertedValues.params.SECRET_KEY).toBe("[REDACTED]");
+    expect(insertedValues.params.authHeader).toBe("[REDACTED]");
+    expect(insertedValues.params.normalField).toBe("keep-this");
+    expect(insertedValues.params.credential).toBe("[REDACTED]");
+  });
+
+  it("handles null params", async () => {
+    const mockReturning = vi.fn().mockResolvedValue([{ id: "a" }]);
+    const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+    (db.insert as any).mockReturnValue({ values: mockValues });
+
+    await logAction({
+      action: "bulk_cancel_active",
+      params: null,
+      success: true,
+    });
+
+    const insertedValues = mockValues.mock.calls[0][0];
+    expect(insertedValues.params).toBeNull();
+  });
+});
+
+describe("listActions", () => {
+  it("returns actions with user info and total count", async () => {
+    const rows = [
+      {
+        id: "a1",
+        userId: "u1",
+        action: "retry_task",
+        params: { id: "task-1" },
+        result: { retried: true },
+        success: true,
+        conversationSnippet: "Retry that task",
+        createdAt: new Date("2026-01-01"),
+        userName: "Alice",
+        userAvatar: "https://example.com/alice.png",
+      },
+    ];
+
+    // Mock the two parallel queries: rows + count
+    const mockOffset = vi.fn().mockResolvedValue(rows);
+    const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
+    const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockWhere1 = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+    const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere1 });
+    const mockFrom1 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin });
+
+    const mockWhere2 = vi.fn().mockResolvedValue([{ count: "1" }]);
+    const mockFrom2 = vi.fn().mockReturnValue({ where: mockWhere2 });
+
+    let selectCallCount = 0;
+    (db.select as any).mockImplementation(() => {
+      selectCallCount++;
+      if (selectCallCount % 2 === 1) {
+        return { from: mockFrom1 };
+      }
+      return { from: mockFrom2 };
+    });
+
+    const result = await listActions({ limit: 10, offset: 0 });
+
+    expect(result.actions).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.actions[0].user).toEqual({
+      id: "u1",
+      displayName: "Alice",
+      avatarUrl: "https://example.com/alice.png",
+    });
+  });
+
+  it("returns undefined user when userId is null", async () => {
+    const rows = [
+      {
+        id: "a1",
+        userId: null,
+        action: "bulk_cancel_active",
+        params: {},
+        result: { cancelled: 3 },
+        success: true,
+        conversationSnippet: null,
+        createdAt: new Date("2026-01-01"),
+        userName: null,
+        userAvatar: null,
+      },
+    ];
+
+    const mockOffset = vi.fn().mockResolvedValue(rows);
+    const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
+    const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockWhere1 = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+    const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere1 });
+    const mockFrom1 = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin });
+
+    const mockWhere2 = vi.fn().mockResolvedValue([{ count: "1" }]);
+    const mockFrom2 = vi.fn().mockReturnValue({ where: mockWhere2 });
+
+    let selectCallCount = 0;
+    (db.select as any).mockImplementation(() => {
+      selectCallCount++;
+      if (selectCallCount % 2 === 1) {
+        return { from: mockFrom1 };
+      }
+      return { from: mockFrom2 };
+    });
+
+    const result = await listActions();
+
+    expect(result.actions[0].user).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/optio-action-service.ts
+++ b/apps/api/src/services/optio-action-service.ts
@@ -1,0 +1,140 @@
+import { eq, desc, and, gte, lte, sql, type SQL } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { optioActions, users } from "../db/schema.js";
+import type { OptioAction } from "@optio/shared";
+
+// ── Sensitive key patterns to strip from params ─────────────────────────────
+
+const SENSITIVE_KEYS = /token|secret|password|key|credential|auth/i;
+
+/** Remove sensitive fields from a params object before persisting. */
+function sanitizeParams(
+  params: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+  if (!params) return null;
+  const clean: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(params)) {
+    if (SENSITIVE_KEYS.test(k)) {
+      clean[k] = "[REDACTED]";
+    } else {
+      clean[k] = v;
+    }
+  }
+  return clean;
+}
+
+// ── Write ───────────────────────────────────────────────────────────────────
+
+export interface LogActionInput {
+  userId?: string;
+  action: string;
+  params?: Record<string, unknown> | null;
+  result?: Record<string, unknown> | null;
+  success: boolean;
+  conversationSnippet?: string | null;
+}
+
+/**
+ * Record an Optio agent action in the audit trail.
+ * Params are sanitized to strip any sensitive values before storage.
+ */
+export async function logAction(input: LogActionInput): Promise<OptioAction> {
+  const [row] = await db
+    .insert(optioActions)
+    .values({
+      userId: input.userId,
+      action: input.action,
+      params: sanitizeParams(input.params),
+      result: input.result ?? null,
+      success: input.success,
+      conversationSnippet: input.conversationSnippet ?? null,
+    })
+    .returning();
+  return row as unknown as OptioAction;
+}
+
+// ── Read ────────────────────────────────────────────────────────────────────
+
+export interface ListActionsInput {
+  userId?: string;
+  action?: string;
+  success?: boolean;
+  after?: Date;
+  before?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * List Optio actions with optional filters, ordered newest-first.
+ * Joins user info for display.
+ */
+export async function listActions(
+  filters: ListActionsInput = {},
+): Promise<{ actions: OptioAction[]; total: number }> {
+  const limit = Math.min(filters.limit ?? 50, 500);
+  const offset = filters.offset ?? 0;
+
+  const conditions: SQL[] = [];
+  if (filters.userId) {
+    conditions.push(eq(optioActions.userId, filters.userId));
+  }
+  if (filters.action) {
+    conditions.push(eq(optioActions.action, filters.action));
+  }
+  if (filters.success !== undefined) {
+    conditions.push(eq(optioActions.success, filters.success));
+  }
+  if (filters.after) {
+    conditions.push(gte(optioActions.createdAt, filters.after));
+  }
+  if (filters.before) {
+    conditions.push(lte(optioActions.createdAt, filters.before));
+  }
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const [rows, countResult] = await Promise.all([
+    db
+      .select({
+        id: optioActions.id,
+        userId: optioActions.userId,
+        action: optioActions.action,
+        params: optioActions.params,
+        result: optioActions.result,
+        success: optioActions.success,
+        conversationSnippet: optioActions.conversationSnippet,
+        createdAt: optioActions.createdAt,
+        userName: users.displayName,
+        userAvatar: users.avatarUrl,
+      })
+      .from(optioActions)
+      .leftJoin(users, eq(optioActions.userId, users.id))
+      .where(where)
+      .orderBy(desc(optioActions.createdAt))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ count: sql<string>`count(*)::text` })
+      .from(optioActions)
+      .where(where),
+  ]);
+
+  const total = parseInt(countResult[0]?.count ?? "0", 10);
+
+  const actions: OptioAction[] = rows.map((row) => ({
+    id: row.id,
+    userId: row.userId,
+    action: row.action,
+    params: row.params,
+    result: row.result,
+    success: row.success,
+    conversationSnippet: row.conversationSnippet,
+    createdAt: row.createdAt,
+    user: row.userId
+      ? { id: row.userId, displayName: row.userName!, avatarUrl: row.userAvatar }
+      : undefined,
+  }));
+
+  return { actions, total };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,4 +18,5 @@ export * from "./types/session.js";
 export * from "./types/mcp.js";
 export * from "./utils/off-peak.js";
 export * from "./types/optio-settings.js";
+export * from "./types/optio-action.js";
 export * from "./optio-tools.js";

--- a/packages/shared/src/types/optio-action.ts
+++ b/packages/shared/src/types/optio-action.ts
@@ -1,0 +1,17 @@
+/** Audit trail entry for an Optio agent write action. */
+export interface OptioAction {
+  id: string;
+  userId?: string | null;
+  action: string; // tool name e.g. "retry_task", "bulk_cancel_active"
+  params?: Record<string, unknown> | null;
+  result?: Record<string, unknown> | null;
+  success: boolean;
+  conversationSnippet?: string | null;
+  createdAt: Date;
+  /** Joined user info (optional, populated on list queries). */
+  user?: {
+    id: string;
+    displayName: string;
+    avatarUrl?: string | null;
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `optio_actions` database table to log every write operation the Optio agent performs, creating a clear audit trail of who requested what and what happened
- Implements `optio-action-service.ts` with `logAction()` (auto-sanitizes sensitive params) and `listActions()` (paginated, filterable queries with user join)
- Adds `GET /api/optio/actions` endpoint with filters: `userId`, `action`, `success`, `after`/`before` date range, pagination (`limit`/`offset`)

## Test plan
- [x] Service tests verify logAction inserts, param sanitization (tokens/secrets/passwords redacted), null handling
- [x] Route tests verify pagination, filter passthrough, validation (invalid UUID → 400), error handling (500)
- [x] All 767 existing tests pass
- [x] TypeScript compiles cleanly across all 6 packages
- [x] Pre-commit hooks (lint-staged, format, typecheck) all pass

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)