### PR TITLE
fix: add allowlist for container capabilities and host path mounts

### DIFF
--- a/packages/container-runtime/src/index.ts
+++ b/packages/container-runtime/src/index.ts
@@ -1,7 +1,11 @@
 export type { ContainerRuntime, LogOptions, ExecOptions } from "./types.js";
 export { DockerContainerRuntime } from "./docker.js";
 export type { DockerRuntimeOptions } from "./docker.js";
-export { KubernetesContainerRuntime } from "./kubernetes.js";
+export {
+  KubernetesContainerRuntime,
+  ALLOWED_CAPABILITIES,
+  ALLOWED_HOST_PATH_PREFIXES,
+} from "./kubernetes.js";
 
 import type { ContainerRuntime } from "./types.js";
 import { DockerContainerRuntime, type DockerRuntimeOptions } from "./docker.js";

--- a/packages/container-runtime/src/kubernetes.test.ts
+++ b/packages/container-runtime/src/kubernetes.test.ts
@@ -45,7 +45,11 @@ vi.mock("@kubernetes/client-node", () => ({
   V1EmptyDirVolumeSource: vi.fn(() => ({})),
 }));
 
-import { KubernetesContainerRuntime } from "./kubernetes.js";
+import {
+  KubernetesContainerRuntime,
+  ALLOWED_CAPABILITIES,
+  ALLOWED_HOST_PATH_PREFIXES,
+} from "./kubernetes.js";
 import type { ContainerSpec } from "@optio/shared";
 
 // ---------------------------------------------------------------------------
@@ -133,22 +137,15 @@ describe("KubernetesContainerRuntime", () => {
       expect(container.resources.requests).toEqual({ cpu: "2", memory: "4Gi" });
     });
 
-    it("builds hostPath volumes with mounts", async () => {
+    it("rejects hostPath volumes when no host paths are allowed", async () => {
       const spec = baseSpec({
         volumes: [{ hostPath: "/host/data", mountPath: "/data" }],
       });
 
-      await runtime.create(spec);
-
-      const body = mockCoreApi.createNamespacedPod.mock.calls[0][0].body;
-      expect(body.spec.volumes).toHaveLength(1);
-      expect(body.spec.volumes[0].name).toBe("vol-0");
-      expect(body.spec.volumes[0].hostPath).toEqual({ path: "/host/data" });
-
-      const mount = body.spec.containers[0].volumeMounts[0];
-      expect(mount.name).toBe("vol-0");
-      expect(mount.mountPath).toBe("/data");
-      expect(mount.readOnly).toBe(false);
+      await expect(runtime.create(spec)).rejects.toThrow(
+        'Host path volume mount "/host/data" is not permitted',
+      );
+      expect(mockCoreApi.createNamespacedPod).not.toHaveBeenCalled();
     });
 
     it("builds PVC volumes with mounts", async () => {
@@ -202,13 +199,16 @@ describe("KubernetesContainerRuntime", () => {
       });
     });
 
-    it("sets security context capabilities", async () => {
-      const spec = baseSpec({ capabilities: ["SYS_ADMIN", "NET_ADMIN"] });
+    it("sets security context with allowed capabilities and drops ALL", async () => {
+      const spec = baseSpec({ capabilities: ["NET_ADMIN", "NET_RAW"] });
 
       await runtime.create(spec);
 
       const container = mockCoreApi.createNamespacedPod.mock.calls[0][0].body.spec.containers[0];
-      expect(container.securityContext.capabilities).toEqual({ add: ["SYS_ADMIN", "NET_ADMIN"] });
+      expect(container.securityContext.capabilities).toEqual({
+        drop: ["ALL"],
+        add: ["NET_ADMIN", "NET_RAW"],
+      });
     });
 
     it("adds sidecar containers", async () => {
@@ -299,6 +299,79 @@ describe("KubernetesContainerRuntime", () => {
       const handle = await runtime.create(baseSpec());
 
       expect(handle).toEqual({ id: "uid-xyz", name: "optio-task-task-123" });
+    });
+  });
+
+  // =========================================================================
+  // Security: capability and host-path allowlists
+  // =========================================================================
+  describe("security allowlists", () => {
+    it("drops ALL capabilities by default when none are requested", async () => {
+      const spec = baseSpec();
+
+      await runtime.create(spec);
+
+      const container = mockCoreApi.createNamespacedPod.mock.calls[0][0].body.spec.containers[0];
+      expect(container.securityContext.capabilities).toEqual({ drop: ["ALL"] });
+    });
+
+    it("rejects disallowed capabilities (SYS_ADMIN)", async () => {
+      const spec = baseSpec({ capabilities: ["SYS_ADMIN"] });
+
+      await expect(runtime.create(spec)).rejects.toThrow(
+        "Disallowed container capabilities requested: SYS_ADMIN",
+      );
+      expect(mockCoreApi.createNamespacedPod).not.toHaveBeenCalled();
+    });
+
+    it("rejects multiple disallowed capabilities", async () => {
+      const spec = baseSpec({ capabilities: ["SYS_ADMIN", "SYS_PTRACE", "NET_ADMIN"] });
+
+      await expect(runtime.create(spec)).rejects.toThrow(
+        "Disallowed container capabilities requested: SYS_ADMIN, SYS_PTRACE",
+      );
+    });
+
+    it("allows all capabilities in the ALLOWED_CAPABILITIES set", async () => {
+      const spec = baseSpec({ capabilities: [...ALLOWED_CAPABILITIES] });
+
+      await runtime.create(spec);
+
+      const container = mockCoreApi.createNamespacedPod.mock.calls[0][0].body.spec.containers[0];
+      expect(container.securityContext.capabilities.drop).toEqual(["ALL"]);
+      expect(container.securityContext.capabilities.add).toEqual([...ALLOWED_CAPABILITIES]);
+    });
+
+    it("rejects host path mounts by default (empty allowlist)", async () => {
+      const spec = baseSpec({
+        volumes: [{ hostPath: "/etc/shadow", mountPath: "/mnt/shadow" }],
+      });
+
+      await expect(runtime.create(spec)).rejects.toThrow(
+        "Host path mounts are disabled. Use persistentVolumeClaim volumes instead.",
+      );
+    });
+
+    it("still allows PVC volumes when host paths are rejected", async () => {
+      const spec = baseSpec({
+        volumes: [{ persistentVolumeClaim: "my-pvc", mountPath: "/storage" }],
+      });
+
+      await runtime.create(spec);
+
+      const body = mockCoreApi.createNamespacedPod.mock.calls[0][0].body;
+      expect(body.spec.volumes[0].persistentVolumeClaim).toEqual({ claimName: "my-pvc" });
+    });
+
+    it("exports ALLOWED_CAPABILITIES as a Set", () => {
+      expect(ALLOWED_CAPABILITIES).toBeInstanceOf(Set);
+      expect(ALLOWED_CAPABILITIES.has("NET_ADMIN")).toBe(true);
+      expect(ALLOWED_CAPABILITIES.has("SYS_ADMIN")).toBe(false);
+    });
+
+    it("exports ALLOWED_HOST_PATH_PREFIXES as an empty array by default", () => {
+      expect(Array.isArray(ALLOWED_HOST_PATH_PREFIXES)).toBe(true);
+      expect(ALLOWED_HOST_PATH_PREFIXES).toHaveLength(0);
     });
   });
 

--- a/packages/container-runtime/src/kubernetes.ts
+++ b/packages/container-runtime/src/kubernetes.ts
@@ -26,6 +26,37 @@ const CONTAINER_NAME = "main";
 const POD_READY_TIMEOUT_MS = 120_000;
 const POD_READY_POLL_MS = 1_000;
 
+/**
+ * Capabilities that are permitted to be added to container security contexts.
+ * Any capability not in this set will be rejected during pod creation.
+ * Dangerous capabilities like SYS_ADMIN are intentionally excluded to prevent
+ * privilege escalation.
+ */
+export const ALLOWED_CAPABILITIES = new Set([
+  "AUDIT_WRITE",
+  "CHOWN",
+  "DAC_OVERRIDE",
+  "FOWNER",
+  "FSETID",
+  "KILL",
+  "MKNOD",
+  "NET_ADMIN",
+  "NET_BIND_SERVICE",
+  "NET_RAW",
+  "SETFCAP",
+  "SETGID",
+  "SETPCAP",
+  "SETUID",
+  "SYS_CHROOT",
+]);
+
+/**
+ * Host path prefixes that are permitted for volume mounts.
+ * Paths must start with one of these prefixes to be allowed.
+ * An empty set means all host path mounts are rejected.
+ */
+export const ALLOWED_HOST_PATH_PREFIXES: readonly string[] = [];
+
 export class KubernetesContainerRuntime implements ContainerRuntime {
   private kubeConfig: KubeConfig;
   private coreApi: CoreV1Api;
@@ -101,6 +132,7 @@ export class KubernetesContainerRuntime implements ContainerRuntime {
         volume.name = volumeName;
 
         if (v.hostPath) {
+          this.validateHostPath(v.hostPath);
           const hostPath = new V1HostPathVolumeSource();
           hostPath.path = v.hostPath;
           volume.hostPath = hostPath;
@@ -155,11 +187,18 @@ export class KubernetesContainerRuntime implements ContainerRuntime {
       }
     }
 
-    // Set security context (capabilities for DinD, etc.)
-    if (spec.capabilities && spec.capabilities.length > 0) {
+    // Set security context — always drop ALL capabilities, then selectively add
+    // only those that pass the allowlist check.
+    {
       const secCtx = new V1SecurityContext();
       const caps = new V1Capabilities();
-      caps.add = spec.capabilities;
+      caps.drop = ["ALL"];
+
+      if (spec.capabilities && spec.capabilities.length > 0) {
+        this.validateCapabilities(spec.capabilities);
+        caps.add = spec.capabilities;
+      }
+
       secCtx.capabilities = caps;
       container.securityContext = secCtx;
     }
@@ -394,6 +433,39 @@ export class KubernetesContainerRuntime implements ContainerRuntime {
   }
 
   // ---- Private helpers ----
+
+  /**
+   * Validate that all requested capabilities are in the allowlist.
+   * Throws if any capability is not permitted.
+   */
+  private validateCapabilities(capabilities: string[]): void {
+    const disallowed = capabilities.filter((cap) => !ALLOWED_CAPABILITIES.has(cap));
+    if (disallowed.length > 0) {
+      throw new Error(
+        `Disallowed container capabilities requested: ${disallowed.join(", ")}. ` +
+          `Allowed capabilities: ${[...ALLOWED_CAPABILITIES].join(", ")}`,
+      );
+    }
+  }
+
+  /**
+   * Validate that a host path is permitted by the allowlist.
+   * Throws if the path is not under any allowed prefix.
+   */
+  private validateHostPath(path: string): void {
+    const normalizedPath = path.replace(/\/+$/, "");
+    const allowed = ALLOWED_HOST_PATH_PREFIXES.some(
+      (prefix) => normalizedPath === prefix || normalizedPath.startsWith(prefix + "/"),
+    );
+    if (!allowed) {
+      throw new Error(
+        `Host path volume mount "${path}" is not permitted. ` +
+          (ALLOWED_HOST_PATH_PREFIXES.length > 0
+            ? `Allowed host path prefixes: ${ALLOWED_HOST_PATH_PREFIXES.join(", ")}`
+            : `Host path mounts are disabled. Use persistentVolumeClaim volumes instead.`),
+      );
+    }
+  }
 
   private async ensureNamespace(): Promise<void> {
     if (this.namespaceEnsured) return;


### PR DESCRIPTION
## Summary

- **Capability allowlist**: Validates requested Linux capabilities against a strict allowlist, rejecting dangerous ones like `SYS_ADMIN`, `SYS_PTRACE`, `SYS_RAWIO`, etc. that could enable privilege escalation
- **Drop ALL by default**: Every pod now gets `drop: ["ALL"]` in its security context, with only explicitly allowed capabilities added back
- **Host path rejection**: All host path volume mounts are rejected by default (empty prefix allowlist), directing users to use `persistentVolumeClaim` volumes instead

## Test plan

- [x] Existing tests updated to reflect new security behavior
- [x] New tests added for capability validation (allowed, disallowed, mixed)
- [x] New tests added for host path rejection and PVC passthrough
- [x] All 91 container-runtime tests pass
- [x] Full test suite passes (940+ tests across all packages)
- [x] Typecheck and formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)