### PR TITLE
fix: copy all workspace package.json files in Dockerfile.web deps stage

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -8,9 +8,13 @@ WORKDIR /app
 # Copy workspace config
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.base.json ./
 
-# Copy package.json and tsconfig for workspace packages
+# Copy package.json for ALL workspace packages (pnpm needs full workspace graph)
+COPY apps/api/package.json apps/api/
 COPY apps/web/package.json apps/web/tsconfig.json apps/web/
 COPY packages/shared/package.json packages/shared/tsconfig.json packages/shared/
+COPY packages/agent-adapters/package.json packages/agent-adapters/
+COPY packages/container-runtime/package.json packages/container-runtime/
+COPY packages/ticket-providers/package.json packages/ticket-providers/
 
 # Install all dependencies (dev deps needed for build)
 RUN pnpm install --frozen-lockfile --prod=false


### PR DESCRIPTION
## Summary

- Adds the 4 missing workspace `package.json` files to the `Dockerfile.web` deps stage (`apps/api`, `packages/agent-adapters`, `packages/container-runtime`, `packages/ticket-providers`)
- `pnpm install --frozen-lockfile` needs the full workspace graph to correctly resolve dependencies and create proper symlinks — only having 2 of 6 packages caused `typescript` (and potentially other deps) to not be symlinked into `packages/shared/node_modules/`
- Only `package.json` files are added (not source code), preserving Docker layer caching

Fixes #212

## Test plan

- [ ] Run `docker build -f Dockerfile.web .` and verify the build succeeds without symlink errors
- [ ] Verify `pnpm install --frozen-lockfile` completes cleanly in the deps stage
- [ ] Verify the final web image starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)