### PR TITLE
fix: add Secure flag to session cookie on logout

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -248,4 +248,42 @@ describe("POST /api/auth/logout", () => {
     expect(res.headers["set-cookie"]).toContain("optio_session=");
     expect(res.headers["set-cookie"]).toContain("Max-Age=0");
   });
+
+  it("includes Secure flag in production", async () => {
+    const origEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      mockRevokeSession.mockResolvedValue(undefined);
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/auth/logout",
+        headers: {
+          authorization: "Bearer token",
+        },
+      });
+      expect(res.headers["set-cookie"]).toContain("Secure;");
+    } finally {
+      process.env.NODE_ENV = origEnv;
+    }
+  });
+
+  it("omits Secure flag in non-production", async () => {
+    const origEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "test";
+    try {
+      mockRevokeSession.mockResolvedValue(undefined);
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/auth/logout",
+        headers: {
+          authorization: "Bearer token",
+        },
+      });
+      expect(res.headers["set-cookie"]).not.toContain("Secure");
+    } finally {
+      process.env.NODE_ENV = origEnv;
+    }
+  });
 });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -302,8 +302,12 @@ export async function authRoutes(app: FastifyInstance) {
       await revokeSession(token);
     }
 
+    const secure = process.env.NODE_ENV === "production" ? " Secure;" : "";
     reply
-      .header("Set-Cookie", `${SESSION_COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`)
+      .header(
+        "Set-Cookie",
+        `${SESSION_COOKIE_NAME}=; Path=/; HttpOnly;${secure} SameSite=Lax; Max-Age=0`,
+      )
       .send({ ok: true });
   });
 }


### PR DESCRIPTION
## Summary
- Adds the `Secure` cookie flag to the logout `Set-Cookie` header when `NODE_ENV=production`, preventing the cookie-clearing response from being transmitted over plain HTTP.
- Two new tests verify the flag is present in production and absent in non-production environments.

## Test plan
- [x] Existing auth tests still pass (14/14)
- [x] New test: `includes Secure flag in production` — verifies `Secure;` is in the cookie header when `NODE_ENV=production`
- [x] New test: `omits Secure flag in non-production` — verifies `Secure` is absent when `NODE_ENV=test`
- [x] Typecheck passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)