### PR TITLE
refactor: extract credential secret logic from route into service

### DIFF
--- a/apps/api/src/routes/github-app.test.ts
+++ b/apps/api/src/routes/github-app.test.ts
@@ -14,7 +14,11 @@ vi.mock("../services/github-app-service.js", () => ({
   isGitHubAppConfigured: (...args: unknown[]) => mockIsGitHubAppConfigured(...args),
 }));
 
-import githubAppRoutes, { getCredentialSecret, resetCredentialSecret } from "./github-app.js";
+import githubAppRoutes from "./github-app.js";
+import {
+  getCredentialSecret,
+  resetCredentialSecret,
+} from "../services/credential-secret-service.js";
 
 // ─── Helpers ───
 

--- a/apps/api/src/routes/github-app.ts
+++ b/apps/api/src/routes/github-app.ts
@@ -1,46 +1,14 @@
-import { createHash, timingSafeEqual } from "node:crypto";
+import { timingSafeEqual } from "node:crypto";
 import type { FastifyInstance } from "fastify";
 import { getGitHubToken } from "../services/github-token-service.js";
 import { isGitHubAppConfigured } from "../services/github-app-service.js";
+import {
+  getCredentialSecret,
+  getOrDeriveCredentialSecret,
+  resetCredentialSecret,
+} from "../services/credential-secret-service.js";
 
-function deriveCredentialSecret(): string | null {
-  if (process.env.OPTIO_CREDENTIAL_SECRET) return process.env.OPTIO_CREDENTIAL_SECRET;
-  if (process.env.OPTIO_ENCRYPTION_KEY) {
-    // Derive a separate secret — never expose the raw encryption key to pods.
-    // Must match the Helm template: sha256sum of "{key}:credential-secret"
-    return createHash("sha256")
-      .update(`${process.env.OPTIO_ENCRYPTION_KEY}:credential-secret`)
-      .digest("hex");
-  }
-  return null;
-}
-
-// Lazy-initialized credential secret. Computed on first access so that:
-// 1. Local dev without GitHub App doesn't crash on module load
-// 2. Test module loading order doesn't matter
-let credentialSecret: string | null | undefined;
-
-function getOrDeriveCredentialSecret(): string | null {
-  if (credentialSecret === undefined) {
-    credentialSecret = deriveCredentialSecret();
-  }
-  return credentialSecret;
-}
-
-export function getCredentialSecret(): string {
-  const secret = getOrDeriveCredentialSecret();
-  if (!secret) {
-    throw new Error(
-      "OPTIO_CREDENTIAL_SECRET or OPTIO_ENCRYPTION_KEY required for credential endpoint",
-    );
-  }
-  return secret;
-}
-
-/** Re-derive the credential secret from current env vars. For testing only. */
-export function resetCredentialSecret(): void {
-  credentialSecret = undefined;
-}
+export { getCredentialSecret, resetCredentialSecret };
 
 export function buildStatusResponse(): {
   configured: boolean;

--- a/apps/api/src/services/credential-secret-service.ts
+++ b/apps/api/src/services/credential-secret-service.ts
@@ -1,0 +1,43 @@
+import { createHash } from "node:crypto";
+
+function deriveCredentialSecret(): string | null {
+  if (process.env.OPTIO_CREDENTIAL_SECRET) return process.env.OPTIO_CREDENTIAL_SECRET;
+  if (process.env.OPTIO_ENCRYPTION_KEY) {
+    // Derive a separate secret — never expose the raw encryption key to pods.
+    // Must match the Helm template: sha256sum of "{key}:credential-secret"
+    return createHash("sha256")
+      .update(`${process.env.OPTIO_ENCRYPTION_KEY}:credential-secret`)
+      .digest("hex");
+  }
+  return null;
+}
+
+// Lazy-initialized credential secret. Computed on first access so that:
+// 1. Local dev without GitHub App doesn't crash on module load
+// 2. Test module loading order doesn't matter
+let credentialSecret: string | null | undefined;
+
+function getOrDeriveCredentialSecret(): string | null {
+  if (credentialSecret === undefined) {
+    credentialSecret = deriveCredentialSecret();
+  }
+  return credentialSecret;
+}
+
+export function getCredentialSecret(): string {
+  const secret = getOrDeriveCredentialSecret();
+  if (!secret) {
+    throw new Error(
+      "OPTIO_CREDENTIAL_SECRET or OPTIO_ENCRYPTION_KEY required for credential endpoint",
+    );
+  }
+  return secret;
+}
+
+/** Re-derive the credential secret from current env vars. For testing only. */
+export function resetCredentialSecret(): void {
+  credentialSecret = undefined;
+}
+
+/** Get the credential secret if available, or null. Used by route handlers. */
+export { getOrDeriveCredentialSecret };

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -23,7 +23,7 @@ import { publishEvent } from "../services/event-bus.js";
 import { resolveSecretsForTask, retrieveSecretWithFallback } from "../services/secret-service.js";
 import { getPromptTemplate } from "../services/prompt-template-service.js";
 import { isGitHubAppConfigured } from "../services/github-app-service.js";
-import { getCredentialSecret } from "../routes/github-app.js";
+import { getCredentialSecret } from "../services/credential-secret-service.js";
 import { logger } from "../logger.js";
 
 const redisUrl = process.env.REDIS_URL ?? "redis://localhost:6379";


### PR DESCRIPTION
## Summary
- Extracted `deriveCredentialSecret`, `getOrDeriveCredentialSecret`, `getCredentialSecret`, and `resetCredentialSecret` from `apps/api/src/routes/github-app.ts` into a new `apps/api/src/services/credential-secret-service.ts`
- Updated `task-worker.ts` to import from the service instead of the route file, fixing the inverted dependency direction
- Updated test file to import from the new service location
- Route file re-exports the functions for backward compatibility

## Test plan
- [x] All 828 existing tests pass
- [x] TypeScript typecheck passes across all packages
- [x] Pre-commit hooks (lint, format, typecheck) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)