### PR TITLE
fix: pass OAuth redirects through BFF proxy to browser

### DIFF
--- a/apps/web/src/app/api/[...path]/route.ts
+++ b/apps/web/src/app/api/[...path]/route.ts
@@ -35,9 +35,15 @@ async function proxyRequest(request: NextRequest) {
   }
 
   try {
+    // OAuth login routes return 302 redirects that the browser must follow
+    // directly (to GitHub, Google, etc.). Don't let fetch() silently follow
+    // them — pass the redirect through to the browser instead.
+    const isAuthRedirect = url.pathname.match(/^\/api\/auth\/[^/]+\/(login|callback)$/);
+
     const fetchInit: RequestInit = {
       method: request.method,
       headers,
+      redirect: isAuthRedirect ? "manual" : "follow",
     };
 
     // Forward request body for non-GET/HEAD methods
@@ -48,6 +54,14 @@ async function proxyRequest(request: NextRequest) {
     }
 
     const apiRes = await fetch(targetUrl, fetchInit);
+
+    // For auth redirects, pass the Location header through to the browser
+    if (isAuthRedirect && apiRes.status >= 300 && apiRes.status < 400) {
+      const location = apiRes.headers.get("location");
+      if (location) {
+        return NextResponse.redirect(location, apiRes.status);
+      }
+    }
 
     // Build a clean response — don't forward Set-Cookie or other sensitive
     // headers from the API that could conflict with the web origin.

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 const INTERNAL_API_URL = process.env.INTERNAL_API_URL ?? "http://localhost:4000";
+const PUBLIC_URL = process.env.PUBLIC_URL ?? "http://localhost:3000";
 const SESSION_COOKIE_NAME = "optio_session";
-const IS_PRODUCTION = process.env.NODE_ENV === "production";
+const IS_SECURE = PUBLIC_URL.startsWith("https://");
 
 /**
  * OAuth callback handler for the BFF (Backend for Frontend) pattern.
@@ -21,7 +22,7 @@ export async function GET(request: NextRequest) {
   const code = searchParams.get("code");
 
   if (!code) {
-    return NextResponse.redirect(new URL("/login?error=missing_code", request.url));
+    return NextResponse.redirect(new URL("/login?error=missing_code", PUBLIC_URL));
   }
 
   try {
@@ -32,22 +33,22 @@ export async function GET(request: NextRequest) {
     });
 
     if (!res.ok) {
-      return NextResponse.redirect(new URL("/login?error=exchange_failed", request.url));
+      return NextResponse.redirect(new URL("/login?error=exchange_failed", PUBLIC_URL));
     }
 
     const { token } = (await res.json()) as { token: string };
 
-    const response = NextResponse.redirect(new URL("/", request.url));
+    const response = NextResponse.redirect(new URL("/", PUBLIC_URL));
     response.cookies.set(SESSION_COOKIE_NAME, token, {
       path: "/",
       httpOnly: true,
       sameSite: "lax",
-      secure: IS_PRODUCTION,
+      secure: IS_SECURE,
       maxAge: 30 * 24 * 60 * 60, // 30 days
     });
 
     return response;
   } catch {
-    return NextResponse.redirect(new URL("/login?error=exchange_failed", request.url));
+    return NextResponse.redirect(new URL("/login?error=exchange_failed", PUBLIC_URL));
   }
 }

--- a/helm/optio/templates/web-deployment.yaml
+++ b/helm/optio/templates/web-deployment.yaml
@@ -61,6 +61,10 @@ spec:
               value: "http://{{ .Release.Name }}-api:{{ .Values.api.port }}"
             - name: OPTIO_AUTH_DISABLED
               value: {{ .Values.auth.disabled | quote }}
+            {{- if .Values.publicUrl }}
+            - name: PUBLIC_URL
+              value: {{ .Values.publicUrl | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
 ---


### PR DESCRIPTION
## Summary

- BFF proxy `fetch()` silently followed OAuth redirects server-side instead of passing them to the browser, breaking the login flow when running behind a gateway
- Auth callback route used `request.url` (pod hostname) instead of `PUBLIC_URL` for redirect targets
- Session cookie had the `Secure` flag set on HTTP origins because `NODE_ENV=production` in the Next.js production build

## Changes

- Use `redirect: "manual"` for auth login/callback routes in the BFF proxy and pass `Location` headers through via `NextResponse.redirect()`
- Use `PUBLIC_URL` env var as the base for all redirects in the auth callback route
- Derive the cookie `Secure` flag from `PUBLIC_URL` protocol instead of `NODE_ENV`
- Inject `PUBLIC_URL` into the web pod via Helm values

## Test plan

- [ ] Login via GitHub OAuth with the app behind a gateway/ingress
- [ ] Verify browser redirects to GitHub (not a proxied HTML page)
- [ ] Verify callback redirects to the public URL (not pod hostname)
- [ ] Verify session cookie is set and persists after redirect
- [ ] Verify HTTP deployments work (no Secure flag blocking cookie)