### PR TITLE
fix(helm): enable readOnlyRootFilesystem on web and API pods

### DIFF
--- a/helm/optio/templates/api-deployment.yaml
+++ b/helm/optio/templates/api-deployment.yaml
@@ -51,12 +51,17 @@ spec:
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - containerPort: {{ .Values.api.port }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           envFrom:
             - secretRef:
                 name: {{ .Release.Name }}-config
@@ -91,6 +96,9 @@ spec:
               port: {{ .Values.api.port }}
             initialDelaySeconds: 15
             periodSeconds: 20
+      volumes:
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/optio/templates/web-deployment.yaml
+++ b/helm/optio/templates/web-deployment.yaml
@@ -50,12 +50,19 @@ spec:
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - containerPort: {{ .Values.web.port }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: next-cache
+              mountPath: /app/.next/cache
           env:
             - name: INTERNAL_API_URL
               value: "http://{{ .Release.Name }}-api:{{ .Values.api.port }}"
@@ -74,6 +81,11 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: next-cache
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

- Set `readOnlyRootFilesystem: true` on both web and API container security contexts (was `false`)
- Added `seccompProfile: type: RuntimeDefault` to both containers
- Mounted `emptyDir` volumes for `/tmp` (both pods) and `/app/.next/cache` (web pod) so the containers can still write to required directories

These changes prevent a compromised process from writing to the container's root filesystem (dropping binaries, modifying Next.js cache, persisting webshells). The existing `runAsNonRoot: true`, `runAsUser: 1000`, and `capabilities.drop: [ALL]` were already set at the pod/container level.

## Test plan

- [ ] Verify `helm lint` passes
- [ ] Deploy to local K8s and confirm web pod starts and serves pages correctly
- [ ] Deploy to local K8s and confirm API pod starts and health endpoint responds
- [ ] Verify Next.js cache writes succeed via the emptyDir mount at `/app/.next/cache`
- [ ] Confirm no filesystem write errors in pod logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)