### PR TITLE
feat: implement Notion as a ticket provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ packages/
                       error classifier, constants, normalize-repo-url
   container-runtime/  ContainerRuntime interface, DockerContainerRuntime, KubernetesContainerRuntime
   agent-adapters/     AgentAdapter interface, ClaudeCodeAdapter, CodexAdapter, CopilotAdapter
-  ticket-providers/   TicketProvider interface, GitHubTicketProvider, LinearTicketProvider, JiraTicketProvider
+  ticket-providers/   TicketProvider interface, GitHubTicketProvider, LinearTicketProvider, JiraTicketProvider, NotionTicketProvider
 
 Dockerfile.api        API server Docker image (tsx-based)
 Dockerfile.web        Web UI Docker image (Next.js production build)
@@ -622,7 +622,7 @@ Six BullMQ workers run as part of the API server:
 - Agent images are built locally — `setup-local.sh` handles this, but CI push to a registry is not yet configured
 - `setup-local.sh` installs `metrics-server` automatically; production clusters should install it separately
 - Workspace RBAC roles (admin/member/viewer) are in the schema but not fully enforced in all routes
-- Notion ticket provider is a stub (GitHub Issues, Linear, and Jira are implemented)
+- All four ticket providers are implemented (GitHub Issues, Linear, Jira, and Notion)
 - Some duplicate-numbered migration files exist from concurrent agent branches — the drizzle journal (`meta/_journal.json`) is authoritative
 - OAuth tokens from `claude setup-token` have limited scopes and may not support usage tracking (Keychain-extracted tokens have full scopes)
 - The API container runs via `tsx` (TypeScript execution) rather than compiled JS, since workspace packages export `./src/index.ts` not `./dist/index.js`

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1097,6 +1097,11 @@ export default function SettingsPage() {
                     {p.source === "github" &&
                       p.config?.owner &&
                       `${p.config.owner}/${p.config.repo}`}
+                    {p.source === "notion" &&
+                      p.config?.databaseId &&
+                      `Database: ${p.config.databaseId}`}
+                    {p.source === "linear" && p.config?.teamId && `Team: ${p.config.teamId}`}
+                    {p.source === "jira" && p.config?.baseUrl && `${p.config.baseUrl}`}
                   </span>
                 </div>
               ))}

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -103,8 +103,12 @@ export default function SetupPage() {
 
   // Step 6: Tickets
   const [enableTickets, setEnableTickets] = useState(false);
+  const [ticketProvider, setTicketProvider] = useState("github");
   const [ticketOwner, setTicketOwner] = useState("");
   const [ticketRepo, setTicketRepo] = useState("");
+  // Notion-specific
+  const [notionApiKey, setNotionApiKey] = useState("");
+  const [notionDatabaseId, setNotionDatabaseId] = useState("");
 
   // Check runtime on mount
   useEffect(() => {
@@ -370,16 +374,27 @@ export default function SetupPage() {
   const saveTicketsStep = async () => {
     setLoading(true);
     try {
-      if (enableTickets && ticketOwner && ticketRepo) {
-        await api.createTicketProvider({
-          source: "github",
-          config: {
-            token: githubToken,
-            owner: ticketOwner,
-            repo: ticketRepo,
-            label: "optio",
-          },
-        });
+      if (enableTickets) {
+        if (ticketProvider === "github" && ticketOwner && ticketRepo) {
+          await api.createTicketProvider({
+            source: "github",
+            config: {
+              token: githubToken,
+              owner: ticketOwner,
+              repo: ticketRepo,
+              label: "optio",
+            },
+          });
+        } else if (ticketProvider === "notion" && notionApiKey && notionDatabaseId) {
+          await api.createTicketProvider({
+            source: "notion",
+            config: {
+              apiKey: notionApiKey,
+              databaseId: notionDatabaseId,
+              label: "optio",
+            },
+          });
+        }
       }
       goNext();
     } catch (err) {
@@ -1238,7 +1253,7 @@ export default function SetupPage() {
                 <h2 className="text-lg font-bold">Ticket Integration</h2>
               </div>
               <p className="text-text-muted text-sm">
-                Optionally connect a GitHub repository to auto-create tasks from issues labeled{" "}
+                Optionally connect a ticket provider to auto-create tasks from items labeled{" "}
                 <code className="px-1 py-0.5 bg-bg rounded text-primary text-xs">optio</code>.
               </p>
 
@@ -1249,7 +1264,12 @@ export default function SetupPage() {
                   onChange={(e) => {
                     setEnableTickets(e.target.checked);
                     // Auto-populate from the first selected repo
-                    if (e.target.checked && !ticketOwner && repos.length > 0) {
+                    if (
+                      e.target.checked &&
+                      ticketProvider === "github" &&
+                      !ticketOwner &&
+                      repos.length > 0
+                    ) {
                       const firstRepo = repos[0];
                       const name = firstRepo.fullName ?? firstRepo.url;
                       const match = name.match(/([^/]+)\/([^/.]+?)(?:\.git)?$/);
@@ -1261,33 +1281,84 @@ export default function SetupPage() {
                   }}
                   className="w-4 h-4 rounded"
                 />
-                <span className="text-sm">Enable GitHub Issues integration</span>
+                <span className="text-sm">Enable ticket integration</span>
               </label>
 
               {enableTickets && (
                 <div className="p-4 rounded-md bg-bg border border-border space-y-3">
-                  <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <label className="block text-xs text-text-muted mb-1">Owner</label>
-                      <input
-                        value={ticketOwner}
-                        onChange={(e) => setTicketOwner(e.target.value)}
-                        placeholder="your-org"
-                        className="w-full px-3 py-2 rounded-md bg-bg-card border border-border text-sm focus:outline-none focus:border-primary"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-xs text-text-muted mb-1">Repository</label>
-                      <input
-                        value={ticketRepo}
-                        onChange={(e) => setTicketRepo(e.target.value)}
-                        placeholder="your-repo"
-                        className="w-full px-3 py-2 rounded-md bg-bg-card border border-border text-sm focus:outline-none focus:border-primary"
-                      />
-                    </div>
+                  <div>
+                    <label className="block text-xs text-text-muted mb-1">Provider</label>
+                    <select
+                      value={ticketProvider}
+                      onChange={(e) => setTicketProvider(e.target.value)}
+                      className="w-full px-3 py-2 rounded-md bg-bg-card border border-border text-sm focus:outline-none focus:border-primary"
+                    >
+                      <option value="github">GitHub Issues</option>
+                      <option value="notion">Notion</option>
+                      <option value="linear">Linear</option>
+                      <option value="jira">Jira</option>
+                    </select>
                   </div>
+
+                  {ticketProvider === "github" && (
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="block text-xs text-text-muted mb-1">Owner</label>
+                        <input
+                          value={ticketOwner}
+                          onChange={(e) => setTicketOwner(e.target.value)}
+                          placeholder="your-org"
+                          className="w-full px-3 py-2 rounded-md bg-bg-card border border-border text-sm focus:outline-none focus:border-primary"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-text-muted mb-1">Repository</label>
+                        <input
+                          value={ticketRepo}
+                          onChange={(e) => setTicketRepo(e.target.value)}
+                          placeholder="your-repo"
+                          className="w-full px-3 py-2 rounded-md bg-bg-card border border-border text-sm focus:outline-none focus:border-primary"
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  {ticketProvider === "notion" && (
+                    <div className="space-y-3">
+                      <div>
+                        <label className="block text-xs text-text-muted mb-1">
+                          Integration Token
+                        </label>
+                        <input
+                          type="password"
+                          value={notionApiKey}
+                          onChange={(e) => setNotionApiKey(e.target.value)}
+                          placeholder="ntn_..."
+                          className="w-full px-3 py-2 rounded-md bg-bg-card border border-border text-sm focus:outline-none focus:border-primary"
+                        />
+                        <p className="text-xs text-text-muted mt-1">
+                          Create an integration at notion.so/my-integrations and share the database
+                          with it.
+                        </p>
+                      </div>
+                      <div>
+                        <label className="block text-xs text-text-muted mb-1">Database ID</label>
+                        <input
+                          value={notionDatabaseId}
+                          onChange={(e) => setNotionDatabaseId(e.target.value)}
+                          placeholder="abc123..."
+                          className="w-full px-3 py-2 rounded-md bg-bg-card border border-border text-sm focus:outline-none focus:border-primary"
+                        />
+                        <p className="text-xs text-text-muted mt-1">
+                          Found in the database URL after the workspace name and before the query
+                          string.
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
                   <p className="text-xs text-text-muted">
-                    Issues with the{" "}
+                    Items with the{" "}
                     <code className="px-1 py-0.5 bg-bg-card rounded text-primary">optio</code> label
                     will be synced automatically.
                   </p>

--- a/packages/shared/src/types/ticket.ts
+++ b/packages/shared/src/types/ticket.ts
@@ -2,6 +2,7 @@ export enum TicketSource {
   GITHUB = "github",
   LINEAR = "linear",
   JIRA = "jira",
+  NOTION = "notion",
 }
 
 export interface TicketComment {

--- a/packages/ticket-providers/package.json
+++ b/packages/ticket-providers/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@optio/shared": "workspace:*",
+    "@notionhq/client": "^2.2.15",
     "@octokit/rest": "^21.1.1",
     "@linear/sdk": "^37.0.0",
     "jira.js": "^4.0.0"

--- a/packages/ticket-providers/src/index.ts
+++ b/packages/ticket-providers/src/index.ts
@@ -2,12 +2,14 @@ export type { TicketProvider } from "./types.js";
 export { GitHubTicketProvider } from "./github.js";
 export { LinearTicketProvider } from "./linear.js";
 export { JiraTicketProvider } from "./jira.js";
+export { NotionTicketProvider } from "./notion.js";
 
 import type { TicketProvider } from "./types.js";
 import type { TicketSource } from "@optio/shared";
 import { GitHubTicketProvider } from "./github.js";
 import { LinearTicketProvider } from "./linear.js";
 import { JiraTicketProvider } from "./jira.js";
+import { NotionTicketProvider } from "./notion.js";
 
 export function getTicketProvider(source: TicketSource): TicketProvider {
   switch (source) {
@@ -17,6 +19,8 @@ export function getTicketProvider(source: TicketSource): TicketProvider {
       return new LinearTicketProvider();
     case "jira":
       return new JiraTicketProvider();
+    case "notion":
+      return new NotionTicketProvider();
     default:
       throw new Error(`Unknown ticket source: ${source}`);
   }

--- a/packages/ticket-providers/src/notion.test.ts
+++ b/packages/ticket-providers/src/notion.test.ts
@@ -1,0 +1,465 @@
+import { describe, it, expect, vi } from "vitest";
+import { NotionTicketProvider, asNotionConfig } from "./notion.js";
+import type { NotionProviderConfig } from "./notion.js";
+
+vi.mock("@notionhq/client", () => {
+  return {
+    Client: vi.fn().mockImplementation(() => ({
+      databases: {
+        query: vi.fn(),
+      },
+      blocks: {
+        children: {
+          list: vi.fn(),
+        },
+      },
+      comments: {
+        list: vi.fn(),
+        create: vi.fn(),
+      },
+      pages: {
+        update: vi.fn(),
+      },
+    })),
+  };
+});
+
+import { Client } from "@notionhq/client";
+
+function makeNotionPage(id: string, num: number, labels: string[] = ["optio"]) {
+  return {
+    id,
+    url: `https://notion.so/${id.replace(/-/g, "")}`,
+    created_time: "2025-01-01T00:00:00Z",
+    last_edited_time: "2025-01-01T00:00:00Z",
+    properties: {
+      Name: {
+        type: "title",
+        title: [{ plain_text: `Task ${num}` }],
+      },
+      Status: {
+        type: "status",
+        status: { name: "In Progress" },
+      },
+      Tags: {
+        type: "multi_select",
+        multi_select: labels.map((l) => ({ name: l })),
+      },
+      Assignee: {
+        type: "people",
+        people: [{ name: "Test User", id: "user-1" }],
+      },
+    },
+  };
+}
+
+function baseConfig(): NotionProviderConfig {
+  return { apiKey: "ntn_test-token", databaseId: "db-123" };
+}
+
+describe("NotionTicketProvider config validation", () => {
+  it("throws when apiKey is missing", () => {
+    expect(() => asNotionConfig({ databaseId: "db-123" })).toThrow(
+      "Notion provider requires apiKey and databaseId in config",
+    );
+  });
+
+  it("throws when databaseId is missing", () => {
+    expect(() => asNotionConfig({ apiKey: "ntn_test" })).toThrow(
+      "Notion provider requires apiKey and databaseId in config",
+    );
+  });
+
+  it("returns config when valid", () => {
+    const config = asNotionConfig({ apiKey: "ntn_test", databaseId: "db-123" });
+    expect(config.apiKey).toBe("ntn_test");
+    expect(config.databaseId).toBe("db-123");
+  });
+});
+
+describe("NotionTicketProvider fetchActionableTickets", () => {
+  it("fetches a single page of results", async () => {
+    const pages = Array.from({ length: 3 }, (_, i) => makeNotionPage(`page-${i + 1}`, i + 1));
+
+    const query = vi.fn().mockResolvedValueOnce({
+      results: pages,
+      has_more: false,
+      next_cursor: null,
+    });
+    const blocksList = vi.fn().mockResolvedValue({
+      results: [
+        {
+          type: "paragraph",
+          paragraph: { rich_text: [{ plain_text: "Page content" }] },
+        },
+      ],
+    });
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          databases: { query },
+          blocks: { children: { list: blocksList } },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(3);
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        database_id: "db-123",
+        page_size: 100,
+      }),
+    );
+  });
+
+  it("paginates using cursor-based pagination", async () => {
+    const page1 = Array.from({ length: 2 }, (_, i) => makeNotionPage(`page-${i + 1}`, i + 1));
+    const page2 = [makeNotionPage("page-3", 3)];
+
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({
+        results: page1,
+        has_more: true,
+        next_cursor: "cursor-abc",
+      })
+      .mockResolvedValueOnce({
+        results: page2,
+        has_more: false,
+        next_cursor: null,
+      });
+    const blocksList = vi.fn().mockResolvedValue({
+      results: [],
+    });
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          databases: { query },
+          blocks: { children: { list: blocksList } },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(3);
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ start_cursor: "cursor-abc" }),
+    );
+  });
+
+  it("respects maxPages limit", async () => {
+    const pages = Array.from({ length: 2 }, (_, i) => makeNotionPage(`page-${i + 1}`, i + 1));
+
+    const query = vi.fn().mockResolvedValue({
+      results: pages,
+      has_more: true,
+      next_cursor: "cursor-next",
+    });
+    const blocksList = vi.fn().mockResolvedValue({
+      results: [],
+    });
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          databases: { query },
+          blocks: { children: { list: blocksList } },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    const config: NotionProviderConfig = { ...baseConfig(), maxPages: 1 };
+    const tickets = await provider.fetchActionableTickets(config);
+
+    // Only one page fetched, so only 2 tickets
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(tickets).toHaveLength(2);
+  });
+
+  it("returns empty array when no results", async () => {
+    const query = vi.fn().mockResolvedValueOnce({
+      results: [],
+      has_more: false,
+      next_cursor: null,
+    });
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          databases: { query },
+          blocks: { children: { list: vi.fn() } },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(0);
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters pages by label", async () => {
+    const pages = [
+      makeNotionPage("page-1", 1, ["optio"]),
+      makeNotionPage("page-2", 2, ["other-label"]),
+      makeNotionPage("page-3", 3, ["optio", "bug"]),
+    ];
+
+    const query = vi.fn().mockResolvedValueOnce({
+      results: pages,
+      has_more: false,
+      next_cursor: null,
+    });
+    const blocksList = vi.fn().mockResolvedValue({
+      results: [],
+    });
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          databases: { query },
+          blocks: { children: { list: blocksList } },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(2);
+    expect(tickets.map((t) => t.externalId)).toEqual(["page-1", "page-3"]);
+  });
+
+  it("transforms Notion page to Ticket format correctly", async () => {
+    const page = makeNotionPage("page-abc-123", 1, ["optio"]);
+    const query = vi.fn().mockResolvedValueOnce({
+      results: [page],
+      has_more: false,
+      next_cursor: null,
+    });
+    const blocksList = vi.fn().mockResolvedValue({
+      results: [
+        {
+          type: "paragraph",
+          paragraph: { rich_text: [{ plain_text: "Task description here" }] },
+        },
+      ],
+    });
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          databases: { query },
+          blocks: { children: { list: blocksList } },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets).toHaveLength(1);
+    const ticket = tickets[0];
+    expect(ticket.externalId).toBe("page-abc-123");
+    expect(ticket.source).toBe("notion");
+    expect(ticket.title).toBe("Task 1");
+    expect(ticket.body).toBe("Task description here");
+    expect(ticket.labels).toEqual(["optio"]);
+    expect(ticket.assignee).toBe("Test User");
+    expect(ticket.repo).toBeUndefined();
+    expect(ticket.metadata).toMatchObject({
+      pageId: "page-abc-123",
+      status: "In Progress",
+    });
+  });
+
+  it("uses custom statusProperty and doneValue", async () => {
+    const query = vi.fn().mockResolvedValueOnce({
+      results: [],
+      has_more: false,
+      next_cursor: null,
+    });
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          databases: { query },
+          blocks: { children: { list: vi.fn() } },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    const config: NotionProviderConfig = {
+      ...baseConfig(),
+      statusProperty: "Phase",
+      doneValue: "Completed",
+    };
+    await provider.fetchActionableTickets(config);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: {
+          and: [
+            {
+              property: "Phase",
+              status: { does_not_equal: "Completed" },
+            },
+          ],
+        },
+      }),
+    );
+  });
+});
+
+describe("NotionTicketProvider fetchTicketComments", () => {
+  it("fetches comments for a page", async () => {
+    const commentsList = vi.fn().mockResolvedValueOnce({
+      results: [
+        {
+          created_by: { name: "Alice" },
+          rich_text: [{ plain_text: "Looks good!" }],
+          created_time: "2025-01-15T10:00:00Z",
+        },
+        {
+          created_by: { id: "user-2" },
+          rich_text: [{ plain_text: "Needs changes" }],
+          created_time: "2025-01-16T10:00:00Z",
+        },
+      ],
+    });
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          comments: { list: commentsList },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    const comments = await provider.fetchTicketComments("page-123", baseConfig());
+
+    expect(comments).toHaveLength(2);
+    expect(comments[0]).toEqual({
+      author: "Alice",
+      body: "Looks good!",
+      createdAt: "2025-01-15T10:00:00Z",
+    });
+    expect(comments[1]).toEqual({
+      author: "user-2",
+      body: "Needs changes",
+      createdAt: "2025-01-16T10:00:00Z",
+    });
+    expect(commentsList).toHaveBeenCalledWith({
+      block_id: "page-123",
+      page_size: 100,
+    });
+  });
+});
+
+describe("NotionTicketProvider addComment", () => {
+  it("creates a comment on a page", async () => {
+    const create = vi.fn().mockResolvedValueOnce({});
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          comments: { create },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    await provider.addComment("page-123", "Agent completed the task", baseConfig());
+
+    expect(create).toHaveBeenCalledWith({
+      parent: { page_id: "page-123" },
+      rich_text: [
+        {
+          type: "text",
+          text: { content: "Agent completed the task" },
+        },
+      ],
+    });
+  });
+});
+
+describe("NotionTicketProvider updateState", () => {
+  it("updates page status to done value when closing", async () => {
+    const update = vi.fn().mockResolvedValueOnce({});
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          pages: { update },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    await provider.updateState("page-123", "closed", baseConfig());
+
+    expect(update).toHaveBeenCalledWith({
+      page_id: "page-123",
+      properties: {
+        Status: {
+          status: { name: "Done" },
+        },
+      },
+    });
+  });
+
+  it("updates page status to open value when reopening", async () => {
+    const update = vi.fn().mockResolvedValueOnce({});
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          pages: { update },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    await provider.updateState("page-123", "open", baseConfig());
+
+    expect(update).toHaveBeenCalledWith({
+      page_id: "page-123",
+      properties: {
+        Status: {
+          status: { name: "Not started" },
+        },
+      },
+    });
+  });
+
+  it("uses custom statusProperty and doneValue", async () => {
+    const update = vi.fn().mockResolvedValueOnce({});
+
+    vi.mocked(Client).mockImplementation(
+      () =>
+        ({
+          pages: { update },
+        }) as unknown as InstanceType<typeof Client>,
+    );
+
+    const provider = new NotionTicketProvider();
+    const config: NotionProviderConfig = {
+      ...baseConfig(),
+      statusProperty: "Phase",
+      doneValue: "Completed",
+    };
+    await provider.updateState("page-123", "closed", config);
+
+    expect(update).toHaveBeenCalledWith({
+      page_id: "page-123",
+      properties: {
+        Phase: {
+          status: { name: "Completed" },
+        },
+      },
+    });
+  });
+});

--- a/packages/ticket-providers/src/notion.ts
+++ b/packages/ticket-providers/src/notion.ts
@@ -1,0 +1,224 @@
+import { Client } from "@notionhq/client";
+import {
+  TicketSource,
+  DEFAULT_TICKET_LABEL,
+  DEFAULT_MAX_TICKET_PAGES,
+  type Ticket,
+  type TicketComment,
+  type TicketProviderConfig,
+} from "@optio/shared";
+import type { TicketProvider } from "./types.js";
+
+/**
+ * Convert Notion rich text array to plaintext.
+ */
+function richTextToPlaintext(richText: Array<{ plain_text: string }>): string {
+  return richText.map((rt) => rt.plain_text).join("");
+}
+
+/**
+ * Extract plaintext from Notion block children (page body content).
+ */
+function blocksToPlaintext(blocks: any[]): string {
+  const parts: string[] = [];
+
+  for (const block of blocks) {
+    const type = block.type;
+    const data = block[type];
+
+    if (data?.rich_text) {
+      parts.push(richTextToPlaintext(data.rich_text));
+    } else if (type === "divider") {
+      parts.push("---");
+    }
+  }
+
+  return parts.join("\n");
+}
+
+export interface NotionProviderConfig extends TicketProviderConfig {
+  apiKey: string;
+  databaseId: string;
+  label?: string;
+  statusProperty?: string;
+  doneValue?: string;
+  titleProperty?: string;
+  maxPages?: number;
+}
+
+export function asNotionConfig(config: TicketProviderConfig): NotionProviderConfig {
+  const c = config as NotionProviderConfig;
+  if (!c.apiKey || !c.databaseId) {
+    throw new Error("Notion provider requires apiKey and databaseId in config");
+  }
+  return c;
+}
+
+export class NotionTicketProvider implements TicketProvider {
+  readonly source = TicketSource.NOTION;
+
+  async fetchActionableTickets(config: TicketProviderConfig): Promise<Ticket[]> {
+    const notionConfig = asNotionConfig(config);
+    const client = new Client({ auth: notionConfig.apiKey });
+    const label = notionConfig.label ?? DEFAULT_TICKET_LABEL;
+    const maxPages = notionConfig.maxPages ?? DEFAULT_MAX_TICKET_PAGES;
+    const statusProperty = notionConfig.statusProperty ?? "Status";
+    const doneValue = notionConfig.doneValue ?? "Done";
+    const titleProperty = notionConfig.titleProperty ?? "Name";
+
+    const allTickets: Ticket[] = [];
+    let startCursor: string | undefined;
+    let pageCount = 0;
+
+    while (pageCount < maxPages) {
+      const response = await client.databases.query({
+        database_id: notionConfig.databaseId,
+        filter: {
+          and: [
+            {
+              property: statusProperty,
+              status: {
+                does_not_equal: doneValue,
+              },
+            },
+          ],
+        },
+        ...(startCursor ? { start_cursor: startCursor } : {}),
+        page_size: 100,
+      });
+
+      for (const page of response.results) {
+        if (!("properties" in page)) continue;
+
+        const properties = page.properties as Record<string, any>;
+
+        // Extract title
+        const titleProp = properties[titleProperty];
+        const title = titleProp?.title ? richTextToPlaintext(titleProp.title) : "";
+
+        // Extract labels from multi-select Tags/Labels property
+        const labels: string[] = [];
+        for (const [, prop] of Object.entries(properties)) {
+          const p = prop as any;
+          if (p.type === "multi_select") {
+            for (const option of p.multi_select) {
+              labels.push(option.name);
+            }
+          }
+        }
+
+        // Filter by label if configured
+        if (label && !labels.some((l) => l.toLowerCase() === label.toLowerCase())) {
+          continue;
+        }
+
+        // Extract status
+        const statusProp = properties[statusProperty];
+        const status = statusProp?.status?.name ?? statusProp?.select?.name ?? "";
+
+        // Extract assignee from People property
+        let assignee: string | undefined;
+        for (const [, prop] of Object.entries(properties)) {
+          const p = prop as any;
+          if (p.type === "people" && p.people?.length > 0) {
+            assignee = p.people[0].name ?? p.people[0].id;
+            break;
+          }
+        }
+
+        // Fetch page content blocks for body
+        let body = "";
+        try {
+          const blocks = await client.blocks.children.list({
+            block_id: page.id,
+            page_size: 100,
+          });
+          body = blocksToPlaintext(blocks.results);
+        } catch {
+          // If we can't read blocks, use empty body
+        }
+
+        allTickets.push({
+          externalId: page.id,
+          source: TicketSource.NOTION,
+          title,
+          body,
+          url: (page as any).url ?? `https://notion.so/${page.id.replace(/-/g, "")}`,
+          labels,
+          assignee,
+          repo: undefined,
+          metadata: {
+            pageId: page.id,
+            status,
+            createdTime: (page as any).created_time,
+            lastEditedTime: (page as any).last_edited_time,
+          },
+        });
+      }
+
+      if (!response.has_more || !response.next_cursor) break;
+      startCursor = response.next_cursor;
+      pageCount++;
+    }
+
+    return allTickets;
+  }
+
+  async fetchTicketComments(
+    ticketId: string,
+    config: TicketProviderConfig,
+  ): Promise<TicketComment[]> {
+    const notionConfig = asNotionConfig(config);
+    const client = new Client({ auth: notionConfig.apiKey });
+
+    const response = await client.comments.list({
+      block_id: ticketId,
+      page_size: 100,
+    });
+
+    return response.results.map((comment: any) => ({
+      author: comment.created_by?.name ?? comment.created_by?.id ?? "unknown",
+      body: richTextToPlaintext(comment.rich_text ?? []),
+      createdAt: comment.created_time ?? "",
+    }));
+  }
+
+  async addComment(ticketId: string, comment: string, config: TicketProviderConfig): Promise<void> {
+    const notionConfig = asNotionConfig(config);
+    const client = new Client({ auth: notionConfig.apiKey });
+
+    await client.comments.create({
+      parent: { page_id: ticketId },
+      rich_text: [
+        {
+          type: "text",
+          text: { content: comment },
+        },
+      ],
+    });
+  }
+
+  async updateState(
+    ticketId: string,
+    state: "open" | "closed",
+    config: TicketProviderConfig,
+  ): Promise<void> {
+    const notionConfig = asNotionConfig(config);
+    const client = new Client({ auth: notionConfig.apiKey });
+    const statusProperty = notionConfig.statusProperty ?? "Status";
+    const doneValue = notionConfig.doneValue ?? "Done";
+
+    const newStatus = state === "closed" ? doneValue : "Not started";
+
+    await client.pages.update({
+      page_id: ticketId,
+      properties: {
+        [statusProperty]: {
+          status: {
+            name: newStatus,
+          },
+        },
+      },
+    });
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,6 +295,9 @@ importers:
       '@linear/sdk':
         specifier: ^37.0.0
         version: 37.0.0
+      '@notionhq/client':
+        specifier: ^2.2.15
+        version: 2.3.0
       '@octokit/rest':
         specifier: ^21.1.1
         version: 21.1.1
@@ -1286,6 +1289,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@notionhq/client@2.3.0':
+    resolution: {integrity: sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==}
+    engines: {node: '>=12'}
 
   '@octokit/auth-token@5.1.2':
     resolution: {integrity: sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==}
@@ -5064,6 +5071,13 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.5.14':
     optional: true
+
+  '@notionhq/client@2.3.0':
+    dependencies:
+      '@types/node-fetch': 2.6.13
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@octokit/auth-token@5.1.2': {}
 


### PR DESCRIPTION
## Summary

- Implements a fully functional Notion ticket provider (`NotionTicketProvider`) on par with GitHub Issues, Linear, and Jira integrations
- Notion databases can now be synced into Optio as agent tasks, with support for configurable status/title properties, label filtering, cursor-based pagination, rich text conversion, comments, and state updates
- Adds `@notionhq/client` SDK and comprehensive unit tests covering config validation, pagination, filtering, field mapping, comments, and state transitions

## Changes

- `packages/shared/src/types/ticket.ts` — Add `NOTION = "notion"` to `TicketSource` enum
- `packages/ticket-providers/src/notion.ts` — Full provider implementation (new file)
- `packages/ticket-providers/src/notion.test.ts` — Unit tests (new file)
- `packages/ticket-providers/src/index.ts` — Add to factory + exports
- `packages/ticket-providers/package.json` — Add `@notionhq/client` dependency
- `apps/web/src/app/setup/page.tsx` — Add provider selector dropdown with Notion-specific config fields
- `apps/web/src/app/settings/page.tsx` — Display Notion provider info in ticket integration section
- `CLAUDE.md` — Update docs, remove stub note

## Test plan

- [x] All existing tests pass (847 tests across all packages)
- [x] New Notion provider tests pass (config validation, pagination, label filtering, field mapping, comments, state updates)
- [x] TypeScript typecheck passes across all packages
- [ ] Manual: Configure Notion integration in setup wizard with database ID and API key
- [ ] Manual: Verify ticket sync pulls items from Notion database
- [ ] Manual: Verify comments are posted back to Notion pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)