### PR TITLE
fix: resolve SSR 'self is not defined' error on sessions page

### DIFF
--- a/apps/web/src/app/sessions/[id]/page.tsx
+++ b/apps/web/src/app/sessions/[id]/page.tsx
@@ -21,7 +21,19 @@ import {
   ChevronDown,
   Bot,
 } from "lucide-react";
-import { SessionTerminal } from "@/components/session-terminal";
+import dynamic from "next/dynamic";
+
+const SessionTerminal = dynamic(
+  () => import("@/components/session-terminal").then((m) => m.SessionTerminal),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full bg-[#09090b] flex items-center justify-center text-text-muted text-sm">
+        Loading terminal...
+      </div>
+    ),
+  },
+);
 import { SessionChat } from "@/components/session-chat";
 import { SplitPane } from "@/components/split-pane";
 import { ErrorBoundary } from "@/components/error-boundary";


### PR DESCRIPTION
## Summary

- Fix `ReferenceError: self is not defined` crash on `/sessions/[id]` page during server-side rendering
- The xterm.js library (`@xterm/xterm`) accesses `self` during module initialization, which doesn't exist in the Node.js SSR environment
- Changed `SessionTerminal` from a static import to a `next/dynamic` import with `ssr: false`, ensuring it only loads on the client side
- Added a loading placeholder that matches the terminal's dark background

## Root cause

The `SessionTerminal` component imports `@xterm/xterm`, `@xterm/addon-fit`, and `@xterm/addon-web-links` at the top level. These libraries reference the browser `self` global during module evaluation. Even though the component has `"use client"`, Next.js still evaluates client component modules during SSR to generate the initial HTML — this is where the crash occurs.

## Test plan

- [x] `pnpm turbo typecheck` passes
- [x] `next build` succeeds (previously crashed on `/sessions/[id]`)
- [x] All 178 web tests pass
- [x] All pre-commit hooks pass (lint, format, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)