### PR TITLE
fix: use OPTIO_AUTH_DISABLED in ws-auth.ts and update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,8 @@ OPTIO_AUTH_DISABLED=true
 # Must match the secret configured in GitHub's webhook settings
 # GITHUB_WEBHOOK_SECRET=
 
-# Public URLs (used for OAuth callback URLs and redirects)
-# API_PUBLIC_URL=http://localhost:4000
-# WEB_PUBLIC_URL=http://localhost:3000
+# Public URL (used for OAuth callback URLs and redirects)
+# PUBLIC_URL=http://localhost:3000
+
+# WebSocket URL override (optional — only needed when the API runs on a different origin than the web UI)
+# NEXT_PUBLIC_WS_URL=ws://localhost:4000

--- a/apps/web/src/lib/ws-auth.ts
+++ b/apps/web/src/lib/ws-auth.ts
@@ -1,7 +1,7 @@
 import { api } from "./api-client";
 import type { TokenProvider } from "./ws-client";
 
-const AUTH_DISABLED = process.env.NEXT_PUBLIC_AUTH_DISABLED === "true";
+const AUTH_DISABLED = process.env.OPTIO_AUTH_DISABLED === "true";
 
 /** Returns a TokenProvider that fetches short-lived WS tokens from the API. */
 export function getWsTokenProvider(): TokenProvider | undefined {


### PR DESCRIPTION
## Summary
- **Bug fix**: `apps/web/src/lib/ws-auth.ts` still referenced `NEXT_PUBLIC_AUTH_DISABLED` instead of `OPTIO_AUTH_DISABLED` after PR #211's consolidation. This caused `getWsTokenProvider()` to always return a token fetcher even when auth is disabled, triggering unnecessary (and likely failing) token requests.
- **Cleanup**: Updated `.env.example` to replace the removed `API_PUBLIC_URL`/`WEB_PUBLIC_URL` with the consolidated `PUBLIC_URL`.
- **Docs**: Added `NEXT_PUBLIC_WS_URL` to `.env.example` with a comment noting it's optional and only needed when the API runs on a different origin than the web UI.

## Test plan
- [x] `pnpm turbo typecheck` — all 10 tasks pass
- [x] `pnpm turbo test` — all 798 tests pass across 63 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)