### PR TITLE
feat: add workflow to replace expired GitHub token

### DIFF
--- a/apps/api/src/routes/github-token.test.ts
+++ b/apps/api/src/routes/github-token.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+
+// ─── Mocks ───
+
+const mockRetrieveSecret = vi.fn();
+const mockStoreSecret = vi.fn();
+const mockListSecrets = vi.fn();
+
+vi.mock("../services/secret-service.js", () => ({
+  retrieveSecret: (...args: unknown[]) => mockRetrieveSecret(...args),
+  storeSecret: (...args: unknown[]) => mockStoreSecret(...args),
+  listSecrets: (...args: unknown[]) => mockListSecrets(...args),
+}));
+
+const mockIsGitHubAppConfigured = vi.fn();
+
+vi.mock("../services/github-app-service.js", () => ({
+  isGitHubAppConfigured: (...args: unknown[]) => mockIsGitHubAppConfigured(...args),
+}));
+
+vi.mock("../services/oauth/index.js", () => ({
+  isAuthDisabled: () => true,
+}));
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { githubTokenRoutes } from "./github-token.js";
+
+// ─── Helpers ───
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await githubTokenRoutes(app);
+  await app.ready();
+  return app;
+}
+
+describe("GET /api/github-token/status", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockIsGitHubAppConfigured.mockReturnValue(false);
+    app = await buildTestApp();
+  });
+
+  it("returns valid status when stored token is valid", async () => {
+    mockRetrieveSecret.mockResolvedValue("ghp_validtoken123");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ login: "testuser", name: "Test User" }),
+    });
+
+    const res = await app.inject({ method: "GET", url: "/api/github-token/status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe("valid");
+    expect(body.user).toEqual({ login: "testuser", name: "Test User" });
+    expect(body.source).toBe("pat");
+  });
+
+  it("returns expired status when stored token fails GitHub validation", async () => {
+    mockRetrieveSecret.mockResolvedValue("ghp_expiredtoken");
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+    });
+
+    const res = await app.inject({ method: "GET", url: "/api/github-token/status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe("expired");
+    expect(body.error).toContain("401");
+  });
+
+  it("returns missing status when no token is stored", async () => {
+    mockRetrieveSecret.mockRejectedValue(new Error("Secret not found"));
+    mockIsGitHubAppConfigured.mockReturnValue(false);
+
+    const res = await app.inject({ method: "GET", url: "/api/github-token/status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe("missing");
+  });
+
+  it("returns github_app source when GitHub App is configured and no PAT", async () => {
+    mockRetrieveSecret.mockRejectedValue(new Error("Secret not found"));
+    mockIsGitHubAppConfigured.mockReturnValue(true);
+
+    const res = await app.inject({ method: "GET", url: "/api/github-token/status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe("valid");
+    expect(body.source).toBe("github_app");
+  });
+
+  it("returns error status when GitHub API is unreachable", async () => {
+    mockRetrieveSecret.mockResolvedValue("ghp_sometoken");
+    mockFetch.mockRejectedValue(new Error("Network error"));
+
+    const res = await app.inject({ method: "GET", url: "/api/github-token/status" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe("error");
+  });
+});
+
+describe("POST /api/github-token/rotate", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("validates and stores a new token successfully", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ login: "newuser", name: "New User" }),
+    });
+    mockStoreSecret.mockResolvedValue(undefined);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/github-token/rotate",
+      payload: { token: "ghp_newvalidtoken" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.success).toBe(true);
+    expect(body.user).toEqual({ login: "newuser", name: "New User" });
+    expect(mockStoreSecret).toHaveBeenCalledWith("GITHUB_TOKEN", "ghp_newvalidtoken", "global");
+  });
+
+  it("rejects an invalid token without storing it", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/github-token/rotate",
+      payload: { token: "ghp_badtoken" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBeDefined();
+    expect(mockStoreSecret).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when token is missing from request body", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/github-token/rotate",
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns failure when GitHub API is unreachable during rotation", async () => {
+    mockFetch.mockRejectedValue(new Error("Network error"));
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/github-token/rotate",
+      payload: { token: "ghp_sometoken" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.success).toBe(false);
+    expect(mockStoreSecret).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/github-token.ts
+++ b/apps/api/src/routes/github-token.ts
@@ -1,0 +1,138 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { retrieveSecret, storeSecret } from "../services/secret-service.js";
+import { isGitHubAppConfigured } from "../services/github-app-service.js";
+import { isAuthDisabled } from "../services/oauth/index.js";
+
+/** Rate limit: 10 requests per minute per IP. */
+const RATE_LIMIT = {
+  max: 10,
+  timeWindow: "1 minute",
+};
+
+const requireAdminWhenAuthenticated = async (req: FastifyRequest, reply: FastifyReply) => {
+  if (isAuthDisabled()) return;
+  if (!req.user) return;
+  if (req.user.workspaceRole !== "admin") {
+    return reply.status(403).send({ error: "Admin role required" });
+  }
+};
+
+export async function githubTokenRoutes(app: FastifyInstance) {
+  /**
+   * GET /api/github-token/status
+   *
+   * Check the health of the stored GITHUB_TOKEN by validating it against
+   * the GitHub API. Returns the token status and authenticated user info.
+   */
+  app.get(
+    "/api/github-token/status",
+    { config: { rateLimit: RATE_LIMIT } },
+    async (_req, reply) => {
+      // Check if a PAT is stored
+      let token: string | null = null;
+      try {
+        token = await retrieveSecret("GITHUB_TOKEN");
+      } catch {
+        // No token stored
+      }
+
+      if (!token) {
+        // No PAT — check if GitHub App is configured as an alternative
+        if (isGitHubAppConfigured()) {
+          return reply.send({
+            status: "valid",
+            source: "github_app",
+            message: "GitHub App integration is configured. No PAT required.",
+          });
+        }
+        return reply.send({
+          status: "missing",
+          message:
+            "No GitHub token configured. PR watching, issue sync, and repo detection will not work.",
+        });
+      }
+
+      // Validate the stored token against the GitHub API
+      try {
+        const res = await fetch("https://api.github.com/user", {
+          headers: { Authorization: `Bearer ${token}`, "User-Agent": "Optio" },
+        });
+
+        if (res.ok) {
+          const user = (await res.json()) as { login: string; name: string };
+          return reply.send({
+            status: "valid",
+            source: "pat",
+            user: { login: user.login, name: user.name },
+          });
+        }
+
+        return reply.send({
+          status: "expired",
+          source: "pat",
+          error: `GitHub returned ${res.status} — token may be expired or revoked`,
+          message:
+            "Replace your GitHub token to restore PR watching, issue sync, and repo detection.",
+        });
+      } catch (err) {
+        app.log.error(err, "GitHub token validation failed");
+        return reply.send({
+          status: "error",
+          source: "pat",
+          error: "Could not reach GitHub API to validate token",
+        });
+      }
+    },
+  );
+
+  /**
+   * POST /api/github-token/rotate
+   *
+   * Validate a new GitHub token and replace the stored GITHUB_TOKEN secret.
+   * The new token is validated first — if invalid, the existing token is not replaced.
+   */
+  app.post(
+    "/api/github-token/rotate",
+    {
+      config: { rateLimit: RATE_LIMIT },
+      preHandler: [requireAdminWhenAuthenticated],
+    },
+    async (req, reply) => {
+      const { token } = req.body as { token?: string };
+      if (!token || !token.trim()) {
+        return reply.status(400).send({ success: false, error: "Token is required" });
+      }
+
+      // Validate the new token before storing
+      try {
+        const res = await fetch("https://api.github.com/user", {
+          headers: { Authorization: `Bearer ${token.trim()}`, "User-Agent": "Optio" },
+        });
+
+        if (!res.ok) {
+          return reply.send({
+            success: false,
+            error: `GitHub returned ${res.status} — token is invalid or expired`,
+          });
+        }
+
+        const user = (await res.json()) as { login: string; name: string };
+
+        // Token is valid — store it
+        await storeSecret("GITHUB_TOKEN", token.trim(), "global");
+
+        return reply.send({
+          success: true,
+          user: { login: user.login, name: user.name },
+          message: "GitHub token replaced successfully. PR watching and issue sync will resume.",
+        });
+      } catch (err) {
+        app.log.error(err, "GitHub token rotation failed");
+        return reply.send({
+          success: false,
+          error: "Could not validate token — GitHub API may be unreachable",
+        });
+      }
+    },
+  );
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -32,6 +32,7 @@ import { skillRoutes } from "./routes/skills.js";
 import { optioRoutes } from "./routes/optio.js";
 import { optioSettingsRoutes } from "./routes/optio-settings.js";
 import githubAppRoutes from "./routes/github-app.js";
+import { githubTokenRoutes } from "./routes/github-token.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import { sessionTerminalWs } from "./ws/session-terminal.js";
@@ -102,6 +103,7 @@ export async function buildServer() {
   await app.register(optioRoutes);
   await app.register(optioSettingsRoutes);
   await app.register(githubAppRoutes);
+  await app.register(githubTokenRoutes);
 
   // WebSocket routes
   await app.register(logStreamWs);

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -20,6 +20,8 @@ import {
   AlertTriangle,
   ChevronDown,
   ChevronRight,
+  Github,
+  KeyRound,
 } from "lucide-react";
 import { OPTIO_TOOL_CATEGORIES, ALL_OPTIO_TOOL_NAMES } from "@optio/shared";
 
@@ -987,6 +989,194 @@ function OptioAgentSettings() {
   );
 }
 
+function GitHubTokenManager() {
+  const [status, setStatus] = useState<"valid" | "expired" | "missing" | "error" | null>(null);
+  const [source, setSource] = useState<"pat" | "github_app" | undefined>();
+  const [user, setUser] = useState<{ login: string; name: string } | undefined>();
+  const [message, setMessage] = useState<string | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [newToken, setNewToken] = useState("");
+  const [rotating, setRotating] = useState(false);
+  const [showRotateForm, setShowRotateForm] = useState(false);
+
+  const checkStatus = async () => {
+    setLoading(true);
+    try {
+      const res = await api.getGithubTokenStatus();
+      setStatus(res.status);
+      setSource(res.source);
+      setUser(res.user);
+      setMessage(res.message ?? res.error);
+    } catch {
+      setStatus("error");
+      setMessage("Failed to check token status");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    checkStatus();
+  }, []);
+
+  const handleRotate = async () => {
+    if (!newToken.trim()) return;
+    setRotating(true);
+    try {
+      const res = await api.rotateGithubToken(newToken.trim());
+      if (res.success) {
+        toast.success(res.message ?? "GitHub token replaced successfully");
+        setNewToken("");
+        setShowRotateForm(false);
+        checkStatus();
+      } else {
+        toast.error(res.error ?? "Token validation failed");
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to replace token");
+    } finally {
+      setRotating(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-5 rounded-xl border border-border/50 bg-bg-card text-center text-text-muted text-sm">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" /> Checking token status...
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-5 rounded-xl border border-border/50 bg-bg-card space-y-4">
+      {/* Current status */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          {status === "valid" ? (
+            <CheckCircle2 className="w-5 h-5 text-success shrink-0" />
+          ) : status === "expired" ? (
+            <AlertTriangle className="w-5 h-5 text-warning shrink-0" />
+          ) : status === "missing" ? (
+            <XCircle className="w-5 h-5 text-error shrink-0" />
+          ) : (
+            <AlertTriangle className="w-5 h-5 text-text-muted shrink-0" />
+          )}
+          <div>
+            <p className="text-sm font-medium">
+              {status === "valid"
+                ? "Token is valid"
+                : status === "expired"
+                  ? "Token is expired or revoked"
+                  : status === "missing"
+                    ? "No token configured"
+                    : "Unable to verify token"}
+            </p>
+            {user && (
+              <p className="text-xs text-text-muted">
+                Authenticated as <span className="font-medium text-text">{user.login}</span>
+                {user.name && ` (${user.name})`}
+              </p>
+            )}
+            {source === "github_app" && (
+              <p className="text-xs text-text-muted">Using GitHub App integration</p>
+            )}
+            {message && !user && <p className="text-xs text-text-muted">{message}</p>}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={checkStatus}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs text-text-muted hover:bg-bg-hover transition-colors"
+          >
+            <RefreshCw className="w-3 h-3" />
+            Refresh
+          </button>
+          {source !== "github_app" && (
+            <button
+              onClick={() => setShowRotateForm(!showRotateForm)}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary/10 text-primary text-xs hover:bg-primary/20 transition-colors"
+            >
+              <KeyRound className="w-3 h-3" />
+              {status === "missing" ? "Add Token" : "Replace Token"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Expired/missing warning */}
+      {(status === "expired" || status === "missing") && (
+        <div
+          className={`flex items-start gap-2 p-3 rounded-lg text-xs ${
+            status === "expired"
+              ? "bg-warning/10 border border-warning/20 text-warning"
+              : "bg-error/10 border border-error/20 text-error"
+          }`}
+        >
+          <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+          <div>
+            <p className="font-medium">
+              {status === "expired"
+                ? "Your GitHub token has expired or been revoked"
+                : "No GitHub token is configured"}
+            </p>
+            <p className="mt-0.5 opacity-70">
+              PR watching, issue sync, and repo detection require a valid GitHub token. Replace it
+              below to restore these features.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Rotation form */}
+      {showRotateForm && (
+        <div className="space-y-3 p-3 rounded-lg border border-primary/30 bg-primary/5">
+          <p className="text-xs text-text-muted">
+            Enter a new GitHub Personal Access Token. The token will be validated before replacing
+            the existing one.
+          </p>
+          <div className="flex gap-2">
+            <input
+              type="password"
+              value={newToken}
+              onChange={(e) => setNewToken(e.target.value)}
+              onPaste={(e) => {
+                e.preventDefault();
+                const pasted = e.clipboardData.getData("text").trim();
+                if (pasted) setNewToken(pasted);
+              }}
+              placeholder="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+              className="flex-1 px-3 py-2 rounded-lg bg-bg border border-border text-sm font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+            />
+            <button
+              onClick={handleRotate}
+              disabled={!newToken.trim() || rotating}
+              className="px-4 py-2 rounded-md bg-primary text-white text-xs font-medium hover:bg-primary-hover disabled:opacity-50 whitespace-nowrap"
+            >
+              {rotating ? (
+                <span className="flex items-center gap-1.5">
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                  Validating...
+                </span>
+              ) : (
+                "Validate & Save"
+              )}
+            </button>
+          </div>
+          <button
+            onClick={() => {
+              setShowRotateForm(false);
+              setNewToken("");
+            }}
+            className="text-xs text-text-muted hover:text-text"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function SettingsPage() {
   usePageTitle("Settings");
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
@@ -1043,6 +1233,15 @@ export default function SettingsPage() {
       <section>
         <h2 className="text-sm font-medium text-text-muted mb-3">Authentication</h2>
         <AuthenticationSettings />
+      </section>
+
+      {/* GitHub Token */}
+      <section>
+        <h2 className="text-sm font-medium text-text-muted mb-3 flex items-center gap-2">
+          <Github className="w-4 h-4" />
+          GitHub Token
+        </h2>
+        <GitHubTokenManager />
       </section>
 
       {/* Notifications */}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -271,6 +271,27 @@ export const api = {
       body: JSON.stringify({ targetVersion }),
     }),
 
+  // GitHub Token Management
+  getGithubTokenStatus: () =>
+    request<{
+      status: "valid" | "expired" | "missing" | "error";
+      source?: "pat" | "github_app";
+      user?: { login: string; name: string };
+      message?: string;
+      error?: string;
+    }>("/api/github-token/status"),
+
+  rotateGithubToken: (token: string) =>
+    request<{
+      success: boolean;
+      user?: { login: string; name: string };
+      message?: string;
+      error?: string;
+    }>("/api/github-token/rotate", {
+      method: "POST",
+      body: JSON.stringify({ token }),
+    }),
+
   // Setup
   getSetupStatus: () =>
     request<{


### PR DESCRIPTION
## Summary
- Adds `GET /api/github-token/status` endpoint that validates the stored `GITHUB_TOKEN` against the GitHub API, returning whether it is valid, expired, missing, or unreachable — and which auth source is in use (PAT vs GitHub App)
- Adds `POST /api/github-token/rotate` endpoint that validates a new token first, then atomically replaces the stored secret only if the new token is valid
- Adds a **GitHub Token** section to the Settings page with a clear status indicator, authenticated user info, and a guided replacement form with validation
- Previously, an expired token caused PR watching, issue sync, and repo detection to silently fail with no way to diagnose or fix from the UI

## Test plan
- [x] 9 new tests covering all status scenarios (valid, expired, missing, GitHub App fallback, network error) and rotation scenarios (success, invalid token rejected, missing body, network error)
- [x] All 1091 existing tests pass
- [x] TypeScript typecheck passes across all packages
- [x] Next.js web build succeeds
- [x] Prettier formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)