### PR TITLE
fix: validate package names in repo-init.sh to prevent command injection

### DIFF
--- a/scripts/repo-init.sh
+++ b/scripts/repo-init.sh
@@ -48,6 +48,13 @@ fi
 # Install extra packages if requested (comma or space separated)
 if [ -n "${OPTIO_EXTRA_PACKAGES:-}" ]; then
   PACKAGES=$(echo "${OPTIO_EXTRA_PACKAGES}" | tr ',' ' ')
+  # Validate package names to prevent command injection
+  for pkg in ${PACKAGES}; do
+    if [[ ! "$pkg" =~ ^[a-zA-Z0-9][a-zA-Z0-9.+\-]+$ ]]; then
+      echo "[optio] Error: invalid package name: $pkg" >&2
+      exit 1
+    fi
+  done
   echo "[optio] Installing packages: ${PACKAGES}"
   sudo apt-get update -qq 2>/dev/null && sudo apt-get install -y -qq ${PACKAGES} 2>&1 | tail -3 || echo "[optio] Warning: package install failed"
 fi


### PR DESCRIPTION
## Summary
- Fixes command injection vulnerability in `scripts/repo-init.sh` where `OPTIO_EXTRA_PACKAGES` was passed unvalidated to `apt-get install`
- Adds regex allowlist validation (`^[a-zA-Z0-9][a-zA-Z0-9.+-]+$`) that rejects malformed package names before installation
- Script exits with error if any package name fails validation

## Test plan
- [ ] Verify valid package names (e.g., `curl`, `build-essential`, `libssl-dev`) pass validation
- [ ] Verify malicious input (e.g., `curl; rm -rf /`, `$(whoami)`, `` `id` ``) is rejected
- [ ] Verify comma-separated and space-separated package lists still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)