### PR TITLE
fix: address review feedback from PR #288 (Jira provider)

### DIFF
--- a/apps/api/src/routes/tickets.ts
+++ b/apps/api/src/routes/tickets.ts
@@ -7,7 +7,15 @@ import { ticketProviders } from "../db/schema.js";
 import { TaskState } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
 import { syncAllTickets } from "../services/ticket-sync-service.js";
+import { storeSecret, deleteSecret } from "../services/secret-service.js";
 import { logger } from "../logger.js";
+
+/** Fields per provider type that contain credentials and must be encrypted. */
+const SENSITIVE_PROVIDER_FIELDS: Record<string, string[]> = {
+  jira: ["apiToken"],
+  linear: ["apiKey"],
+  notion: ["apiKey"],
+};
 
 /** Maximum age (in minutes) for a webhook event before it is rejected. */
 const WEBHOOK_MAX_AGE_MINUTES = 5;
@@ -53,14 +61,37 @@ export async function ticketRoutes(app: FastifyInstance) {
   // Configure a ticket provider
   app.post("/api/tickets/providers", async (req, reply) => {
     const body = req.body as { source: string; config: Record<string, unknown>; enabled?: boolean };
+
+    // Separate sensitive fields from config — they go into encrypted secrets
+    const sensitiveFields = SENSITIVE_PROVIDER_FIELDS[body.source] ?? [];
+    const safeConfig = { ...body.config };
+    const sensitiveValues: Record<string, string> = {};
+
+    for (const field of sensitiveFields) {
+      if (safeConfig[field]) {
+        sensitiveValues[field] = safeConfig[field] as string;
+        delete safeConfig[field];
+      }
+    }
+
     const [provider] = await db
       .insert(ticketProviders)
       .values({
         source: body.source,
-        config: body.config,
+        config: safeConfig,
         enabled: body.enabled ?? true,
       })
       .returning();
+
+    // Store sensitive fields as encrypted secret
+    if (Object.keys(sensitiveValues).length > 0) {
+      await storeSecret(
+        `ticket-provider:${provider.id}`,
+        JSON.stringify(sensitiveValues),
+        "ticket-provider",
+      );
+    }
+
     reply.status(201).send({ provider });
   });
 
@@ -68,6 +99,8 @@ export async function ticketRoutes(app: FastifyInstance) {
   app.delete("/api/tickets/providers/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     await db.delete(ticketProviders).where(eq(ticketProviders.id, id));
+    // Clean up associated encrypted credentials
+    await deleteSecret(`ticket-provider:${id}`, "ticket-provider");
     reply.status(204).send();
   });
 

--- a/apps/api/src/services/ticket-sync-service.test.ts
+++ b/apps/api/src/services/ticket-sync-service.test.ts
@@ -36,6 +36,10 @@ vi.mock("./repo-service.js", () => ({
   getRepoByUrl: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock("./secret-service.js", () => ({
+  retrieveSecret: vi.fn(),
+}));
+
 vi.mock("../logger.js", () => ({
   logger: {
     info: vi.fn(),
@@ -45,42 +49,44 @@ vi.mock("../logger.js", () => ({
 }));
 
 import { db } from "../db/client.js";
+import { ticketProviders, repos } from "../db/schema.js";
 import { getTicketProvider } from "@optio/ticket-providers";
 import * as taskService from "./task-service.js";
 import { taskQueue } from "../workers/task-worker.js";
+import { retrieveSecret } from "./secret-service.js";
 import { syncAllTickets } from "./ticket-sync-service.js";
 
 /**
- * Mock db.select() to handle two sequential query patterns:
- * 1. db.select().from(ticketProviders).where(...) — returns providers
- * 2. db.select({...}).from(repos) — returns configured repos (no .where())
+ * Mock db.select() to handle two query patterns, matching on the .from() argument:
+ * - db.select().from(ticketProviders).where(...) — returns providers
+ * - db.select({...}).from(repos) — returns configured repos (no .where())
  */
 function mockDbSelect(providers: any[], configuredRepos: any[] = []) {
-  let callCount = 0;
-  (db.select as any) = vi.fn().mockImplementation(() => {
-    callCount++;
-    if (callCount === 1) {
-      return {
-        from: vi.fn().mockReturnValue({
+  (db.select as any) = vi.fn().mockImplementation(() => ({
+    from: vi.fn().mockImplementation((table: any) => {
+      if (table === ticketProviders) {
+        return {
           where: vi.fn().mockResolvedValue(providers),
-        }),
-      };
-    }
-    // Subsequent calls: repos query (awaited directly, no .where())
-    return {
-      from: vi.fn().mockResolvedValue(configuredRepos),
-    };
-  });
+        };
+      }
+      if (table === repos) {
+        return Promise.resolve(configuredRepos);
+      }
+      return { where: vi.fn().mockResolvedValue([]) };
+    }),
+  }));
 }
 
 describe("ticket-sync-service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no secrets stored
+    vi.mocked(retrieveSecret).mockRejectedValue(new Error("Secret not found"));
   });
 
   it("syncs new tickets and creates tasks", async () => {
     mockDbSelect([
-      { source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
+      { id: "p1", source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
     ]);
 
     const mockProvider = {
@@ -127,7 +133,7 @@ describe("ticket-sync-service", () => {
 
   it("skips tickets that already have tasks", async () => {
     mockDbSelect([
-      { source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
+      { id: "p1", source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
     ]);
 
     vi.mocked(getTicketProvider).mockReturnValue({
@@ -157,7 +163,7 @@ describe("ticket-sync-service", () => {
 
   it("uses codex agent type when ticket has codex label", async () => {
     mockDbSelect([
-      { source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
+      { id: "p1", source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
     ]);
 
     vi.mocked(getTicketProvider).mockReturnValue({
@@ -190,6 +196,7 @@ describe("ticket-sync-service", () => {
     mockDbSelect(
       [
         {
+          id: "p1",
           source: "github",
           config: { repoUrl: "https://github.com/fallback/repo" },
           enabled: true,
@@ -227,7 +234,7 @@ describe("ticket-sync-service", () => {
   });
 
   it("skips tickets without repo URL", async () => {
-    mockDbSelect([{ source: "github", config: {}, enabled: true }]);
+    mockDbSelect([{ id: "p1", source: "github", config: {}, enabled: true }]);
 
     vi.mocked(getTicketProvider).mockReturnValue({
       fetchActionableTickets: vi.fn().mockResolvedValue([
@@ -252,7 +259,7 @@ describe("ticket-sync-service", () => {
   });
 
   it("handles provider errors gracefully", async () => {
-    mockDbSelect([{ source: "github", config: {}, enabled: true }]);
+    mockDbSelect([{ id: "p1", source: "github", config: {}, enabled: true }]);
 
     vi.mocked(getTicketProvider).mockReturnValue({
       fetchActionableTickets: vi.fn().mockRejectedValue(new Error("API error")),
@@ -264,7 +271,7 @@ describe("ticket-sync-service", () => {
 
   it("continues syncing when comment fails", async () => {
     mockDbSelect([
-      { source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
+      { id: "p1", source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
     ]);
 
     vi.mocked(getTicketProvider).mockReturnValue({
@@ -288,5 +295,106 @@ describe("ticket-sync-service", () => {
 
     const count = await syncAllTickets();
     expect(count).toBe(1); // Task still synced despite comment failure
+  });
+
+  it("queries configuredRepos only once even with multiple providers", async () => {
+    mockDbSelect(
+      [
+        {
+          id: "p1",
+          source: "github",
+          config: { repoUrl: "https://github.com/o/r" },
+          enabled: true,
+        },
+        {
+          id: "p2",
+          source: "jira",
+          config: { baseUrl: "https://j.example.com", email: "a@b.com" },
+          enabled: true,
+        },
+      ],
+      [{ repoUrl: "https://github.com/o/r" }],
+    );
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    await syncAllTickets();
+
+    // db.select() should be called exactly twice:
+    // 1. providers query (from ticketProviders)
+    // 2. configuredRepos query (from repos) — only once, not per provider
+    expect(db.select).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses provider config baseUrl for GitLab instead of hardcoded default", async () => {
+    mockDbSelect(
+      [
+        {
+          id: "p1",
+          source: "gitlab",
+          config: { baseUrl: "https://gitlab.corp.example.com" },
+          enabled: true,
+        },
+      ],
+      [], // no configured repos — forces URL construction fallback
+    );
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([
+        {
+          title: "GL task",
+          body: "",
+          source: "gitlab",
+          externalId: "42",
+          url: "",
+          labels: [],
+          repo: "team/project",
+        },
+      ]),
+      fetchTicketComments: vi.fn().mockResolvedValue([]),
+      addComment: vi.fn(),
+    } as any);
+
+    vi.mocked(taskService.listTasks).mockResolvedValue([] as any);
+    vi.mocked(taskService.createTask).mockResolvedValue({ id: "t-1", maxRetries: 3 } as any);
+
+    await syncAllTickets();
+
+    expect(taskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoUrl: "https://gitlab.corp.example.com/team/project",
+      }),
+    );
+  });
+
+  it("merges encrypted credentials from secrets store into provider config", async () => {
+    mockDbSelect([
+      {
+        id: "p1",
+        source: "jira",
+        config: { baseUrl: "https://j.example.com", email: "a@b.com", label: "optio" },
+        enabled: true,
+      },
+    ]);
+
+    // Secret contains the sensitive credentials
+    vi.mocked(retrieveSecret).mockResolvedValue(JSON.stringify({ apiToken: "secret-token" }));
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    await syncAllTickets();
+
+    // The provider should receive the merged config with credentials
+    const provider = vi.mocked(getTicketProvider).mock.results[0].value;
+    const configPassedToProvider = provider.fetchActionableTickets.mock.calls[0][0];
+    expect(configPassedToProvider.apiToken).toBe("secret-token");
+    expect(configPassedToProvider.baseUrl).toBe("https://j.example.com");
+
+    // Secret should be retrieved with the provider ID
+    expect(retrieveSecret).toHaveBeenCalledWith("ticket-provider:p1", "ticket-provider");
   });
 });

--- a/apps/api/src/services/ticket-sync-service.ts
+++ b/apps/api/src/services/ticket-sync-service.ts
@@ -6,6 +6,7 @@ import type { TicketSource } from "@optio/shared";
 import { TaskState, normalizeRepoUrl } from "@optio/shared";
 import * as taskService from "./task-service.js";
 import { taskQueue } from "../workers/task-worker.js";
+import { retrieveSecret } from "./secret-service.js";
 import { logger } from "../logger.js";
 
 export async function syncAllTickets(): Promise<number> {
@@ -14,15 +15,28 @@ export async function syncAllTickets(): Promise<number> {
     .from(ticketProviders)
     .where(eq(ticketProviders.enabled, true));
 
+  // Fetch configured repos once before the provider loop (avoids redundant queries)
+  const configuredRepos = await db.select({ repoUrl: repos.repoUrl }).from(repos);
+
   let totalSynced = 0;
 
   for (const providerConfig of providers) {
     try {
-      const provider = getTicketProvider(providerConfig.source as TicketSource);
-      const tickets = await provider.fetchActionableTickets(providerConfig.config);
+      // Merge encrypted credentials from secrets store into provider config
+      let mergedConfig = { ...((providerConfig.config as Record<string, unknown>) ?? {}) };
+      try {
+        const secretJson = await retrieveSecret(
+          `ticket-provider:${providerConfig.id}`,
+          "ticket-provider",
+        );
+        const credentials = JSON.parse(secretJson);
+        mergedConfig = { ...mergedConfig, ...credentials };
+      } catch {
+        // No secrets stored for this provider — use config as-is
+      }
 
-      // Fetch configured repos once for path-suffix matching (avoids N+1 queries)
-      const configuredRepos = await db.select({ repoUrl: repos.repoUrl }).from(repos);
+      const provider = getTicketProvider(providerConfig.source as TicketSource);
+      const tickets = await provider.fetchActionableTickets(mergedConfig);
 
       for (const ticket of tickets) {
         // Construct repo URL: use the ticket's repo field, or fall back to provider config
@@ -40,13 +54,16 @@ export async function syncAllTickets(): Promise<number> {
             if (match) {
               repoUrl = normalizeRepoUrl(match.repoUrl);
             } else if (providerConfig.source === "gitlab") {
-              repoUrl = normalizeRepoUrl(`https://gitlab.com/${repo}`);
+              // Use provider config baseUrl for self-hosted GitLab instances
+              const baseUrl =
+                (mergedConfig as Record<string, unknown>).baseUrl ?? "https://gitlab.com";
+              repoUrl = normalizeRepoUrl(`${baseUrl}/${repo}`);
             } else {
               repoUrl = normalizeRepoUrl(`https://github.com/${repo}`);
             }
           }
         } else {
-          repoUrl = (providerConfig.config as any).repoUrl;
+          repoUrl = (mergedConfig as any).repoUrl;
         }
 
         if (!repoUrl) {
@@ -69,10 +86,7 @@ export async function syncAllTickets(): Promise<number> {
         // Fetch comments for context
         let commentsSection = "";
         try {
-          const comments = await provider.fetchTicketComments(
-            ticket.externalId,
-            providerConfig.config,
-          );
+          const comments = await provider.fetchTicketComments(ticket.externalId, mergedConfig);
           if (comments.length > 0) {
             commentsSection =
               "\n\n## Comments\n\n" +
@@ -128,7 +142,7 @@ export async function syncAllTickets(): Promise<number> {
           await provider.addComment(
             ticket.externalId,
             `🤖 **Optio** is working on this issue.\n\nTask ID: \`${task.id}\`\nAgent: ${agentType}`,
-            providerConfig.config,
+            mergedConfig,
           );
         } catch (commentErr) {
           logger.warn(

--- a/packages/ticket-providers/src/jira.test.ts
+++ b/packages/ticket-providers/src/jira.test.ts
@@ -264,6 +264,27 @@ describe("JiraTicketProvider pagination", () => {
     ]);
   });
 
+  it("trims whitespace from repo: label extraction", async () => {
+    const issue = makeJiraIssue("TEST-1", 1);
+    // Simulate a label like "repo: acme/backend" (space after colon)
+    issue.fields.labels = ["optio", "repo: acme/backend"];
+    const searchForIssuesUsingJqlEnhancedSearch = vi.fn().mockResolvedValueOnce({
+      issues: [issue],
+    });
+
+    vi.mocked(Version3Client).mockImplementation(
+      () =>
+        ({
+          issueSearch: { searchForIssuesUsingJqlEnhancedSearch },
+        }) as unknown as InstanceType<typeof Version3Client>,
+    );
+
+    const provider = new JiraTicketProvider();
+    const tickets = await provider.fetchActionableTickets(baseConfig());
+
+    expect(tickets[0].repo).toBe("acme/backend");
+  });
+
   it("converts ADF description to plaintext", async () => {
     const issue = makeJiraIssue("TEST-123", 1);
     const searchForIssuesUsingJqlEnhancedSearch = vi.fn().mockResolvedValueOnce({

--- a/packages/ticket-providers/src/jira.ts
+++ b/packages/ticket-providers/src/jira.ts
@@ -130,7 +130,10 @@ export class JiraTicketProvider implements TicketProvider {
           assignee: fields.assignee?.displayName,
           // Extract target repo from a "repo:<owner/repo>" Jira label (e.g. "repo:acme/backend").
           // Accepts full URLs, "owner/repo" paths, or bare repo names for suffix matching.
-          repo: (fields.labels ?? []).find((l: string) => l.startsWith("repo:"))?.slice(5),
+          repo: (fields.labels ?? [])
+            .find((l: string) => l.startsWith("repo:"))
+            ?.slice(5)
+            .trim(),
           attachments: attachments.length > 0 ? attachments : undefined,
           metadata: {
             key: issue.key,


### PR DESCRIPTION
## Summary

Addresses the review feedback items from PR #288 (Jira provider improvements):

- **Hoist `configuredRepos` query**: Moved the DB query above the `for...of providerConfigs` loop so it runs once regardless of how many providers are configured, eliminating redundant identical queries
- **Trim `repo:` label extraction**: Added `.trim()` after `.slice(5)` in the Jira provider so labels like `"repo: acme/backend"` (space after colon) match correctly during path-suffix lookup
- **Encrypt provider credentials**: Sensitive fields (`apiToken`, `apiKey`) are now extracted from the config JSONB and stored in the encrypted secrets table (AES-256-GCM) when creating a provider. The sync service retrieves and merges them at runtime. Associated secrets are cleaned up on provider deletion
- **Argument-based test mocking**: Replaced call-count-based `mockDbSelect` with `.from()` argument matching — tests now correctly identify queries by table reference instead of fragile invocation order
- **GitLab self-hosted URL**: The GitLab repo URL fallback now reads `baseUrl` from the provider config instead of hardcoding `https://gitlab.com`, supporting self-hosted instances

### Minor items
- `Plus` icon import verified — already imported at line 17 of `settings/page.tsx`
- `confirm()` dialog: All delete actions across the app (templates, workflows, workspace-settings, activity-feed) use `confirm()` consistently, so changing only this instance would break consistency. Left as-is — an app-wide modal system would be a separate effort

## Test plan
- [x] New test: Jira `repo:` label with space after colon trims correctly
- [x] New test: `configuredRepos` query runs only once with multiple providers
- [x] New test: GitLab uses provider config `baseUrl` instead of hardcoded default
- [x] New test: Encrypted credentials merge from secrets store into provider config
- [x] Refactored `mockDbSelect` — all 7 existing tests pass with new argument-matching approach
- [x] Full test suite: 1094 tests passing
- [x] Typecheck, format check, lint all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)