### PR TITLE
fix: prevent pod cleanup for active interactive sessions

### DIFF
--- a/apps/api/src/services/repo-pool-service.test.ts
+++ b/apps/api/src/services/repo-pool-service.test.ts
@@ -37,6 +37,12 @@ vi.mock("../db/schema.js", () => ({
     lastPodId: "lastPodId",
     updatedAt: "updatedAt",
   },
+  interactiveSessions: {
+    id: "id",
+    repoUrl: "repoUrl",
+    state: "state",
+    podId: "podId",
+  },
 }));
 
 const mockRuntimeCreate = vi.fn();
@@ -196,7 +202,15 @@ describe("cleanupIdleRepoPods", () => {
       instanceIndex: 0,
     };
 
-    vi.mocked(db.select().from(undefined as any).where as any).mockResolvedValueOnce([idlePod]);
+    // where() is used as both a terminal (idle pods, delete) and chainable (.limit() for sessions).
+    // Return an object that supports .limit() and is also thenable.
+    const chainable = {
+      limit: vi.fn().mockResolvedValue([]),
+      then: (res: any, rej?: any) => Promise.resolve([]).then(res, rej),
+    };
+    vi.mocked(db.select().from(undefined as any).where as any)
+      .mockResolvedValueOnce([idlePod]) // idle pods query
+      .mockReturnValueOnce(chainable); // interactive sessions query (chainable to .limit())
 
     mockRuntimeDestroy.mockResolvedValueOnce(undefined);
     vi.mocked(db.delete(undefined as any).where as any).mockResolvedValueOnce(undefined);
@@ -229,7 +243,14 @@ describe("cleanupIdleRepoPods", () => {
       },
     ];
 
-    vi.mocked(db.select().from(undefined as any).where as any).mockResolvedValueOnce(pods);
+    const chainable = {
+      limit: vi.fn().mockResolvedValue([]),
+      then: (res: any, rej?: any) => Promise.resolve([]).then(res, rej),
+    };
+    vi.mocked(db.select().from(undefined as any).where as any)
+      .mockResolvedValueOnce(pods)
+      .mockReturnValueOnce(chainable) // session check for pod-2 (sorted desc by instanceIndex)
+      .mockReturnValueOnce(chainable); // session check for pod-1
 
     mockRuntimeDestroy
       .mockRejectedValueOnce(new Error("Failed to destroy"))
@@ -252,7 +273,13 @@ describe("cleanupIdleRepoPods", () => {
       instanceIndex: 0,
     };
 
-    vi.mocked(db.select().from(undefined as any).where as any).mockResolvedValueOnce([pod]);
+    const chainable = {
+      limit: vi.fn().mockResolvedValue([]),
+      then: (res: any, rej?: any) => Promise.resolve([]).then(res, rej),
+    };
+    vi.mocked(db.select().from(undefined as any).where as any)
+      .mockResolvedValueOnce([pod])
+      .mockReturnValueOnce(chainable); // session check
     vi.mocked(db.delete(undefined as any).where as any).mockResolvedValue(undefined);
 
     const cleaned = await cleanupIdleRepoPods();

--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { eq, and, lt, sql, asc } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { repoPods, tasks } from "../db/schema.js";
+import { repoPods, tasks, interactiveSessions } from "../db/schema.js";
 import { getRuntime } from "./container-service.js";
 import type { ContainerHandle, ContainerSpec, ExecSession, RepoImageConfig } from "@optio/shared";
 import {
@@ -657,6 +657,20 @@ export async function cleanupIdleRepoPods(): Promise<number> {
     const sorted = repoIdlePods.sort((a, b) => b.instanceIndex - a.instanceIndex);
 
     for (const pod of sorted) {
+      // Skip pods that have active interactive sessions
+      const [activeSession] = await db
+        .select({ id: interactiveSessions.id })
+        .from(interactiveSessions)
+        .where(and(eq(interactiveSessions.podId, pod.id), eq(interactiveSessions.state, "active")))
+        .limit(1);
+      if (activeSession) {
+        logger.info(
+          { podName: pod.podName, sessionId: activeSession.id },
+          "Skipping idle pod cleanup — active session exists",
+        );
+        continue;
+      }
+
       try {
         if (pod.podName) {
           await deleteNetworkPolicy(pod.podName).catch(() => {});

--- a/apps/api/src/ws/session-chat.ts
+++ b/apps/api/src/ws/session-chat.ts
@@ -89,7 +89,13 @@ export async function sessionChatWs(app: FastifyInstance) {
     // Get pod info
     const [pod] = await db.select().from(repoPods).where(eq(repoPods.id, session.podId));
     if (!pod || !pod.podName) {
-      socket.send(JSON.stringify({ type: "error", message: "Pod not found or not ready" }));
+      socket.send(
+        JSON.stringify({
+          type: "error",
+          message:
+            "Session pod was cleaned up due to inactivity. Please end this session and start a new one.",
+        }),
+      );
       releaseConnection(clientIp);
       socket.close();
       return;

--- a/apps/api/src/ws/session-terminal.ts
+++ b/apps/api/src/ws/session-terminal.ts
@@ -66,7 +66,12 @@ export async function sessionTerminalWs(app: FastifyInstance) {
     // Get pod info
     const [pod] = await db.select().from(repoPods).where(eq(repoPods.id, session.podId));
     if (!pod || !pod.podName) {
-      socket.send(JSON.stringify({ error: "Pod not found or not ready" }));
+      socket.send(
+        JSON.stringify({
+          error:
+            "Session pod was cleaned up due to inactivity. Please end this session and start a new one.",
+        }),
+      );
       releaseConnection(clientIp);
       socket.close();
       return;


### PR DESCRIPTION
## Summary
- **repo-pool-service**: Skip idle pod cleanup when the pod has active interactive sessions, preventing sessions from losing their pod mid-use
- **session-chat / session-terminal**: Replace generic "Pod not found or not ready" error with a clear message explaining the pod was cleaned up due to inactivity, guiding the user to end and restart the session

## Test plan
- [x] Typecheck passes
- [x] Tests updated with session-aware mock for cleanup logic
- [ ] Start an interactive session, wait for idle timeout — session pod should survive
- [ ] End a session, wait for idle timeout — pod should be cleaned up normally
- [ ] Open a session whose pod was already cleaned up — should see the descriptive error

🤖 Generated with [Claude Code](https://claude.com/claude-code)