### PR TITLE
fix: restore PUBLIC_URL env var in web-deployment.yaml

### DIFF
--- a/helm/optio/templates/web-deployment.yaml
+++ b/helm/optio/templates/web-deployment.yaml
@@ -61,6 +61,10 @@ spec:
               value: "http://{{ .Release.Name }}-api:{{ .Values.api.port }}"
             - name: OPTIO_AUTH_DISABLED
               value: {{ .Values.auth.disabled | quote }}
+            {{- if .Values.publicUrl }}
+            - name: PUBLIC_URL
+              value: {{ .Values.publicUrl | quote }}
+            {{- end }}
             {{- if .Values.web.publicApiUrl }}
             - name: PUBLIC_API_URL
               value: {{ .Values.web.publicApiUrl | quote }}


### PR DESCRIPTION
## Summary

- Restores the `PUBLIC_URL` env var block in `helm/optio/templates/web-deployment.yaml` that was accidentally removed by PR #290 (`fix/ws-url-config`)
- PR #290 replaced `PUBLIC_URL` with `PUBLIC_API_URL` instead of adding it alongside — this broke OAuth login for deployments with `publicUrl` set
- The `PUBLIC_URL` env var is used in `apps/web/src/app/auth/callback/route.ts` for constructing OAuth redirect URLs

## What changed

Added the `PUBLIC_URL` conditional block back before the `PUBLIC_API_URL` block so both env vars are present in the web container:

```yaml
{{- if .Values.publicUrl }}
- name: PUBLIC_URL
  value: {{ .Values.publicUrl | quote }}
{{- end }}
```

## Test plan

- [ ] Deploy with `publicUrl` set in Helm values and verify `PUBLIC_URL` env var is present in the web container
- [ ] Verify OAuth login works correctly with the restored env var
- [ ] Verify `PUBLIC_API_URL` still works as expected (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)