### PR TITLE
feat(web): add HTTP security headers to Next.js config

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,6 +10,42 @@ const nextConfig: NextConfig = {
     };
     return config;
   },
+  async headers() {
+    const isProd = process.env.NODE_ENV === "production";
+    const baseHeaders = [
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "X-Frame-Options", value: "DENY" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      {
+        key: "Permissions-Policy",
+        value: "camera=(), microphone=(), geolocation=()",
+      },
+      {
+        key: "Content-Security-Policy-Report-Only",
+        value: [
+          "default-src 'self'",
+          "script-src 'self' 'unsafe-inline'",
+          "style-src 'self' 'unsafe-inline'",
+          "connect-src 'self' wss: ws:",
+          "img-src 'self' data: https:",
+          "font-src 'self' data:",
+          "frame-ancestors 'none'",
+        ].join("; "),
+      },
+    ];
+    if (isProd) {
+      baseHeaders.push({
+        key: "Strict-Transport-Security",
+        value: "max-age=31536000; includeSubDomains; preload",
+      });
+    }
+    return [
+      {
+        source: "/(.*)",
+        headers: baseHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/security-headers.test.ts
+++ b/apps/web/src/security-headers.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("next.config.ts security headers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  async function loadConfig() {
+    const mod = await import("../next.config.js");
+    return mod.default;
+  }
+
+  it("exports a headers function", async () => {
+    const config = await loadConfig();
+    expect(typeof config.headers).toBe("function");
+  });
+
+  it("returns headers for all routes", async () => {
+    const config = await loadConfig();
+    const result = await config.headers();
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ source: "/(.*)" })]));
+  });
+
+  describe("always-present headers", () => {
+    it("includes X-Content-Type-Options: nosniff", async () => {
+      const config = await loadConfig();
+      const result = await config.headers();
+      const headers = result[0].headers;
+      expect(headers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          }),
+        ]),
+      );
+    });
+
+    it("includes X-Frame-Options: DENY", async () => {
+      const config = await loadConfig();
+      const result = await config.headers();
+      const headers = result[0].headers;
+      expect(headers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "X-Frame-Options",
+            value: "DENY",
+          }),
+        ]),
+      );
+    });
+
+    it("includes Referrer-Policy: strict-origin-when-cross-origin", async () => {
+      const config = await loadConfig();
+      const result = await config.headers();
+      const headers = result[0].headers;
+      expect(headers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          }),
+        ]),
+      );
+    });
+
+    it("includes Permissions-Policy restricting sensitive APIs", async () => {
+      const config = await loadConfig();
+      const result = await config.headers();
+      const headers = result[0].headers;
+      expect(headers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          }),
+        ]),
+      );
+    });
+
+    it("includes Content-Security-Policy-Report-Only", async () => {
+      const config = await loadConfig();
+      const result = await config.headers();
+      const headers = result[0].headers;
+      const cspHeader = headers.find(
+        (h: { key: string }) => h.key === "Content-Security-Policy-Report-Only",
+      );
+      expect(cspHeader).toBeDefined();
+      expect(cspHeader.value).toContain("default-src 'self'");
+      expect(cspHeader.value).toContain("script-src 'self' 'unsafe-inline'");
+      expect(cspHeader.value).toContain("style-src 'self' 'unsafe-inline'");
+      expect(cspHeader.value).toContain("connect-src 'self' wss: ws:");
+      expect(cspHeader.value).toContain("img-src 'self' data: https:");
+      expect(cspHeader.value).toContain("font-src 'self' data:");
+      expect(cspHeader.value).toContain("frame-ancestors 'none'");
+    });
+  });
+
+  describe("production-only headers", () => {
+    it("includes HSTS in production", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      const config = await loadConfig();
+      const result = await config.headers();
+      const headers = result[0].headers;
+      expect(headers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains; preload",
+          }),
+        ]),
+      );
+    });
+
+    it("does not include HSTS in development", async () => {
+      vi.stubEnv("NODE_ENV", "development");
+      const config = await loadConfig();
+      const result = await config.headers();
+      const headers = result[0].headers;
+      const hsts = headers.find((h: { key: string }) => h.key === "Strict-Transport-Security");
+      expect(hsts).toBeUndefined();
+    });
+  });
+
+  it("preserves existing config properties", async () => {
+    const config = await loadConfig();
+    expect(config.output).toBe("standalone");
+    expect(config.transpilePackages).toContain("@optio/shared");
+    expect(typeof config.webpack).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `headers()` function to `apps/web/next.config.ts` that returns standard HTTP security headers for all routes
- Headers added: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (restricts camera/mic/geo), and `Content-Security-Policy-Report-Only`
- `Strict-Transport-Security` (HSTS with preload) is included in production only
- CSP is deployed in **report-only mode** to avoid breaking existing functionality — once verified clean in production, switch to enforcing by changing the header key to `Content-Security-Policy`

## Why

The web app had no HTTP security headers, leaving it vulnerable to clickjacking (`X-Frame-Options`), MIME confusion (`X-Content-Type-Options`), referrer leaks (`Referrer-Policy`), and XSS without CSP mitigation. This closes a medium-severity security gap.

## Test plan

- [x] 10 new tests in `apps/web/src/security-headers.test.ts` covering all headers, production-only HSTS, and config preservation
- [x] Full test suite passes (188 tests across 15 files in web, plus shared/api)
- [x] Typecheck passes across all packages
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)