### PR TITLE
feat: add UI for managing task dependencies

### DIFF
--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -30,9 +30,13 @@ import {
   Key,
   Check,
   Copy,
+  Plus,
+  X,
+  Link2,
 } from "lucide-react";
 import { toast } from "sonner";
 import { useOptioChatStore } from "@/hooks/use-optio-chat";
+import { AddDependencyDialog } from "@/components/add-dependency-dialog";
 
 export default function TaskDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -48,6 +52,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   const [tokenSaving, setTokenSaving] = useState(false);
   const [dependents, setDependents] = useState<any[]>([]);
   const [showCreateSubtask, setShowCreateSubtask] = useState(false);
+  const [showAddDependency, setShowAddDependency] = useState(false);
   const optioChat = useOptioChatStore();
   const [newSubtask, setNewSubtask] = useState({
     title: "",
@@ -595,62 +600,105 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
         )}
 
       {/* Dependencies */}
-      {(dependencies.length > 0 || dependents.length > 0) && (
-        <div className="shrink-0 border-b border-border bg-bg px-4 py-2.5">
-          <div className="max-w-5xl mx-auto">
-            {dependencies.length > 0 && (
-              <div className="mb-2">
-                <h3 className="text-xs font-medium text-text-muted mb-1">
-                  Depends on (
-                  {
-                    dependencies.filter(
-                      (d: any) => d.state === "completed" || d.state === "pr_opened",
-                    ).length
-                  }
-                  /{dependencies.length} complete)
-                </h3>
-                <div className="flex flex-wrap gap-1.5">
-                  {dependencies.map((dep: any) => (
-                    <Link
-                      key={dep.id}
-                      href={`/tasks/${dep.id}`}
-                      className={cn(
-                        "inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs border",
-                        dep.state === "completed" || dep.state === "pr_opened"
-                          ? "border-green-500/30 text-green-400 bg-green-500/5"
-                          : dep.state === "failed"
-                            ? "border-red-500/30 text-red-400 bg-red-500/5"
-                            : "border-border text-text-muted bg-bg-card",
-                      )}
-                    >
+      <div className="shrink-0 border-b border-border bg-bg px-4 py-2.5">
+        <div className="max-w-5xl mx-auto">
+          <div className={dependencies.length > 0 ? "mb-2" : ""}>
+            <div className="flex items-center justify-between mb-1">
+              <h3 className="text-xs font-medium text-text-muted">
+                {dependencies.length > 0
+                  ? `Depends on (${dependencies.filter((d: any) => d.state === "completed" || d.state === "pr_opened").length}/${dependencies.length} complete)`
+                  : "Dependencies"}
+              </h3>
+              <button
+                onClick={() => setShowAddDependency(true)}
+                className="flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                <Plus className="w-3 h-3" />
+                Add Dependency
+              </button>
+            </div>
+            {dependencies.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {dependencies.map((dep: any) => (
+                  <div
+                    key={dep.id}
+                    className={cn(
+                      "inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs border group",
+                      dep.state === "completed" || dep.state === "pr_opened"
+                        ? "border-green-500/30 text-green-400 bg-green-500/5"
+                        : dep.state === "failed"
+                          ? "border-red-500/30 text-red-400 bg-red-500/5"
+                          : "border-border text-text-muted bg-bg-card",
+                    )}
+                  >
+                    <Link href={`/tasks/${dep.id}`} className="inline-flex items-center gap-1.5">
                       {dep.title}
                       <span className="opacity-60">{dep.state}</span>
                     </Link>
-                  ))}
-                </div>
-              </div>
-            )}
-            {dependents.length > 0 && (
-              <div>
-                <h3 className="text-xs font-medium text-text-muted mb-1">
-                  Blocks ({dependents.length} task{dependents.length !== 1 ? "s" : ""})
-                </h3>
-                <div className="flex flex-wrap gap-1.5">
-                  {dependents.map((dep: any) => (
-                    <Link
-                      key={dep.id}
-                      href={`/tasks/${dep.id}`}
-                      className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs border border-border text-text-muted bg-bg-card hover:bg-bg-hover"
+                    <button
+                      onClick={async (e) => {
+                        e.stopPropagation();
+                        if (!confirm(`Remove dependency on "${dep.title}"?`)) return;
+                        try {
+                          await api.removeTaskDependency(id, dep.id);
+                          setDependencies((prev) => prev.filter((d: any) => d.id !== dep.id));
+                          toast.success("Dependency removed");
+                        } catch (err) {
+                          toast.error(
+                            err instanceof Error ? err.message : "Failed to remove dependency",
+                          );
+                        }
+                      }}
+                      className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-bg-hover transition-opacity"
+                      title="Remove dependency"
                     >
-                      {dep.title}
-                      <span className="opacity-60">{dep.state}</span>
-                    </Link>
-                  ))}
-                </div>
+                      <X className="w-3 h-3" />
+                    </button>
+                  </div>
+                ))}
               </div>
+            ) : (
+              <p className="text-xs text-text-muted/60">
+                No dependencies. Add one to ensure this task waits for another to complete.
+              </p>
             )}
           </div>
+          {dependents.length > 0 && (
+            <div>
+              <h3 className="text-xs font-medium text-text-muted mb-1">
+                Blocks ({dependents.length} task{dependents.length !== 1 ? "s" : ""})
+              </h3>
+              <div className="flex flex-wrap gap-1.5">
+                {dependents.map((dep: any) => (
+                  <Link
+                    key={dep.id}
+                    href={`/tasks/${dep.id}`}
+                    className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs border border-border text-text-muted bg-bg-card hover:bg-bg-hover"
+                  >
+                    {dep.title}
+                    <span className="opacity-60">{dep.state}</span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
+      </div>
+
+      {/* Add Dependency Dialog */}
+      {showAddDependency && (
+        <AddDependencyDialog
+          taskId={id}
+          existingDependencyIds={dependencies.map((d: any) => d.id)}
+          onAdd={async (depId) => {
+            await api.addTaskDependencies(id, [depId]);
+            const res = await api.getTaskDependencies(id);
+            setDependencies(res.dependencies);
+            setShowAddDependency(false);
+            toast.success("Dependency added");
+          }}
+          onClose={() => setShowAddDependency(false)}
+        />
       )}
 
       {/* Subtasks */}

--- a/apps/web/src/components/add-dependency-dialog.tsx
+++ b/apps/web/src/components/add-dependency-dialog.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api-client";
+import { StateBadge } from "@/components/state-badge";
+import { Search, X, Loader2, Link2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface AddDependencyDialogProps {
+  taskId: string;
+  existingDependencyIds: string[];
+  onAdd: (dependsOnId: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export function AddDependencyDialog({
+  taskId,
+  existingDependencyIds,
+  onAdd,
+  onClose,
+}: AddDependencyDialogProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<any[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [adding, setAdding] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const excludeIds = new Set([taskId, ...existingDependencyIds]);
+
+  const search = useCallback(
+    async (q: string) => {
+      setSearching(true);
+      setError(null);
+      try {
+        const res = await api.searchTasks({ q: q || undefined, limit: 20 });
+        setResults(res.tasks.filter((t: any) => !excludeIds.has(t.id)));
+      } catch {
+        setResults([]);
+      }
+      setSearching(false);
+    },
+    [taskId, existingDependencyIds.join(",")],
+  );
+
+  useEffect(() => {
+    const timer = setTimeout(() => search(query), 300);
+    return () => clearTimeout(timer);
+  }, [query, search]);
+
+  const handleAdd = async (depTaskId: string) => {
+    setAdding(depTaskId);
+    setError(null);
+    try {
+      await onAdd(depTaskId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add dependency");
+      setAdding(null);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-card border border-border rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[70vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <div className="flex items-center gap-2">
+            <Link2 className="w-4 h-4 text-primary" />
+            <h2 className="text-sm font-medium">Add Dependency</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 rounded-md hover:bg-bg-hover text-text-muted transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="px-4 py-2 border-b border-border">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search tasks by title or ID..."
+              autoFocus
+              className="w-full pl-8 pr-3 py-2 rounded-md bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+            />
+          </div>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="px-4 py-2 text-xs text-error bg-error/5 border-b border-error/20">
+            {error}
+          </div>
+        )}
+
+        {/* Results */}
+        <div className="flex-1 overflow-auto">
+          {searching ? (
+            <div className="flex items-center justify-center py-8 text-text-muted text-sm">
+              <Loader2 className="w-4 h-4 animate-spin mr-2" />
+              Searching...
+            </div>
+          ) : results.length === 0 ? (
+            <div className="flex items-center justify-center py-8 text-text-muted text-sm">
+              {query ? "No matching tasks found" : "No tasks available"}
+            </div>
+          ) : (
+            <div className="py-1">
+              {results.map((task: any) => (
+                <button
+                  key={task.id}
+                  onClick={() => handleAdd(task.id)}
+                  disabled={adding !== null}
+                  className={cn(
+                    "w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-bg-hover transition-colors disabled:opacity-50",
+                    adding === task.id && "bg-primary/5",
+                  )}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm truncate">{task.title}</div>
+                    <div className="text-[10px] text-text-muted font-mono mt-0.5">
+                      {task.id.slice(0, 8)}
+                      {task.repoUrl && (
+                        <span className="ml-2">
+                          {task.repoUrl.replace(/.*\/\/[^/]+\//, "").replace(/\.git$/, "")}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <StateBadge state={task.state} />
+                  {adding === task.id && (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin text-primary shrink-0" />
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add "Add Dependency" button on the task detail page that opens a search dialog to find and select tasks by title or ID
- Add remove (X) button on each dependency entry with confirmation prompt
- Dependencies section now always renders (even when empty) with a helpful empty state message
- Circular dependency prevention is handled server-side; errors are shown via toast notifications

## Test plan
- [ ] Open a task detail page — verify the Dependencies section is visible even with no dependencies
- [ ] Click "Add Dependency" — verify search dialog opens and tasks can be searched by title
- [ ] Select a task — verify the dependency is added and the list updates without page reload
- [ ] Hover a dependency badge — verify the X remove button appears
- [ ] Click remove and confirm — verify the dependency is removed
- [ ] Try adding a circular dependency — verify the error toast is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)