### PR TITLE
fix: add auth and rate limiting to setup routes

### DIFF
--- a/apps/api/src/plugins/auth.test.ts
+++ b/apps/api/src/plugins/auth.test.ts
@@ -20,7 +20,12 @@ vi.mock("../services/workspace-service.js", () => ({
   ensureUserHasWorkspace: () => "ws-1",
 }));
 
-import { requireRole } from "./auth.js";
+const mockListSecrets = vi.fn();
+vi.mock("../services/secret-service.js", () => ({
+  listSecrets: (...args: unknown[]) => mockListSecrets(...args),
+}));
+
+import { requireRole, isSetupComplete, resetSetupCompleteCache } from "./auth.js";
 
 // ─── Helpers ───
 
@@ -151,5 +156,63 @@ describe("requireRole", () => {
       const res = await inject(await buildApp("viewer", null));
       expect(res.statusCode).toBe(403);
     });
+  });
+});
+
+describe("isSetupComplete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSetupCompleteCache();
+  });
+
+  it("returns true when an agent key secret exists", async () => {
+    mockListSecrets.mockResolvedValue([{ name: "ANTHROPIC_API_KEY" }]);
+    expect(await isSetupComplete()).toBe(true);
+  });
+
+  it("returns true for OPENAI_API_KEY", async () => {
+    mockListSecrets.mockResolvedValue([{ name: "OPENAI_API_KEY" }]);
+    expect(await isSetupComplete()).toBe(true);
+  });
+
+  it("returns true for CLAUDE_CODE_OAUTH_TOKEN", async () => {
+    mockListSecrets.mockResolvedValue([{ name: "CLAUDE_CODE_OAUTH_TOKEN" }]);
+    expect(await isSetupComplete()).toBe(true);
+  });
+
+  it("returns true for COPILOT_GITHUB_TOKEN", async () => {
+    mockListSecrets.mockResolvedValue([{ name: "COPILOT_GITHUB_TOKEN" }]);
+    expect(await isSetupComplete()).toBe(true);
+  });
+
+  it("returns false when no agent key secrets exist", async () => {
+    mockListSecrets.mockResolvedValue([{ name: "GITHUB_TOKEN" }]);
+    expect(await isSetupComplete()).toBe(false);
+  });
+
+  it("returns false when secrets list is empty", async () => {
+    mockListSecrets.mockResolvedValue([]);
+    expect(await isSetupComplete()).toBe(false);
+  });
+
+  it("returns false when listSecrets throws", async () => {
+    mockListSecrets.mockRejectedValue(new Error("db error"));
+    expect(await isSetupComplete()).toBe(false);
+  });
+
+  it("caches the result across calls", async () => {
+    mockListSecrets.mockResolvedValue([{ name: "ANTHROPIC_API_KEY" }]);
+    await isSetupComplete();
+    await isSetupComplete();
+    expect(mockListSecrets).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes after cache reset", async () => {
+    mockListSecrets.mockResolvedValue([{ name: "ANTHROPIC_API_KEY" }]);
+    await isSetupComplete();
+    resetSetupCompleteCache();
+    mockListSecrets.mockResolvedValue([]);
+    expect(await isSetupComplete()).toBe(false);
+    expect(mockListSecrets).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -3,6 +3,7 @@ import fp from "fastify-plugin";
 import { validateSession, type SessionUser } from "../services/session-service.js";
 import { isAuthDisabled } from "../services/oauth/index.js";
 import { getUserRole, ensureUserHasWorkspace } from "../services/workspace-service.js";
+import { listSecrets } from "../services/secret-service.js";
 import type { WorkspaceRole } from "@optio/shared";
 
 declare module "fastify" {
@@ -45,11 +46,50 @@ const WORKSPACE_HEADER = "x-workspace-id";
 const PUBLIC_ROUTES = [
   "/api/health",
   "/api/auth/",
-  "/api/setup/",
+  "/api/setup/status",
   "/api/webhooks/",
   "/ws/",
   "/api/internal/git-credentials",
 ];
+
+/**
+ * Secrets whose presence indicates that initial setup has been completed.
+ * Once any agent API key is configured, setup POST routes require auth.
+ */
+const AGENT_KEY_SECRETS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "COPILOT_GITHUB_TOKEN",
+];
+
+let _setupCompleteCache: { value: boolean; expires: number } | null = null;
+const SETUP_CACHE_TTL_MS = 60_000; // 60 seconds
+
+/**
+ * Returns true when at least one agent API key secret exists, indicating
+ * initial setup is complete. Result is cached for 60 seconds.
+ */
+export async function isSetupComplete(): Promise<boolean> {
+  const now = Date.now();
+  if (_setupCompleteCache && now < _setupCompleteCache.expires) {
+    return _setupCompleteCache.value;
+  }
+  try {
+    const allSecrets = await listSecrets();
+    const names = allSecrets.map((s) => s.name);
+    const complete = AGENT_KEY_SECRETS.some((k) => names.includes(k));
+    _setupCompleteCache = { value: complete, expires: now + SETUP_CACHE_TTL_MS };
+    return complete;
+  } catch {
+    return false;
+  }
+}
+
+/** Reset the setup-complete cache (for testing). */
+export function resetSetupCompleteCache(): void {
+  _setupCompleteCache = null;
+}
 
 function isPublicRoute(url: string): boolean {
   return PUBLIC_ROUTES.some((prefix) => url.startsWith(prefix));
@@ -73,6 +113,14 @@ async function authPlugin(app: FastifyInstance) {
 
     // Public routes — no auth needed
     if (isPublicRoute(req.url)) return;
+
+    // Setup routes (other than /status) are public only before initial setup.
+    // Once setup is complete they require authentication like any other route.
+    if (req.url.startsWith("/api/setup/")) {
+      const complete = await isSetupComplete();
+      if (!complete) return; // Allow without auth during initial setup
+      // Fall through to normal auth check
+    }
 
     // Token resolution order: Bearer header → session cookie → query param (WS)
     const token =

--- a/apps/api/src/routes/setup.test.ts
+++ b/apps/api/src/routes/setup.test.ts
@@ -21,13 +21,23 @@ vi.mock("../services/auth-service.js", () => ({
   isSubscriptionAvailable: () => false,
 }));
 
+let authDisabled = false;
+vi.mock("../services/oauth/index.js", () => ({
+  isAuthDisabled: () => authDisabled,
+}));
+
 import { setupRoutes } from "./setup.js";
 
 // ─── Helpers ───
 
-async function buildTestApp(): Promise<FastifyInstance> {
+async function buildTestApp(user?: { workspaceRole: string } | null): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
   app.decorateRequest("user", undefined as any);
+  if (user !== undefined) {
+    app.addHook("onRequest", async (req) => {
+      (req as any).user = user;
+    });
+  }
   await setupRoutes(app);
   await app.ready();
   return app;
@@ -334,5 +344,102 @@ describe("POST /api/setup/repos", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json().repos).toHaveLength(1);
     expect(res.json().repos[0].fullName).toBe("org/repo");
+  });
+});
+
+describe("admin guard on POST setup routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authDisabled = false;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("allows POST requests when no user is set (setup not yet complete)", async () => {
+    const app = await buildTestApp(); // no user
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ login: "testuser", name: "Test" }),
+      }),
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/setup/validate/github-token",
+      payload: { token: "ghp_test" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().valid).toBe(true);
+  });
+
+  it("allows POST requests for admin users", async () => {
+    const app = await buildTestApp({ workspaceRole: "admin" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ login: "testuser", name: "Test" }),
+      }),
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/setup/validate/github-token",
+      payload: { token: "ghp_test" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().valid).toBe(true);
+  });
+
+  it("rejects POST requests for non-admin users with 403", async () => {
+    const app = await buildTestApp({ workspaceRole: "member" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/setup/validate/github-token",
+      payload: { token: "ghp_test" },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error).toContain("Admin role required");
+  });
+
+  it("rejects viewer role on POST routes", async () => {
+    const app = await buildTestApp({ workspaceRole: "viewer" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/setup/validate/anthropic-key",
+      payload: { key: "sk-ant-test" },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("skips admin guard when auth is disabled", async () => {
+    authDisabled = true;
+    const app = await buildTestApp({ workspaceRole: "viewer" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ login: "testuser", name: "Test" }),
+      }),
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/setup/validate/github-token",
+      payload: { token: "ghp_test" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().valid).toBe(true);
   });
 });

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -1,8 +1,38 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { checkRuntimeHealth } from "../services/container-service.js";
 import { listSecrets, retrieveSecret } from "../services/secret-service.js";
 import { isSubscriptionAvailable } from "../services/auth-service.js";
 import { isGitHubAppConfigured } from "../services/github-app-service.js";
+import { isAuthDisabled } from "../services/oauth/index.js";
+
+/** Rate limit config for setup POST endpoints: 5 requests per 15 minutes per IP. */
+const SETUP_POST_RATE_LIMIT = {
+  max: 5,
+  timeWindow: "15 minutes",
+};
+
+/** Rate limit config for the status endpoint: 20 requests per minute per IP. */
+const SETUP_STATUS_RATE_LIMIT = {
+  max: 20,
+  timeWindow: "1 minute",
+};
+
+/**
+ * Pre-handler for POST setup routes.
+ *
+ * When auth is enabled and the user is authenticated (i.e. setup is already
+ * complete — the auth plugin only lets unauthenticated requests through when
+ * setup is NOT complete), require the admin role.
+ */
+const requireAdminWhenAuthenticated = async (req: FastifyRequest, reply: FastifyReply) => {
+  if (isAuthDisabled()) return;
+  if (!req.user) return; // Not authenticated → setup not yet complete, allow
+  if (req.user.workspaceRole !== "admin") {
+    return reply.status(403).send({
+      error: "Admin role required for setup operations",
+    });
+  }
+};
 
 function sanitizeError(err: unknown): string {
   if (process.env.NODE_ENV !== "production") return String(err);
@@ -11,246 +41,292 @@ function sanitizeError(err: unknown): string {
 
 export async function setupRoutes(app: FastifyInstance) {
   // Check if the system has been set up (secrets exist)
-  app.get("/api/setup/status", async (_req, reply) => {
-    const secrets = await listSecrets();
-    const secretNames = secrets.map((s) => s.name);
+  app.get(
+    "/api/setup/status",
+    { config: { rateLimit: SETUP_STATUS_RATE_LIMIT } },
+    async (_req, reply) => {
+      const secrets = await listSecrets();
+      const secretNames = secrets.map((s) => s.name);
 
-    const hasAnthropicKey = secretNames.includes("ANTHROPIC_API_KEY");
-    const hasOpenAIKey = secretNames.includes("OPENAI_API_KEY");
-    // GitHub App configured at deployment level satisfies the GitHub token requirement
-    const hasGithubToken = secretNames.includes("GITHUB_TOKEN") || isGitHubAppConfigured();
+      const hasAnthropicKey = secretNames.includes("ANTHROPIC_API_KEY");
+      const hasOpenAIKey = secretNames.includes("OPENAI_API_KEY");
+      // GitHub App configured at deployment level satisfies the GitHub token requirement
+      const hasGithubToken = secretNames.includes("GITHUB_TOKEN") || isGitHubAppConfigured();
 
-    // Check if using Max subscription or OAuth token mode
-    let usingSubscription = false;
-    let hasOauthToken = false;
-    try {
-      const authMode = await retrieveSecret("CLAUDE_AUTH_MODE").catch(() => null);
-      if (authMode === "max-subscription") {
-        usingSubscription = isSubscriptionAvailable();
-      }
-      if (authMode === "oauth-token") {
-        hasOauthToken = secretNames.includes("CLAUDE_CODE_OAUTH_TOKEN");
-      }
-    } catch {}
+      // Check if using Max subscription or OAuth token mode
+      let usingSubscription = false;
+      let hasOauthToken = false;
+      try {
+        const authMode = await retrieveSecret("CLAUDE_AUTH_MODE").catch(() => null);
+        if (authMode === "max-subscription") {
+          usingSubscription = isSubscriptionAvailable();
+        }
+        if (authMode === "oauth-token") {
+          hasOauthToken = secretNames.includes("CLAUDE_CODE_OAUTH_TOKEN");
+        }
+      } catch {}
 
-    // Check if using Codex app-server mode (no API key needed)
-    let hasCodexAppServer = false;
-    try {
-      const codexAuthMode = await retrieveSecret("CODEX_AUTH_MODE").catch(() => null);
-      if (codexAuthMode === "app-server") {
-        hasCodexAppServer = secretNames.includes("CODEX_APP_SERVER_URL");
-      }
-    } catch {}
+      // Check if using Codex app-server mode (no API key needed)
+      let hasCodexAppServer = false;
+      try {
+        const codexAuthMode = await retrieveSecret("CODEX_AUTH_MODE").catch(() => null);
+        if (codexAuthMode === "app-server") {
+          hasCodexAppServer = secretNames.includes("CODEX_APP_SERVER_URL");
+        }
+      } catch {}
 
-    // Check for Copilot token
-    const hasCopilotToken = secretNames.includes("COPILOT_GITHUB_TOKEN");
+      // Check for Copilot token
+      const hasCopilotToken = secretNames.includes("COPILOT_GITHUB_TOKEN");
 
-    const hasAnyAgentKey =
-      hasAnthropicKey ||
-      hasOpenAIKey ||
-      usingSubscription ||
-      hasOauthToken ||
-      hasCodexAppServer ||
-      hasCopilotToken;
+      const hasAnyAgentKey =
+        hasAnthropicKey ||
+        hasOpenAIKey ||
+        usingSubscription ||
+        hasOauthToken ||
+        hasCodexAppServer ||
+        hasCopilotToken;
 
-    let runtimeHealthy = false;
-    try {
-      runtimeHealthy = await checkRuntimeHealth();
-    } catch {}
+      let runtimeHealthy = false;
+      try {
+        runtimeHealthy = await checkRuntimeHealth();
+      } catch {}
 
-    const isSetUp = hasAnyAgentKey && hasGithubToken && runtimeHealthy;
+      const isSetUp = hasAnyAgentKey && hasGithubToken && runtimeHealthy;
 
-    reply.send({
-      isSetUp,
-      steps: {
-        runtime: { done: runtimeHealthy, label: "Container runtime" },
-        githubToken: { done: hasGithubToken, label: "GitHub token" },
-        anthropicKey: { done: hasAnthropicKey, label: "Anthropic API key" },
-        openaiKey: { done: hasOpenAIKey, label: "OpenAI API key" },
-        codexAppServer: { done: hasCodexAppServer, label: "Codex app-server" },
-        copilotToken: { done: hasCopilotToken, label: "GitHub Copilot token" },
-        anyAgentKey: { done: hasAnyAgentKey, label: "At least one agent API key" },
-      },
-    });
-  });
-
-  // Validate a GitHub token by trying to get the authenticated user
-  app.post("/api/setup/validate/github-token", async (req, reply) => {
-    const { token } = req.body as { token: string };
-    if (!token) return reply.status(400).send({ valid: false, error: "Token is required" });
-
-    try {
-      const res = await fetch("https://api.github.com/user", {
-        headers: { Authorization: `Bearer ${token}`, "User-Agent": "Optio" },
-      });
-      if (!res.ok) {
-        return reply.send({ valid: false, error: `GitHub returned ${res.status}` });
-      }
-      const user = (await res.json()) as { login: string; name: string };
-      reply.send({ valid: true, user: { login: user.login, name: user.name } });
-    } catch (err) {
-      app.log.error(err, "GitHub token validation failed");
-      reply.send({ valid: false, error: sanitizeError(err) });
-    }
-  });
-
-  // Validate an Anthropic API key
-  app.post("/api/setup/validate/anthropic-key", async (req, reply) => {
-    const { key } = req.body as { key: string };
-    if (!key) return reply.status(400).send({ valid: false, error: "Key is required" });
-
-    try {
-      const res = await fetch("https://api.anthropic.com/v1/models", {
-        headers: {
-          "x-api-key": key,
-          "anthropic-version": "2023-06-01",
+      reply.send({
+        isSetUp,
+        steps: {
+          runtime: { done: runtimeHealthy, label: "Container runtime" },
+          githubToken: { done: hasGithubToken, label: "GitHub token" },
+          anthropicKey: { done: hasAnthropicKey, label: "Anthropic API key" },
+          openaiKey: { done: hasOpenAIKey, label: "OpenAI API key" },
+          codexAppServer: { done: hasCodexAppServer, label: "Codex app-server" },
+          copilotToken: { done: hasCopilotToken, label: "GitHub Copilot token" },
+          anyAgentKey: { done: hasAnyAgentKey, label: "At least one agent API key" },
         },
       });
-      if (res.ok) {
-        reply.send({ valid: true });
-      } else {
-        const body = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
-        reply.send({ valid: false, error: body.error?.message ?? `API returned ${res.status}` });
+    },
+  );
+
+  // Validate a GitHub token by trying to get the authenticated user
+  app.post(
+    "/api/setup/validate/github-token",
+    {
+      config: { rateLimit: SETUP_POST_RATE_LIMIT },
+      preHandler: [requireAdminWhenAuthenticated],
+    },
+    async (req, reply) => {
+      const { token } = req.body as { token: string };
+      if (!token) return reply.status(400).send({ valid: false, error: "Token is required" });
+
+      try {
+        const res = await fetch("https://api.github.com/user", {
+          headers: { Authorization: `Bearer ${token}`, "User-Agent": "Optio" },
+        });
+        if (!res.ok) {
+          return reply.send({ valid: false, error: `GitHub returned ${res.status}` });
+        }
+        const user = (await res.json()) as { login: string; name: string };
+        reply.send({ valid: true, user: { login: user.login, name: user.name } });
+      } catch (err) {
+        app.log.error(err, "GitHub token validation failed");
+        reply.send({ valid: false, error: sanitizeError(err) });
       }
-    } catch (err) {
-      app.log.error(err, "Anthropic key validation failed");
-      reply.send({ valid: false, error: sanitizeError(err) });
-    }
-  });
+    },
+  );
 
-  // Validate a GitHub Copilot token
-  app.post("/api/setup/validate/copilot-token", async (req, reply) => {
-    const { token } = req.body as { token: string };
-    if (!token) return reply.status(400).send({ valid: false, error: "Token is required" });
+  // Validate an Anthropic API key
+  app.post(
+    "/api/setup/validate/anthropic-key",
+    {
+      config: { rateLimit: SETUP_POST_RATE_LIMIT },
+      preHandler: [requireAdminWhenAuthenticated],
+    },
+    async (req, reply) => {
+      const { key } = req.body as { key: string };
+      if (!key) return reply.status(400).send({ valid: false, error: "Key is required" });
 
-    // Classic PATs (ghp_*) are not supported by Copilot CLI
-    if (token.startsWith("ghp_")) {
-      return reply.send({
-        valid: false,
-        error:
-          "Classic personal access tokens (ghp_) are not supported by Copilot. Use a fine-grained PAT with the Copilot Requests permission.",
-      });
-    }
-
-    try {
-      const res = await fetch("https://api.github.com/user", {
-        headers: { Authorization: `Bearer ${token}`, "User-Agent": "Optio" },
-      });
-      if (!res.ok) {
-        return reply.send({ valid: false, error: `GitHub returned ${res.status}` });
-      }
-      const user = (await res.json()) as { login: string; name: string };
-      reply.send({ valid: true, user: { login: user.login, name: user.name } });
-    } catch (err) {
-      app.log.error(err, "Copilot token validation failed");
-      reply.send({ valid: false, error: sanitizeError(err) });
-    }
-  });
-
-  // Validate an OpenAI API key
-  app.post("/api/setup/validate/openai-key", async (req, reply) => {
-    const { key } = req.body as { key: string };
-    if (!key) return reply.status(400).send({ valid: false, error: "Key is required" });
-
-    try {
-      const res = await fetch("https://api.openai.com/v1/models", {
-        headers: { Authorization: `Bearer ${key}` },
-      });
-      if (res.ok) {
-        reply.send({ valid: true });
-      } else {
-        const body = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
-        reply.send({ valid: false, error: body.error?.message ?? `API returned ${res.status}` });
-      }
-    } catch (err) {
-      app.log.error(err, "OpenAI key validation failed");
-      reply.send({ valid: false, error: sanitizeError(err) });
-    }
-  });
-
-  // List recent repos for the authenticated user
-  app.post("/api/setup/repos", async (req, reply) => {
-    const { token } = req.body as { token: string };
-    if (!token) return reply.status(400).send({ repos: [], error: "Token is required" });
-
-    try {
-      const headers = { Authorization: `Bearer ${token}`, "User-Agent": "Optio" };
-
-      // Fetch repos sorted by most recently pushed
-      const res = await fetch(
-        "https://api.github.com/user/repos?sort=pushed&direction=desc&per_page=20&affiliation=owner,collaborator,organization_member",
-        { headers },
-      );
-      if (!res.ok) {
-        return reply.send({ repos: [], error: `GitHub returned ${res.status}` });
-      }
-
-      const data = (await res.json()) as Array<{
-        full_name: string;
-        html_url: string;
-        clone_url: string;
-        default_branch: string;
-        private: boolean;
-        description: string | null;
-        language: string | null;
-        pushed_at: string;
-      }>;
-
-      const repos = data.map((r) => ({
-        fullName: r.full_name,
-        cloneUrl: r.clone_url,
-        htmlUrl: r.html_url,
-        defaultBranch: r.default_branch,
-        isPrivate: r.private,
-        description: r.description,
-        language: r.language,
-        pushedAt: r.pushed_at,
-      }));
-
-      reply.send({ repos });
-    } catch (err) {
-      app.log.error(err, "Repo listing failed");
-      reply.send({ repos: [], error: sanitizeError(err) });
-    }
-  });
-
-  // Validate repo access (try to ls-remote)
-  app.post("/api/setup/validate/repo", async (req, reply) => {
-    const { repoUrl, token } = req.body as { repoUrl: string; token?: string };
-    if (!repoUrl) return reply.status(400).send({ valid: false, error: "Repo URL is required" });
-
-    try {
-      // Use the GitHub API to check if the repo exists and is accessible
-      const match = repoUrl.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
-      if (!match) {
-        return reply.send({ valid: false, error: "Could not parse GitHub repo from URL" });
-      }
-      const [, owner, repo] = match;
-      const headers: Record<string, string> = { "User-Agent": "Optio" };
-      const effectiveToken = token ?? (await retrieveSecret("GITHUB_TOKEN").catch(() => null));
-      if (effectiveToken) headers["Authorization"] = `Bearer ${effectiveToken}`;
-
-      const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers });
-      if (res.ok) {
-        const data = (await res.json()) as {
-          full_name: string;
-          default_branch: string;
-          private: boolean;
-        };
-        reply.send({
-          valid: true,
-          repo: {
-            fullName: data.full_name,
-            defaultBranch: data.default_branch,
-            isPrivate: data.private,
+      try {
+        const res = await fetch("https://api.anthropic.com/v1/models", {
+          headers: {
+            "x-api-key": key,
+            "anthropic-version": "2023-06-01",
           },
         });
-      } else {
-        reply.send({ valid: false, error: `Repository not accessible (${res.status})` });
+        if (res.ok) {
+          reply.send({ valid: true });
+        } else {
+          const body = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
+          reply.send({ valid: false, error: body.error?.message ?? `API returned ${res.status}` });
+        }
+      } catch (err) {
+        app.log.error(err, "Anthropic key validation failed");
+        reply.send({ valid: false, error: sanitizeError(err) });
       }
-    } catch (err) {
-      app.log.error(err, "Repo validation failed");
-      reply.send({ valid: false, error: sanitizeError(err) });
-    }
-  });
+    },
+  );
+
+  // Validate a GitHub Copilot token
+  app.post(
+    "/api/setup/validate/copilot-token",
+    {
+      config: { rateLimit: SETUP_POST_RATE_LIMIT },
+      preHandler: [requireAdminWhenAuthenticated],
+    },
+    async (req, reply) => {
+      const { token } = req.body as { token: string };
+      if (!token) return reply.status(400).send({ valid: false, error: "Token is required" });
+
+      // Classic PATs (ghp_*) are not supported by Copilot CLI
+      if (token.startsWith("ghp_")) {
+        return reply.send({
+          valid: false,
+          error:
+            "Classic personal access tokens (ghp_) are not supported by Copilot. Use a fine-grained PAT with the Copilot Requests permission.",
+        });
+      }
+
+      try {
+        const res = await fetch("https://api.github.com/user", {
+          headers: { Authorization: `Bearer ${token}`, "User-Agent": "Optio" },
+        });
+        if (!res.ok) {
+          return reply.send({ valid: false, error: `GitHub returned ${res.status}` });
+        }
+        const user = (await res.json()) as { login: string; name: string };
+        reply.send({ valid: true, user: { login: user.login, name: user.name } });
+      } catch (err) {
+        app.log.error(err, "Copilot token validation failed");
+        reply.send({ valid: false, error: sanitizeError(err) });
+      }
+    },
+  );
+
+  // Validate an OpenAI API key
+  app.post(
+    "/api/setup/validate/openai-key",
+    {
+      config: { rateLimit: SETUP_POST_RATE_LIMIT },
+      preHandler: [requireAdminWhenAuthenticated],
+    },
+    async (req, reply) => {
+      const { key } = req.body as { key: string };
+      if (!key) return reply.status(400).send({ valid: false, error: "Key is required" });
+
+      try {
+        const res = await fetch("https://api.openai.com/v1/models", {
+          headers: { Authorization: `Bearer ${key}` },
+        });
+        if (res.ok) {
+          reply.send({ valid: true });
+        } else {
+          const body = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
+          reply.send({ valid: false, error: body.error?.message ?? `API returned ${res.status}` });
+        }
+      } catch (err) {
+        app.log.error(err, "OpenAI key validation failed");
+        reply.send({ valid: false, error: sanitizeError(err) });
+      }
+    },
+  );
+
+  // List recent repos for the authenticated user
+  app.post(
+    "/api/setup/repos",
+    {
+      config: { rateLimit: SETUP_POST_RATE_LIMIT },
+      preHandler: [requireAdminWhenAuthenticated],
+    },
+    async (req, reply) => {
+      const { token } = req.body as { token: string };
+      if (!token) return reply.status(400).send({ repos: [], error: "Token is required" });
+
+      try {
+        const headers = { Authorization: `Bearer ${token}`, "User-Agent": "Optio" };
+
+        // Fetch repos sorted by most recently pushed
+        const res = await fetch(
+          "https://api.github.com/user/repos?sort=pushed&direction=desc&per_page=20&affiliation=owner,collaborator,organization_member",
+          { headers },
+        );
+        if (!res.ok) {
+          return reply.send({ repos: [], error: `GitHub returned ${res.status}` });
+        }
+
+        const data = (await res.json()) as Array<{
+          full_name: string;
+          html_url: string;
+          clone_url: string;
+          default_branch: string;
+          private: boolean;
+          description: string | null;
+          language: string | null;
+          pushed_at: string;
+        }>;
+
+        const repos = data.map((r) => ({
+          fullName: r.full_name,
+          cloneUrl: r.clone_url,
+          htmlUrl: r.html_url,
+          defaultBranch: r.default_branch,
+          isPrivate: r.private,
+          description: r.description,
+          language: r.language,
+          pushedAt: r.pushed_at,
+        }));
+
+        reply.send({ repos });
+      } catch (err) {
+        app.log.error(err, "Repo listing failed");
+        reply.send({ repos: [], error: sanitizeError(err) });
+      }
+    },
+  );
+
+  // Validate repo access (try to ls-remote)
+  app.post(
+    "/api/setup/validate/repo",
+    {
+      config: { rateLimit: SETUP_POST_RATE_LIMIT },
+      preHandler: [requireAdminWhenAuthenticated],
+    },
+    async (req, reply) => {
+      const { repoUrl, token } = req.body as { repoUrl: string; token?: string };
+      if (!repoUrl) return reply.status(400).send({ valid: false, error: "Repo URL is required" });
+
+      try {
+        // Use the GitHub API to check if the repo exists and is accessible
+        const match = repoUrl.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
+        if (!match) {
+          return reply.send({ valid: false, error: "Could not parse GitHub repo from URL" });
+        }
+        const [, owner, repo] = match;
+        const headers: Record<string, string> = { "User-Agent": "Optio" };
+        const effectiveToken = token ?? (await retrieveSecret("GITHUB_TOKEN").catch(() => null));
+        if (effectiveToken) headers["Authorization"] = `Bearer ${effectiveToken}`;
+
+        const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers });
+        if (res.ok) {
+          const data = (await res.json()) as {
+            full_name: string;
+            default_branch: string;
+            private: boolean;
+          };
+          reply.send({
+            valid: true,
+            repo: {
+              fullName: data.full_name,
+              defaultBranch: data.default_branch,
+              isPrivate: data.private,
+            },
+          });
+        } else {
+          reply.send({ valid: false, error: `Repository not accessible (${res.status})` });
+        }
+      } catch (err) {
+        app.log.error(err, "Repo validation failed");
+        reply.send({ valid: false, error: sanitizeError(err) });
+      }
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- **Removed blanket public access** for `/api/setup/*` routes — only `/api/setup/status` remains always-public (needed by the web UI setup-check component)
- **Added post-setup auth gating**: once any agent API key secret exists (via cached `isSetupComplete()` with 60s TTL), setup POST routes require authentication through the normal auth plugin
- **Added aggressive per-route rate limiting**: 5 requests/15 minutes per IP on all POST setup endpoints, 20 requests/minute on the status endpoint (via `@fastify/rate-limit` route config)
- **Added admin role guard** (`requireAdminWhenAuthenticated`): authenticated users must have admin role to access setup POST routes; unauthenticated access is only allowed during initial setup before any agent key is configured

## Test plan
- [x] `isSetupComplete` returns true/false based on agent key secret presence
- [x] `isSetupComplete` caches results and respects cache reset
- [x] `isSetupComplete` returns false on DB errors (fail-open for setup)
- [x] POST setup routes allow unauthenticated access when no user is set (initial setup)
- [x] POST setup routes allow admin users
- [x] POST setup routes reject member/viewer users with 403
- [x] Admin guard is skipped when auth is disabled (local dev)
- [x] All 954 existing tests continue to pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)