### PR TITLE
fix: pin Docker base image tags to SHA256 digests

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,6 +1,6 @@
 # Legacy compatibility — use images/base.Dockerfile instead
 # This file exists so `docker build -t optio-agent:latest -f Dockerfile.agent .` still works
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,5 +1,5 @@
 # ---- Dependencies stage ----
-FROM node:22-slim AS deps
+FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea AS deps
 
 RUN corepack enable && corepack prepare pnpm@10 --activate
 
@@ -19,7 +19,7 @@ COPY packages/ticket-providers/package.json packages/ticket-providers/tsconfig.j
 RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 
 # ---- Runtime stage ----
-FROM node:22-slim
+FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea
 
 ARG OPTIO_VERSION=dev
 ENV OPTIO_VERSION=${OPTIO_VERSION}

--- a/Dockerfile.optio
+++ b/Dockerfile.optio
@@ -1,7 +1,7 @@
 # Optio operations assistant pod.
 # Lightweight image: Claude Code + HTTP tools. No repo/language tooling needed.
 
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,5 @@
 # ---- Dependencies stage ----
-FROM node:22-slim AS deps
+FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea AS deps
 
 RUN corepack enable && corepack prepare pnpm@10 --activate
 
@@ -33,7 +33,7 @@ RUN pnpm turbo build --filter=@optio/shared
 RUN cd apps/web && npx next build
 
 # ---- Runtime stage ----
-FROM node:22-slim
+FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea
 
 ARG OPTIO_VERSION=dev
 ENV OPTIO_VERSION=${OPTIO_VERSION}

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary

- Pin all Dockerfile `FROM` instructions to SHA256 digests to mitigate supply chain attacks via tag mutation
- `node:22-slim` pinned to `sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea`
- `ubuntu:24.04` pinned to `sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c`

## Files changed

- `Dockerfile.api` — both deps and runtime stages
- `Dockerfile.web` — both deps and runtime stages
- `Dockerfile.agent` — base image
- `Dockerfile.optio` — base image
- `images/base.Dockerfile` — base image (other image presets inherit via `${BASE_IMAGE}` ARG)

## Test plan

- [ ] Verify `docker build -f Dockerfile.api .` succeeds
- [ ] Verify `docker build -f Dockerfile.web .` succeeds
- [ ] Verify `docker build -f Dockerfile.agent .` succeeds
- [ ] Verify `docker build -f Dockerfile.optio .` succeeds
- [ ] Verify `./images/build.sh` builds all image presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)