### PR TITLE
fix: raise WebSocket per-IP connection limit and stop retry on 4429

### DIFF
--- a/apps/api/src/ws/ws-limits.test.ts
+++ b/apps/api/src/ws/ws-limits.test.ts
@@ -32,7 +32,7 @@ describe("ws-limits", () => {
 
   describe("constants", () => {
     it("exports expected limit values", () => {
-      expect(MAX_WS_CONNECTIONS_PER_IP).toBe(10);
+      expect(MAX_WS_CONNECTIONS_PER_IP).toBe(50);
       expect(MAX_WS_MESSAGE_SIZE).toBe(1_048_576);
       expect(WS_CLOSE_CONNECTION_LIMIT).toBe(4429);
       expect(WS_CLOSE_MESSAGE_TOO_LARGE).toBe(4413);

--- a/apps/api/src/ws/ws-limits.ts
+++ b/apps/api/src/ws/ws-limits.ts
@@ -10,7 +10,7 @@ const log = logger.child({ module: "ws-limits" });
  */
 
 /** Maximum concurrent WebSocket connections per IP address. */
-export const MAX_WS_CONNECTIONS_PER_IP = 10;
+export const MAX_WS_CONNECTIONS_PER_IP = 50;
 
 /** Maximum message size in bytes (1 MB). */
 export const MAX_WS_MESSAGE_SIZE = 1_048_576;

--- a/apps/web/src/lib/ws-client.test.ts
+++ b/apps/web/src/lib/ws-client.test.ts
@@ -9,7 +9,7 @@ class MockWebSocket {
   readyState = MockWebSocket.OPEN;
   url: string;
   onmessage: ((msg: { data: string }) => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((ev: { code: number }) => void) | null = null;
   onerror: (() => void) | null = null;
 
   close = vi.fn(() => {
@@ -111,7 +111,7 @@ describe("WsClient", () => {
 
     const ws = MockWebSocket.instances[0];
     ws.readyState = MockWebSocket.CLOSED;
-    ws.onclose!();
+    ws.onclose!({ code: 1006 });
 
     vi.advanceTimersByTime(3000);
     expect(MockWebSocket.instances).toHaveLength(2);

--- a/apps/web/src/lib/ws-client.ts
+++ b/apps/web/src/lib/ws-client.ts
@@ -50,7 +50,8 @@ export class WsClient {
       }
     };
 
-    this.ws.onclose = () => {
+    this.ws.onclose = (ev) => {
+      if (ev.code === 4429) return; // connection limit exceeded — retry can't help
       this.reconnectTimer = setTimeout(() => this.connect(), 3000);
     };
 


### PR DESCRIPTION
## Summary

- Raise `MAX_WS_CONNECTIONS_PER_IP` from 10 to 50 — in local dev (Docker Desktop K8s) all traffic shares one gateway IP, so 10 was too low for normal multi-tab usage (6+ WS connections per tab)
- Stop auto-reconnecting on close code 4429 (connection limit exceeded) — previously every rejected connection retried every 3s forever, creating a log flood of "WebSocket connection limit exceeded" warnings

## Test plan

- [x] `ws-limits.test.ts` — 18 tests pass with new limit value
- [x] `ws-client.test.ts` — 19 tests pass with updated `onclose` signature
- [x] Full typecheck passes
- [x] Deployed locally and confirmed "WebSocket connection limit exceeded" spam stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)