### PR TITLE
fix: remove default encryption key and move postgres password to K8s Secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,9 @@ REDIS_URL=redis://localhost:6379
 # Container Runtime: "docker" | "kubernetes"
 OPTIO_RUNTIME=kubernetes
 
-# Encryption key for secrets at rest (generate with: openssl rand -hex 32)
-OPTIO_ENCRYPTION_KEY=change-me-in-production
+# Encryption key for secrets at rest (REQUIRED — generate with: openssl rand -hex 32)
+# The server will refuse to start if this is empty or set to a known-weak value.
+OPTIO_ENCRYPTION_KEY=
 
 # API server
 API_PORT=4000

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -81,6 +81,10 @@ async function checkMetricsServer() {
 }
 
 async function main() {
+  // Validate encryption key before anything else — fail fast on weak/missing keys
+  const { validateEncryptionKey } = await import("./services/secret-service.js");
+  validateEncryptionKey();
+
   // Run database migrations before anything else
   const { migrate } = await import("drizzle-orm/postgres-js/migrator");
   const { db } = await import("./db/client.js");

--- a/apps/api/src/services/encryption-validation.test.ts
+++ b/apps/api/src/services/encryption-validation.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the database module — required by secret-service but not used for validation
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  secrets: {
+    id: "secrets.id",
+    name: "secrets.name",
+    scope: "secrets.scope",
+    encryptedValue: "secrets.encrypted_value",
+    iv: "secrets.iv",
+    authTag: "secrets.auth_tag",
+    createdAt: "secrets.created_at",
+    updatedAt: "secrets.updated_at",
+  },
+}));
+
+describe("encryption key validation", () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.OPTIO_ENCRYPTION_KEY;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalKey !== undefined) {
+      process.env.OPTIO_ENCRYPTION_KEY = originalKey;
+    } else {
+      delete process.env.OPTIO_ENCRYPTION_KEY;
+    }
+  });
+
+  it("throws when OPTIO_ENCRYPTION_KEY is not set", async () => {
+    delete process.env.OPTIO_ENCRYPTION_KEY;
+    const { validateEncryptionKey } = await import("./secret-service.js");
+    expect(() => validateEncryptionKey()).toThrow("OPTIO_ENCRYPTION_KEY is not set");
+  });
+
+  it("throws when encryption key is set to 'change-me-in-production'", async () => {
+    process.env.OPTIO_ENCRYPTION_KEY = "change-me-in-production";
+    const { validateEncryptionKey } = await import("./secret-service.js");
+    expect(() => validateEncryptionKey()).toThrow("known-weak value");
+  });
+
+  it("throws for weak values regardless of case", async () => {
+    process.env.OPTIO_ENCRYPTION_KEY = "Change-Me-In-Production";
+    const { validateEncryptionKey } = await import("./secret-service.js");
+    expect(() => validateEncryptionKey()).toThrow("known-weak value");
+  });
+
+  it("throws for other known-weak values", async () => {
+    for (const weak of ["changeme", "test", "secret", "password", "default"]) {
+      vi.resetModules();
+      process.env.OPTIO_ENCRYPTION_KEY = weak;
+      const { validateEncryptionKey } = await import("./secret-service.js");
+      expect(() => validateEncryptionKey()).toThrow("known-weak value");
+    }
+  });
+
+  it("accepts a valid 64-character hex key", async () => {
+    process.env.OPTIO_ENCRYPTION_KEY = "a".repeat(64);
+    const { validateEncryptionKey } = await import("./secret-service.js");
+    expect(() => validateEncryptionKey()).not.toThrow();
+  });
+
+  it("accepts a valid non-hex key", async () => {
+    process.env.OPTIO_ENCRYPTION_KEY = "my-sufficiently-complex-production-key-2024!";
+    const { validateEncryptionKey } = await import("./secret-service.js");
+    expect(() => validateEncryptionKey()).not.toThrow();
+  });
+});

--- a/apps/api/src/services/secret-service.ts
+++ b/apps/api/src/services/secret-service.ts
@@ -6,9 +6,25 @@ import type { SecretRef } from "@optio/shared";
 
 const ALGORITHM = "aes-256-gcm";
 
+/** Values that must never be accepted as encryption keys. */
+const WEAK_KEY_VALUES = new Set([
+  "change-me-in-production",
+  "changeme",
+  "test",
+  "secret",
+  "password",
+  "default",
+]);
+
 function getEncryptionKey(): Buffer {
   const key = process.env.OPTIO_ENCRYPTION_KEY;
   if (!key) throw new Error("OPTIO_ENCRYPTION_KEY is not set");
+  if (WEAK_KEY_VALUES.has(key.toLowerCase())) {
+    throw new Error(
+      `OPTIO_ENCRYPTION_KEY is set to a known-weak value ("${key}"). ` +
+        "Generate a strong key with: openssl rand -hex 32",
+    );
+  }
   if (key.length === 64 && /^[0-9a-f]+$/i.test(key)) {
     return Buffer.from(key, "hex");
   }
@@ -21,6 +37,14 @@ function encryptionKey(): Buffer {
     _encryptionKey = getEncryptionKey();
   }
   return _encryptionKey;
+}
+
+/**
+ * Eagerly validate the encryption key on startup.
+ * Call this during server boot to fail fast rather than on first secret access.
+ */
+export function validateEncryptionKey(): void {
+  encryptionKey();
 }
 
 export function encrypt(plaintext: string): { encrypted: Buffer; iv: Buffer; authTag: Buffer } {

--- a/helm/optio/templates/_helpers.tpl
+++ b/helm/optio/templates/_helpers.tpl
@@ -48,6 +48,18 @@ Called from secrets.yaml to fail early on misconfiguration.
 {{- end }}
 
 {{/*
+Validate that encryption.key is not a known-weak placeholder value.
+Called from secrets.yaml to prevent deploying with insecure defaults.
+*/}}
+{{- define "optio.validateEncryptionKey" -}}
+{{- $lower := .Values.encryption.key | lower -}}
+{{- $weak := list "change-me-in-production" "changeme" "test" "secret" "password" "default" -}}
+{{- if has $lower $weak -}}
+  {{- fail (printf "encryption.key is set to a known-weak value (%q). Generate a strong key with: openssl rand -hex 32" .Values.encryption.key) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Validate that ingress and gatewayAPI are not both enabled.
 Called from gateway.yaml / ingress.yaml guards.
 */}}

--- a/helm/optio/templates/postgres.yaml
+++ b/helm/optio/templates/postgres.yaml
@@ -1,5 +1,16 @@
 {{- if .Values.postgresql.enabled }}
 apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-postgres-credentials
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "optio.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: {{ required "postgresql.auth.password is required when postgresql is enabled" .Values.postgresql.auth.password | quote }}
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-postgres-data
@@ -49,7 +60,10 @@ spec:
             - name: POSTGRES_USER
               value: {{ .Values.postgresql.auth.username }}
             - name: POSTGRES_PASSWORD
-              value: {{ .Values.postgresql.auth.password }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-postgres-credentials
+                  key: POSTGRES_PASSWORD
           ports:
             - containerPort: 5432
           volumeMounts:

--- a/helm/optio/templates/secrets.yaml
+++ b/helm/optio/templates/secrets.yaml
@@ -2,6 +2,7 @@
   {{- fail "postgresql.auth.password is required when auth is enabled. Set a strong password for production use." }}
 {{- end }}
 {{- include "optio.validateRequired" . }}
+{{- include "optio.validateEncryptionKey" . }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/k8s/infrastructure.yaml
+++ b/k8s/infrastructure.yaml
@@ -1,5 +1,16 @@
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+  namespace: optio
+type: Opaque
+stringData:
+  # Override this in your deployment — do NOT use the default value in production.
+  # Generate with: openssl rand -base64 24
+  POSTGRES_PASSWORD: optio_dev
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: postgres-data
@@ -34,7 +45,10 @@ spec:
             - name: POSTGRES_USER
               value: optio
             - name: POSTGRES_PASSWORD
-              value: optio_dev
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_PASSWORD
           ports:
             - containerPort: 5432
           volumeMounts:


### PR DESCRIPTION
## Summary
- Removed the default `change-me-in-production` encryption key from `.env.example` — it is now blank, forcing explicit configuration
- Added startup validation that rejects known-weak encryption key values (e.g., `change-me-in-production`, `changeme`, `password`) — both at API server boot time and at Helm deploy time
- Moved PostgreSQL password from hardcoded inline env var to a proper K8s Secret resource in both `k8s/infrastructure.yaml` and the Helm postgres template (`helm/optio/templates/postgres.yaml`)

## Test plan
- [x] New test file `encryption-validation.test.ts` covers all weak-key rejection paths (missing key, known-weak values, case-insensitive matching, valid keys)
- [x] All 946 existing tests pass
- [x] Typecheck passes across all packages
- [x] Pre-commit hooks (lint-staged, format, typecheck) pass
- [ ] Verify Helm `helm template` renders postgres `secretKeyRef` correctly
- [ ] Verify API server refuses to start with `OPTIO_ENCRYPTION_KEY=change-me-in-production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)