### PR TITLE
fix: add workspace/ownership checks across multiple routes (IDOR)

### DIFF
--- a/apps/api/src/db/migrations/0038_workspace_scoping_idor.sql
+++ b/apps/api/src/db/migrations/0038_workspace_scoping_idor.sql
@@ -1,0 +1,11 @@
+-- Add workspace_id columns to tables missing workspace scoping (IDOR fix)
+ALTER TABLE "interactive_sessions" ADD COLUMN IF NOT EXISTS "workspace_id" uuid;
+ALTER TABLE "schedules" ADD COLUMN IF NOT EXISTS "workspace_id" uuid;
+ALTER TABLE "task_templates" ADD COLUMN IF NOT EXISTS "workspace_id" uuid;
+ALTER TABLE "prompt_templates" ADD COLUMN IF NOT EXISTS "workspace_id" uuid;
+
+-- Add indexes for workspace-scoped queries
+CREATE INDEX IF NOT EXISTS "interactive_sessions_workspace_id_idx" ON "interactive_sessions" ("workspace_id");
+CREATE INDEX IF NOT EXISTS "schedules_workspace_id_idx" ON "schedules" ("workspace_id");
+CREATE INDEX IF NOT EXISTS "task_templates_workspace_id_idx" ON "task_templates" ("workspace_id");
+CREATE INDEX IF NOT EXISTS "prompt_templates_workspace_id_idx" ON "prompt_templates" ("workspace_id");

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1776182400000,
       "tag": "0037_encrypt_webhook_slack_secrets",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1776268800000,
+      "tag": "0038_workspace_scoping_idor",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -363,6 +363,7 @@ export const interactiveSessions = pgTable(
     state: interactiveSessionStateEnum("state").notNull().default("active"),
     podId: uuid("pod_id"),
     costUsd: text("cost_usd"),
+    workspaceId: uuid("workspace_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     endedAt: timestamp("ended_at", { withTimezone: true }),
   },
@@ -370,6 +371,7 @@ export const interactiveSessions = pgTable(
     index("interactive_sessions_repo_url_idx").on(table.repoUrl),
     index("interactive_sessions_state_idx").on(table.state),
     index("interactive_sessions_user_id_idx").on(table.userId),
+    index("interactive_sessions_workspace_id_idx").on(table.workspaceId),
   ],
 );
 
@@ -413,10 +415,14 @@ export const schedules = pgTable(
     lastRunAt: timestamp("last_run_at", { withTimezone: true }),
     nextRunAt: timestamp("next_run_at", { withTimezone: true }),
     createdBy: uuid("created_by"),
+    workspaceId: uuid("workspace_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [index("schedules_enabled_next_run_idx").on(table.enabled, table.nextRunAt)],
+  (table) => [
+    index("schedules_enabled_next_run_idx").on(table.enabled, table.nextRunAt),
+    index("schedules_workspace_id_idx").on(table.workspaceId),
+  ],
 );
 
 export const scheduleRuns = pgTable(
@@ -449,17 +455,22 @@ export const taskComments = pgTable(
   (table) => [index("task_comments_task_id_idx").on(table.taskId)],
 );
 
-export const taskTemplates = pgTable("task_templates", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  name: text("name").notNull(),
-  repoUrl: text("repo_url"),
-  prompt: text("prompt").notNull(),
-  agentType: text("agent_type").notNull().default("claude-code"),
-  priority: integer("priority").notNull().default(100),
-  metadata: jsonb("metadata").$type<Record<string, unknown>>(),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+export const taskTemplates = pgTable(
+  "task_templates",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: text("name").notNull(),
+    repoUrl: text("repo_url"),
+    prompt: text("prompt").notNull(),
+    agentType: text("agent_type").notNull().default("claude-code"),
+    priority: integer("priority").notNull().default(100),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    workspaceId: uuid("workspace_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("task_templates_workspace_id_idx").on(table.workspaceId)],
+);
 
 // ── Task Dependencies (DAG edges) ────────────────────────────────────────────
 
@@ -649,13 +660,18 @@ export const reviewDrafts = pgTable(
   ],
 );
 
-export const promptTemplates = pgTable("prompt_templates", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  name: text("name").notNull().unique(),
-  template: text("template").notNull(),
-  isDefault: boolean("is_default").notNull().default(false),
-  repoUrl: text("repo_url"), // null = global default, set = repo-specific
-  autoMerge: boolean("auto_merge").notNull().default(false),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+export const promptTemplates = pgTable(
+  "prompt_templates",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: text("name").notNull().unique(),
+    template: text("template").notNull(),
+    isDefault: boolean("is_default").notNull().default(false),
+    repoUrl: text("repo_url"), // null = global default, set = repo-specific
+    autoMerge: boolean("auto_merge").notNull().default(false),
+    workspaceId: uuid("workspace_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("prompt_templates_workspace_id_idx").on(table.workspaceId)],
+);

--- a/apps/api/src/routes/comments.test.ts
+++ b/apps/api/src/routes/comments.test.ts
@@ -49,7 +49,7 @@ describe("GET /api/tasks/:id/comments", () => {
   });
 
   it("lists comments for a task", async () => {
-    mockGetTask.mockResolvedValue({ id: "task-1" });
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-1" });
     mockListComments.mockResolvedValue([{ id: "c-1", content: "Hello" }]);
 
     const res = await app.inject({ method: "GET", url: "/api/tasks/task-1/comments" });
@@ -76,7 +76,7 @@ describe("POST /api/tasks/:id/comments", () => {
   });
 
   it("adds a comment", async () => {
-    mockGetTask.mockResolvedValue({ id: "task-1" });
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-1" });
     mockAddComment.mockResolvedValue({ id: "c-1", content: "New comment", taskId: "task-1" });
 
     const res = await app.inject({
@@ -90,7 +90,7 @@ describe("POST /api/tasks/:id/comments", () => {
   });
 
   it("rejects empty content (Zod throws)", async () => {
-    mockGetTask.mockResolvedValue({ id: "task-1" });
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-1" });
 
     const res = await app.inject({
       method: "POST",
@@ -191,7 +191,7 @@ describe("GET /api/tasks/:id/activity", () => {
   });
 
   it("returns interleaved activity feed", async () => {
-    mockGetTask.mockResolvedValue({ id: "task-1" });
+    mockGetTask.mockResolvedValue({ id: "task-1", workspaceId: "ws-1" });
     mockListComments.mockResolvedValue([
       {
         id: "c-1",

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -12,20 +12,28 @@ const updateCommentSchema = z.object({
 });
 
 export async function commentRoutes(app: FastifyInstance) {
-  // List comments for a task
+  // List comments for a task — verify workspace
   app.get("/api/tasks/:id/comments", async (req, reply) => {
     const { id } = req.params as { id: string };
     const task = await taskService.getTask(id);
     if (!task) return reply.status(404).send({ error: "Task not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && task.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Task not found" });
+    }
     const comments = await commentService.listComments(id);
     reply.send({ comments });
   });
 
-  // Add a comment to a task
+  // Add a comment to a task — verify workspace
   app.post("/api/tasks/:id/comments", async (req, reply) => {
     const { id } = req.params as { id: string };
     const task = await taskService.getTask(id);
     if (!task) return reply.status(404).send({ error: "Task not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && task.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Task not found" });
+    }
     const { content } = createCommentSchema.parse(req.body);
     const comment = await commentService.addComment(id, content, req.user?.id);
     reply.status(201).send({ comment });
@@ -72,11 +80,15 @@ export async function commentRoutes(app: FastifyInstance) {
     }
   });
 
-  // Activity feed: interleaved comments + events
+  // Activity feed: interleaved comments + events — verify workspace
   app.get("/api/tasks/:id/activity", async (req, reply) => {
     const { id } = req.params as { id: string };
     const task = await taskService.getTask(id);
     if (!task) return reply.status(404).send({ error: "Task not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && task.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Task not found" });
+    }
     const [comments, events] = await Promise.all([
       commentService.listComments(id),
       taskService.getTaskEvents(id),

--- a/apps/api/src/routes/mcp-servers.test.ts
+++ b/apps/api/src/routes/mcp-servers.test.ts
@@ -60,6 +60,31 @@ describe("GET /api/mcp-servers", () => {
   });
 });
 
+describe("GET /api/mcp-servers/:id", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns 404 for MCP server from another workspace", async () => {
+    mockGetMcpServer.mockResolvedValue({ id: "mcp-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "GET", url: "/api/mcp-servers/mcp-1" });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns MCP server from own workspace", async () => {
+    mockGetMcpServer.mockResolvedValue({ id: "mcp-1", workspaceId: "ws-1", name: "test" });
+
+    const res = await app.inject({ method: "GET", url: "/api/mcp-servers/mcp-1" });
+
+    expect(res.statusCode).toBe(200);
+  });
+});
+
 describe("POST /api/mcp-servers", () => {
   let app: FastifyInstance;
 
@@ -104,7 +129,7 @@ describe("PATCH /api/mcp-servers/:id", () => {
   });
 
   it("updates an MCP server", async () => {
-    mockGetMcpServer.mockResolvedValue({ id: "mcp-1" });
+    mockGetMcpServer.mockResolvedValue({ id: "mcp-1", workspaceId: "ws-1" });
     mockUpdateMcpServer.mockResolvedValue({ id: "mcp-1", enabled: false });
 
     const res = await app.inject({
@@ -114,6 +139,18 @@ describe("PATCH /api/mcp-servers/:id", () => {
     });
 
     expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 404 for MCP server from another workspace", async () => {
+    mockGetMcpServer.mockResolvedValue({ id: "mcp-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/mcp-servers/mcp-1",
+      payload: { enabled: false },
+    });
+
+    expect(res.statusCode).toBe(404);
   });
 
   it("returns 404 for nonexistent server", async () => {
@@ -138,7 +175,7 @@ describe("DELETE /api/mcp-servers/:id", () => {
   });
 
   it("deletes an MCP server", async () => {
-    mockGetMcpServer.mockResolvedValue({ id: "mcp-1" });
+    mockGetMcpServer.mockResolvedValue({ id: "mcp-1", workspaceId: "ws-1" });
     mockDeleteMcpServer.mockResolvedValue(undefined);
 
     const res = await app.inject({ method: "DELETE", url: "/api/mcp-servers/mcp-1" });

--- a/apps/api/src/routes/mcp-servers.ts
+++ b/apps/api/src/routes/mcp-servers.ts
@@ -30,11 +30,15 @@ export async function mcpServerRoutes(app: FastifyInstance) {
     reply.send({ servers });
   });
 
-  // Get a single MCP server
+  // Get a single MCP server — verify workspace ownership
   app.get("/api/mcp-servers/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const server = await mcpService.getMcpServer(id);
     if (!server) return reply.status(404).send({ error: "MCP server not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && server.workspaceId && server.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "MCP server not found" });
+    }
     reply.send({ server });
   });
 
@@ -46,21 +50,29 @@ export async function mcpServerRoutes(app: FastifyInstance) {
     reply.status(201).send({ server });
   });
 
-  // Update an MCP server
+  // Update an MCP server — verify workspace ownership
   app.patch("/api/mcp-servers/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const existing = await mcpService.getMcpServer(id);
     if (!existing) return reply.status(404).send({ error: "MCP server not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && existing.workspaceId && existing.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "MCP server not found" });
+    }
     const input = updateMcpServerSchema.parse(req.body);
     const server = await mcpService.updateMcpServer(id, input);
     reply.send({ server });
   });
 
-  // Delete an MCP server
+  // Delete an MCP server — verify workspace ownership
   app.delete("/api/mcp-servers/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const existing = await mcpService.getMcpServer(id);
     if (!existing) return reply.status(404).send({ error: "MCP server not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && existing.workspaceId && existing.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "MCP server not found" });
+    }
     await mcpService.deleteMcpServer(id);
     reply.status(204).send();
   });

--- a/apps/api/src/routes/prompt-templates.ts
+++ b/apps/api/src/routes/prompt-templates.ts
@@ -45,15 +45,17 @@ export async function promptTemplateRoutes(app: FastifyInstance) {
     }
   });
 
-  // List all templates
-  app.get("/api/prompt-templates", async (_req, reply) => {
-    const templates = await listPromptTemplates();
+  // List all templates — scoped to workspace
+  app.get("/api/prompt-templates", async (req, reply) => {
+    const workspaceId = req.user?.workspaceId ?? null;
+    const templates = await listPromptTemplates(workspaceId);
     reply.send({ templates });
   });
 
-  // Save template
+  // Save template — assign workspace on insert
   app.post("/api/prompt-templates", async (req, reply) => {
     const body = saveTemplateSchema.parse(req.body);
+    const workspaceId = req.user?.workspaceId ?? null;
     if (body.isReview) {
       // Save as review default
       const [existing] = await db
@@ -61,14 +63,21 @@ export async function promptTemplateRoutes(app: FastifyInstance) {
         .from(promptTemplates)
         .where(and(eq(promptTemplates.name, "review-default"), isNull(promptTemplates.repoUrl)));
       if (existing) {
+        // Verify workspace ownership before updating
+        if (workspaceId && existing.workspaceId && existing.workspaceId !== workspaceId) {
+          return reply.status(404).send({ error: "Template not found" });
+        }
         await db
           .update(promptTemplates)
           .set({ template: body.template, updatedAt: new Date() })
           .where(eq(promptTemplates.id, existing.id));
       } else {
-        await db
-          .insert(promptTemplates)
-          .values({ name: "review-default", template: body.template, isDefault: false });
+        await db.insert(promptTemplates).values({
+          name: "review-default",
+          template: body.template,
+          isDefault: false,
+          workspaceId,
+        });
       }
     } else if (body.repoUrl) {
       await saveRepoPromptTemplate(body.repoUrl, body.template, body.autoMerge ?? false);

--- a/apps/api/src/routes/schedules.test.ts
+++ b/apps/api/src/routes/schedules.test.ts
@@ -46,7 +46,7 @@ async function buildTestApp(): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
   app.decorateRequest("user", undefined as any);
   app.addHook("preHandler", (req, _reply, done) => {
-    (req as any).user = { id: "user-1" };
+    (req as any).user = { id: "user-1", workspaceId: "ws-1" };
     done();
   });
   await scheduleRoutes(app);
@@ -146,6 +146,7 @@ describe("PATCH /api/schedules/:id", () => {
   });
 
   it("updates a schedule", async () => {
+    mockGetSchedule.mockResolvedValue({ ...mockScheduleData, workspaceId: "ws-1" });
     mockUpdateSchedule.mockResolvedValue({ ...mockScheduleData, name: "Updated" });
 
     const res = await app.inject({
@@ -158,11 +159,23 @@ describe("PATCH /api/schedules/:id", () => {
   });
 
   it("returns 404 for nonexistent schedule", async () => {
-    mockUpdateSchedule.mockResolvedValue(null);
+    mockGetSchedule.mockResolvedValue(null);
 
     const res = await app.inject({
       method: "PATCH",
       url: "/api/schedules/nonexistent",
+      payload: { name: "Updated" },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 for schedule from another workspace", async () => {
+    mockGetSchedule.mockResolvedValue({ ...mockScheduleData, workspaceId: "ws-other" });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/schedules/sched-1",
       payload: { name: "Updated" },
     });
 
@@ -179,6 +192,7 @@ describe("DELETE /api/schedules/:id", () => {
   });
 
   it("deletes a schedule", async () => {
+    mockGetSchedule.mockResolvedValue({ ...mockScheduleData, workspaceId: "ws-1" });
     mockDeleteSchedule.mockResolvedValue(true);
 
     const res = await app.inject({ method: "DELETE", url: "/api/schedules/sched-1" });
@@ -187,9 +201,17 @@ describe("DELETE /api/schedules/:id", () => {
   });
 
   it("returns 404 for nonexistent schedule", async () => {
-    mockDeleteSchedule.mockResolvedValue(false);
+    mockGetSchedule.mockResolvedValue(null);
 
     const res = await app.inject({ method: "DELETE", url: "/api/schedules/nonexistent" });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 when deleting schedule from another workspace", async () => {
+    mockGetSchedule.mockResolvedValue({ ...mockScheduleData, workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "DELETE", url: "/api/schedules/sched-1" });
 
     expect(res.statusCode).toBe(404);
   });

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -35,21 +35,26 @@ const updateScheduleSchema = z.object({
 });
 
 export async function scheduleRoutes(app: FastifyInstance) {
-  // List schedules
-  app.get("/api/schedules", async (_req, reply) => {
-    const list = await scheduleService.listSchedules();
+  // List schedules — scoped to workspace
+  app.get("/api/schedules", async (req, reply) => {
+    const workspaceId = req.user?.workspaceId ?? null;
+    const list = await scheduleService.listSchedules(workspaceId);
     reply.send({ schedules: list });
   });
 
-  // Get a single schedule
+  // Get a single schedule — verify workspace ownership
   app.get("/api/schedules/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const schedule = await scheduleService.getSchedule(id);
     if (!schedule) return reply.status(404).send({ error: "Schedule not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && schedule.workspaceId && schedule.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Schedule not found" });
+    }
     reply.send({ schedule });
   });
 
-  // Create a schedule
+  // Create a schedule — assign to workspace
   app.post("/api/schedules", async (req, reply) => {
     const body = createScheduleSchema.parse(req.body);
 
@@ -59,13 +64,21 @@ export async function scheduleRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: `Invalid cron expression: ${validation.error}` });
     }
 
-    const schedule = await scheduleService.createSchedule(body, (req as any).user?.id);
+    const workspaceId = req.user?.workspaceId ?? null;
+    const schedule = await scheduleService.createSchedule(body, req.user?.id, workspaceId);
     reply.status(201).send({ schedule });
   });
 
-  // Update a schedule
+  // Update a schedule — verify workspace ownership
   app.patch("/api/schedules/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
+    const existing = await scheduleService.getSchedule(id);
+    if (!existing) return reply.status(404).send({ error: "Schedule not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && existing.workspaceId && existing.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Schedule not found" });
+    }
+
     const body = updateScheduleSchema.parse(req.body);
 
     if (body.cronExpression) {
@@ -80,19 +93,29 @@ export async function scheduleRoutes(app: FastifyInstance) {
     reply.send({ schedule });
   });
 
-  // Delete a schedule
+  // Delete a schedule — verify workspace ownership
   app.delete("/api/schedules/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
+    const existing = await scheduleService.getSchedule(id);
+    if (!existing) return reply.status(404).send({ error: "Schedule not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && existing.workspaceId && existing.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Schedule not found" });
+    }
     const deleted = await scheduleService.deleteSchedule(id);
     if (!deleted) return reply.status(404).send({ error: "Schedule not found" });
     reply.status(204).send();
   });
 
-  // Manually trigger a schedule
+  // Manually trigger a schedule — verify workspace ownership
   app.post("/api/schedules/:id/trigger", async (req, reply) => {
     const { id } = req.params as { id: string };
     const schedule = await scheduleService.getSchedule(id);
     if (!schedule) return reply.status(404).send({ error: "Schedule not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && schedule.workspaceId && schedule.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Schedule not found" });
+    }
 
     const config = schedule.taskConfig as {
       title: string;
@@ -115,6 +138,7 @@ export async function scheduleRoutes(app: FastifyInstance) {
         priority: config.priority,
         metadata: { scheduleId: schedule.id, scheduleName: schedule.name, triggeredManually: true },
         createdBy: req.user?.id,
+        workspaceId: req.user?.workspaceId ?? null,
       });
 
       await taskService.transitionTask(task.id, TaskState.QUEUED, "schedule_manual_trigger");
@@ -138,11 +162,15 @@ export async function scheduleRoutes(app: FastifyInstance) {
     }
   });
 
-  // Get schedule run history
+  // Get schedule run history — verify workspace ownership
   app.get("/api/schedules/:id/runs", async (req, reply) => {
     const { id } = req.params as { id: string };
     const schedule = await scheduleService.getSchedule(id);
     if (!schedule) return reply.status(404).send({ error: "Schedule not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && schedule.workspaceId && schedule.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Schedule not found" });
+    }
     const { limit } = (req.query as { limit?: string }) ?? {};
     const runs = await scheduleService.getScheduleRuns(id, limit ? parseInt(limit, 10) : 50);
     reply.send({ runs });

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -85,6 +85,7 @@ describe("GET /api/sessions", () => {
       state: undefined,
       limit: 50,
       offset: 0,
+      userId: "user-1",
     });
   });
 
@@ -103,6 +104,7 @@ describe("GET /api/sessions", () => {
       state: "active",
       limit: 10,
       offset: 5,
+      userId: "user-1",
     });
   });
 });
@@ -134,6 +136,15 @@ describe("GET /api/sessions/:id", () => {
     mockGetSession.mockResolvedValue(null);
 
     const res = await app.inject({ method: "GET", url: "/api/sessions/nonexistent" });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe("Session not found");
+  });
+
+  it("returns 404 for another user's session", async () => {
+    mockGetSession.mockResolvedValue({ ...mockSession, userId: "other-user" });
+
+    const res = await app.inject({ method: "GET", url: "/api/sessions/session-1" });
 
     expect(res.statusCode).toBe(404);
     expect(res.json().error).toBe("Session not found");
@@ -172,6 +183,7 @@ describe("POST /api/sessions", () => {
     expect(mockCreateSession).toHaveBeenCalledWith({
       repoUrl: "https://github.com/org/repo",
       userId: "user-1",
+      workspaceId: "ws-1",
     });
   });
 
@@ -196,6 +208,7 @@ describe("POST /api/sessions/:id/end", () => {
   });
 
   it("ends a session", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
     mockEndSession.mockResolvedValue({ ...mockSession, state: "ended" });
 
     const res = await app.inject({ method: "POST", url: "/api/sessions/session-1/end" });
@@ -204,7 +217,26 @@ describe("POST /api/sessions/:id/end", () => {
     expect(res.json().session.state).toBe("ended");
   });
 
+  it("returns 404 when ending another user's session", async () => {
+    mockGetSession.mockResolvedValue({ ...mockSession, userId: "other-user" });
+
+    const res = await app.inject({ method: "POST", url: "/api/sessions/session-1/end" });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe("Session not found");
+  });
+
+  it("returns 404 when session does not exist", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const res = await app.inject({ method: "POST", url: "/api/sessions/nonexistent/end" });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe("Session not found");
+  });
+
   it("returns 400 when session cannot be ended", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
     mockEndSession.mockRejectedValue(new Error("Session already ended"));
 
     const res = await app.inject({ method: "POST", url: "/api/sessions/session-1/end" });
@@ -223,6 +255,7 @@ describe("session PRs", () => {
   });
 
   it("GET /api/sessions/:id/prs lists PRs", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
     mockGetSessionPrs.mockResolvedValue([
       { id: "pr-1", prUrl: "https://github.com/org/repo/pull/1" },
     ]);
@@ -233,7 +266,16 @@ describe("session PRs", () => {
     expect(res.json().prs).toHaveLength(1);
   });
 
+  it("GET /api/sessions/:id/prs returns 404 for other user's session", async () => {
+    mockGetSession.mockResolvedValue({ ...mockSession, userId: "other-user" });
+
+    const res = await app.inject({ method: "GET", url: "/api/sessions/session-1/prs" });
+
+    expect(res.statusCode).toBe(404);
+  });
+
   it("POST /api/sessions/:id/prs adds a PR", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
     mockAddSessionPr.mockResolvedValue({
       id: "pr-1",
       prUrl: "https://github.com/org/repo/pull/1",
@@ -255,6 +297,7 @@ describe("session PRs", () => {
   });
 
   it("POST /api/sessions/:id/prs rejects missing fields", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
     const res = await app.inject({
       method: "POST",
       url: "/api/sessions/session-1/prs",

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -17,7 +17,7 @@ const createSessionSchema = z.object({
 });
 
 export async function sessionRoutes(app: FastifyInstance) {
-  // List sessions
+  // List sessions — scoped to the current user
   app.get("/api/sessions", async (req, reply) => {
     const parsed = listSessionsQuerySchema.safeParse(req.query);
     if (!parsed.success) {
@@ -29,16 +29,22 @@ export async function sessionRoutes(app: FastifyInstance) {
       state,
       limit,
       offset,
+      userId: req.user?.id,
     });
     const activeCount = await sessionService.getActiveSessionCount(repoUrl);
     reply.send({ sessions, activeCount });
   });
 
-  // Get session — includes model info from repo config
+  // Get session — verify ownership
   app.get("/api/sessions/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const session = await sessionService.getSession(id);
     if (!session) return reply.status(404).send({ error: "Session not found" });
+
+    // Verify the session belongs to the requesting user
+    if (req.user?.id && session.userId && session.userId !== req.user.id) {
+      return reply.status(404).send({ error: "Session not found" });
+    }
 
     // Attach repo model config
     let modelConfig: { claudeModel: string; availableModels: string[] } | null = null;
@@ -62,31 +68,54 @@ export async function sessionRoutes(app: FastifyInstance) {
     const session = await sessionService.createSession({
       repoUrl: input.repoUrl,
       userId,
+      workspaceId: req.user?.workspaceId ?? null,
     });
     reply.status(201).send({ session });
   });
 
-  // End session
+  // End session — verify ownership
   app.post("/api/sessions/:id/end", async (req, reply) => {
     const { id } = req.params as { id: string };
+    const session = await sessionService.getSession(id);
+    if (!session) return reply.status(404).send({ error: "Session not found" });
+
+    // Verify the session belongs to the requesting user
+    if (req.user?.id && session.userId && session.userId !== req.user.id) {
+      return reply.status(404).send({ error: "Session not found" });
+    }
+
     try {
-      const session = await sessionService.endSession(id);
-      reply.send({ session });
+      const updated = await sessionService.endSession(id);
+      reply.send({ session: updated });
     } catch (err) {
       reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
     }
   });
 
-  // List PRs for a session
+  // List PRs for a session — verify ownership
   app.get("/api/sessions/:id/prs", async (req, reply) => {
     const { id } = req.params as { id: string };
+    const session = await sessionService.getSession(id);
+    if (!session) return reply.status(404).send({ error: "Session not found" });
+
+    if (req.user?.id && session.userId && session.userId !== req.user.id) {
+      return reply.status(404).send({ error: "Session not found" });
+    }
+
     const prs = await sessionService.getSessionPrs(id);
     reply.send({ prs });
   });
 
-  // Add a PR to a session
+  // Add a PR to a session — verify ownership
   app.post("/api/sessions/:id/prs", async (req, reply) => {
     const { id } = req.params as { id: string };
+    const session = await sessionService.getSession(id);
+    if (!session) return reply.status(404).send({ error: "Session not found" });
+
+    if (req.user?.id && session.userId && session.userId !== req.user.id) {
+      return reply.status(404).send({ error: "Session not found" });
+    }
+
     const body = req.body as { prUrl: string; prNumber: number };
     if (!body.prUrl || !body.prNumber) {
       return reply.status(400).send({ error: "prUrl and prNumber required" });

--- a/apps/api/src/routes/task-templates.test.ts
+++ b/apps/api/src/routes/task-templates.test.ts
@@ -40,7 +40,7 @@ async function buildTestApp(): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
   app.decorateRequest("user", undefined as any);
   app.addHook("preHandler", (req, _reply, done) => {
-    (req as any).user = { workspaceId: "ws-1" };
+    (req as any).user = { id: "user-1", workspaceId: "ws-1" };
     done();
   });
   await taskTemplateRoutes(app);
@@ -73,6 +73,31 @@ describe("GET /api/task-templates", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().templates).toHaveLength(1);
+  });
+});
+
+describe("GET /api/task-templates/:id", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns 404 for template from another workspace", async () => {
+    mockGetTaskTemplate.mockResolvedValue({ ...mockTemplateData, workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "GET", url: "/api/task-templates/tmpl-1" });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns template from own workspace", async () => {
+    mockGetTaskTemplate.mockResolvedValue({ ...mockTemplateData, workspaceId: "ws-1" });
+
+    const res = await app.inject({ method: "GET", url: "/api/task-templates/tmpl-1" });
+
+    expect(res.statusCode).toBe(200);
   });
 });
 
@@ -171,10 +196,27 @@ describe("DELETE /api/task-templates/:id", () => {
   });
 
   it("deletes a template", async () => {
+    mockGetTaskTemplate.mockResolvedValue({ ...mockTemplateData, workspaceId: "ws-1" });
     mockDeleteTaskTemplate.mockResolvedValue(undefined);
 
     const res = await app.inject({ method: "DELETE", url: "/api/task-templates/tmpl-1" });
 
     expect(res.statusCode).toBe(204);
+  });
+
+  it("returns 404 when deleting template from another workspace", async () => {
+    mockGetTaskTemplate.mockResolvedValue({ ...mockTemplateData, workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "DELETE", url: "/api/task-templates/tmpl-1" });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 for nonexistent template", async () => {
+    mockGetTaskTemplate.mockResolvedValue(null);
+
+    const res = await app.inject({ method: "DELETE", url: "/api/task-templates/tmpl-1" });
+
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/apps/api/src/routes/task-templates.ts
+++ b/apps/api/src/routes/task-templates.ts
@@ -38,51 +38,73 @@ const createFromTemplateSchema = z.object({
 });
 
 export async function taskTemplateRoutes(app: FastifyInstance) {
-  // List templates
+  // List templates — scoped to workspace
   app.get("/api/task-templates", async (req, reply) => {
     const query = req.query as { repoUrl?: string };
-    const templates = await taskTemplateService.listTaskTemplates(query.repoUrl);
+    const workspaceId = req.user?.workspaceId ?? null;
+    const templates = await taskTemplateService.listTaskTemplates(query.repoUrl, workspaceId);
     reply.send({ templates });
   });
 
-  // Get template
+  // Get template — verify workspace ownership
   app.get("/api/task-templates/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const template = await taskTemplateService.getTaskTemplate(id);
     if (!template) return reply.status(404).send({ error: "Template not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && template.workspaceId && template.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Template not found" });
+    }
     reply.send({ template });
   });
 
-  // Create template
+  // Create template — assign to workspace
   app.post("/api/task-templates", async (req, reply) => {
     const body = createTemplateSchema.parse(req.body);
-    const template = await taskTemplateService.createTaskTemplate(body);
+    const workspaceId = req.user?.workspaceId ?? null;
+    const template = await taskTemplateService.createTaskTemplate(body, workspaceId);
     reply.status(201).send({ template });
   });
 
-  // Update template
+  // Update template — verify workspace ownership
   app.patch("/api/task-templates/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
+    const existing = await taskTemplateService.getTaskTemplate(id);
+    if (!existing) return reply.status(404).send({ error: "Template not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && existing.workspaceId && existing.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Template not found" });
+    }
     const body = updateTemplateSchema.parse(req.body);
     const template = await taskTemplateService.updateTaskTemplate(id, body);
     if (!template) return reply.status(404).send({ error: "Template not found" });
     reply.send({ template });
   });
 
-  // Delete template
+  // Delete template — verify workspace ownership
   app.delete("/api/task-templates/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
+    const existing = await taskTemplateService.getTaskTemplate(id);
+    if (!existing) return reply.status(404).send({ error: "Template not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && existing.workspaceId && existing.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Template not found" });
+    }
     await taskTemplateService.deleteTaskTemplate(id);
     reply.status(204).send();
   });
 
-  // Create task from template
+  // Create task from template — verify workspace ownership of template
   app.post("/api/tasks/from-template/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const overrides = createFromTemplateSchema.parse(req.body);
 
     const template = await taskTemplateService.getTaskTemplate(id);
     if (!template) return reply.status(404).send({ error: "Template not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && template.workspaceId && template.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Template not found" });
+    }
 
     if (!template.repoUrl && !overrides.repoUrl) {
       return reply.status(400).send({ error: "repoUrl is required (template has no default)" });
@@ -98,6 +120,7 @@ export async function taskTemplateRoutes(app: FastifyInstance) {
       maxRetries: overrides.maxRetries,
       metadata: overrides.metadata ?? (template.metadata as Record<string, unknown> | undefined),
       createdBy: req.user?.id,
+      workspaceId: req.user?.workspaceId ?? null,
     });
 
     await taskService.transitionTask(task.id, TaskState.QUEUED, "task_from_template");

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -294,7 +294,7 @@ export async function taskRoutes(app: FastifyInstance) {
     reply.send({ logs });
   });
 
-  // Export task logs
+  // Export task logs — verify workspace
   app.get("/api/tasks/:id/logs/export", async (req, reply) => {
     const { id } = req.params as { id: string };
     const query = req.query as { format?: string; search?: string; logType?: string };
@@ -302,6 +302,10 @@ export async function taskRoutes(app: FastifyInstance) {
 
     const task = await taskService.getTask(id);
     if (!task) return reply.status(404).send({ error: "Task not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && task.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Task not found" });
+    }
 
     const logs = await taskService.getAllTaskLogs(id, {
       search: query.search || undefined,
@@ -473,11 +477,21 @@ export async function taskRoutes(app: FastifyInstance) {
     },
   );
 
-  // Reorder tasks (update priorities) — member+
+  // Reorder tasks (update priorities) — member+, workspace-scoped
   app.post("/api/tasks/reorder", { preHandler: [requireRole("member")] }, async (req, reply) => {
     const body = req.body as { taskIds: string[] };
     if (!Array.isArray(body.taskIds)) {
       return reply.status(400).send({ error: "taskIds array required" });
+    }
+    const wsId = req.user?.workspaceId;
+    // Verify all tasks belong to the user's workspace before reordering
+    if (wsId) {
+      for (const taskId of body.taskIds) {
+        const task = await taskService.getTask(taskId);
+        if (!task || task.workspaceId !== wsId) {
+          return reply.status(404).send({ error: "Task not found" });
+        }
+      }
     }
     // Assign priorities based on position: first = 1, second = 2, etc.
     for (let i = 0; i < body.taskIds.length; i++) {

--- a/apps/api/src/routes/webhooks.test.ts
+++ b/apps/api/src/routes/webhooks.test.ts
@@ -26,7 +26,7 @@ async function buildTestApp(): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
   app.decorateRequest("user", undefined as any);
   app.addHook("preHandler", (req, _reply, done) => {
-    (req as any).user = { id: "user-1" };
+    (req as any).user = { id: "user-1", workspaceId: "ws-1" };
     done();
   });
   await webhookRoutes(app);
@@ -87,6 +87,14 @@ describe("GET /api/webhooks/:id", () => {
 
     expect(res.statusCode).toBe(404);
   });
+
+  it("returns 404 for webhook from another workspace", async () => {
+    mockGetWebhook.mockResolvedValue({ id: "wh-1", workspaceId: "ws-other", secret: null });
+
+    const res = await app.inject({ method: "GET", url: "/api/webhooks/wh-1" });
+
+    expect(res.statusCode).toBe(404);
+  });
 });
 
 describe("POST /api/webhooks", () => {
@@ -144,6 +152,7 @@ describe("DELETE /api/webhooks/:id", () => {
   });
 
   it("deletes a webhook", async () => {
+    mockGetWebhook.mockResolvedValue({ id: "wh-1", workspaceId: "ws-1" });
     mockDeleteWebhook.mockResolvedValue(true);
 
     const res = await app.inject({ method: "DELETE", url: "/api/webhooks/wh-1" });
@@ -152,9 +161,17 @@ describe("DELETE /api/webhooks/:id", () => {
   });
 
   it("returns 404 for nonexistent webhook", async () => {
-    mockDeleteWebhook.mockResolvedValue(false);
+    mockGetWebhook.mockResolvedValue(null);
 
     const res = await app.inject({ method: "DELETE", url: "/api/webhooks/nonexistent" });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 when deleting webhook from another workspace", async () => {
+    mockGetWebhook.mockResolvedValue({ id: "wh-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "DELETE", url: "/api/webhooks/wh-1" });
 
     expect(res.statusCode).toBe(404);
   });

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -23,9 +23,10 @@ const createWebhookSchema = z.object({
 });
 
 export async function webhookRoutes(app: FastifyInstance) {
-  // List all webhooks
-  app.get("/api/webhooks", async (_req, reply) => {
-    const hooks = await webhookService.listWebhooks();
+  // List all webhooks — scoped to workspace
+  app.get("/api/webhooks", async (req, reply) => {
+    const workspaceId = req.user?.workspaceId ?? null;
+    const hooks = await webhookService.listWebhooks(workspaceId);
     // Mask secrets in the response
     const masked = hooks.map((h) => ({
       ...h,
@@ -34,36 +35,51 @@ export async function webhookRoutes(app: FastifyInstance) {
     reply.send({ webhooks: masked });
   });
 
-  // Get a single webhook
+  // Get a single webhook — verify workspace ownership
   app.get("/api/webhooks/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const webhook = await webhookService.getWebhook(id);
     if (!webhook) return reply.status(404).send({ error: "Webhook not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && webhook.workspaceId && webhook.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Webhook not found" });
+    }
     reply.send({
       webhook: { ...webhook, secret: webhook.secret ? "••••••" : null },
     });
   });
 
-  // Create a webhook
+  // Create a webhook — assign to workspace
   app.post("/api/webhooks", async (req, reply) => {
     const body = createWebhookSchema.parse(req.body);
-    const webhook = await webhookService.createWebhook(body, (req as any).user?.id);
+    const workspaceId = req.user?.workspaceId ?? null;
+    const webhook = await webhookService.createWebhook(body, req.user?.id, workspaceId);
     reply.status(201).send({ webhook: { ...webhook, secret: webhook.secret ? "••••••" : null } });
   });
 
-  // Delete a webhook
+  // Delete a webhook — verify workspace ownership
   app.delete("/api/webhooks/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
+    const webhook = await webhookService.getWebhook(id);
+    if (!webhook) return reply.status(404).send({ error: "Webhook not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && webhook.workspaceId && webhook.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Webhook not found" });
+    }
     const deleted = await webhookService.deleteWebhook(id);
     if (!deleted) return reply.status(404).send({ error: "Webhook not found" });
     reply.status(204).send();
   });
 
-  // List deliveries for a webhook (delivery log)
+  // List deliveries for a webhook — verify workspace ownership
   app.get("/api/webhooks/:id/deliveries", async (req, reply) => {
     const { id } = req.params as { id: string };
     const webhook = await webhookService.getWebhook(id);
     if (!webhook) return reply.status(404).send({ error: "Webhook not found" });
+    const wsId = req.user?.workspaceId;
+    if (wsId && webhook.workspaceId && webhook.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Webhook not found" });
+    }
     const { limit } = (req.query as { limit?: string }) ?? {};
     const deliveries = await webhookService.getWebhookDeliveries(id, {
       limit: limit ? parseInt(limit, 10) : 50,

--- a/apps/api/src/services/interactive-session-service.ts
+++ b/apps/api/src/services/interactive-session-service.ts
@@ -7,7 +7,11 @@ import { InteractiveSessionState, normalizeRepoUrl, type PresetImageId } from "@
 import { getOrCreateRepoPod } from "./repo-pool-service.js";
 import { logger } from "../logger.js";
 
-export async function createSession(input: { repoUrl: string; userId?: string }) {
+export async function createSession(input: {
+  repoUrl: string;
+  userId?: string;
+  workspaceId?: string | null;
+}) {
   const repoUrl = normalizeRepoUrl(input.repoUrl);
 
   // Look up repo config for branch and image settings
@@ -59,6 +63,7 @@ export async function createSession(input: { repoUrl: string; userId?: string })
       branch,
       state: "active",
       podId: pod.id,
+      workspaceId: input.workspaceId ?? null,
     })
     .returning();
 
@@ -103,10 +108,12 @@ export async function listSessions(opts?: {
   state?: string;
   limit?: number;
   offset?: number;
+  userId?: string;
 }) {
   const conditions = [];
   if (opts?.repoUrl) conditions.push(eq(interactiveSessions.repoUrl, opts.repoUrl));
   if (opts?.state) conditions.push(eq(interactiveSessions.state, opts.state as "active" | "ended"));
+  if (opts?.userId) conditions.push(eq(interactiveSessions.userId, opts.userId));
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;
 

--- a/apps/api/src/services/prompt-template-service.ts
+++ b/apps/api/src/services/prompt-template-service.ts
@@ -1,4 +1,4 @@
-import { eq, and, isNull } from "drizzle-orm";
+import { eq, and, isNull, or } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { promptTemplates, repos } from "../db/schema.js";
 import { DEFAULT_PROMPT_TEMPLATE, normalizeRepoUrl } from "@optio/shared";
@@ -120,8 +120,14 @@ export async function saveRepoPromptTemplate(
 }
 
 /**
- * List all prompt templates.
+ * List all prompt templates, optionally scoped to a workspace.
  */
-export async function listPromptTemplates() {
+export async function listPromptTemplates(workspaceId?: string | null) {
+  if (workspaceId) {
+    return db
+      .select()
+      .from(promptTemplates)
+      .where(or(eq(promptTemplates.workspaceId, workspaceId), isNull(promptTemplates.workspaceId)));
+  }
   return db.select().from(promptTemplates);
 }

--- a/apps/api/src/services/schedule-service.ts
+++ b/apps/api/src/services/schedule-service.ts
@@ -32,7 +32,11 @@ function computeNextRun(cronExpression: string): Date {
   return interval.next().toDate();
 }
 
-export async function createSchedule(input: CreateScheduleInput, createdBy?: string) {
+export async function createSchedule(
+  input: CreateScheduleInput,
+  createdBy?: string,
+  workspaceId?: string | null,
+) {
   const nextRunAt = input.enabled !== false ? computeNextRun(input.cronExpression) : null;
   const [schedule] = await db
     .insert(schedules)
@@ -44,12 +48,20 @@ export async function createSchedule(input: CreateScheduleInput, createdBy?: str
       taskConfig: input.taskConfig,
       nextRunAt,
       createdBy: createdBy ?? null,
+      workspaceId: workspaceId ?? null,
     })
     .returning();
   return schedule;
 }
 
-export async function listSchedules() {
+export async function listSchedules(workspaceId?: string | null) {
+  if (workspaceId) {
+    return db
+      .select()
+      .from(schedules)
+      .where(eq(schedules.workspaceId, workspaceId))
+      .orderBy(desc(schedules.createdAt));
+  }
   return db.select().from(schedules).orderBy(desc(schedules.createdAt));
 }
 

--- a/apps/api/src/services/task-template-service.ts
+++ b/apps/api/src/services/task-template-service.ts
@@ -1,10 +1,17 @@
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { taskTemplates } from "../db/schema.js";
 
-export async function listTaskTemplates(repoUrl?: string) {
-  if (repoUrl) {
-    return db.select().from(taskTemplates).where(eq(taskTemplates.repoUrl, repoUrl));
+export async function listTaskTemplates(repoUrl?: string, workspaceId?: string | null) {
+  const conditions = [];
+  if (repoUrl) conditions.push(eq(taskTemplates.repoUrl, repoUrl));
+  if (workspaceId) conditions.push(eq(taskTemplates.workspaceId, workspaceId));
+
+  if (conditions.length > 0) {
+    return db
+      .select()
+      .from(taskTemplates)
+      .where(and(...conditions));
   }
   return db.select().from(taskTemplates);
 }
@@ -14,14 +21,17 @@ export async function getTaskTemplate(id: string) {
   return template ?? null;
 }
 
-export async function createTaskTemplate(data: {
-  name: string;
-  repoUrl?: string;
-  prompt: string;
-  agentType?: string;
-  priority?: number;
-  metadata?: Record<string, unknown>;
-}) {
+export async function createTaskTemplate(
+  data: {
+    name: string;
+    repoUrl?: string;
+    prompt: string;
+    agentType?: string;
+    priority?: number;
+    metadata?: Record<string, unknown>;
+  },
+  workspaceId?: string | null,
+) {
   const [template] = await db
     .insert(taskTemplates)
     .values({
@@ -31,6 +41,7 @@ export async function createTaskTemplate(data: {
       agentType: data.agentType ?? "claude-code",
       priority: data.priority ?? 100,
       metadata: data.metadata,
+      workspaceId: workspaceId ?? null,
     })
     .returning();
   return template;

--- a/apps/api/src/services/webhook-service.ts
+++ b/apps/api/src/services/webhook-service.ts
@@ -66,6 +66,7 @@ export interface CreateWebhookInput {
 export async function createWebhook(
   input: CreateWebhookInput,
   createdBy?: string,
+  workspaceId?: string | null,
 ): Promise<WebhookRecord> {
   let encryptedSecret: Buffer | null = null;
   let secretIv: Buffer | null = null;
@@ -88,12 +89,21 @@ export async function createWebhook(
       secretAuthTag,
       description: input.description ?? null,
       createdBy: createdBy ?? null,
+      workspaceId: workspaceId ?? null,
     })
     .returning();
   return decryptWebhookRow(webhook);
 }
 
-export async function listWebhooks(): Promise<WebhookRecord[]> {
+export async function listWebhooks(workspaceId?: string | null): Promise<WebhookRecord[]> {
+  if (workspaceId) {
+    const rows = await db
+      .select()
+      .from(webhooks)
+      .where(eq(webhooks.workspaceId, workspaceId))
+      .orderBy(desc(webhooks.createdAt));
+    return rows.map(decryptWebhookRow);
+  }
   const rows = await db.select().from(webhooks).orderBy(desc(webhooks.createdAt));
   return rows.map(decryptWebhookRow);
 }

--- a/apps/api/src/ws/log-stream.ts
+++ b/apps/api/src/ws/log-stream.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { createSubscriber } from "../services/event-bus.js";
 import { authenticateWs } from "./ws-auth.js";
-import { getTaskLogs } from "../services/task-service.js";
+import { getTask, getTaskLogs } from "../services/task-service.js";
 import {
   getClientIp,
   trackConnection,
@@ -25,6 +25,17 @@ export async function logStreamWs(app: FastifyInstance) {
     }
 
     const { taskId } = req.params as { taskId: string };
+
+    // Verify the task exists and belongs to the user's workspace
+    const task = await getTask(taskId);
+    if (!task) {
+      socket.close(4404, "Task not found");
+      return;
+    }
+    if (user.workspaceId && task.workspaceId && task.workspaceId !== user.workspaceId) {
+      socket.close(4403, "Access denied");
+      return;
+    }
 
     // Send catch-up: recent logs so reconnecting clients don't miss data
     try {


### PR DESCRIPTION
## Summary

- **Add workspace scoping and ownership verification** to 10 routes/services to prevent cross-user/cross-workspace resource access via IDOR
- **Add `workspaceId` column** to 4 tables that were missing it: `interactive_sessions`, `schedules`, `task_templates`, `prompt_templates`
- **Update all affected service methods** to accept and filter by `workspaceId`

## Affected Resources

| Resource | Fix Applied |
|----------|------------|
| Sessions (all endpoints) | Filter by `userId`, verify ownership on get/end/prs |
| Task logs (WS stream) | Verify task belongs to user's workspace before streaming |
| Comments/activity | Add workspace check to GET and POST (was only on PATCH/DELETE) |
| Task templates | Workspace filtering on list, ownership check on all CRUD |
| Schedules | Workspace filtering on list, ownership check on all CRUD + trigger |
| Task reorder | Verify all tasks belong to user's workspace before reordering |
| Task log export | Add workspace check before exporting logs |
| Webhooks | Workspace filtering on list, ownership check on all CRUD |
| MCP servers | Add workspace check to get/update/delete |
| Prompt templates | Workspace filtering on list, ownership check on save |

## Test plan

- [x] All 969 existing tests pass
- [x] Added IDOR-specific tests for cross-workspace/cross-user access denial
- [x] Typecheck passes
- [x] Format check passes
- [x] Pre-commit hooks pass (lint-staged + format + typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)