### PR TITLE
fix: detect unrecoverable pod failures and cap provisioning retries

### DIFF
--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -242,8 +242,10 @@ spec:
     logger.warn({ err, pvcName }, "Failed to create PVC, pod will use ephemeral storage");
   }
 
+  let podNameForCleanup: string | undefined;
   try {
     const podName = generateRepoPodName(repoUrl);
+    podNameForCleanup = podName;
     const volumes = pvcReady
       ? [{ persistentVolumeClaim: pvcName, mountPath: "/home/agent" }]
       : undefined;
@@ -392,6 +394,24 @@ spec:
         updatedAt: new Date(),
       })
       .where(eq(repoPods.id, record.id));
+
+    // Clean up the K8s pod if it was created — prevents dead pods from
+    // accumulating when provisioning repeatedly fails (e.g. ErrImageNeverPull).
+    if (podNameForCleanup) {
+      try {
+        const rtForCleanup = getRuntime();
+        await rtForCleanup.destroy({ id: podNameForCleanup, name: podNameForCleanup });
+        await deleteNetworkPolicy(podNameForCleanup).catch(() => {});
+        await deleteEnvoyConfigMap(podNameForCleanup).catch(() => {});
+        logger.info({ podName: podNameForCleanup }, "Cleaned up failed pod");
+      } catch (cleanupErr) {
+        logger.warn(
+          { err: cleanupErr, podName: podNameForCleanup },
+          "Failed to cleanup errored pod",
+        );
+      }
+    }
+
     throw err;
   }
 }

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_MAX_TURNS_REVIEW,
   type PresetImageId,
   msUntilOffPeak,
+  classifyError,
 } from "@optio/shared";
 import { getAdapter } from "@optio/agent-adapters";
 import { parseClaudeEvent } from "../services/agent-event-parser.js";
@@ -56,19 +57,26 @@ export function startTaskWorker() {
   const worker = new Worker(
     "tasks",
     async (job) => {
-      const { taskId, resumeSessionId, resumePrompt, restartFromBranch, reviewOverride } =
-        job.data as {
-          taskId: string;
-          resumeSessionId?: string;
-          resumePrompt?: string;
-          restartFromBranch?: boolean;
-          reviewOverride?: {
-            renderedPrompt: string;
-            taskFileContent: string;
-            taskFilePath: string;
-            claudeModel?: string;
-          };
+      const {
+        taskId,
+        resumeSessionId,
+        resumePrompt,
+        restartFromBranch,
+        reviewOverride,
+        provisioningRetryCount = 0,
+      } = job.data as {
+        taskId: string;
+        resumeSessionId?: string;
+        resumePrompt?: string;
+        restartFromBranch?: boolean;
+        provisioningRetryCount?: number;
+        reviewOverride?: {
+          renderedPrompt: string;
+          taskFileContent: string;
+          taskFilePath: string;
+          claudeModel?: string;
         };
+      };
       const log = logger.child({ taskId, jobId: job.id });
       let repoPodId: string | null = null;
 
@@ -741,12 +749,38 @@ export function startTaskWorker() {
           const currentTask = await taskService.getTask(taskId);
           if (currentTask && ["provisioning", "running"].includes(currentTask.state)) {
             await repoPool.updateWorktreeState(taskId, "dirty").catch(() => {});
-            // If the task is still provisioning (pod never started), re-queue
-            // instead of failing — the pod may become available later (e.g.
-            // image pull in progress, node scaling up).
+            // If the task is still provisioning (pod never started), check if
+            // the error is recoverable and we haven't exceeded the retry cap.
             if (currentTask.state === "provisioning") {
+              const MAX_PROVISIONING_RETRIES = 3;
               const errStr = String(err);
-              log.warn({ err: errStr }, "Pod provisioning failed, re-queuing task");
+              const classified = classifyError(errStr);
+              const isUnrecoverable = !classified.retryable;
+              const retriesExhausted = provisioningRetryCount >= MAX_PROVISIONING_RETRIES;
+
+              if (isUnrecoverable || retriesExhausted) {
+                const reason = isUnrecoverable
+                  ? `Unrecoverable provisioning error (${classified.title})`
+                  : `Provisioning failed after ${provisioningRetryCount} retries`;
+                log.error(
+                  { err: errStr, provisioningRetryCount, classified: classified.title },
+                  reason,
+                );
+                await taskService.updateTaskResult(taskId, undefined, errStr);
+                await taskService.transitionTask(
+                  taskId,
+                  TaskState.FAILED,
+                  "provisioning_permanent_failure",
+                  errStr,
+                );
+                return;
+              }
+
+              // Recoverable — re-queue with incremented retry counter
+              log.warn(
+                { err: errStr, provisioningRetryCount: provisioningRetryCount + 1 },
+                "Pod provisioning failed, re-queuing task",
+              );
               await taskService.updateTaskResult(taskId, undefined, errStr);
               await taskService.transitionTask(
                 taskId,
@@ -755,11 +789,18 @@ export function startTaskWorker() {
                 errStr,
               );
               const jitter = Math.floor(Math.random() * 5000);
-              await taskQueue.add("process-task", job.data, {
-                jobId: `${taskId}-provretry-${Date.now()}`,
-                priority: currentTask.priority ?? 100,
-                delay: 30_000 + jitter,
-              });
+              await taskQueue.add(
+                "process-task",
+                {
+                  ...job.data,
+                  provisioningRetryCount: provisioningRetryCount + 1,
+                },
+                {
+                  jobId: `${taskId}-provretry-${Date.now()}`,
+                  priority: currentTask.priority ?? 100,
+                  delay: 30_000 + jitter,
+                },
+              );
               return;
             }
             await taskService.updateTaskResult(taskId, undefined, String(err));

--- a/packages/container-runtime/src/kubernetes.ts
+++ b/packages/container-runtime/src/kubernetes.ts
@@ -429,6 +429,15 @@ export class KubernetesContainerRuntime implements ContainerRuntime {
     this.namespaceEnsured = true;
   }
 
+  /**
+   * Reasons that indicate the pod will never start successfully.
+   * When detected, we fail immediately instead of waiting for the full timeout.
+   */
+  private static readonly TERMINAL_CONTAINER_REASONS = new Set([
+    "ErrImageNeverPull",
+    "InvalidImageName",
+  ]);
+
   private async waitForPodRunning(podName: string): Promise<void> {
     const deadline = Date.now() + POD_READY_TIMEOUT_MS;
 
@@ -449,12 +458,40 @@ export class KubernetesContainerRuntime implements ContainerRuntime {
         return;
       }
 
+      // Check container statuses for unrecoverable errors (e.g. image not
+      // available locally with imagePullPolicy=Never). Waiting for the full
+      // timeout is pointless — these will never self-resolve.
+      const terminalReason = this.getTerminalContainerReason(pod);
+      if (terminalReason) {
+        throw new Error(`Pod "${podName}" failed with unrecoverable error: ${terminalReason}`);
+      }
+
       await this.sleep(POD_READY_POLL_MS);
     }
 
     throw new Error(
       `Timed out waiting for pod "${podName}" to reach Running state after ${POD_READY_TIMEOUT_MS / 1000}s`,
     );
+  }
+
+  /**
+   * Inspect all container statuses (init + regular) for a waiting reason that
+   * is known to be unrecoverable. Returns the reason string if found, or
+   * undefined if the pod might still recover.
+   */
+  private getTerminalContainerReason(pod: V1Pod): string | undefined {
+    const allStatuses = [
+      ...(pod.status?.containerStatuses ?? []),
+      ...(pod.status?.initContainerStatuses ?? []),
+    ];
+    for (const cs of allStatuses) {
+      const reason = cs.state?.waiting?.reason;
+      if (reason && KubernetesContainerRuntime.TERMINAL_CONTAINER_REASONS.has(reason)) {
+        const message = cs.state?.waiting?.message;
+        return message ? `${reason}: ${message}` : reason;
+      }
+    }
+    return undefined;
   }
 
   private async *followLogs(handle: ContainerHandle, opts?: LogOptions): AsyncGenerator<string> {

--- a/packages/shared/src/error-classifier.test.ts
+++ b/packages/shared/src/error-classifier.test.ts
@@ -114,6 +114,22 @@ describe("classifyError", () => {
     expect(result.retryable).toBe(false);
   });
 
+  it("classifies ErrImageNeverPull as non-retryable image error", () => {
+    const result = classifyError(
+      'Pod "optio-repo-abc" failed with unrecoverable error: ErrImageNeverPull: Container image "optio-node:latest" is not present with pull policy of Never',
+    );
+    expect(result.category).toBe("image");
+    expect(result.title).toBe("Container image not available locally");
+    expect(result.retryable).toBe(false);
+  });
+
+  it("classifies InvalidImageName as non-retryable image error", () => {
+    const result = classifyError("InvalidImageName: invalid reference format");
+    expect(result.category).toBe("image");
+    expect(result.title).toBe("Container image not available locally");
+    expect(result.retryable).toBe(false);
+  });
+
   it("handles null/undefined input", () => {
     expect(classifyError(null).category).toBe("unknown");
     expect(classifyError(undefined).category).toBe("unknown");

--- a/packages/shared/src/error-classifier.ts
+++ b/packages/shared/src/error-classifier.ts
@@ -11,6 +11,20 @@ const ERROR_PATTERNS: Array<{
   classify: (match: RegExpMatchArray) => ClassifiedError;
 }> = [
   {
+    pattern: /ErrImageNeverPull|InvalidImageName/i,
+    classify: (match) => {
+      const reason = match[0];
+      return {
+        category: "image",
+        title: "Container image not available locally",
+        description: `Pod failed with ${reason}. The image pull policy is set to "Never" but the required image does not exist on the node. This will never succeed without building the image first.`,
+        remedy:
+          "Build the missing image locally:\n  ./images/build.sh <preset>\nFor example: ./images/build.sh node\nThen retry the task.",
+        retryable: false,
+      };
+    },
+  },
+  {
     pattern: /ImagePullBackOff|ErrImagePull|failed to pull.*image/i,
     classify: () => ({
       category: "image",


### PR DESCRIPTION
## Summary

- **Detect terminal pod failures early**: `waitForPodRunning()` now inspects container statuses for `ErrImageNeverPull` and `InvalidImageName` and throws immediately instead of waiting the full 120s timeout
- **Cap provisioning retries at 3**: The task worker tracks `provisioningRetryCount` in the BullMQ job data and fails permanently after 3 attempts (or immediately for non-retryable errors like missing images)
- **Clean up failed pods**: `createRepoPod()` now destroys the K8s pod on creation failure, preventing dead pods from accumulating (55+ observed in one incident)
- **Classify new error types**: Added `ErrImageNeverPull` and `InvalidImageName` to the error classifier as non-retryable `image` category errors with actionable remedy messages

## Test plan

- [x] All 1064 existing tests pass (847 API + 149 web + 68 agent-adapters)
- [x] New tests for `ErrImageNeverPull` and `InvalidImageName` error classification
- [x] Typecheck passes across all packages
- [x] Formatting passes (Prettier)
- [ ] Manual: deploy to local cluster, remove an agent image, create a task — verify it fails fast with clear error instead of looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)