### PR TITLE
feat: add self-update button to web UI

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -21,6 +21,9 @@ RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 # ---- Runtime stage ----
 FROM node:22-slim
 
+ARG OPTIO_VERSION=dev
+ENV OPTIO_VERSION=${OPTIO_VERSION}
+
 # Install tsx globally for TypeScript execution at runtime
 # (workspace packages export .ts source, so the API runs via tsx)
 RUN npm install -g tsx

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -35,6 +35,9 @@ RUN cd apps/web && npx next build
 # ---- Runtime stage ----
 FROM node:22-slim
 
+ARG OPTIO_VERSION=dev
+ENV OPTIO_VERSION=${OPTIO_VERSION}
+
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/apps/api/src/routes/cluster.ts
+++ b/apps/api/src/routes/cluster.ts
@@ -1,10 +1,11 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { KubeConfig, CoreV1Api, CustomObjectsApi } from "@kubernetes/client-node";
+import { KubeConfig, CoreV1Api, AppsV1Api, CustomObjectsApi } from "@kubernetes/client-node";
 import { db } from "../db/client.js";
 import { repoPods, tasks, podHealthEvents, repos } from "../db/schema.js";
 import { eq, desc, and, inArray, sql } from "drizzle-orm";
 import { requireRole } from "../plugins/auth.js";
+import { getVersionInfo, isLocalDev } from "../services/version-service.js";
 
 const healthEventsQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(1000).default(50),
@@ -21,6 +22,10 @@ function getK8sApi() {
 }
 
 const NAMESPACE = "optio";
+
+function getAppsApi() {
+  return getK8sConfig().makeApiClient(AppsV1Api);
+}
 
 function getMetricsApi() {
   return getK8sConfig().makeApiClient(CustomObjectsApi);
@@ -438,4 +443,75 @@ export async function clusterRoutes(app: FastifyInstance) {
       reply.send({ ok: true });
     },
   );
+
+  // Version check — any authenticated user can read
+  app.get("/api/cluster/version", async (_req, reply) => {
+    try {
+      const info = await getVersionInfo();
+      reply.send(info);
+    } catch (err) {
+      reply.status(500).send({ error: String(err) });
+    }
+  });
+
+  // Trigger update — admin only
+  const updateBodySchema = z.object({
+    targetVersion: z.string().regex(/^\d+\.\d+\.\d+$/, "Must be a valid semver version"),
+  });
+
+  app.post("/api/cluster/update", { preHandler: [requireRole("admin")] }, async (req, reply) => {
+    if (isLocalDev()) {
+      return reply
+        .status(400)
+        .send({ error: "Self-update is not available in local development mode" });
+    }
+
+    const parsed = updateBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0].message });
+    }
+    const { targetVersion } = parsed.data;
+
+    const imageOwner = process.env.OPTIO_IMAGE_OWNER ?? "jonwiggins";
+    const registry = "ghcr.io";
+
+    const deployments = [
+      { name: "optio-api", image: `${registry}/${imageOwner}/optio-api:${targetVersion}` },
+      { name: "optio-web", image: `${registry}/${imageOwner}/optio-web:${targetVersion}` },
+    ];
+
+    try {
+      const appsApi = getAppsApi();
+
+      for (const dep of deployments) {
+        try {
+          await appsApi.patchNamespacedDeployment({
+            name: dep.name,
+            namespace: NAMESPACE,
+            body: {
+              spec: {
+                template: {
+                  spec: {
+                    containers: [{ name: dep.name, image: dep.image }],
+                  },
+                },
+              },
+            },
+          });
+        } catch (depErr: any) {
+          // If a deployment doesn't exist, skip it
+          if (depErr?.response?.statusCode === 404) continue;
+          throw depErr;
+        }
+      }
+
+      reply.send({
+        ok: true,
+        targetVersion,
+        message: `Rolling update to v${targetVersion} initiated. The API will restart shortly.`,
+      });
+    } catch (err) {
+      reply.status(500).send({ error: `Failed to trigger update: ${String(err)}` });
+    }
+  });
 }

--- a/apps/api/src/services/version-service.ts
+++ b/apps/api/src/services/version-service.ts
@@ -1,0 +1,97 @@
+/**
+ * Version checking service — fetches the latest Optio version from GHCR
+ * and compares it with the current running version.
+ */
+
+const GHCR_API = "https://ghcr.io/v2";
+const IMAGE_OWNER = process.env.OPTIO_IMAGE_OWNER ?? "jonwiggins";
+const IMAGE_NAME = "optio-api";
+const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
+
+export interface VersionInfo {
+  current: string;
+  latest: string | null;
+  updateAvailable: boolean;
+}
+
+let cachedLatest: { version: string | null; fetchedAt: number } | null = null;
+
+/** Returns the current running version from the OPTIO_VERSION env var. */
+export function getCurrentVersion(): string {
+  return process.env.OPTIO_VERSION ?? "dev";
+}
+
+/** Returns true when the instance is running a local dev build (no version baked in). */
+export function isLocalDev(): boolean {
+  const v = process.env.OPTIO_VERSION;
+  return !v || v === "dev";
+}
+
+/**
+ * Fetch available tags from GHCR for the optio-api image.
+ * Uses the OCI Distribution Spec tags/list endpoint which doesn't require auth
+ * for public packages.
+ */
+async function fetchLatestTag(): Promise<string | null> {
+  try {
+    // First get an anonymous token for the GHCR registry
+    const tokenRes = await fetch(
+      `https://ghcr.io/token?scope=repository:${IMAGE_OWNER}/${IMAGE_NAME}:pull`,
+    );
+    if (!tokenRes.ok) return null;
+    const { token } = (await tokenRes.json()) as { token: string };
+
+    // List tags
+    const tagsRes = await fetch(`${GHCR_API}/${IMAGE_OWNER}/${IMAGE_NAME}/tags/list`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!tagsRes.ok) return null;
+
+    const { tags } = (await tagsRes.json()) as { tags: string[] };
+    if (!tags || tags.length === 0) return null;
+
+    // Filter to semver-like tags (e.g. "1.2.3") and sort descending
+    const semverTags = tags
+      .filter((t) => /^\d+\.\d+\.\d+$/.test(t))
+      .sort((a, b) => compareSemver(b, a));
+
+    return semverTags[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Simple semver comparison: returns negative if a < b, positive if a > b, 0 if equal. */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/** Get the latest version, using a 15-minute cache. */
+export async function getLatestVersion(): Promise<string | null> {
+  if (cachedLatest && Date.now() - cachedLatest.fetchedAt < CACHE_TTL_MS) {
+    return cachedLatest.version;
+  }
+
+  const latest = await fetchLatestTag();
+  cachedLatest = { version: latest, fetchedAt: Date.now() };
+  return latest;
+}
+
+/** Get full version info (current + latest + whether an update is available). */
+export async function getVersionInfo(): Promise<VersionInfo> {
+  const current = getCurrentVersion();
+  const latest = await getLatestVersion();
+
+  let updateAvailable = false;
+  if (latest && current !== "dev" && /^\d+\.\d+\.\d+$/.test(current)) {
+    updateAvailable = compareSemver(latest, current) > 0;
+  }
+
+  return { current, latest, updateAvailable };
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -13,6 +13,7 @@ import {
   WelcomeHero,
 } from "@/components/dashboard";
 import { useOptioChatStore } from "@/hooks/use-optio-chat";
+import { UpdateBanner } from "@/components/update-banner";
 
 export default function OverviewPage() {
   usePageTitle("Overview");
@@ -105,6 +106,8 @@ export default function OverviewPage() {
           <RefreshCw className="w-4 h-4" />
         </button>
       </div>
+
+      <UpdateBanner />
 
       <PipelineStatsBar taskStats={taskStats} />
 

--- a/apps/web/src/components/update-banner.tsx
+++ b/apps/web/src/components/update-banner.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { ArrowUpCircle, X, Loader2, ExternalLink, CheckCircle2 } from "lucide-react";
+import { api } from "@/lib/api-client";
+import { toast } from "sonner";
+
+interface VersionInfo {
+  current: string;
+  latest: string | null;
+  updateAvailable: boolean;
+}
+
+export function UpdateBanner() {
+  const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const [updating, setUpdating] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [updateInitiated, setUpdateInitiated] = useState(false);
+  const previousVersion = useRef<string | null>(null);
+
+  const fetchVersion = useCallback(async () => {
+    try {
+      const info = await api.getClusterVersion();
+      // Detect post-update reconnection: version changed after we triggered an update
+      if (updateInitiated && previousVersion.current && info.current !== previousVersion.current) {
+        setUpdateInitiated(false);
+        setUpdating(false);
+        toast.success(`Updated to v${info.current}`);
+      }
+      previousVersion.current = info.current;
+      setVersionInfo(info);
+    } catch {
+      // Silently fail — version check is not critical
+    }
+  }, [updateInitiated]);
+
+  useEffect(() => {
+    fetchVersion();
+  }, [fetchVersion]);
+
+  // Poll more frequently while an update is in progress
+  useEffect(() => {
+    if (!updateInitiated) return;
+    const interval = setInterval(fetchVersion, 10_000);
+    // Stop polling after 3 minutes — if still not updated, show failure
+    const timeout = setTimeout(() => {
+      if (updateInitiated) {
+        setUpdating(false);
+        setUpdateInitiated(false);
+        toast.error("Update may have failed — version has not changed. Check cluster status.", {
+          duration: 10_000,
+        });
+      }
+    }, 180_000);
+    return () => {
+      clearInterval(interval);
+      clearTimeout(timeout);
+    };
+  }, [updateInitiated, fetchVersion]);
+
+  const handleUpdate = async () => {
+    if (!versionInfo?.latest) return;
+    setShowConfirm(false);
+    setUpdating(true);
+    setUpdateInitiated(true);
+    previousVersion.current = versionInfo.current;
+    try {
+      await api.triggerClusterUpdate(versionInfo.latest);
+      toast.info("Rolling update initiated. The page will reconnect automatically.");
+    } catch (err: any) {
+      setUpdating(false);
+      setUpdateInitiated(false);
+      toast.error(`Update failed: ${err.message}`);
+    }
+  };
+
+  // Don't show if: no data, no update, dev mode, or dismissed
+  if (!versionInfo || !versionInfo.updateAvailable || versionInfo.current === "dev" || dismissed) {
+    return null;
+  }
+
+  const rollbackCommand = `kubectl rollout undo deployment/optio-api deployment/optio-web -n optio`;
+
+  return (
+    <>
+      <div className="relative flex items-center gap-3 px-4 py-3 rounded-lg border border-primary/20 bg-primary/5">
+        <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+          {updating ? (
+            <Loader2 className="w-4 h-4 text-primary animate-spin" />
+          ) : (
+            <ArrowUpCircle className="w-4 h-4 text-primary" />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          {updating ? (
+            <>
+              <p className="text-sm text-text">Updating to v{versionInfo.latest}...</p>
+              <p className="text-xs text-text-muted mt-0.5">
+                The page will reconnect automatically when the update completes.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-text">
+                Update available:{" "}
+                <span className="font-medium text-primary">v{versionInfo.latest}</span>
+                <span className="text-text-muted ml-1">(current: v{versionInfo.current})</span>
+              </p>
+              <p className="text-xs text-text-muted mt-0.5">
+                <a
+                  href="https://github.com/jonwiggins/optio/releases"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 hover:text-primary transition-colors"
+                >
+                  View changelog <ExternalLink className="w-3 h-3" />
+                </a>
+              </p>
+            </>
+          )}
+        </div>
+        {!updating && (
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={() => setShowConfirm(true)}
+              className="px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-white hover:bg-primary/90 transition-colors"
+            >
+              Update
+            </button>
+            <button
+              onClick={() => setDismissed(true)}
+              className="p-1 rounded hover:bg-bg-hover text-text-muted transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Confirmation dialog */}
+      {showConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+          <div className="bg-bg-card border border-border rounded-xl shadow-xl max-w-md w-full mx-4 p-6 space-y-4">
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                <ArrowUpCircle className="w-5 h-5 text-primary" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-text">Confirm Update</h3>
+                <p className="text-sm text-text-muted">
+                  v{versionInfo.current} &rarr; v{versionInfo.latest}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <p className="text-sm text-text">This will update the following deployments:</p>
+                <ul className="text-sm text-text-muted space-y-1 ml-4">
+                  <li className="flex items-center gap-2">
+                    <CheckCircle2 className="w-3.5 h-3.5 text-primary" /> optio-api
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <CheckCircle2 className="w-3.5 h-3.5 text-primary" /> optio-web
+                  </li>
+                </ul>
+              </div>
+
+              <div className="p-3 rounded-lg bg-bg/50 border border-border">
+                <p className="text-xs text-text-muted mb-1.5">
+                  If something goes wrong, roll back with:
+                </p>
+                <code className="text-xs text-text font-mono break-all">{rollbackCommand}</code>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                onClick={() => setShowConfirm(false)}
+                className="px-4 py-2 text-sm rounded-lg border border-border hover:bg-bg-hover text-text transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleUpdate}
+                className="px-4 py-2 text-sm rounded-lg bg-primary text-white hover:bg-primary/90 transition-colors font-medium"
+              >
+                Update to v{versionInfo.latest}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -258,6 +258,19 @@ export const api = {
   restartPod: (id: string) =>
     request<{ ok: boolean }>(`/api/cluster/pods/${id}/restart`, { method: "POST" }),
 
+  getClusterVersion: () =>
+    request<{
+      current: string;
+      latest: string | null;
+      updateAvailable: boolean;
+    }>("/api/cluster/version"),
+
+  triggerClusterUpdate: (targetVersion: string) =>
+    request<{ ok: boolean; targetVersion: string; message: string }>("/api/cluster/update", {
+      method: "POST",
+      body: JSON.stringify({ targetVersion }),
+    }),
+
   // Setup
   getSetupStatus: () =>
     request<{


### PR DESCRIPTION
## Summary

- Add `GET /api/cluster/version` endpoint that checks GHCR for the latest published image tag (with 15-minute cache) and compares against the running version
- Add `POST /api/cluster/update` endpoint (admin only) that patches K8s deployments (`optio-api`, `optio-web`) to use the new image tag via `@kubernetes/client-node`
- Add update banner on the overview page: shows when a new version is available, with a confirmation dialog showing the target version and rollback command
- Bake `OPTIO_VERSION` env var into Dockerfile.api and Dockerfile.web via build arg (defaults to `"dev"` — banner is hidden in local dev mode)
- Post-update reconnection detection: polls the version endpoint after triggering an update and shows a success toast when the version changes, or a failure message after 3 minutes

### Manual follow-up required

The release workflow (`.github/workflows/release.yml`) needs a small change to pass `OPTIO_VERSION` as a build arg to the Docker builds. This requires a token with `workflow` scope. The change is:

```yaml
# In build-services job, before "Build and push" step, add:
- name: Extract version from tag
  id: version
  run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"

# And in the build-push-action, add:
build-args: |
  OPTIO_VERSION=${{ steps.version.outputs.version }}
```

## Test plan

- [ ] Verify `GET /api/cluster/version` returns `{ current: "dev", latest: "...", updateAvailable: false }` in local dev
- [ ] Verify the update banner does NOT appear when `OPTIO_VERSION` is unset or `"dev"`
- [ ] Set `OPTIO_VERSION=0.0.1` env var on the API → verify the banner shows with the latest GHCR version
- [ ] Verify clicking "Update" shows the confirmation dialog with rollback command
- [ ] Verify `POST /api/cluster/update` requires admin role (returns 403 for non-admins)
- [ ] Verify typecheck and tests pass (`pnpm turbo typecheck && pnpm turbo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)