### PR TITLE
fix: restrict CORS to explicit origin allowlist

### DIFF
--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -57,6 +57,116 @@ describe("CORS configuration", () => {
     const allowedHeaders = res.headers["access-control-allow-headers"];
     expect(allowedHeaders).toMatch(/content-type/i);
   });
+
+  it("rejects unknown origins in dev mode (no OPTIO_ALLOWED_ORIGINS)", async () => {
+    const res = await app.inject({
+      method: "OPTIONS",
+      url: "/api/health",
+      headers: {
+        origin: "https://evil.example.com",
+        "access-control-request-method": "GET",
+      },
+    });
+    // @fastify/cors returns 200 for disallowed origins but without the allow-origin header
+    expect(res.headers["access-control-allow-origin"]).not.toBe("https://evil.example.com");
+  });
+
+  it("allows localhost:3000 in dev mode", async () => {
+    const res = await app.inject({
+      method: "OPTIONS",
+      url: "/api/health",
+      headers: {
+        origin: "http://localhost:3000",
+        "access-control-request-method": "GET",
+      },
+    });
+    expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:3000");
+  });
+
+  it("allows localhost:3001 in dev mode", async () => {
+    const res = await app.inject({
+      method: "OPTIONS",
+      url: "/api/health",
+      headers: {
+        origin: "http://localhost:3001",
+        "access-control-request-method": "GET",
+      },
+    });
+    expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:3001");
+  });
+
+  it("respects OPTIO_ALLOWED_ORIGINS env var", async () => {
+    const original = process.env.OPTIO_ALLOWED_ORIGINS;
+    process.env.OPTIO_ALLOWED_ORIGINS = "https://app.example.com, https://admin.example.com";
+    try {
+      const customApp = await buildServer();
+      try {
+        // Allowed origin
+        const allowed = await customApp.inject({
+          method: "OPTIONS",
+          url: "/api/health",
+          headers: {
+            origin: "https://app.example.com",
+            "access-control-request-method": "GET",
+          },
+        });
+        expect(allowed.headers["access-control-allow-origin"]).toBe("https://app.example.com");
+
+        // Disallowed origin
+        const denied = await customApp.inject({
+          method: "OPTIONS",
+          url: "/api/health",
+          headers: {
+            origin: "https://evil.example.com",
+            "access-control-request-method": "GET",
+          },
+        });
+        expect(denied.headers["access-control-allow-origin"]).not.toBe("https://evil.example.com");
+      } finally {
+        await customApp.close();
+      }
+    } finally {
+      if (original === undefined) {
+        delete process.env.OPTIO_ALLOWED_ORIGINS;
+      } else {
+        process.env.OPTIO_ALLOWED_ORIGINS = original;
+      }
+    }
+  });
+
+  it("denies all origins in production when OPTIO_ALLOWED_ORIGINS is unset", async () => {
+    const originalOrigins = process.env.OPTIO_ALLOWED_ORIGINS;
+    const originalNodeEnv = process.env.NODE_ENV;
+    delete process.env.OPTIO_ALLOWED_ORIGINS;
+    process.env.NODE_ENV = "production";
+    try {
+      const prodApp = await buildServer();
+      try {
+        const res = await prodApp.inject({
+          method: "OPTIONS",
+          url: "/api/health",
+          headers: {
+            origin: "http://localhost:3000",
+            "access-control-request-method": "GET",
+          },
+        });
+        expect(res.headers["access-control-allow-origin"]).not.toBe("http://localhost:3000");
+      } finally {
+        await prodApp.close();
+      }
+    } finally {
+      if (originalOrigins === undefined) {
+        delete process.env.OPTIO_ALLOWED_ORIGINS;
+      } else {
+        process.env.OPTIO_ALLOWED_ORIGINS = originalOrigins;
+      }
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    }
+  });
 });
 
 describe("POST endpoints accept empty body", () => {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -53,9 +53,11 @@ export async function buildServer() {
   // Plugins
   const allowedOrigins = process.env.OPTIO_ALLOWED_ORIGINS
     ? process.env.OPTIO_ALLOWED_ORIGINS.split(",").map((o) => o.trim())
-    : undefined;
+    : process.env.NODE_ENV === "production"
+      ? [] // deny all cross-origin requests in production by default
+      : ["http://localhost:3000", "http://localhost:3001"];
   await app.register(cors, {
-    origin: allowedOrigins ?? true,
+    origin: allowedOrigins,
     credentials: true,
     methods: ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
   });


### PR DESCRIPTION
## Summary

- **Security fix**: When `OPTIO_ALLOWED_ORIGINS` is unset, CORS was configured with `origin: true`, allowing any website to make authenticated cross-origin requests to the API
- **Production**: Now defaults to an empty allowlist (deny all cross-origin) when `NODE_ENV=production` and `OPTIO_ALLOWED_ORIGINS` is unset
- **Development**: Defaults to `localhost:3000` and `localhost:3001` for local dev convenience
- Added 4 new CORS tests verifying origin rejection, localhost allowance, custom origins via env var, and production deny-all behavior

## Test plan

- [x] Existing CORS tests still pass (PATCH, DELETE preflight, Content-Type header)
- [x] New test: unknown origins are rejected in dev mode
- [x] New test: localhost:3000 and localhost:3001 are allowed in dev mode
- [x] New test: `OPTIO_ALLOWED_ORIGINS` env var is respected
- [x] New test: all origins denied in production when env var is unset
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)