### PR TITLE
feat: skip GitHub PAT step in setup wizard when GitHub App is configured

### DIFF
--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { checkRuntimeHealth } from "../services/container-service.js";
 import { listSecrets, retrieveSecret } from "../services/secret-service.js";
 import { isSubscriptionAvailable } from "../services/auth-service.js";
-import { isGitHubAppConfigured } from "../services/github-app-service.js";
+import { isGitHubAppConfigured, getInstallationToken } from "../services/github-app-service.js";
 import { isAuthDisabled } from "../services/oauth/index.js";
 
 /** Rate limit config for setup POST endpoints: 5 requests per 15 minutes per IP. */
@@ -239,21 +239,34 @@ export async function setupRoutes(app: FastifyInstance) {
     },
     async (req, reply) => {
       const { token } = req.body as { token: string };
-      if (!token) return reply.status(400).send({ repos: [], error: "Token is required" });
+
+      // Resolve an effective token: user-supplied PAT → GitHub App installation token
+      let effectiveToken = token || null;
+      if (!effectiveToken && isGitHubAppConfigured()) {
+        try {
+          effectiveToken = await getInstallationToken();
+        } catch {
+          return reply.send({ repos: [], error: "Failed to get GitHub App token" });
+        }
+      }
+      if (!effectiveToken) {
+        return reply.status(400).send({ repos: [], error: "Token is required" });
+      }
 
       try {
-        const headers = { Authorization: `Bearer ${token}`, "User-Agent": "Optio" };
+        const headers = { Authorization: `Bearer ${effectiveToken}`, "User-Agent": "Optio" };
 
-        // Fetch repos sorted by most recently pushed
-        const res = await fetch(
-          "https://api.github.com/user/repos?sort=pushed&direction=desc&per_page=20&affiliation=owner,collaborator,organization_member",
-          { headers },
-        );
+        // GitHub App installation tokens use /installation/repositories, not /user/repos.
+        // PATs use /user/repos for the authenticated user's repos.
+        const apiUrl = token
+          ? "https://api.github.com/user/repos?sort=pushed&direction=desc&per_page=20&affiliation=owner,collaborator,organization_member"
+          : "https://api.github.com/installation/repositories?sort=pushed&direction=desc&per_page=20";
+        const res = await fetch(apiUrl, { headers });
         if (!res.ok) {
           return reply.send({ repos: [], error: `GitHub returned ${res.status}` });
         }
 
-        const data = (await res.json()) as Array<{
+        type RepoItem = {
           full_name: string;
           html_url: string;
           clone_url: string;
@@ -262,7 +275,11 @@ export async function setupRoutes(app: FastifyInstance) {
           description: string | null;
           language: string | null;
           pushed_at: string;
-        }>;
+        };
+
+        const json = (await res.json()) as RepoItem[] | { repositories: RepoItem[] };
+        // /installation/repositories wraps results; /user/repos returns a flat array
+        const data: RepoItem[] = Array.isArray(json) ? json : json.repositories;
 
         const repos = data.map((r) => ({
           fullName: r.full_name,
@@ -302,8 +319,12 @@ export async function setupRoutes(app: FastifyInstance) {
         }
         const [, owner, repo] = match;
         const headers: Record<string, string> = { "User-Agent": "Optio" };
-        const effectiveToken = token ?? (await retrieveSecret("GITHUB_TOKEN").catch(() => null));
-        if (effectiveToken) headers["Authorization"] = `Bearer ${effectiveToken}`;
+        let repoToken: string | null = token ?? null;
+        if (!repoToken) repoToken = await retrieveSecret("GITHUB_TOKEN").catch(() => null);
+        if (!repoToken && isGitHubAppConfigured()) {
+          repoToken = await getInstallationToken().catch(() => null);
+        }
+        if (repoToken) headers["Authorization"] = `Bearer ${repoToken}`;
 
         const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers });
         if (res.ok) {

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -54,6 +54,7 @@ export default function SetupPage() {
   const [githubUser, setGithubUser] = useState<{ login: string; name: string } | null>(null);
   const [githubValidated, setGithubValidated] = useState(false);
   const [githubError, setGithubError] = useState("");
+  const [githubAppConfigured, setGithubAppConfigured] = useState(false);
 
   // Step 3: Agent keys
   const [anthropicKey, setAnthropicKey] = useState("");
@@ -110,12 +111,16 @@ export default function SetupPage() {
   const [notionApiKey, setNotionApiKey] = useState("");
   const [notionDatabaseId, setNotionDatabaseId] = useState("");
 
-  // Check runtime on mount
+  // Check runtime and GitHub App status on mount
   useEffect(() => {
     api
       .getHealth()
       .then((res) => setRuntimeHealthy(res.healthy))
       .catch(() => setRuntimeHealthy(false));
+    api
+      .getGitHubAppStatus()
+      .then((res) => setGithubAppConfigured(res.configured))
+      .catch(() => {});
   }, []);
 
   // Check if OAuth token is already stored when reaching the agents step
@@ -127,13 +132,17 @@ export default function SetupPage() {
 
   // Fetch suggested repos when reaching the repos step
   useEffect(() => {
-    if (currentStep?.id === "repos" && githubToken && suggestedRepos.length === 0) {
-      setSuggestedLoading(true);
-      api
-        .listUserRepos(githubToken)
-        .then((res) => setSuggestedRepos(res.repos.slice(0, 8)))
-        .catch(() => {})
-        .finally(() => setSuggestedLoading(false));
+    if (currentStep?.id === "repos" && suggestedRepos.length === 0) {
+      // When GitHub App is configured, fetch repos server-side (no PAT needed).
+      // When using a PAT, pass it for the user-scoped repo listing.
+      if (githubAppConfigured || githubToken) {
+        setSuggestedLoading(true);
+        api
+          .listUserRepos(githubToken || "")
+          .then((res) => setSuggestedRepos(res.repos.slice(0, 8)))
+          .catch(() => {})
+          .finally(() => setSuggestedLoading(false));
+      }
     }
   }, [step]);
 
@@ -490,57 +499,77 @@ export default function SetupPage() {
                 <Github className="w-6 h-6 text-text" />
                 <h2 className="text-lg font-bold">GitHub Access</h2>
               </div>
-              <p className="text-text-muted text-sm">
-                Agents need a GitHub token to clone repos, create branches, and open pull requests.
-                Create a token with <code className="px-1 py-0.5 bg-bg rounded text-xs">repo</code>{" "}
-                scope, then paste it below.
-              </p>
-              <a
-                href="https://github.com/settings/tokens/new?scopes=repo,read:org&description=Optio+Agent"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-bg-hover text-text text-sm hover:bg-border transition-colors"
-              >
-                <ExternalLink className="w-4 h-4" />
-                Create GitHub Personal Access Token
-              </a>
-              <div>
-                <label className="block text-sm text-text-muted mb-1.5">GitHub Token</label>
-                <input
-                  type="password"
-                  value={githubToken}
-                  onChange={(e) => {
-                    setGithubToken(e.target.value);
-                    setGithubValidated(false);
-                    setGithubError("");
-                  }}
-                  onPaste={(e) => {
-                    e.preventDefault();
-                    const pasted = e.clipboardData.getData("text").trim();
-                    if (pasted) {
-                      setGithubToken(pasted);
-                      setGithubValidated(false);
-                      setGithubError("");
-                      setTimeout(() => validateGithub(pasted), 50);
-                    }
-                  }}
-                  placeholder="ghp_..."
-                  className="w-full px-3 py-2 rounded-md bg-bg border border-border text-sm focus:outline-none focus:border-primary"
-                />
-              </div>
-              {githubError && (
-                <div className="flex items-center gap-2 text-error text-sm">
-                  <AlertCircle className="w-4 h-4" />
-                  {githubError}
-                </div>
+
+              {githubAppConfigured ? (
+                <>
+                  <div className="flex items-center gap-2 text-success text-sm p-3 rounded-md bg-success/10">
+                    <CheckCircle className="w-4 h-4" />
+                    GitHub App is configured — no personal access token needed.
+                  </div>
+                  <p className="text-text-muted text-sm">
+                    Optio will use the installed GitHub App to clone repos, create branches, and open
+                    pull requests.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="text-text-muted text-sm">
+                    Agents need a GitHub token to clone repos, create branches, and open pull requests.
+                    Create a token with{" "}
+                    <code className="px-1 py-0.5 bg-bg rounded text-xs">repo</code> scope, then paste
+                    it below.
+                  </p>
+                  <a
+                    href="https://github.com/settings/tokens/new?scopes=repo,read:org&description=Optio+Agent"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-bg-hover text-text text-sm hover:bg-border transition-colors"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                    Create GitHub Personal Access Token
+                  </a>
+                  <div>
+                    <label className="block text-sm text-text-muted mb-1.5">GitHub Token</label>
+                    <input
+                      type="password"
+                      value={githubToken}
+                      onChange={(e) => {
+                        setGithubToken(e.target.value);
+                        setGithubValidated(false);
+                        setGithubError("");
+                      }}
+                      onPaste={(e) => {
+                        e.preventDefault();
+                        const pasted = e.clipboardData.getData("text").trim();
+                        if (pasted) {
+                          setGithubToken(pasted);
+                          setGithubValidated(false);
+                          setGithubError("");
+                          setTimeout(() => validateGithub(pasted), 50);
+                        }
+                      }}
+                      placeholder="ghp_..."
+                      className="w-full px-3 py-2 rounded-md bg-bg border border-border text-sm focus:outline-none focus:border-primary"
+                    />
+                  </div>
+                  {githubError && (
+                    <div className="flex items-center gap-2 text-error text-sm">
+                      <AlertCircle className="w-4 h-4" />
+                      {githubError}
+                    </div>
+                  )}
+                  {githubValidated && githubUser && (
+                    <div className="flex items-center gap-2 text-success text-sm p-2 rounded-md bg-success/10">
+                      <CheckCircle className="w-4 h-4" />
+                      Authenticated as <strong>{githubUser.login}</strong>
+                      {githubUser.name && (
+                        <span className="text-text-muted">({githubUser.name})</span>
+                      )}
+                    </div>
+                  )}
+                </>
               )}
-              {githubValidated && githubUser && (
-                <div className="flex items-center gap-2 text-success text-sm p-2 rounded-md bg-success/10">
-                  <CheckCircle className="w-4 h-4" />
-                  Authenticated as <strong>{githubUser.login}</strong>
-                  {githubUser.name && <span className="text-text-muted">({githubUser.name})</span>}
-                </div>
-              )}
+
               <div className="flex items-center justify-between">
                 <button
                   onClick={goBack}
@@ -549,7 +578,7 @@ export default function SetupPage() {
                   <ArrowLeft className="w-4 h-4" /> Back
                 </button>
                 <div className="flex gap-2">
-                  {!githubValidated && (
+                  {!githubAppConfigured && !githubValidated && (
                     <button
                       onClick={() => validateGithub()}
                       disabled={loading || !githubToken.trim()}
@@ -559,8 +588,8 @@ export default function SetupPage() {
                     </button>
                   )}
                   <button
-                    onClick={saveGithubStep}
-                    disabled={!githubValidated || loading}
+                    onClick={githubAppConfigured ? goNext : saveGithubStep}
+                    disabled={!githubAppConfigured && (!githubValidated || loading)}
                     className="flex items-center gap-2 px-5 py-2 rounded-md bg-primary text-white text-sm hover:bg-primary-hover disabled:opacity-50"
                   >
                     {loading ? (
@@ -1408,7 +1437,9 @@ export default function SetupPage() {
                 <h3 className="text-sm font-medium mb-2">Configuration summary</h3>
                 <div className="flex items-center gap-2 text-sm">
                   <CheckCircle className="w-4 h-4 text-success" />
-                  <span>GitHub: {githubUser?.login ?? "configured"}</span>
+                  <span>
+                    GitHub: {githubAppConfigured ? "App configured" : (githubUser?.login ?? "configured")}
+                  </span>
                 </div>
                 {claudeReady && (
                   <div className="flex items-center gap-2 text-sm">

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -507,17 +507,17 @@ export default function SetupPage() {
                     GitHub App is configured — no personal access token needed.
                   </div>
                   <p className="text-text-muted text-sm">
-                    Optio will use the installed GitHub App to clone repos, create branches, and open
-                    pull requests.
+                    Optio will use the installed GitHub App to clone repos, create branches, and
+                    open pull requests.
                   </p>
                 </>
               ) : (
                 <>
                   <p className="text-text-muted text-sm">
-                    Agents need a GitHub token to clone repos, create branches, and open pull requests.
-                    Create a token with{" "}
-                    <code className="px-1 py-0.5 bg-bg rounded text-xs">repo</code> scope, then paste
-                    it below.
+                    Agents need a GitHub token to clone repos, create branches, and open pull
+                    requests. Create a token with{" "}
+                    <code className="px-1 py-0.5 bg-bg rounded text-xs">repo</code> scope, then
+                    paste it below.
                   </p>
                   <a
                     href="https://github.com/settings/tokens/new?scopes=repo,read:org&description=Optio+Agent"
@@ -1438,7 +1438,8 @@ export default function SetupPage() {
                 <div className="flex items-center gap-2 text-sm">
                   <CheckCircle className="w-4 h-4 text-success" />
                   <span>
-                    GitHub: {githubAppConfigured ? "App configured" : (githubUser?.login ?? "configured")}
+                    GitHub:{" "}
+                    {githubAppConfigured ? "App configured" : (githubUser?.login ?? "configured")}
                   </span>
                 </div>
                 {claudeReady && (


### PR DESCRIPTION
## Summary

When a GitHub App is configured at deployment level, the setup wizard now detects it and allows proceeding without a personal access token.

## Changes

**Frontend (`apps/web/src/app/setup/page.tsx`):**
- Check `GET /api/github-app/status` on mount
- Show success message and skip PAT input when GitHub App is configured
- Fetch suggested repos using server-side GitHub App token when no PAT available
- Update done step summary to show "App configured"

**Backend (`apps/api/src/routes/setup.ts`):**
- Repos listing falls back to GitHub App installation token (uses `/installation/repositories` endpoint)
- Repo validation falls back to installation token after checking stored `GITHUB_TOKEN`

## Test plan

- [x] Setup wizard with GitHub App configured shows success on GitHub step
- [x] Continue button works without entering a PAT
- [x] Repos step lists repositories from the GitHub App installation
- [ ] Repo validation works using installation token
- [ ] Setup wizard still works with PAT when no GitHub App is configured