### PR TITLE
feat: make Helm chart publicly available

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,41 @@ The secret must contain these keys: `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GI
 
 ## Production Deployment
 
-Optio ships with a Helm chart for production Kubernetes clusters:
+Optio ships with a Helm chart for production Kubernetes clusters. Three installation methods are available:
+
+### Install from Helm repository (recommended)
 
 ```bash
-helm install optio helm/optio \
+helm repo add optio https://jonwiggins.github.io/optio
+helm repo update
+helm install optio optio/optio -n optio --create-namespace \
+  --set encryption.key=$(openssl rand -hex 32) \
+  --set postgresql.enabled=false \
+  --set externalDatabase.url="postgres://..." \
+  --set redis.enabled=false \
+  --set externalRedis.url="redis://..." \
+  --set ingress.enabled=true \
+  --set ingress.hosts[0].host=optio.example.com
+```
+
+### Install from OCI registry
+
+```bash
+helm install optio oci://ghcr.io/jonwiggins/optio -n optio --create-namespace \
+  --set encryption.key=$(openssl rand -hex 32) \
+  --set postgresql.enabled=false \
+  --set externalDatabase.url="postgres://..." \
+  --set redis.enabled=false \
+  --set externalRedis.url="redis://..." \
+  --set ingress.enabled=true \
+  --set ingress.hosts[0].host=optio.example.com
+```
+
+### Install from source
+
+```bash
+git clone https://github.com/jonwiggins/optio.git && cd optio
+helm install optio helm/optio -n optio --create-namespace \
   --set encryption.key=$(openssl rand -hex 32) \
   --set postgresql.enabled=false \
   --set externalDatabase.url="postgres://..." \

--- a/helm/optio/.helmignore
+++ b/helm/optio/.helmignore
@@ -1,0 +1,33 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# CI/CD
+.github/
+# Documentation
+README.md
+LICENSE
+CONTRIBUTING.md
+# Test values
+values.production.yaml
+# Chart development files
+ci/

--- a/helm/optio/Chart.yaml
+++ b/helm/optio/Chart.yaml
@@ -4,3 +4,15 @@ description: AI Agent Workflow Orchestration
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
+home: https://github.com/jonwiggins/optio
+sources:
+  - https://github.com/jonwiggins/optio
+keywords:
+  - ai
+  - agent
+  - orchestration
+  - kubernetes
+  - workflow
+maintainers:
+  - name: jonwiggins
+    url: https://github.com/jonwiggins


### PR DESCRIPTION
## Summary

Fixes the 403 error when trying to install the Helm chart from the OCI registry. The GHCR container packages are private by default, preventing public `helm install`.

- Add `.helmignore` to exclude unnecessary files from chart packages
- Enrich `Chart.yaml` with home, sources, keywords, and maintainers metadata for better discoverability
- Update README with three installation methods: Helm repository (recommended), OCI registry, and source

## Workflow changes (require `workflow` token scope)

The following workflow file changes could not be pushed due to the GitHub PAT missing the `workflow` scope. They should be applied manually or via a token with the `workflow` scope:

### 1. `.github/workflows/ci.yml` — Add Helm lint CI job

Add this job before `build-image`:

```yaml
  helm-lint:
    name: Helm Lint
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Install Helm
        uses: azure/setup-helm@v4
      - name: Lint chart
        run: helm lint helm/optio --set encryption.key=ci-test-key
      - name: Template chart
        run: helm template optio helm/optio --set encryption.key=ci-test-key > /dev/null
```

### 2. `.github/workflows/release.yml` — Fix OCI visibility + upload release asset

Change permissions from `contents: read` to `contents: write`, then add these steps after the "Push chart to GHCR" step:

```yaml
      - name: Set GHCR package visibility to public
        continue-on-error: true
        run: |
          # Attempt to make the Helm chart OCI package publicly accessible.
          # This requires the repository to be public and appropriate permissions.
          gh api --method PATCH \
            /user/packages/container/optio \
            -f visibility=public \
            2>/dev/null || \
          gh api --method PATCH \
            /orgs/${{ env.IMAGE_OWNER }}/packages/container/optio \
            -f visibility=public \
            2>/dev/null || \
          echo "::warning::Could not auto-set package visibility. Manually set the 'optio' container package to public at https://github.com/users/${{ env.IMAGE_OWNER }}/packages/container/optio/settings"
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

      - name: Upload chart to GitHub Release
        run: |
          gh release upload "${{ github.ref_name }}" \
            .helm-pkg/optio-${{ steps.version.outputs.version }}.tgz \
            --clobber \
            2>/dev/null || \
          gh release create "${{ github.ref_name }}" \
            .helm-pkg/optio-${{ steps.version.outputs.version }}.tgz \
            --title "Optio ${{ steps.version.outputs.version }}" \
            --generate-notes
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

### 3. `.github/workflows/helm-release.yml` — New chart-releaser workflow

Create this new file to publish the chart to a GitHub Pages-based Helm repository:

```yaml
name: Helm Chart Release

on:
  push:
    branches: [main]
    paths:
      - "helm/optio/**"
      - ".github/workflows/helm-release.yml"
  workflow_dispatch:

permissions:
  contents: write
  pages: write

jobs:
  release:
    name: Publish Helm chart to GitHub Pages
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4
        with:
          fetch-depth: 0

      - name: Configure Git
        run: |
          git config user.name "$GITHUB_ACTOR"
          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"

      - name: Install Helm
        uses: azure/setup-helm@v4

      - name: Run chart-releaser
        uses: helm/chart-releaser-action@v1
        with:
          charts_dir: helm
          pages_branch: gh-pages
          skip_existing: true
        env:
          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
```

### Post-merge: Enable GitHub Pages for Helm repo

After the `helm-release.yml` workflow runs and creates the `gh-pages` branch with `index.yaml`, configure GitHub Pages to serve from the `gh-pages` branch (or keep the current Actions-based deployment if you prefer OCI-only distribution). This enables:

```bash
helm repo add optio https://jonwiggins.github.io/optio
helm install optio optio/optio
```

### Post-merge: Set GHCR package visibility

For the OCI method to work without authentication, manually set the `optio` container package to public:
1. Go to https://github.com/users/jonwiggins/packages/container/optio/settings
2. Change visibility to "Public"

## Test plan

- [ ] Verify `helm lint helm/optio --set encryption.key=test` passes
- [ ] Verify `helm template optio helm/optio --set encryption.key=test` renders without errors
- [ ] After applying workflow changes: verify CI helm-lint job passes
- [ ] After release: verify `helm install optio oci://ghcr.io/jonwiggins/optio` works without auth
- [ ] After enabling Pages: verify `helm repo add optio https://jonwiggins.github.io/optio` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)