### PR TITLE
fix: don't require GITHUB_TOKEN secret when GitHub App auth is configured

### DIFF
--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -328,8 +328,13 @@ export function startTaskWorker() {
         }
 
         // Resolve secrets (workspace → repo-scoped → global fallback)
-        // Always include GITHUB_TOKEN so repo pods can clone private repos
-        const secretNames = [...new Set([...agentConfig.requiredSecrets, "GITHUB_TOKEN"])];
+        // Only require GITHUB_TOKEN when GitHub App auth is not configured
+        const secretNames = [
+          ...new Set([
+            ...agentConfig.requiredSecrets,
+            ...(!isGitHubAppConfigured() ? ["GITHUB_TOKEN"] : []),
+          ]),
+        ];
         const resolvedSecrets = await resolveSecretsForTask(
           secretNames,
           task.repoUrl,


### PR DESCRIPTION
## Summary

- Fix regression where tasks fail with `Secret not found: GITHUB_TOKEN` when using GitHub App authentication instead of a PAT
- `GITHUB_TOKEN` was unconditionally added to the required secrets list at task-worker.ts:332, causing `resolveSecretsForTask()` to throw before reaching the `isGitHubAppConfigured()` guard at line 355
- Now only includes `GITHUB_TOKEN` in the required secrets when GitHub App auth is **not** configured — GitHub App users get credentials dynamically via the credential helper

## Test plan

- [ ] Verify tasks succeed with GitHub App auth configured and no `GITHUB_TOKEN` secret stored
- [ ] Verify tasks still succeed with PAT auth (`GITHUB_TOKEN` secret stored, no GitHub App)
- [ ] Verify tasks succeed when both auth methods are configured (existing guard at line 355 removes the static token)