### PR TITLE
fix: JIRA provider sets repo to project key instead of undefined

### DIFF
--- a/packages/ticket-providers/src/jira.test.ts
+++ b/packages/ticket-providers/src/jira.test.ts
@@ -229,7 +229,7 @@ describe("JiraTicketProvider pagination", () => {
     expect(ticket.url).toBe("https://test.atlassian.net/browse/TEST-123");
     expect(ticket.labels).toEqual(["optio"]);
     expect(ticket.assignee).toBe("Test User");
-    expect(ticket.repo).toBe("TEST");
+    expect(ticket.repo).toBeUndefined();
     expect(ticket.metadata).toMatchObject({
       key: "TEST-123",
       status: "To Do",

--- a/packages/ticket-providers/src/jira.ts
+++ b/packages/ticket-providers/src/jira.ts
@@ -127,7 +127,7 @@ export class JiraTicketProvider implements TicketProvider {
           url: `${jiraConfig.baseUrl}/browse/${issue.key}`,
           labels: fields.labels ?? [],
           assignee: fields.assignee?.displayName,
-          repo: fields.project.key,
+          repo: undefined,
           attachments: attachments.length > 0 ? attachments : undefined,
           metadata: {
             key: issue.key,


### PR DESCRIPTION
## Summary
- Changed `repo: fields.project.key` to `repo: undefined` in the JIRA ticket provider to prevent the ticket sync service from building invalid GitHub URLs (e.g., `https://github.com/TEST`)
- The project key is already preserved in `metadata.projectKey`, matching how the Linear provider handles non-GitHub repos
- Updated corresponding test assertion in `jira.test.ts`

## Test plan
- [x] Existing JIRA provider tests pass (22/22)
- [x] TypeScript typecheck passes across all packages
- [x] Formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Optio Task ID: 7d5ddd15-5f52-4093-82a5-c685858eb12a*