### PR TITLE
fix: setup wizard UX improvements for token expiry and existing repos

### DIFF
--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -343,12 +343,18 @@ export default function SetupPage() {
     try {
       for (const repo of repos) {
         if (repo.fullName && repo.url) {
-          await api.createRepoConfig({
-            repoUrl: repo.url,
-            fullName: repo.fullName,
-            defaultBranch: repo.defaultBranch,
-            isPrivate: repo.isPrivate,
-          });
+          try {
+            await api.createRepoConfig({
+              repoUrl: repo.url,
+              fullName: repo.fullName,
+              defaultBranch: repo.defaultBranch,
+              isPrivate: repo.isPrivate,
+            });
+          } catch (err) {
+            // Repo already exists from a previous setup — safe to skip
+            if (err instanceof Error && err.message.includes("already been added")) continue;
+            throw err;
+          }
         }
       }
       goNext();
@@ -628,17 +634,18 @@ export default function SetupPage() {
                               <Loader2 className="w-3 h-3 animate-spin" /> Checking for existing
                               token...
                             </span>
-                          ) : oauthExpired ? (
-                            <span className="text-xs text-error flex items-center gap-2">
-                              <AlertTriangle className="w-3 h-3" /> OAuth token has expired — paste
-                              a new one below
-                            </span>
                           ) : oauthTokenDetected ? (
                             <span className="text-xs text-success flex items-center gap-1">
                               <CheckCircle className="w-3 h-3" /> Claude subscription token detected
                             </span>
                           ) : (
                             <>
+                              {oauthExpired && (
+                                <span className="text-xs text-error flex items-center gap-2">
+                                  <AlertTriangle className="w-3 h-3" /> OAuth token has expired —
+                                  paste a new one below
+                                </span>
+                              )}
                               <div>
                                 <p className="text-xs text-text-muted mb-1.5">
                                   Run this in a terminal to copy your token:


### PR DESCRIPTION
## Summary

Two UX fixes for the setup wizard:

1. **Expired OAuth token**: The expired warning and paste input were in mutually exclusive if/else branches, so users saw "token expired" but had no way to paste a replacement. Now both render together.

2. **Existing repos**: Re-running the setup wizard failed with "Failed to save repos" when repos already existed (409 from the API). Now skips repos that are already added.

## Test plan

- [x] With an expired OAuth token, verify the warning AND paste input both appear
- [x] Re-run the setup wizard with previously added repos and verify it proceeds without error