### PR TITLE
fix: address review issues in Gateway API Helm templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ apps/api/.env
 .tool-versions
 .values.local.yaml
 .worktrees/
-issues/

--- a/helm/optio/templates/gateway.yaml
+++ b/helm/optio/templates/gateway.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "optio.labels" . | nindent 4 }}
-  {{- with .Values.gatewayAPI.annotations }}
+  {{- with .Values.gatewayAPI.gatewayAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/optio/templates/httproute.yaml
+++ b/helm/optio/templates/httproute.yaml
@@ -1,3 +1,4 @@
+{{- include "optio.validateNetworking" . }}
 {{- if and .Values.gatewayAPI.enabled (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -6,7 +7,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "optio.labels" . | nindent 4 }}
-  {{- with .Values.gatewayAPI.annotations }}
+  {{- with .Values.gatewayAPI.httpRouteAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -288,7 +288,10 @@ gatewayAPI:
     #       - name: optio-tls
   # Hostname for the Gateway and HTTPRoute. Leave empty for wildcard.
   hostname: ""
-  annotations: {}
+  # Annotations for the Gateway resource (e.g., cert-manager).
+  gatewayAnnotations: {}
+  # Annotations for the HTTPRoute resource (e.g., rate-limiting).
+  httpRouteAnnotations: {}
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Namespace


### PR DESCRIPTION
## Summary

- Added missing `{{- include "optio.validateNetworking" . }}` guard to `httproute.yaml` for consistency with `gateway.yaml`
- Split shared `annotations` into separate `gatewayAnnotations` and `httpRouteAnnotations` in values.yaml so Gateway and HTTPRoute resources can be annotated independently (e.g., cert-manager on Gateway, rate-limiting on HTTPRoute)
- Removed unrelated `issues/` entry from `.gitignore` that was bundled into the Gateway API PR

Closes #215

## Test plan

- [ ] `helm lint helm/optio --set encryption.key=test` passes
- [ ] `helm template` with `gatewayAPI.enabled=true` and `gatewayAPI.gatewayClassName=test` renders both resources with correct annotation keys
- [ ] Verify `validateNetworking` fails when both `ingress.enabled` and `gatewayAPI.enabled` are true

🤖 Generated with [Claude Code](https://claude.com/claude-code)