### PR TITLE
feat: show issue author username in GitHub Issues view

### DIFF
--- a/apps/api/src/routes/issues.test.ts
+++ b/apps/api/src/routes/issues.test.ts
@@ -82,6 +82,110 @@ describe("GET /api/issues", () => {
     expect(res.json().error).toContain("No GitHub token");
   });
 
+  it("includes author username in issue response", async () => {
+    mockRetrieveSecret.mockResolvedValue("ghp_token");
+
+    // repos query returns one repo
+    const repoChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([
+        {
+          id: "repo-1",
+          repoUrl: "https://github.com/org/repo",
+          fullName: "org/repo",
+          workspaceId: "ws-1",
+        },
+      ]),
+    };
+    // tasks query returns empty
+    const taskChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    };
+    mockDbSelect.mockReturnValueOnce(repoChain).mockReturnValueOnce(taskChain);
+
+    // Mock GitHub API response
+    const mockIssue = {
+      id: 1,
+      number: 42,
+      title: "Test issue",
+      body: "Test body",
+      state: "open",
+      html_url: "https://github.com/org/repo/issues/42",
+      labels: [],
+      user: { login: "testauthor" },
+      assignee: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([mockIssue]),
+      }),
+    );
+
+    const res = await app.inject({ method: "GET", url: "/api/issues" });
+
+    expect(res.statusCode).toBe(200);
+    const { issues } = res.json();
+    expect(issues).toHaveLength(1);
+    expect(issues[0].author).toBe("testauthor");
+    expect(issues[0].number).toBe(42);
+  });
+
+  it("returns null author when issue has no user", async () => {
+    mockRetrieveSecret.mockResolvedValue("ghp_token");
+
+    const repoChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([
+        {
+          id: "repo-1",
+          repoUrl: "https://github.com/org/repo",
+          fullName: "org/repo",
+          workspaceId: "ws-1",
+        },
+      ]),
+    };
+    const taskChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([]),
+    };
+    mockDbSelect.mockReturnValueOnce(repoChain).mockReturnValueOnce(taskChain);
+
+    const mockIssue = {
+      id: 2,
+      number: 43,
+      title: "No author issue",
+      body: "",
+      state: "open",
+      html_url: "https://github.com/org/repo/issues/43",
+      labels: [],
+      user: null,
+      assignee: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([mockIssue]),
+      }),
+    );
+
+    const res = await app.inject({ method: "GET", url: "/api/issues" });
+
+    expect(res.statusCode).toBe(200);
+    const { issues } = res.json();
+    expect(issues).toHaveLength(1);
+    expect(issues[0].author).toBeNull();
+  });
+
   it("returns empty issues when no repos are configured", async () => {
     mockRetrieveSecret.mockResolvedValue("ghp_token");
 

--- a/apps/api/src/routes/issues.ts
+++ b/apps/api/src/routes/issues.ts
@@ -105,6 +105,7 @@ export async function issueRoutes(app: FastifyInstance) {
             url: issue.html_url,
             labels,
             hasOptioLabel,
+            author: issue.user?.login ?? null,
             assignee: issue.assignee?.login,
             repo: {
               id: repo.id,

--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -280,7 +280,8 @@ function IssuesBrowser() {
                       <GitBranch className="w-3 h-3" />
                       {issue.repo.fullName}
                     </span>
-                    {issue.assignee && <span>@{issue.assignee}</span>}
+                    {issue.author && <span>@{issue.author}</span>}
+                    {issue.assignee && <span>assignee: @{issue.assignee}</span>}
                     <span>{formatRelativeTime(issue.updatedAt)}</span>
                   </div>
                   {/* Labels */}


### PR DESCRIPTION
## Summary
- Add `author` field (from GitHub API's `issue.user.login`) to the issues API response
- Display the issue author's `@username` in the Tasks panel GitHub Issues browser
- Disambiguate author from assignee by prefixing assignee display with "assignee:"
- Add 2 tests verifying author field is returned correctly (present and null cases)

## Test plan
- [x] All 800 existing tests pass
- [x] 2 new tests for author field in `issues.test.ts` pass
- [x] TypeScript typecheck passes across all packages
- [x] Next.js production build succeeds
- [x] Pre-commit hooks (lint, format, typecheck) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)