### PR TITLE
fix: encrypt webhook secrets and Slack webhook URLs at rest

### DIFF
--- a/apps/api/src/db/migrations/0037_encrypt_webhook_slack_secrets.sql
+++ b/apps/api/src/db/migrations/0037_encrypt_webhook_slack_secrets.sql
@@ -1,0 +1,14 @@
+-- Encrypt webhook secrets and Slack webhook URLs at rest using AES-256-GCM
+-- Replaces plaintext text columns with encrypted bytea columns
+
+-- Webhooks: replace plaintext secret with encrypted columns
+ALTER TABLE "webhooks" ADD COLUMN "encrypted_secret" bytea;
+ALTER TABLE "webhooks" ADD COLUMN "secret_iv" bytea;
+ALTER TABLE "webhooks" ADD COLUMN "secret_auth_tag" bytea;
+ALTER TABLE "webhooks" DROP COLUMN IF EXISTS "secret";
+
+-- Repos: replace plaintext slack_webhook_url with encrypted columns
+ALTER TABLE "repos" ADD COLUMN "encrypted_slack_webhook_url" bytea;
+ALTER TABLE "repos" ADD COLUMN "slack_webhook_url_iv" bytea;
+ALTER TABLE "repos" ADD COLUMN "slack_webhook_url_auth_tag" bytea;
+ALTER TABLE "repos" DROP COLUMN IF EXISTS "slack_webhook_url";

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1776096000000,
       "tag": "0036_review_drafts",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1776182400000,
+      "tag": "0037_encrypt_webhook_slack_secrets",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -226,7 +226,9 @@ export const repos = pgTable(
     testCommand: text("test_command"), // "npm test", "cargo test", etc.
     reviewModel: text("review_model").default("sonnet"), // can use cheaper model for reviews
     maxAutoResumes: integer("max_auto_resumes"), // null = use OPTIO_MAX_AUTO_RESUMES env var or default (10)
-    slackWebhookUrl: text("slack_webhook_url"), // Slack incoming webhook URL
+    encryptedSlackWebhookUrl: bytea("encrypted_slack_webhook_url"), // AES-256-GCM encrypted Slack webhook URL
+    slackWebhookUrlIv: bytea("slack_webhook_url_iv"),
+    slackWebhookUrlAuthTag: bytea("slack_webhook_url_auth_tag"),
     slackChannel: text("slack_channel"), // override channel (optional)
     slackNotifyOn: jsonb("slack_notify_on").$type<string[]>(), // e.g. ["completed","failed","pr_opened","needs_attention"]
     slackEnabled: boolean("slack_enabled").notNull().default(false),
@@ -321,7 +323,9 @@ export const webhooks = pgTable(
     url: text("url").notNull(),
     workspaceId: uuid("workspace_id"), // nullable for backward compat
     events: jsonb("events").$type<string[]>().notNull(), // array of webhook_event values
-    secret: text("secret"), // HMAC-SHA256 signing secret (plaintext; only used for outbound signing)
+    encryptedSecret: bytea("encrypted_secret"), // AES-256-GCM encrypted signing secret
+    secretIv: bytea("secret_iv"),
+    secretAuthTag: bytea("secret_auth_tag"),
     description: text("description"),
     active: boolean("active").notNull().default(true),
     createdBy: uuid("created_by"),

--- a/apps/api/src/services/repo-service.test.ts
+++ b/apps/api/src/services/repo-service.test.ts
@@ -21,6 +21,18 @@ vi.mock("../db/schema.js", () => ({
   },
 }));
 
+vi.mock("./secret-service.js", () => ({
+  encrypt: vi.fn().mockImplementation((plaintext: string) => ({
+    encrypted: Buffer.from(`enc:${plaintext}`),
+    iv: Buffer.from("mock-iv-1234567"),
+    authTag: Buffer.from("mock-auth-tag12"),
+  })),
+  decrypt: vi.fn().mockImplementation((encrypted: Buffer) => {
+    const str = encrypted.toString();
+    return str.startsWith("enc:") ? str.slice(4) : str;
+  }),
+}));
+
 import { db } from "../db/client.js";
 import {
   listRepos,
@@ -44,7 +56,8 @@ describe("repo-service", () => {
       });
 
       const result = await listRepos();
-      expect(result).toEqual(repos);
+      expect(result).toMatchObject(repos);
+      expect(result[0].slackWebhookUrl).toBeNull();
     });
 
     it("filters by workspaceId", async () => {
@@ -56,7 +69,7 @@ describe("repo-service", () => {
       });
 
       const result = await listRepos("ws-1");
-      expect(result).toEqual(repos);
+      expect(result).toMatchObject(repos);
     });
   });
 
@@ -70,7 +83,8 @@ describe("repo-service", () => {
       });
 
       const result = await getRepo("r-1");
-      expect(result).toEqual(repo);
+      expect(result).toMatchObject(repo);
+      expect(result!.slackWebhookUrl).toBeNull();
     });
 
     it("returns null when not found", async () => {
@@ -95,7 +109,7 @@ describe("repo-service", () => {
       });
 
       const result = await getRepoByUrl("https://github.com/o/r.git", "ws-1");
-      expect(result).toEqual(repo);
+      expect(result).toMatchObject(repo);
     });
 
     it("returns null when not found", async () => {
@@ -185,7 +199,7 @@ describe("repo-service", () => {
       });
 
       const result = await updateRepo("r-1", { autoMerge: true });
-      expect(result!.autoMerge).toBe(true);
+      expect(result).toMatchObject({ id: "r-1", autoMerge: true });
     });
 
     it("returns null when repo not found", async () => {

--- a/apps/api/src/services/repo-service.ts
+++ b/apps/api/src/services/repo-service.ts
@@ -1,6 +1,7 @@
 import { eq, and, isNull } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { repos, workspaces } from "../db/schema.js";
+import { encrypt, decrypt } from "./secret-service.js";
 import { normalizeRepoUrl } from "@optio/shared";
 
 export interface RepoRecord {
@@ -51,18 +52,38 @@ export interface RepoRecord {
   updatedAt: Date;
 }
 
-export async function listRepos(workspaceId?: string | null): Promise<RepoRecord[]> {
-  if (workspaceId) {
-    return db.select().from(repos).where(eq(repos.workspaceId, workspaceId)) as Promise<
-      RepoRecord[]
-    >;
+/**
+ * Decrypt the encrypted Slack webhook URL from a raw DB row and map to RepoRecord shape.
+ */
+function decryptRepoRow(row: typeof repos.$inferSelect): RepoRecord {
+  let slackWebhookUrl: string | null = null;
+  if (row.encryptedSlackWebhookUrl && row.slackWebhookUrlIv && row.slackWebhookUrlAuthTag) {
+    slackWebhookUrl = decrypt(
+      row.encryptedSlackWebhookUrl,
+      row.slackWebhookUrlIv,
+      row.slackWebhookUrlAuthTag,
+    );
   }
-  return db.select().from(repos) as Promise<RepoRecord[]>;
+  const {
+    encryptedSlackWebhookUrl: _e,
+    slackWebhookUrlIv: _iv,
+    slackWebhookUrlAuthTag: _tag,
+    ...rest
+  } = row;
+  return { ...rest, slackWebhookUrl } as RepoRecord;
+}
+
+export async function listRepos(workspaceId?: string | null): Promise<RepoRecord[]> {
+  const rows = workspaceId
+    ? await db.select().from(repos).where(eq(repos.workspaceId, workspaceId))
+    : await db.select().from(repos);
+  return rows.map(decryptRepoRow);
 }
 
 export async function getRepo(id: string): Promise<RepoRecord | null> {
   const [repo] = await db.select().from(repos).where(eq(repos.id, id));
-  return (repo as RepoRecord) ?? null;
+  if (!repo) return null;
+  return decryptRepoRow(repo);
 }
 
 async function getDefaultWorkspaceId(): Promise<string | null> {
@@ -90,7 +111,7 @@ export async function getRepoByUrl(
         .select()
         .from(repos)
         .where(and(eq(repos.repoUrl, normalized), eq(repos.workspaceId, defaultWsId)));
-      if (repo) return repo as RepoRecord;
+      if (repo) return decryptRepoRow(repo);
     }
     conditions.push(isNull(repos.workspaceId));
   }
@@ -98,7 +119,8 @@ export async function getRepoByUrl(
     .select()
     .from(repos)
     .where(and(...conditions));
-  return (repo as RepoRecord) ?? null;
+  if (!repo) return null;
+  return decryptRepoRow(repo);
 }
 
 export async function createRepo(data: {
@@ -131,7 +153,7 @@ export async function createRepo(data: {
       },
     })
     .returning();
-  return repo as RepoRecord;
+  return decryptRepoRow(repo);
 }
 
 export async function updateRepo(
@@ -174,12 +196,26 @@ export async function updateRepo(
     dockerInDocker?: boolean;
   },
 ): Promise<RepoRecord | null> {
-  const [repo] = await db
-    .update(repos)
-    .set({ ...data, updatedAt: new Date() })
-    .where(eq(repos.id, id))
-    .returning();
-  return (repo as RepoRecord) ?? null;
+  // Extract slackWebhookUrl for encryption; pass everything else through
+  const { slackWebhookUrl, ...restData } = data;
+  const setData: Record<string, unknown> = { ...restData, updatedAt: new Date() };
+
+  if (slackWebhookUrl !== undefined) {
+    if (slackWebhookUrl === null) {
+      setData.encryptedSlackWebhookUrl = null;
+      setData.slackWebhookUrlIv = null;
+      setData.slackWebhookUrlAuthTag = null;
+    } else {
+      const { encrypted, iv, authTag } = encrypt(slackWebhookUrl);
+      setData.encryptedSlackWebhookUrl = encrypted;
+      setData.slackWebhookUrlIv = iv;
+      setData.slackWebhookUrlAuthTag = authTag;
+    }
+  }
+
+  const [repo] = await db.update(repos).set(setData).where(eq(repos.id, id)).returning();
+  if (!repo) return null;
+  return decryptRepoRow(repo);
 }
 
 export async function deleteRepo(id: string): Promise<void> {

--- a/apps/api/src/services/webhook-service.test.ts
+++ b/apps/api/src/services/webhook-service.test.ts
@@ -30,6 +30,22 @@ vi.mock("../logger.js", () => ({
   },
 }));
 
+// Mock encrypt/decrypt from secret-service
+const mockEncrypt = vi.fn().mockImplementation((plaintext: string) => ({
+  encrypted: Buffer.from(`enc:${plaintext}`),
+  iv: Buffer.from("mock-iv-1234567"),
+  authTag: Buffer.from("mock-auth-tag12"),
+}));
+const mockDecrypt = vi.fn().mockImplementation((encrypted: Buffer) => {
+  const str = encrypted.toString();
+  return str.startsWith("enc:") ? str.slice(4) : str;
+});
+
+vi.mock("./secret-service.js", () => ({
+  encrypt: (...args: unknown[]) => mockEncrypt(...args),
+  decrypt: (...args: unknown[]) => mockDecrypt(...args),
+}));
+
 import { db } from "../db/client.js";
 import {
   signPayload,
@@ -42,6 +58,35 @@ import {
   deliverWebhook,
   getWebhooksForEvent,
 } from "./webhook-service.js";
+
+/** Helper to build a mock DB row with encrypted secret columns */
+function makeDbRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "wh-1",
+    url: "https://example.com/hook",
+    workspaceId: null,
+    events: ["task.completed"],
+    encryptedSecret: null as Buffer | null,
+    secretIv: null as Buffer | null,
+    secretAuthTag: null as Buffer | null,
+    description: null,
+    active: true,
+    createdBy: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+/** Helper to build a DB row with an encrypted secret */
+function makeDbRowWithSecret(secret: string, overrides: Record<string, unknown> = {}) {
+  return makeDbRow({
+    encryptedSecret: Buffer.from(`enc:${secret}`),
+    secretIv: Buffer.from("mock-iv-1234567"),
+    secretAuthTag: Buffer.from("mock-auth-tag12"),
+    ...overrides,
+  });
+}
 
 describe("signPayload", () => {
   it("produces a valid HMAC-SHA256 hex signature", () => {
@@ -90,11 +135,30 @@ describe("webhook CRUD", () => {
   });
 
   describe("createWebhook", () => {
-    it("creates a webhook with defaults", async () => {
-      const webhook = { id: "wh-1", url: "https://example.com/hook" };
+    it("creates a webhook and encrypts the secret", async () => {
+      const dbRow = makeDbRowWithSecret("my-secret");
       (db.insert as any) = vi.fn().mockReturnValue({
         values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([webhook]),
+          returning: vi.fn().mockResolvedValue([dbRow]),
+        }),
+      });
+
+      const result = await createWebhook({
+        url: "https://example.com/hook",
+        events: ["task.completed"],
+        secret: "my-secret",
+      });
+
+      expect(mockEncrypt).toHaveBeenCalledWith("my-secret");
+      expect(result.secret).toBe("my-secret");
+      expect(result.id).toBe("wh-1");
+    });
+
+    it("creates a webhook without secret", async () => {
+      const dbRow = makeDbRow();
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([dbRow]),
         }),
       });
 
@@ -103,7 +167,8 @@ describe("webhook CRUD", () => {
         events: ["task.completed"],
       });
 
-      expect(result).toEqual(webhook);
+      expect(mockEncrypt).not.toHaveBeenCalled();
+      expect(result.secret).toBeNull();
     });
 
     it("passes createdBy when provided", async () => {
@@ -111,7 +176,7 @@ describe("webhook CRUD", () => {
       (db.insert as any) = vi.fn().mockReturnValue({
         values: vi.fn().mockImplementation((vals: any) => {
           capturedValues = vals;
-          return { returning: vi.fn().mockResolvedValue([{ id: "wh-1" }]) };
+          return { returning: vi.fn().mockResolvedValue([makeDbRow()]) };
         }),
       });
 
@@ -122,8 +187,8 @@ describe("webhook CRUD", () => {
   });
 
   describe("listWebhooks", () => {
-    it("returns all webhooks ordered by createdAt", async () => {
-      const hooks = [{ id: "wh-1" }, { id: "wh-2" }];
+    it("returns all webhooks with decrypted secrets ordered by createdAt", async () => {
+      const hooks = [makeDbRowWithSecret("secret-1", { id: "wh-1" }), makeDbRow({ id: "wh-2" })];
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           orderBy: vi.fn().mockResolvedValue(hooks),
@@ -131,20 +196,27 @@ describe("webhook CRUD", () => {
       });
 
       const result = await listWebhooks();
-      expect(result).toEqual(hooks);
+      expect(result).toHaveLength(2);
+      expect(result[0].secret).toBe("secret-1");
+      expect(result[1].secret).toBeNull();
     });
   });
 
   describe("getWebhook", () => {
-    it("returns webhook when found", async () => {
+    it("returns webhook with decrypted secret when found", async () => {
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([{ id: "wh-1", url: "https://example.com" }]),
+          where: vi
+            .fn()
+            .mockResolvedValue([
+              makeDbRowWithSecret("real-secret", { url: "https://example.com" }),
+            ]),
         }),
       });
 
       const result = await getWebhook("wh-1");
       expect(result!.url).toBe("https://example.com");
+      expect(result!.secret).toBe("real-secret");
     });
 
     it("returns null when not found", async () => {
@@ -208,7 +280,7 @@ describe("deliverWebhook", () => {
     vi.clearAllMocks();
   });
 
-  it("delivers a standard webhook with signature", async () => {
+  it("delivers a standard webhook with signature using decrypted secret", async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -225,12 +297,17 @@ describe("deliverWebhook", () => {
     const webhook = {
       id: "wh-1",
       url: "https://example.com/hook",
+      workspaceId: null,
       secret: "my-secret",
       events: ["task.completed"],
+      description: null,
       active: true,
+      createdBy: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
     };
 
-    const result = await deliverWebhook(webhook as any, "task.completed", {
+    const result = await deliverWebhook(webhook, "task.completed", {
       taskId: "t-1",
       taskTitle: "Test",
     });
@@ -265,12 +342,17 @@ describe("deliverWebhook", () => {
     const webhook = {
       id: "wh-1",
       url: "https://hooks.slack.com/services/T00/B00/xxx",
+      workspaceId: null,
       secret: null,
       events: ["task.completed"],
+      description: null,
       active: true,
+      createdBy: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
     };
 
-    await deliverWebhook(webhook as any, "task.completed", { taskId: "t-1", taskTitle: "My Task" });
+    await deliverWebhook(webhook, "task.completed", { taskId: "t-1", taskTitle: "My Task" });
 
     const callArgs = mockFetch.mock.calls[0];
     const body = JSON.parse(callArgs[1].body);
@@ -296,7 +378,18 @@ describe("deliverWebhook", () => {
     });
 
     await deliverWebhook(
-      { id: "wh-1", url: "https://example.com", secret: null, events: [], active: true } as any,
+      {
+        id: "wh-1",
+        url: "https://example.com",
+        workspaceId: null,
+        secret: null,
+        events: [],
+        description: null,
+        active: true,
+        createdBy: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
       "task.failed",
       { taskId: "t-1" },
     );
@@ -317,7 +410,18 @@ describe("deliverWebhook", () => {
     });
 
     await deliverWebhook(
-      { id: "wh-1", url: "https://example.com", secret: null, events: [], active: true } as any,
+      {
+        id: "wh-1",
+        url: "https://example.com",
+        workspaceId: null,
+        secret: null,
+        events: [],
+        description: null,
+        active: true,
+        createdBy: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
       "task.failed",
       {},
     );
@@ -341,7 +445,18 @@ describe("deliverWebhook", () => {
     });
 
     await deliverWebhook(
-      { id: "wh-1", url: "https://example.com", secret: null, events: [], active: true } as any,
+      {
+        id: "wh-1",
+        url: "https://example.com",
+        workspaceId: null,
+        secret: null,
+        events: [],
+        description: null,
+        active: true,
+        createdBy: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
       "task.completed",
       {},
     );
@@ -356,12 +471,16 @@ describe("getWebhooksForEvent", () => {
     vi.clearAllMocks();
   });
 
-  it("returns active webhooks subscribed to the event", async () => {
+  it("returns active webhooks subscribed to the event with decrypted secrets", async () => {
     (db.select as any) = vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([
-          { id: "wh-1", events: ["task.completed", "task.failed"], active: true },
-          { id: "wh-2", events: ["task.failed"], active: true },
+          makeDbRowWithSecret("s1", {
+            id: "wh-1",
+            events: ["task.completed", "task.failed"],
+            active: true,
+          }),
+          makeDbRow({ id: "wh-2", events: ["task.failed"], active: true }),
         ]),
       }),
     });
@@ -369,12 +488,15 @@ describe("getWebhooksForEvent", () => {
     const result = await getWebhooksForEvent("task.completed");
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("wh-1");
+    expect(result[0].secret).toBe("s1");
   });
 
   it("returns empty array when no webhooks match", async () => {
     (db.select as any) = vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue([{ id: "wh-1", events: ["task.failed"], active: true }]),
+        where: vi
+          .fn()
+          .mockResolvedValue([makeDbRow({ id: "wh-1", events: ["task.failed"], active: true })]),
       }),
     });
 

--- a/apps/api/src/services/webhook-service.ts
+++ b/apps/api/src/services/webhook-service.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { eq, desc } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { webhooks, webhookDeliveries } from "../db/schema.js";
+import { encrypt, decrypt } from "./secret-service.js";
 import { logger } from "../logger.js";
 
 export type WebhookEvent =
@@ -19,6 +20,41 @@ export const VALID_EVENTS: WebhookEvent[] = [
   "review.completed",
 ];
 
+export interface WebhookRecord {
+  id: string;
+  url: string;
+  workspaceId: string | null;
+  events: string[];
+  secret: string | null;
+  description: string | null;
+  active: boolean;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Decrypt a webhook row's encrypted secret into a WebhookRecord with a plaintext `secret` field.
+ */
+function decryptWebhookRow(row: typeof webhooks.$inferSelect): WebhookRecord {
+  let secret: string | null = null;
+  if (row.encryptedSecret && row.secretIv && row.secretAuthTag) {
+    secret = decrypt(row.encryptedSecret, row.secretIv, row.secretAuthTag);
+  }
+  return {
+    id: row.id,
+    url: row.url,
+    workspaceId: row.workspaceId ?? null,
+    events: row.events as string[],
+    secret,
+    description: row.description ?? null,
+    active: row.active,
+    createdBy: row.createdBy ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
 export interface CreateWebhookInput {
   url: string;
   events: WebhookEvent[];
@@ -26,27 +62,45 @@ export interface CreateWebhookInput {
   description?: string;
 }
 
-export async function createWebhook(input: CreateWebhookInput, createdBy?: string) {
+export async function createWebhook(
+  input: CreateWebhookInput,
+  createdBy?: string,
+): Promise<WebhookRecord> {
+  let encryptedSecret: Buffer | null = null;
+  let secretIv: Buffer | null = null;
+  let secretAuthTag: Buffer | null = null;
+
+  if (input.secret) {
+    const { encrypted, iv, authTag } = encrypt(input.secret);
+    encryptedSecret = encrypted;
+    secretIv = iv;
+    secretAuthTag = authTag;
+  }
+
   const [webhook] = await db
     .insert(webhooks)
     .values({
       url: input.url,
       events: input.events,
-      secret: input.secret ?? null,
+      encryptedSecret,
+      secretIv,
+      secretAuthTag,
       description: input.description ?? null,
       createdBy: createdBy ?? null,
     })
     .returning();
-  return webhook;
+  return decryptWebhookRow(webhook);
 }
 
-export async function listWebhooks() {
-  return db.select().from(webhooks).orderBy(desc(webhooks.createdAt));
+export async function listWebhooks(): Promise<WebhookRecord[]> {
+  const rows = await db.select().from(webhooks).orderBy(desc(webhooks.createdAt));
+  return rows.map(decryptWebhookRow);
 }
 
-export async function getWebhook(id: string) {
+export async function getWebhook(id: string): Promise<WebhookRecord | null> {
   const [webhook] = await db.select().from(webhooks).where(eq(webhooks.id, id));
-  return webhook ?? null;
+  if (!webhook) return null;
+  return decryptWebhookRow(webhook);
 }
 
 export async function deleteWebhook(id: string) {
@@ -161,7 +215,7 @@ function isSlackWebhook(url: string): boolean {
  * Returns the delivery record.
  */
 export async function deliverWebhook(
-  webhook: typeof webhooks.$inferSelect,
+  webhook: WebhookRecord,
   event: WebhookEvent,
   data: Record<string, unknown>,
   attempt: number = 1,
@@ -235,11 +289,13 @@ export async function deliverWebhook(
 /**
  * Find all active webhooks subscribed to an event and dispatch delivery jobs.
  */
-export async function getWebhooksForEvent(event: WebhookEvent) {
+export async function getWebhooksForEvent(event: WebhookEvent): Promise<WebhookRecord[]> {
   const allWebhooks = await db.select().from(webhooks).where(eq(webhooks.active, true));
 
-  return allWebhooks.filter((w) => {
-    const events = w.events as string[];
-    return events.includes(event);
-  });
+  return allWebhooks
+    .filter((w) => {
+      const events = w.events as string[];
+      return events.includes(event);
+    })
+    .map(decryptWebhookRow);
 }


### PR DESCRIPTION
## Summary
- Replace plaintext `webhooks.secret` and `repos.slack_webhook_url` text columns with AES-256-GCM encrypted bytea columns (`encrypted_*`, `*_iv`, `*_auth_tag`)
- Webhook signing secrets and Slack incoming webhook URLs (which are bearer credentials) are now encrypted at rest using the same pattern as the `secrets` table
- Service layer handles transparent encrypt-on-write / decrypt-on-read so callers (routes, workers, slack-service) are unaffected

## Changes
- **`apps/api/src/db/schema.ts`** — Replace `secret` text column on `webhooks` and `slack_webhook_url` text column on `repos` with encrypted bytea triplets
- **`apps/api/src/services/webhook-service.ts`** — Add `WebhookRecord` type and `decryptWebhookRow` helper; encrypt secret in `createWebhook`, decrypt in `getWebhook`/`listWebhooks`/`getWebhooksForEvent`
- **`apps/api/src/services/repo-service.ts`** — Add `decryptRepoRow` helper; encrypt `slackWebhookUrl` in `updateRepo`, decrypt in all read paths (`listRepos`, `getRepo`, `getRepoByUrl`, `createRepo`)
- **`apps/api/src/db/migrations/0037_encrypt_webhook_slack_secrets.sql`** — Migration to add encrypted columns and drop plaintext columns
- **Tests updated** for both services with encryption mocks

## Test plan
- [x] All 941 existing tests pass (68 test files)
- [x] TypeScript typecheck passes across all 11 packages
- [x] Prettier formatting passes
- [x] Webhook service tests verify encrypt is called on create, decrypt returns plaintext
- [x] Repo service tests verify `slackWebhookUrl` is null when no encrypted data present

🤖 Generated with [Claude Code](https://claude.com/claude-code)