### PR TITLE
fix: sanitize error messages returned to API clients

### DIFF
--- a/apps/api/src/routes/setup.test.ts
+++ b/apps/api/src/routes/setup.test.ts
@@ -219,6 +219,69 @@ describe("POST /api/setup/validate/openai-key", () => {
   });
 });
 
+describe("error sanitization in setup routes", () => {
+  let app: FastifyInstance;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it("returns generic error in production when github-token validation throws", async () => {
+    process.env.NODE_ENV = "production";
+    // Re-import to pick up the env change
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED 127.0.0.1:443")));
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/setup/validate/github-token",
+      payload: { token: "ghp_test" },
+    });
+
+    expect(res.json().valid).toBe(false);
+    // Should NOT contain the internal error details
+    expect(res.json().error).not.toContain("ECONNREFUSED");
+  });
+
+  it("returns detailed error in development when github-token validation throws", async () => {
+    process.env.NODE_ENV = "development";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED 127.0.0.1:443")));
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/setup/validate/github-token",
+      payload: { token: "ghp_test" },
+    });
+
+    expect(res.json().valid).toBe(false);
+    expect(res.json().error).toContain("ECONNREFUSED");
+  });
+
+  it("returns generic error in production when repos listing throws", async () => {
+    process.env.NODE_ENV = "production";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("getaddrinfo ENOTFOUND api.github.com")),
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/setup/repos",
+      payload: { token: "ghp_test" },
+    });
+
+    expect(res.json().repos).toEqual([]);
+    expect(res.json().error).not.toContain("ENOTFOUND");
+    expect(res.json().error).toBe("An unexpected error occurred");
+  });
+});
+
 describe("POST /api/setup/repos", () => {
   let app: FastifyInstance;
 

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -4,6 +4,11 @@ import { listSecrets, retrieveSecret } from "../services/secret-service.js";
 import { isSubscriptionAvailable } from "../services/auth-service.js";
 import { isGitHubAppConfigured } from "../services/github-app-service.js";
 
+function sanitizeError(err: unknown): string {
+  if (process.env.NODE_ENV !== "production") return String(err);
+  return "An unexpected error occurred";
+}
+
 export async function setupRoutes(app: FastifyInstance) {
   // Check if the system has been set up (secrets exist)
   app.get("/api/setup/status", async (_req, reply) => {
@@ -84,7 +89,8 @@ export async function setupRoutes(app: FastifyInstance) {
       const user = (await res.json()) as { login: string; name: string };
       reply.send({ valid: true, user: { login: user.login, name: user.name } });
     } catch (err) {
-      reply.send({ valid: false, error: String(err) });
+      app.log.error(err, "GitHub token validation failed");
+      reply.send({ valid: false, error: sanitizeError(err) });
     }
   });
 
@@ -107,7 +113,8 @@ export async function setupRoutes(app: FastifyInstance) {
         reply.send({ valid: false, error: body.error?.message ?? `API returned ${res.status}` });
       }
     } catch (err) {
-      reply.send({ valid: false, error: String(err) });
+      app.log.error(err, "Anthropic key validation failed");
+      reply.send({ valid: false, error: sanitizeError(err) });
     }
   });
 
@@ -135,7 +142,8 @@ export async function setupRoutes(app: FastifyInstance) {
       const user = (await res.json()) as { login: string; name: string };
       reply.send({ valid: true, user: { login: user.login, name: user.name } });
     } catch (err) {
-      reply.send({ valid: false, error: String(err) });
+      app.log.error(err, "Copilot token validation failed");
+      reply.send({ valid: false, error: sanitizeError(err) });
     }
   });
 
@@ -155,7 +163,8 @@ export async function setupRoutes(app: FastifyInstance) {
         reply.send({ valid: false, error: body.error?.message ?? `API returned ${res.status}` });
       }
     } catch (err) {
-      reply.send({ valid: false, error: String(err) });
+      app.log.error(err, "OpenAI key validation failed");
+      reply.send({ valid: false, error: sanitizeError(err) });
     }
   });
 
@@ -200,7 +209,8 @@ export async function setupRoutes(app: FastifyInstance) {
 
       reply.send({ repos });
     } catch (err) {
-      reply.send({ repos: [], error: String(err) });
+      app.log.error(err, "Repo listing failed");
+      reply.send({ repos: [], error: sanitizeError(err) });
     }
   });
 
@@ -239,7 +249,8 @@ export async function setupRoutes(app: FastifyInstance) {
         reply.send({ valid: false, error: `Repository not accessible (${res.status})` });
       }
     } catch (err) {
-      reply.send({ valid: false, error: String(err) });
+      app.log.error(err, "Repo validation failed");
+      reply.send({ valid: false, error: sanitizeError(err) });
     }
   });
 }

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { buildServer } from "./server.js";
 import type { FastifyInstance } from "fastify";
 
@@ -88,5 +88,69 @@ describe("error handler", () => {
       url: "/api/health",
     });
     expect([200, 503]).toContain(res.statusCode);
+  });
+});
+
+describe("Zod error sanitization", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("returns field names only for Zod errors in production", async () => {
+    process.env.NODE_ENV = "production";
+    const testApp = await buildServer();
+
+    // Use /api/setup/ path to bypass auth middleware
+    testApp.post("/api/setup/test-zod", async () => {
+      const { z } = await import("zod");
+      const schema = z.object({ name: z.string(), age: z.number() });
+      schema.parse({ name: 123, age: "not-a-number" });
+    });
+
+    const res = await testApp.inject({
+      method: "POST",
+      url: "/api/setup/test-zod",
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.error).toBe("Validation error");
+    expect(body.details).toContain("Invalid fields:");
+    expect(body.details).toContain("name");
+    expect(body.details).toContain("age");
+    // Should NOT contain full validation messages
+    expect(body.details).not.toContain("Expected string");
+    expect(body.details).not.toContain("Expected number");
+
+    await testApp.close();
+  });
+
+  it("returns full Zod error details in development", async () => {
+    process.env.NODE_ENV = "development";
+    const testApp = await buildServer();
+
+    testApp.post("/api/setup/test-zod-dev", async () => {
+      const { z } = await import("zod");
+      const schema = z.object({ name: z.string() });
+      schema.parse({ name: 123 });
+    });
+
+    const res = await testApp.inject({
+      method: "POST",
+      url: "/api/setup/test-zod-dev",
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.error).toBe("Validation error");
+    // In dev, the full message is returned
+    expect(body.details).toBeDefined();
+    expect(body.details.length).toBeGreaterThan(0);
+
+    await testApp.close();
   });
 });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -111,7 +111,17 @@ export async function buildServer() {
   // Global error handler for Zod validation
   app.setErrorHandler((error: FastifyError | Error, _req, reply) => {
     if (error.name === "ZodError") {
-      return reply.status(400).send({ error: "Validation error", details: error.message });
+      app.log.error(error, "Zod validation error");
+      const isDev = process.env.NODE_ENV !== "production";
+      if (isDev) {
+        return reply.status(400).send({ error: "Validation error", details: error.message });
+      }
+      const zodError = error as unknown as { issues: Array<{ path: (string | number)[] }> };
+      const fields = zodError.issues.map((i) => i.path.join(".")).filter(Boolean);
+      const details = fields.length
+        ? `Invalid fields: ${fields.join(", ")}`
+        : "Invalid request body";
+      return reply.status(400).send({ error: "Validation error", details });
     }
     if (error.name === "InvalidTransitionError") {
       return reply.status(409).send({ error: error.message });


### PR DESCRIPTION
## Summary
- Replace raw `String(err)` in setup routes with a `sanitizeError` helper that returns generic messages in production and detailed messages only in development
- Log full errors server-side via `app.log.error()` for debugging
- Sanitize Zod validation error responses in production to expose only field names, not full validation messages that reveal schema structure

## Test plan
- [x] Added tests verifying generic error messages in production (`setup.test.ts`)
- [x] Added tests verifying detailed error messages in development (`setup.test.ts`)
- [x] Added tests for Zod error field-only output in production (`server.test.ts`)
- [x] Added tests for full Zod error details in development (`server.test.ts`)
- [x] All 23 tests pass across both test files
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)