### PR TITLE
fix: replace query param fallback with single-use WS upgrade tokens

### DIFF
--- a/apps/api/src/services/session-service.test.ts
+++ b/apps/api/src/services/session-service.test.ts
@@ -35,12 +35,15 @@ import {
   revokeSession,
   revokeAllUserSessions,
   createWsToken,
+  validateWsToken,
   cleanupExpiredSessions,
+  _wsTokenStoreForTesting,
 } from "./session-service.js";
 
 describe("session-service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _wsTokenStoreForTesting.clear();
   });
 
   describe("createSession", () => {
@@ -203,14 +206,94 @@ describe("session-service", () => {
   });
 
   describe("createWsToken", () => {
-    it("creates a short-lived WebSocket token", async () => {
-      (db.insert as any) = vi.fn().mockReturnValue({
-        values: vi.fn().mockResolvedValue(undefined),
-      });
-
+    it("creates a short-lived WebSocket upgrade token in memory", async () => {
       const token = await createWsToken("user-1");
       expect(token).toBeDefined();
       expect(token.length).toBe(64); // 32 bytes hex
+      // Token should be stored in the in-memory map, not in the DB
+      expect(_wsTokenStoreForTesting.size).toBe(1);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("validateWsToken", () => {
+    it("validates and consumes a valid upgrade token", async () => {
+      // Mock the user lookup that happens after token validation
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                userId: "user-1",
+                provider: "github",
+                email: "test@test.com",
+                displayName: "Test User",
+                avatarUrl: null,
+                defaultWorkspaceId: "ws-1",
+              },
+            ]),
+          }),
+        }),
+      });
+
+      const token = await createWsToken("user-1");
+      expect(_wsTokenStoreForTesting.size).toBe(1);
+
+      const user = await validateWsToken(token);
+      expect(user).not.toBeNull();
+      expect(user!.id).toBe("user-1");
+      expect(user!.email).toBe("test@test.com");
+
+      // Token should be consumed (deleted from map)
+      expect(_wsTokenStoreForTesting.size).toBe(0);
+    });
+
+    it("rejects a token that has already been consumed (single-use)", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                userId: "user-1",
+                provider: "github",
+                email: "test@test.com",
+                displayName: "Test User",
+                avatarUrl: null,
+                defaultWorkspaceId: null,
+              },
+            ]),
+          }),
+        }),
+      });
+
+      const token = await createWsToken("user-1");
+
+      // First use succeeds
+      const user1 = await validateWsToken(token);
+      expect(user1).not.toBeNull();
+
+      // Second use fails (consumed)
+      const user2 = await validateWsToken(token);
+      expect(user2).toBeNull();
+    });
+
+    it("rejects an unknown token", async () => {
+      const user = await validateWsToken("nonexistent-token");
+      expect(user).toBeNull();
+    });
+
+    it("rejects an expired token", async () => {
+      const token = await createWsToken("user-1");
+
+      // Manually expire the token in the store
+      for (const [, entry] of _wsTokenStoreForTesting) {
+        entry.expiresAt = Date.now() - 1000;
+      }
+
+      const user = await validateWsToken(token);
+      expect(user).toBeNull();
+      // Token should still be removed from the map even though expired
+      expect(_wsTokenStoreForTesting.size).toBe(0);
     });
   });
 

--- a/apps/api/src/services/session-service.ts
+++ b/apps/api/src/services/session-service.ts
@@ -131,17 +131,88 @@ export async function revokeAllUserSessions(userId: string): Promise<void> {
   await db.delete(sessions).where(eq(sessions.userId, userId));
 }
 
-/** Create a short-lived token for WebSocket authentication. */
+// ── In-memory store for single-use WebSocket upgrade tokens ──────────────
+
+const WS_TOKEN_TTL_MS = 30_000; // 30 seconds — just enough for the WS upgrade
+const WS_TOKEN_CLEANUP_INTERVAL_MS = 60_000;
+
+interface WsUpgradeEntry {
+  userId: string;
+  expiresAt: number; // epoch ms
+}
+
+/** Map from token-hash → { userId, expiresAt }. Tokens are deleted on first use. */
+const wsUpgradeTokens = new Map<string, WsUpgradeEntry>();
+
+/** Periodic cleanup of expired entries (prevents slow leak if tokens are never used). */
+const _wsCleanupTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [hash, entry] of wsUpgradeTokens) {
+    if (entry.expiresAt <= now) wsUpgradeTokens.delete(hash);
+  }
+}, WS_TOKEN_CLEANUP_INTERVAL_MS);
+// Allow the process to exit even if the timer is still running.
+if (_wsCleanupTimer.unref) _wsCleanupTimer.unref();
+
+/** Create a short-lived, single-use token for WebSocket authentication. */
 export async function createWsToken(userId: string): Promise<string> {
-  const WS_TOKEN_TTL_MS = 60_000; // 60 seconds — enough for the WS upgrade
   const token = randomBytes(32).toString("hex");
   const tokenHash = hashToken(token);
-  const expiresAt = new Date(Date.now() + WS_TOKEN_TTL_MS);
 
-  await db.insert(sessions).values({ userId, tokenHash, expiresAt });
+  wsUpgradeTokens.set(tokenHash, {
+    userId,
+    expiresAt: Date.now() + WS_TOKEN_TTL_MS,
+  });
 
   return token;
 }
+
+/**
+ * Validate and consume a single-use WebSocket upgrade token.
+ * Returns the SessionUser on success (token is deleted), or null if
+ * the token is invalid, expired, or already consumed.
+ */
+export async function validateWsToken(token: string): Promise<SessionUser | null> {
+  const tokenHash = hashToken(token);
+  const entry = wsUpgradeTokens.get(tokenHash);
+
+  if (!entry) return null;
+
+  // Always delete — single use regardless of expiry check
+  wsUpgradeTokens.delete(tokenHash);
+
+  if (entry.expiresAt <= Date.now()) return null;
+
+  // Look up the user by ID
+  const rows = await db
+    .select({
+      userId: users.id,
+      provider: users.provider,
+      email: users.email,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      defaultWorkspaceId: users.defaultWorkspaceId,
+    })
+    .from(users)
+    .where(eq(users.id, entry.userId))
+    .limit(1);
+
+  if (rows.length === 0) return null;
+
+  const row = rows[0];
+  return {
+    id: row.userId,
+    provider: row.provider,
+    email: row.email,
+    displayName: row.displayName,
+    avatarUrl: row.avatarUrl,
+    workspaceId: row.defaultWorkspaceId,
+    workspaceRole: null,
+  };
+}
+
+/** Expose internals for testing only. */
+export const _wsTokenStoreForTesting = wsUpgradeTokens;
 
 /** Delete all expired sessions. Returns count of deleted rows. */
 export async function cleanupExpiredSessions(): Promise<number> {

--- a/apps/api/src/ws/ws-auth.test.ts
+++ b/apps/api/src/ws/ws-auth.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock session service
 const mockValidateSession = vi.fn();
+const mockValidateWsToken = vi.fn();
 vi.mock("../services/session-service.js", () => ({
   validateSession: (...args: unknown[]) => mockValidateSession(...args),
+  validateWsToken: (...args: unknown[]) => mockValidateWsToken(...args),
 }));
 
 // Mock oauth index for isAuthDisabled
@@ -56,6 +58,7 @@ describe("authenticateWs", () => {
     });
     expect(socket.close).not.toHaveBeenCalled();
     expect(mockValidateSession).not.toHaveBeenCalled();
+    expect(mockValidateWsToken).not.toHaveBeenCalled();
   });
 
   it("closes socket with 4401 when no token is provided", async () => {
@@ -68,7 +71,7 @@ describe("authenticateWs", () => {
     expect(socket.close).toHaveBeenCalledWith(4401, "Authentication required");
   });
 
-  it("validates session from cookie", async () => {
+  it("validates session from cookie via validateSession", async () => {
     const mockUser = {
       id: "user-1",
       provider: "github",
@@ -84,10 +87,11 @@ describe("authenticateWs", () => {
 
     expect(user).toEqual(mockUser);
     expect(mockValidateSession).toHaveBeenCalledWith("abc123");
+    expect(mockValidateWsToken).not.toHaveBeenCalled();
     expect(socket.close).not.toHaveBeenCalled();
   });
 
-  it("validates session from query param token", async () => {
+  it("validates query param token via validateWsToken (single-use)", async () => {
     const mockUser = {
       id: "user-2",
       provider: "google",
@@ -95,14 +99,16 @@ describe("authenticateWs", () => {
       displayName: "Query User",
       avatarUrl: null,
     };
-    mockValidateSession.mockResolvedValue(mockUser);
+    mockValidateWsToken.mockResolvedValue(mockUser);
     const socket = createMockSocket();
-    const req = createMockRequest({ token: "token456" });
+    const req = createMockRequest({ token: "upgrade-token-456" });
 
     const user = await authenticateWs(socket as any, req);
 
     expect(user).toEqual(mockUser);
-    expect(mockValidateSession).toHaveBeenCalledWith("token456");
+    expect(mockValidateWsToken).toHaveBeenCalledWith("upgrade-token-456");
+    // Should NOT call validateSession for query param tokens (no cookie present)
+    expect(mockValidateSession).not.toHaveBeenCalled();
     expect(socket.close).not.toHaveBeenCalled();
   });
 
@@ -121,12 +127,57 @@ describe("authenticateWs", () => {
     await authenticateWs(socket as any, req);
 
     expect(mockValidateSession).toHaveBeenCalledWith("fromcookie");
+    // Upgrade token should not be checked when cookie succeeds
+    expect(mockValidateWsToken).not.toHaveBeenCalled();
+  });
+
+  it("falls back to upgrade token when cookie is invalid", async () => {
+    const mockUser = {
+      id: "user-4",
+      provider: "github",
+      email: "fallback@example.com",
+      displayName: "Fallback User",
+      avatarUrl: null,
+    };
+    mockValidateSession.mockResolvedValue(null); // cookie invalid
+    mockValidateWsToken.mockResolvedValue(mockUser);
+    const socket = createMockSocket();
+    const req = createMockRequest({ cookie: "optio_session=bad-cookie", token: "good-upgrade" });
+
+    const user = await authenticateWs(socket as any, req);
+
+    expect(user).toEqual(mockUser);
+    expect(mockValidateSession).toHaveBeenCalledWith("bad-cookie");
+    expect(mockValidateWsToken).toHaveBeenCalledWith("good-upgrade");
   });
 
   it("closes socket with 4401 when session is invalid", async () => {
     mockValidateSession.mockResolvedValue(null);
     const socket = createMockSocket();
     const req = createMockRequest({ cookie: "optio_session=expired-token" });
+
+    const user = await authenticateWs(socket as any, req);
+
+    expect(user).toBeNull();
+    expect(socket.close).toHaveBeenCalledWith(4401, "Invalid or expired session");
+  });
+
+  it("closes socket when both cookie and upgrade token are invalid", async () => {
+    mockValidateSession.mockResolvedValue(null);
+    mockValidateWsToken.mockResolvedValue(null);
+    const socket = createMockSocket();
+    const req = createMockRequest({ cookie: "optio_session=bad", token: "also-bad" });
+
+    const user = await authenticateWs(socket as any, req);
+
+    expect(user).toBeNull();
+    expect(socket.close).toHaveBeenCalledWith(4401, "Invalid or expired session");
+  });
+
+  it("closes socket when upgrade token alone is invalid", async () => {
+    mockValidateWsToken.mockResolvedValue(null);
+    const socket = createMockSocket();
+    const req = createMockRequest({ token: "consumed-token" });
 
     const user = await authenticateWs(socket as any, req);
 
@@ -151,12 +202,12 @@ describe("extractSessionToken", () => {
     expect(extractSessionToken(req)).toBe("my-token");
   });
 
-  it("extracts token from query param", () => {
+  it("does NOT extract token from query param (security fix)", () => {
     const req = createMockRequest({ token: "query-token" });
-    expect(extractSessionToken(req)).toBe("query-token");
+    expect(extractSessionToken(req)).toBeUndefined();
   });
 
-  it("prefers cookie over query param", () => {
+  it("returns cookie token even when query param is present", () => {
     const req = createMockRequest({ cookie: "optio_session=cookie-token", token: "query-token" });
     expect(extractSessionToken(req)).toBe("cookie-token");
   });

--- a/apps/api/src/ws/ws-auth.ts
+++ b/apps/api/src/ws/ws-auth.ts
@@ -1,5 +1,5 @@
 import type { FastifyRequest } from "fastify";
-import { validateSession, type SessionUser } from "../services/session-service.js";
+import { validateSession, validateWsToken, type SessionUser } from "../services/session-service.js";
 import { isAuthDisabled } from "../services/oauth/index.js";
 
 /** Minimal WebSocket interface for auth — avoids depending on @types/ws. */
@@ -16,7 +16,13 @@ function parseCookie(header: string | undefined, name: string): string | undefin
 }
 
 /**
- * Authenticate a WebSocket connection using session cookie or token query param.
+ * Authenticate a WebSocket connection.
+ *
+ * Two paths:
+ *  1. Session cookie (`optio_session`) — validated against the sessions table.
+ *  2. Single-use upgrade token (`?token=`) — validated and consumed from the
+ *     in-memory WS token store (short-lived, ~30 s, one-time use).
+ *
  * Returns the session user on success, or null after closing the socket with code 4401.
  * When auth is disabled, returns a synthetic dev user.
  */
@@ -36,34 +42,40 @@ export async function authenticateWs(
     };
   }
 
-  const token =
-    parseCookie(req.headers.cookie, SESSION_COOKIE_NAME) ??
-    (req.query as Record<string, string>)?.token;
-
-  if (!token) {
-    socket.close(4401, "Authentication required");
-    return null;
+  // Path 1: cookie-based session auth (long-lived session token)
+  const cookieToken = parseCookie(req.headers.cookie, SESSION_COOKIE_NAME);
+  if (cookieToken) {
+    const user = await validateSession(cookieToken);
+    if (user) return user;
+    // Cookie was present but invalid/expired — fall through to close
   }
 
-  const user = await validateSession(token);
-  if (!user) {
-    socket.close(4401, "Invalid or expired session");
-    return null;
+  // Path 2: single-use upgrade token via query param
+  const upgradeToken = (req.query as Record<string, string>)?.token;
+  if (upgradeToken) {
+    const user = await validateWsToken(upgradeToken);
+    if (user) return user;
+    // Token was present but invalid/expired/already consumed
   }
 
-  return user;
+  // No valid auth found
+  const reason =
+    cookieToken || upgradeToken ? "Invalid or expired session" : "Authentication required";
+  socket.close(4401, reason);
+  return null;
 }
 
 /**
- * Extract the raw session token from a Fastify request (cookie or query param).
+ * Extract the raw session token from a Fastify request (cookie only).
  * Used for auth passthrough — the raw token is forwarded to agent pods so they
  * can make authenticated API calls on behalf of the user.
+ *
+ * Only reads the session cookie — never the query param upgrade token, which is
+ * single-use and not suitable for passthrough.
+ *
  * Returns undefined if no token is found or auth is disabled.
  */
 export function extractSessionToken(req: FastifyRequest): string | undefined {
   if (isAuthDisabled()) return undefined;
-  return (
-    parseCookie(req.headers.cookie, SESSION_COOKIE_NAME) ??
-    (req.query as Record<string, string>)?.token
-  );
+  return parseCookie(req.headers.cookie, SESSION_COOKIE_NAME);
 }


### PR DESCRIPTION
## Summary

- Replace insecure query parameter session token fallback in WebSocket auth with short-lived (~30s), single-use upgrade tokens stored in memory
- `extractSessionToken` now reads cookies only, preventing ephemeral WS tokens from being passed through to agent pods
- WS upgrade tokens are consumed on first use and automatically cleaned up when expired

**Security issue:** WebSocket authentication previously accepted any valid session token (including long-lived 30-day sessions) via `?token=` query parameters. Tokens in query params appear in server logs, browser history, and HTTP referrer headers.

**Fix:** Query param auth now only accepts single-use upgrade tokens from `/api/auth/ws-token` (which already existed). These tokens are:
- Stored in-memory (not in the sessions table)
- Valid for 30 seconds
- Consumed on first use (deleted from store)
- Periodically cleaned up if unused

## Test plan

- [x] Typecheck passes (`pnpm turbo typecheck`)
- [x] All 947 tests pass (`pnpm turbo test`)
- [x] New tests verify single-use consumption, expiry rejection, and cookie-only `extractSessionToken`
- [ ] Manual: verify WS connections work via cookie auth
- [ ] Manual: verify WS connections work via upgrade token flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)