### PR TITLE
fix: add WebSocket rate limiting and message size limits

### DIFF
--- a/apps/api/src/ws/events.ts
+++ b/apps/api/src/ws/events.ts
@@ -2,11 +2,27 @@ import type { FastifyInstance } from "fastify";
 import { createSubscriber } from "../services/event-bus.js";
 import { authenticateWs } from "./ws-auth.js";
 import { getRecentEvents } from "../services/task-service.js";
+import {
+  getClientIp,
+  trackConnection,
+  releaseConnection,
+  WS_CLOSE_CONNECTION_LIMIT,
+} from "./ws-limits.js";
 
 export async function eventsWs(app: FastifyInstance) {
   app.get("/ws/events", { websocket: true }, async (socket, req) => {
+    const clientIp = getClientIp(req);
+
+    if (!trackConnection(clientIp)) {
+      socket.close(WS_CLOSE_CONNECTION_LIMIT, "Too many connections");
+      return;
+    }
+
     const user = await authenticateWs(socket, req);
-    if (!user) return;
+    if (!user) {
+      releaseConnection(clientIp);
+      return;
+    }
 
     // Send catch-up: recent state-change events so reconnecting clients stay in sync
     try {
@@ -36,6 +52,7 @@ export async function eventsWs(app: FastifyInstance) {
     });
 
     socket.on("close", () => {
+      releaseConnection(clientIp);
       subscriber.unsubscribe(channel);
       subscriber.disconnect();
     });

--- a/apps/api/src/ws/log-stream.ts
+++ b/apps/api/src/ws/log-stream.ts
@@ -2,11 +2,27 @@ import type { FastifyInstance } from "fastify";
 import { createSubscriber } from "../services/event-bus.js";
 import { authenticateWs } from "./ws-auth.js";
 import { getTaskLogs } from "../services/task-service.js";
+import {
+  getClientIp,
+  trackConnection,
+  releaseConnection,
+  WS_CLOSE_CONNECTION_LIMIT,
+} from "./ws-limits.js";
 
 export async function logStreamWs(app: FastifyInstance) {
   app.get("/ws/logs/:taskId", { websocket: true }, async (socket, req) => {
+    const clientIp = getClientIp(req);
+
+    if (!trackConnection(clientIp)) {
+      socket.close(WS_CLOSE_CONNECTION_LIMIT, "Too many connections");
+      return;
+    }
+
     const user = await authenticateWs(socket, req);
-    if (!user) return;
+    if (!user) {
+      releaseConnection(clientIp);
+      return;
+    }
 
     const { taskId } = req.params as { taskId: string };
 
@@ -48,6 +64,7 @@ export async function logStreamWs(app: FastifyInstance) {
     });
 
     socket.on("close", () => {
+      releaseConnection(clientIp);
       subscriber.unsubscribe(channel);
       subscriber.disconnect();
     });

--- a/apps/api/src/ws/optio-chat.ts
+++ b/apps/api/src/ws/optio-chat.ts
@@ -7,6 +7,14 @@ import { authenticateWs } from "./ws-auth.js";
 import { logger } from "../logger.js";
 import { OPTIO_TOOL_CATEGORIES, type OptioToolDefinition } from "@optio/shared";
 import type { ExecSession } from "@optio/shared";
+import {
+  getClientIp,
+  trackConnection,
+  releaseConnection,
+  isMessageWithinSizeLimit,
+  WS_CLOSE_CONNECTION_LIMIT,
+  WS_CLOSE_MESSAGE_TOO_LARGE,
+} from "./ws-limits.js";
 
 const NAMESPACE = "optio";
 const POD_ROLE_LABEL = "optio.pod-role=optio";
@@ -210,8 +218,18 @@ export function parseActionResult(text: string): ParsedActionResult | null {
 
 export async function optioChatWs(app: FastifyInstance) {
   app.get("/ws/optio/chat", { websocket: true }, async (socket, req) => {
+    const clientIp = getClientIp(req);
+
+    if (!trackConnection(clientIp)) {
+      socket.close(WS_CLOSE_CONNECTION_LIMIT, "Too many connections");
+      return;
+    }
+
     const user = await authenticateWs(socket, req);
-    if (!user) return;
+    if (!user) {
+      releaseConnection(clientIp);
+      return;
+    }
 
     const userId = user.id;
     const log = logger.child({ userId, ws: "optio-chat" });
@@ -224,6 +242,7 @@ export async function optioChatWs(app: FastifyInstance) {
           message: "You already have an active Optio conversation. Close the other one first.",
         }),
       );
+      releaseConnection(clientIp);
       socket.close(4409, "Concurrent conversation");
       return;
     }
@@ -416,6 +435,11 @@ export async function optioChatWs(app: FastifyInstance) {
 
     // Handle incoming messages from the client
     socket.on("message", (data: Buffer | string) => {
+      if (!isMessageWithinSizeLimit(data)) {
+        socket.close(WS_CLOSE_MESSAGE_TOO_LARGE, "Message too large");
+        return;
+      }
+
       const str = typeof data === "string" ? data : data.toString("utf-8");
 
       let msg: {
@@ -514,6 +538,7 @@ export async function optioChatWs(app: FastifyInstance) {
 
     socket.on("close", () => {
       log.info("Optio chat disconnected");
+      releaseConnection(clientIp);
       activeConnections.delete(userId);
       if (execSession) {
         execSession.close();

--- a/apps/api/src/ws/session-chat.ts
+++ b/apps/api/src/ws/session-chat.ts
@@ -10,6 +10,14 @@ import { parseClaudeEvent } from "../services/agent-event-parser.js";
 import { publishSessionEvent } from "../services/event-bus.js";
 import type { ExecSession, OptioSettings } from "@optio/shared";
 import { extractSessionToken } from "./ws-auth.js";
+import {
+  getClientIp,
+  trackConnection,
+  releaseConnection,
+  isMessageWithinSizeLimit,
+  WS_CLOSE_CONNECTION_LIMIT,
+  WS_CLOSE_MESSAGE_TOO_LARGE,
+} from "./ws-limits.js";
 
 /**
  * Session chat WebSocket handler.
@@ -30,6 +38,13 @@ import { extractSessionToken } from "./ws-auth.js";
  */
 export async function sessionChatWs(app: FastifyInstance) {
   app.get("/ws/sessions/:sessionId/chat", { websocket: true }, async (socket, req) => {
+    const clientIp = getClientIp(req);
+
+    if (!trackConnection(clientIp)) {
+      socket.close(WS_CLOSE_CONNECTION_LIMIT, "Too many connections");
+      return;
+    }
+
     const { sessionId } = req.params as { sessionId: string };
     const log = logger.child({ sessionId, ws: "session-chat" });
 
@@ -41,18 +56,21 @@ export async function sessionChatWs(app: FastifyInstance) {
     const session = await getSession(sessionId);
     if (!session) {
       socket.send(JSON.stringify({ type: "error", message: "Session not found" }));
+      releaseConnection(clientIp);
       socket.close();
       return;
     }
 
     if (session.state !== "active") {
       socket.send(JSON.stringify({ type: "error", message: "Session is not active" }));
+      releaseConnection(clientIp);
       socket.close();
       return;
     }
 
     if (!session.podId) {
       socket.send(JSON.stringify({ type: "error", message: "Session has no pod assigned" }));
+      releaseConnection(clientIp);
       socket.close();
       return;
     }
@@ -61,6 +79,7 @@ export async function sessionChatWs(app: FastifyInstance) {
     const [pod] = await db.select().from(repoPods).where(eq(repoPods.id, session.podId));
     if (!pod || !pod.podName) {
       socket.send(JSON.stringify({ type: "error", message: "Pod not found or not ready" }));
+      releaseConnection(clientIp);
       socket.close();
       return;
     }
@@ -239,6 +258,11 @@ export async function sessionChatWs(app: FastifyInstance) {
 
     // Handle incoming messages from the client
     socket.on("message", (data: Buffer | string) => {
+      if (!isMessageWithinSizeLimit(data)) {
+        socket.close(WS_CLOSE_MESSAGE_TOO_LARGE, "Message too large");
+        return;
+      }
+
       const str = typeof data === "string" ? data : data.toString("utf-8");
 
       let msg: { type: string; content?: string; model?: string };
@@ -291,6 +315,7 @@ export async function sessionChatWs(app: FastifyInstance) {
 
     socket.on("close", () => {
       log.info("Session chat disconnected");
+      releaseConnection(clientIp);
       if (execSession) {
         execSession.close();
         execSession = null;

--- a/apps/api/src/ws/session-terminal.ts
+++ b/apps/api/src/ws/session-terminal.ts
@@ -6,29 +6,47 @@ import { repoPods } from "../db/schema.js";
 import { eq } from "drizzle-orm";
 import { logger } from "../logger.js";
 import type { ContainerHandle, ExecSession } from "@optio/shared";
+import {
+  getClientIp,
+  trackConnection,
+  releaseConnection,
+  isMessageWithinSizeLimit,
+  WS_CLOSE_CONNECTION_LIMIT,
+  WS_CLOSE_MESSAGE_TOO_LARGE,
+} from "./ws-limits.js";
 
 const PR_URL_REGEX = /https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/g;
 
 export async function sessionTerminalWs(app: FastifyInstance) {
   app.get("/ws/sessions/:sessionId/terminal", { websocket: true }, async (socket, req) => {
+    const clientIp = getClientIp(req);
+
+    if (!trackConnection(clientIp)) {
+      socket.close(WS_CLOSE_CONNECTION_LIMIT, "Too many connections");
+      return;
+    }
+
     const { sessionId } = req.params as { sessionId: string };
     const log = logger.child({ sessionId });
 
     const session = await getSession(sessionId);
     if (!session) {
       socket.send(JSON.stringify({ error: "Session not found" }));
+      releaseConnection(clientIp);
       socket.close();
       return;
     }
 
     if (session.state !== "active") {
       socket.send(JSON.stringify({ error: "Session is not active" }));
+      releaseConnection(clientIp);
       socket.close();
       return;
     }
 
     if (!session.podId) {
       socket.send(JSON.stringify({ error: "Session has no pod assigned" }));
+      releaseConnection(clientIp);
       socket.close();
       return;
     }
@@ -37,6 +55,7 @@ export async function sessionTerminalWs(app: FastifyInstance) {
     const [pod] = await db.select().from(repoPods).where(eq(repoPods.id, session.podId));
     if (!pod || !pod.podName) {
       socket.send(JSON.stringify({ error: "Pod not found or not ready" }));
+      releaseConnection(clientIp);
       socket.close();
       return;
     }
@@ -110,6 +129,11 @@ export async function sessionTerminalWs(app: FastifyInstance) {
 
       // Pipe WebSocket → exec stdin
       socket.on("message", (data: Buffer | string) => {
+        if (!isMessageWithinSizeLimit(data)) {
+          socket.close(WS_CLOSE_MESSAGE_TOO_LARGE, "Message too large");
+          return;
+        }
+
         const str = typeof data === "string" ? data : data.toString("utf-8");
 
         // Check for resize messages
@@ -136,11 +160,13 @@ export async function sessionTerminalWs(app: FastifyInstance) {
       // Handle WebSocket close
       socket.on("close", () => {
         log.info("Session terminal disconnected");
+        releaseConnection(clientIp);
         execSession?.close();
       });
     } catch (err) {
       log.error({ err }, "Failed to start terminal exec session");
       socket.send(JSON.stringify({ error: "Failed to start terminal" }));
+      releaseConnection(clientIp);
       socket.close();
     }
   });

--- a/apps/api/src/ws/ws-limits.test.ts
+++ b/apps/api/src/ws/ws-limits.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Mock the logger before importing the module under test
+import { vi } from "vitest";
+vi.mock("../logger.js", () => ({
+  logger: {
+    child: () => ({
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+import {
+  trackConnection,
+  releaseConnection,
+  isMessageWithinSizeLimit,
+  getClientIp,
+  MAX_WS_CONNECTIONS_PER_IP,
+  MAX_WS_MESSAGE_SIZE,
+  WS_CLOSE_CONNECTION_LIMIT,
+  WS_CLOSE_MESSAGE_TOO_LARGE,
+  _resetConnectionCounts,
+  _getConnectionCounts,
+} from "./ws-limits.js";
+
+describe("ws-limits", () => {
+  beforeEach(() => {
+    _resetConnectionCounts();
+  });
+
+  describe("constants", () => {
+    it("exports expected limit values", () => {
+      expect(MAX_WS_CONNECTIONS_PER_IP).toBe(10);
+      expect(MAX_WS_MESSAGE_SIZE).toBe(1_048_576);
+      expect(WS_CLOSE_CONNECTION_LIMIT).toBe(4429);
+      expect(WS_CLOSE_MESSAGE_TOO_LARGE).toBe(4413);
+    });
+  });
+
+  describe("getClientIp", () => {
+    it("returns the raw IP when no x-forwarded-for header", () => {
+      const req = { ip: "192.168.1.1", headers: {} };
+      expect(getClientIp(req)).toBe("192.168.1.1");
+    });
+
+    it("returns the first IP from x-forwarded-for", () => {
+      const req = {
+        ip: "10.0.0.1",
+        headers: { "x-forwarded-for": "203.0.113.50, 70.41.3.18, 150.172.238.178" },
+      };
+      expect(getClientIp(req)).toBe("203.0.113.50");
+    });
+
+    it("returns the single IP from x-forwarded-for", () => {
+      const req = {
+        ip: "10.0.0.1",
+        headers: { "x-forwarded-for": "203.0.113.50" },
+      };
+      expect(getClientIp(req)).toBe("203.0.113.50");
+    });
+
+    it("falls back to req.ip when x-forwarded-for is an array", () => {
+      const req = {
+        ip: "10.0.0.1",
+        headers: { "x-forwarded-for": ["203.0.113.50", "70.41.3.18"] as unknown as string },
+      };
+      // Array type doesn't match string, so it falls back
+      expect(getClientIp(req)).toBe("10.0.0.1");
+    });
+  });
+
+  describe("trackConnection / releaseConnection", () => {
+    it("allows connections up to the limit", () => {
+      const ip = "192.168.1.1";
+      for (let i = 0; i < MAX_WS_CONNECTIONS_PER_IP; i++) {
+        expect(trackConnection(ip)).toBe(true);
+      }
+      expect(_getConnectionCounts().get(ip)).toBe(MAX_WS_CONNECTIONS_PER_IP);
+    });
+
+    it("rejects connections over the limit", () => {
+      const ip = "192.168.1.1";
+      for (let i = 0; i < MAX_WS_CONNECTIONS_PER_IP; i++) {
+        trackConnection(ip);
+      }
+      expect(trackConnection(ip)).toBe(false);
+      // Count should not increase beyond the limit
+      expect(_getConnectionCounts().get(ip)).toBe(MAX_WS_CONNECTIONS_PER_IP);
+    });
+
+    it("releases connections correctly", () => {
+      const ip = "192.168.1.1";
+      trackConnection(ip);
+      trackConnection(ip);
+      expect(_getConnectionCounts().get(ip)).toBe(2);
+
+      releaseConnection(ip);
+      expect(_getConnectionCounts().get(ip)).toBe(1);
+
+      releaseConnection(ip);
+      expect(_getConnectionCounts().has(ip)).toBe(false);
+    });
+
+    it("handles releasing when no connections are tracked", () => {
+      releaseConnection("192.168.1.1");
+      expect(_getConnectionCounts().has("192.168.1.1")).toBe(false);
+    });
+
+    it("allows new connections after releasing", () => {
+      const ip = "192.168.1.1";
+      for (let i = 0; i < MAX_WS_CONNECTIONS_PER_IP; i++) {
+        trackConnection(ip);
+      }
+      expect(trackConnection(ip)).toBe(false);
+
+      releaseConnection(ip);
+      expect(trackConnection(ip)).toBe(true);
+    });
+
+    it("tracks different IPs independently", () => {
+      const ip1 = "192.168.1.1";
+      const ip2 = "192.168.1.2";
+
+      for (let i = 0; i < MAX_WS_CONNECTIONS_PER_IP; i++) {
+        trackConnection(ip1);
+      }
+      expect(trackConnection(ip1)).toBe(false);
+      expect(trackConnection(ip2)).toBe(true);
+    });
+  });
+
+  describe("isMessageWithinSizeLimit", () => {
+    it("allows small string messages", () => {
+      expect(isMessageWithinSizeLimit("hello")).toBe(true);
+    });
+
+    it("allows small buffer messages", () => {
+      expect(isMessageWithinSizeLimit(Buffer.from("hello"))).toBe(true);
+    });
+
+    it("allows messages at exactly the limit", () => {
+      const msg = Buffer.alloc(MAX_WS_MESSAGE_SIZE);
+      expect(isMessageWithinSizeLimit(msg)).toBe(true);
+    });
+
+    it("rejects messages over the limit", () => {
+      const msg = Buffer.alloc(MAX_WS_MESSAGE_SIZE + 1);
+      expect(isMessageWithinSizeLimit(msg)).toBe(false);
+    });
+
+    it("rejects large string messages", () => {
+      // Create a string that exceeds the limit
+      const msg = "x".repeat(MAX_WS_MESSAGE_SIZE + 1);
+      expect(isMessageWithinSizeLimit(msg)).toBe(false);
+    });
+
+    it("allows empty messages", () => {
+      expect(isMessageWithinSizeLimit("")).toBe(true);
+      expect(isMessageWithinSizeLimit(Buffer.alloc(0))).toBe(true);
+    });
+
+    it("correctly handles multi-byte UTF-8 characters in strings", () => {
+      // Each emoji is 4 bytes in UTF-8, so fewer characters are needed
+      const singleByteStr = "a".repeat(MAX_WS_MESSAGE_SIZE);
+      expect(isMessageWithinSizeLimit(singleByteStr)).toBe(true);
+
+      // This string has MAX_WS_MESSAGE_SIZE characters but each is 4 bytes
+      const multiByteStr = "\u{1F600}".repeat(MAX_WS_MESSAGE_SIZE / 4 + 1);
+      expect(isMessageWithinSizeLimit(multiByteStr)).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/ws/ws-limits.ts
+++ b/apps/api/src/ws/ws-limits.ts
@@ -1,0 +1,87 @@
+import { logger } from "../logger.js";
+
+const log = logger.child({ module: "ws-limits" });
+
+/**
+ * WebSocket connection and message limits.
+ *
+ * Enforces per-IP connection counts and message size validation
+ * to protect against resource exhaustion attacks.
+ */
+
+/** Maximum concurrent WebSocket connections per IP address. */
+export const MAX_WS_CONNECTIONS_PER_IP = 10;
+
+/** Maximum message size in bytes (1 MB). */
+export const MAX_WS_MESSAGE_SIZE = 1_048_576;
+
+/** WebSocket close code for connection limit exceeded (custom application code). */
+export const WS_CLOSE_CONNECTION_LIMIT = 4429;
+
+/** WebSocket close code for message too large (custom application code). */
+export const WS_CLOSE_MESSAGE_TOO_LARGE = 4413;
+
+// ─── Per-IP connection tracking ───
+
+const connectionCounts = new Map<string, number>();
+
+/** @internal Expose for testing. */
+export function _getConnectionCounts(): Map<string, number> {
+  return connectionCounts;
+}
+
+/** @internal Reset all tracking state — only for tests. */
+export function _resetConnectionCounts(): void {
+  connectionCounts.clear();
+}
+
+/**
+ * Extract the client IP address from a Fastify request.
+ * Uses x-forwarded-for if present (trusted proxy), otherwise raw IP.
+ */
+export function getClientIp(req: {
+  ip: string;
+  headers: Record<string, string | string[] | undefined>;
+}): string {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string") {
+    return forwarded.split(",")[0].trim();
+  }
+  return req.ip;
+}
+
+/**
+ * Track a new WebSocket connection for the given IP.
+ * Returns `true` if the connection is allowed, `false` if the limit is exceeded.
+ */
+export function trackConnection(ip: string): boolean {
+  const current = connectionCounts.get(ip) ?? 0;
+  if (current >= MAX_WS_CONNECTIONS_PER_IP) {
+    log.warn({ ip, current }, "WebSocket connection limit exceeded");
+    return false;
+  }
+  connectionCounts.set(ip, current + 1);
+  return true;
+}
+
+/**
+ * Release a tracked WebSocket connection for the given IP.
+ * Call this when a WebSocket disconnects.
+ */
+export function releaseConnection(ip: string): void {
+  const current = connectionCounts.get(ip) ?? 0;
+  if (current <= 1) {
+    connectionCounts.delete(ip);
+  } else {
+    connectionCounts.set(ip, current - 1);
+  }
+}
+
+/**
+ * Check whether a WebSocket message exceeds the size limit.
+ * Returns `true` if the message is within limits, `false` if too large.
+ */
+export function isMessageWithinSizeLimit(data: Buffer | string): boolean {
+  const size = typeof data === "string" ? Buffer.byteLength(data, "utf-8") : data.length;
+  return size <= MAX_WS_MESSAGE_SIZE;
+}


### PR DESCRIPTION
## Summary

- Add per-IP WebSocket connection limits (max 10 concurrent connections per IP) across all 5 WS handlers
- Add message size validation (1 MB max) before JSON parsing on handlers that accept client input
- Close connections exceeding limits with appropriate WebSocket close codes (4429 for connection limit, 4413 for oversized messages)

## Changes

**New file:** `apps/api/src/ws/ws-limits.ts` — shared module with:
- `trackConnection(ip)` / `releaseConnection(ip)` — per-IP connection counting
- `isMessageWithinSizeLimit(data)` — validates message size before parsing
- `getClientIp(req)` — extracts client IP (supports x-forwarded-for)

**Modified handlers:**
- `log-stream.ts` — connection limit + release on close
- `events.ts` — connection limit + release on close
- `session-terminal.ts` — connection limit + message size check + release on close
- `session-chat.ts` — connection limit + message size check + release on close
- `optio-chat.ts` — connection limit + message size check + release on close

## Test plan
- [x] 18 new tests in `ws-limits.test.ts` covering connection tracking, size validation, IP extraction
- [x] All 50 WS tests pass
- [x] Full test suite passes (958 tests across 69 files)
- [x] TypeScript typecheck passes
- [x] Prettier formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)