### PR TITLE
fix(security): add rate limiting to auth endpoints

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import Fastify from "fastify";
+import rateLimit from "@fastify/rate-limit";
 import type { FastifyInstance } from "fastify";
 
 // ─── Mocks ───
@@ -349,5 +350,119 @@ describe("POST /api/auth/logout", () => {
     } finally {
       process.env.NODE_ENV = origEnv;
     }
+  });
+});
+
+describe("Auth rate limiting", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    redisStore.clear();
+    authDisabled = false;
+  });
+
+  afterEach(async () => {
+    if (app) await app.close();
+  });
+
+  async function buildRateLimitedApp(): Promise<FastifyInstance> {
+    const server = Fastify({ logger: false });
+    await server.register(rateLimit, { global: false });
+    await authRoutes(server);
+    await server.ready();
+    return server;
+  }
+
+  it("rate-limits POST /api/auth/exchange-code after 10 requests", async () => {
+    app = await buildRateLimitedApp();
+
+    // First 10 requests should succeed (status 400 because code is missing, but not 429)
+    for (let i = 0; i < 10; i++) {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/auth/exchange-code",
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+    }
+
+    // 11th request should be rate-limited
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/auth/exchange-code",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(429);
+  });
+
+  it("rate-limits GET /api/auth/:provider/login after 10 requests", async () => {
+    app = await buildRateLimitedApp();
+
+    // First 10 requests — 404 because provider is unknown (mocked)
+    for (let i = 0; i < 10; i++) {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/auth/github/login",
+      });
+      expect(res.statusCode).toBe(404);
+    }
+
+    // 11th request should be rate-limited
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/auth/github/login",
+    });
+    expect(res.statusCode).toBe(429);
+  });
+
+  it("rate-limits GET /api/auth/:provider/callback after 10 requests", async () => {
+    app = await buildRateLimitedApp();
+
+    for (let i = 0; i < 10; i++) {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/auth/github/callback?code=x&state=y",
+      });
+      // Redirects to login with error (invalid state)
+      expect(res.statusCode).toBe(302);
+    }
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/auth/github/callback?code=x&state=y",
+    });
+    expect(res.statusCode).toBe(429);
+  });
+
+  it("rate-limits POST /api/auth/logout after 10 requests", async () => {
+    app = await buildRateLimitedApp();
+    mockRevokeSession.mockResolvedValue(undefined);
+
+    for (let i = 0; i < 10; i++) {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/auth/logout",
+      });
+      expect(res.statusCode).toBe(200);
+    }
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/auth/logout",
+    });
+    expect(res.statusCode).toBe(429);
+  });
+
+  it("includes rate limit headers in responses", async () => {
+    app = await buildRateLimitedApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/auth/exchange-code",
+      payload: {},
+    });
+    expect(res.headers["x-ratelimit-limit"]).toBe("10");
+    expect(res.headers["x-ratelimit-remaining"]).toBe("9");
   });
 });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -62,6 +62,16 @@ async function deleteAuthCode(code: string): Promise<void> {
   await redis.del(`${AUTH_CODE_PREFIX}${code}`);
 }
 
+// Stricter rate limit for auth endpoints (10 req/min vs 100 req/min global)
+const AUTH_RATE_LIMIT = {
+  config: {
+    rateLimit: {
+      max: 10,
+      timeWindow: "1 minute",
+    },
+  },
+};
+
 export async function authRoutes(app: FastifyInstance) {
   // ─── Existing Claude auth endpoints ───
 
@@ -144,25 +154,29 @@ export async function authRoutes(app: FastifyInstance) {
   });
 
   /** Initiate OAuth flow — redirects to provider. */
-  app.get<{ Params: { provider: string } }>("/api/auth/:provider/login", async (req, reply) => {
-    const providerName = req.params.provider;
-    const provider = getOAuthProvider(providerName);
-    if (!provider) {
-      return reply.status(404).send({ error: `Unknown provider: ${providerName}` });
-    }
+  app.get<{ Params: { provider: string } }>(
+    "/api/auth/:provider/login",
+    AUTH_RATE_LIMIT,
+    async (req, reply) => {
+      const providerName = req.params.provider;
+      const provider = getOAuthProvider(providerName);
+      if (!provider) {
+        return reply.status(404).send({ error: `Unknown provider: ${providerName}` });
+      }
 
-    const state = randomBytes(16).toString("hex");
-    await addOAuthState(state, providerName);
+      const state = randomBytes(16).toString("hex");
+      await addOAuthState(state, providerName);
 
-    const url = provider.authorizeUrl(state);
-    reply.redirect(url);
-  });
+      const url = provider.authorizeUrl(state);
+      reply.redirect(url);
+    },
+  );
 
   /** OAuth callback — exchange code, create session, redirect to web. */
   app.get<{
     Params: { provider: string };
     Querystring: { code?: string; state?: string; error?: string };
-  }>("/api/auth/:provider/callback", async (req, reply) => {
+  }>("/api/auth/:provider/callback", AUTH_RATE_LIMIT, async (req, reply) => {
     const { provider: providerName } = req.params;
     const { code, state, error } = req.query;
 
@@ -214,7 +228,7 @@ export async function authRoutes(app: FastifyInstance) {
   });
 
   /** Exchange a short-lived auth code for the session token. */
-  app.post("/api/auth/exchange-code", async (req, reply) => {
+  app.post("/api/auth/exchange-code", AUTH_RATE_LIMIT, async (req, reply) => {
     const { code } = (req.body ?? {}) as { code?: string };
     if (!code) {
       return reply.status(400).send({ error: "Missing code" });
@@ -288,7 +302,7 @@ export async function authRoutes(app: FastifyInstance) {
   });
 
   /** Logout — revoke session and clear cookie. */
-  app.post("/api/auth/logout", async (req, reply) => {
+  app.post("/api/auth/logout", AUTH_RATE_LIMIT, async (req, reply) => {
     // Resolve token: Bearer header (BFF proxy) → session cookie (direct)
     const authHeader = req.headers.authorization;
     let token: string | undefined;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,4 +1,5 @@
 import Fastify, { type FastifyError } from "fastify";
+import { Redis } from "ioredis";
 import cors from "@fastify/cors";
 import formbody from "@fastify/formbody";
 import rateLimit from "@fastify/rate-limit";
@@ -62,10 +63,12 @@ export async function buildServer() {
     credentials: true,
     methods: ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
   });
+  const redisUrl = process.env.REDIS_URL ?? "redis://localhost:6379";
   await app.register(rateLimit, {
     max: 100,
     timeWindow: "1 minute",
     allowList: ["127.0.0.1", "::1"],
+    redis: new Redis(redisUrl),
   });
   await app.register(formbody);
   await app.register(websocket);


### PR DESCRIPTION
## Summary

- Added per-route rate limits (10 req/min) to sensitive auth endpoints: OAuth login, callback, exchange-code, and logout — preventing credential stuffing, account enumeration, and brute-force attacks on the OAuth state/code namespace
- Configured Redis as the rate-limit store so limits are enforced correctly across multiple API replicas
- Added 5 tests verifying rate limiting behavior on auth routes

## Changes

**`apps/api/src/routes/auth.ts`**
- Defined `AUTH_RATE_LIMIT` config object (10 req/min) and applied it to `/api/auth/:provider/login`, `/api/auth/:provider/callback`, `/api/auth/exchange-code`, and `/api/auth/logout`

**`apps/api/src/server.ts`**
- Added Redis store (`ioredis`) to `@fastify/rate-limit` registration so rate-limit counters are shared across API replicas

**`apps/api/src/routes/auth.test.ts`**
- Added "Auth rate limiting" test suite with 5 tests: verifies 429 after 10 requests on each rate-limited endpoint and checks rate-limit headers

## Test plan

- [x] All 5 new rate-limiting tests pass
- [x] All 1131 existing tests pass (76 test files)
- [x] Typecheck passes across all packages
- [x] Prettier formatting passes
- [x] Pre-commit hooks (lint-staged, typecheck) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)