### PR TITLE
fix: update prState on PR terminal actions in pr-watcher

### DIFF
--- a/apps/api/src/workers/pr-watcher-worker.ts
+++ b/apps/api/src/workers/pr-watcher-worker.ts
@@ -405,7 +405,7 @@ export function startPrWatcherWorker() {
                 case "complete":
                   await db
                     .update(tasks)
-                    .set({ prChecksStatus: effectiveChecksStatus })
+                    .set({ prChecksStatus: effectiveChecksStatus, prState: "merged" })
                     .where(eq(tasks.id, task.id));
                   await taskService.transitionTask(
                     task.id,
@@ -419,7 +419,7 @@ export function startPrWatcherWorker() {
                 case "fail":
                   await db
                     .update(tasks)
-                    .set({ prChecksStatus: effectiveChecksStatus })
+                    .set({ prChecksStatus: effectiveChecksStatus, prState: "closed" })
                     .where(eq(tasks.id, task.id));
                   await taskService.transitionTask(
                     task.id,
@@ -441,7 +441,7 @@ export function startPrWatcherWorker() {
                   if (mergeRes.ok) {
                     await db
                       .update(tasks)
-                      .set({ prChecksStatus: effectiveChecksStatus })
+                      .set({ prChecksStatus: effectiveChecksStatus, prState: "merged" })
                       .where(eq(tasks.id, task.id));
                     await taskService.transitionTask(
                       task.id,


### PR DESCRIPTION
## Summary
- Fix `prState` stuck at `"open"` after auto-merge by adding `prState: "merged"` to the DB update in the `auto_merge` action
- Also set `prState: "merged"` in the `complete` case and `prState: "closed"` in the `fail` case for consistency, ensuring `prState` always reflects reality when tasks reach terminal states

## Test plan
- [x] All 1078 existing tests pass
- [x] Typecheck passes
- [ ] Verify completed tasks via auto-merge now show `prState: "merged"` instead of `"open"`
- [ ] Verify tasks completed via external PR merge show `prState: "merged"`
- [ ] Verify tasks failed via PR close show `prState: "closed"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)