### PR TITLE
fix(security): constant-time session token comparison + sliding-window expiry

### DIFF
--- a/apps/api/src/services/session-service.test.ts
+++ b/apps/api/src/services/session-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHash } from "node:crypto";
 
 vi.mock("../db/client.js", () => ({
   db: {
@@ -27,6 +28,11 @@ vi.mock("../db/schema.js", () => ({
     createdAt: "sessions.created_at",
   },
 }));
+
+/** Helper to compute SHA-256 hex hash (mirrors session-service internals). */
+function testHashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
 
 import { db } from "../db/client.js";
 import {
@@ -140,46 +146,114 @@ describe("session-service", () => {
   });
 
   describe("validateSession", () => {
-    it("returns user for valid session", async () => {
+    const VALID_TOKEN = "some-token";
+    const VALID_TOKEN_HASH = testHashToken(VALID_TOKEN);
+
+    function mockValidSessionRow(overrides: Record<string, unknown> = {}) {
+      return {
+        sessionId: "sess-1",
+        tokenHash: VALID_TOKEN_HASH,
+        sessionCreatedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), // 1 day ago
+        expiresAt: new Date(Date.now() + 6 * 24 * 60 * 60 * 1000), // 6 days from now
+        userId: "user-1",
+        provider: "github",
+        email: "test@test.com",
+        displayName: "Test",
+        avatarUrl: null,
+        defaultWorkspaceId: "ws-1",
+        ...overrides,
+      };
+    }
+
+    function setupSelectMock(rows: unknown[]) {
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           innerJoin: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([
-                {
-                  sessionId: "sess-1",
-                  userId: "user-1",
-                  provider: "github",
-                  email: "test@test.com",
-                  displayName: "Test",
-                  avatarUrl: null,
-                  defaultWorkspaceId: "ws-1",
-                },
-              ]),
+              limit: vi.fn().mockResolvedValue(rows),
             }),
           }),
         }),
       });
+    }
 
-      const result = await validateSession("some-token");
+    function setupUpdateMock() {
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+    }
+
+    it("returns user for valid session and extends expiry (sliding window)", async () => {
+      setupSelectMock([mockValidSessionRow()]);
+      setupUpdateMock();
+
+      const result = await validateSession(VALID_TOKEN);
       expect(result).not.toBeNull();
       expect(result!.id).toBe("user-1");
       expect(result!.email).toBe("test@test.com");
+      expect(result!.workspaceId).toBe("ws-1");
+
+      // Sliding window: should have called db.update to extend expiry
+      expect(db.update).toHaveBeenCalled();
     });
 
-    it("returns null for invalid or expired session", async () => {
-      (db.select as any) = vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          innerJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([]),
-            }),
-          }),
-        }),
-      });
+    it("returns null when no session row found (invalid token)", async () => {
+      setupSelectMock([]);
 
       const result = await validateSession("bad-token");
       expect(result).toBeNull();
+    });
+
+    it("returns null when session is expired (post-fetch check)", async () => {
+      setupSelectMock([
+        mockValidSessionRow({
+          expiresAt: new Date(Date.now() - 1000), // expired 1 second ago
+        }),
+      ]);
+
+      const result = await validateSession(VALID_TOKEN);
+      expect(result).toBeNull();
+    });
+
+    it("performs constant-time hash comparison via timingSafeEqual", async () => {
+      // Row with a mismatched tokenHash — should be rejected by timingSafeEqual
+      setupSelectMock([
+        mockValidSessionRow({
+          tokenHash: testHashToken("different-token"),
+        }),
+      ]);
+
+      const result = await validateSession(VALID_TOKEN);
+      expect(result).toBeNull();
+    });
+
+    it("caps sliding window at max TTL from session creation", async () => {
+      // Session created 28 days ago — max TTL is 30 days, so cap at 2 days from now
+      const sessionCreatedAt = new Date(Date.now() - 28 * 24 * 60 * 60 * 1000);
+      setupSelectMock([
+        mockValidSessionRow({
+          sessionCreatedAt,
+          expiresAt: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000), // 1 day left
+        }),
+      ]);
+      setupUpdateMock();
+
+      const result = await validateSession(VALID_TOKEN);
+      expect(result).not.toBeNull();
+
+      // Verify the update was called (sliding window extension)
+      expect(db.update).toHaveBeenCalled();
+      // The new expiry should be capped: createdAt + 30 days < now + 7 days
+      const setCalls = (db.update as any).mock.results[0].value.set.mock.calls;
+      const newExpiry: Date = setCalls[0][0].expiresAt;
+      const maxExpiry = new Date(sessionCreatedAt.getTime() + 30 * 24 * 60 * 60 * 1000);
+      // newExpiry should not exceed maxExpiry
+      expect(newExpiry.getTime()).toBeLessThanOrEqual(maxExpiry.getTime());
+      // newExpiry should be less than now + 7 days (because of the cap)
+      const slidingExpiry = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      expect(newExpiry.getTime()).toBeLessThan(slidingExpiry.getTime());
     });
   });
 

--- a/apps/api/src/services/session-service.ts
+++ b/apps/api/src/services/session-service.ts
@@ -1,10 +1,11 @@
-import { randomBytes, createHash } from "node:crypto";
+import { randomBytes, createHash, timingSafeEqual } from "node:crypto";
 import { db } from "../db/client.js";
 import { users, sessions } from "../db/schema.js";
-import { eq, and, gt, lt } from "drizzle-orm";
+import { eq, and, lt } from "drizzle-orm";
 import type { OAuthUser } from "./oauth/provider.js";
 
-const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const SESSION_MAX_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days absolute max
+const SESSION_SLIDING_WINDOW_MS = 7 * 24 * 60 * 60 * 1000; // 7 days sliding window
 
 function hashToken(token: string): string {
   return createHash("sha256").update(token).digest("hex");
@@ -65,7 +66,7 @@ export async function createSession(
   // Create session token
   const token = randomBytes(32).toString("hex");
   const tokenHash = hashToken(token);
-  const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
+  const expiresAt = new Date(Date.now() + SESSION_SLIDING_WINDOW_MS);
 
   await db.insert(sessions).values({
     userId: user.id,
@@ -90,10 +91,14 @@ export async function createSession(
 /** Validate a session token and return the user if valid. */
 export async function validateSession(token: string): Promise<SessionUser | null> {
   const tokenHash = hashToken(token);
+  const now = new Date();
 
   const rows = await db
     .select({
       sessionId: sessions.id,
+      tokenHash: sessions.tokenHash,
+      sessionCreatedAt: sessions.createdAt,
+      expiresAt: sessions.expiresAt,
       userId: users.id,
       provider: users.provider,
       email: users.email,
@@ -103,12 +108,27 @@ export async function validateSession(token: string): Promise<SessionUser | null
     })
     .from(sessions)
     .innerJoin(users, eq(sessions.userId, users.id))
-    .where(and(eq(sessions.tokenHash, tokenHash), gt(sessions.expiresAt, new Date())))
+    .where(eq(sessions.tokenHash, tokenHash))
     .limit(1);
 
   if (rows.length === 0) return null;
 
   const row = rows[0];
+
+  // Constant-time comparison of token hash (defense-in-depth)
+  if (!timingSafeEqual(Buffer.from(row.tokenHash), Buffer.from(tokenHash))) return null;
+
+  // Check expiry in application code
+  if (row.expiresAt <= now) return null;
+
+  // Sliding-window: extend session expiry on successful validation
+  const slidingExpiry = new Date(now.getTime() + SESSION_SLIDING_WINDOW_MS);
+  const maxExpiry = new Date(row.sessionCreatedAt.getTime() + SESSION_MAX_TTL_MS);
+  const newExpiry = slidingExpiry < maxExpiry ? slidingExpiry : maxExpiry;
+  if (newExpiry > now) {
+    await db.update(sessions).set({ expiresAt: newExpiry }).where(eq(sessions.id, row.sessionId));
+  }
+
   return {
     id: row.userId,
     provider: row.provider,

--- a/apps/api/src/services/workspace-service.test.ts
+++ b/apps/api/src/services/workspace-service.test.ts
@@ -9,6 +9,10 @@ vi.mock("../db/client.js", () => ({
   },
 }));
 
+vi.mock("./session-service.js", () => ({
+  revokeAllUserSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../db/schema.js", () => ({
   workspaces: {
     id: "workspaces.id",
@@ -31,6 +35,7 @@ vi.mock("../db/schema.js", () => ({
 }));
 
 import { db } from "../db/client.js";
+import { revokeAllUserSessions } from "./session-service.js";
 import {
   createWorkspace,
   getWorkspace,
@@ -306,9 +311,26 @@ describe("workspace-service", () => {
           where: vi.fn().mockResolvedValue(undefined),
         }),
       });
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
 
       await updateMemberRole("ws-1", "user-1", "admin");
       expect(db.update).toHaveBeenCalled();
+    });
+
+    it("revokes user sessions after role change", async () => {
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await updateMemberRole("ws-1", "user-1", "viewer");
+      expect(revokeAllUserSessions).toHaveBeenCalledWith("user-1");
     });
   });
 
@@ -320,6 +342,15 @@ describe("workspace-service", () => {
 
       await removeMember("ws-1", "user-1");
       expect(db.delete).toHaveBeenCalled();
+    });
+
+    it("revokes user sessions after removal", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await removeMember("ws-1", "user-1");
+      expect(revokeAllUserSessions).toHaveBeenCalledWith("user-1");
     });
   });
 

--- a/apps/api/src/services/workspace-service.ts
+++ b/apps/api/src/services/workspace-service.ts
@@ -1,6 +1,7 @@
 import { eq, and } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { workspaces, workspaceMembers, users } from "../db/schema.js";
+import { revokeAllUserSessions } from "./session-service.js";
 import type {
   Workspace,
   WorkspaceMemberWithUser,
@@ -136,7 +137,7 @@ export async function addMember(
     });
 }
 
-/** Update a member's role. */
+/** Update a member's role. Revokes sessions to force re-authentication with updated privileges. */
 export async function updateMemberRole(
   workspaceId: string,
   userId: string,
@@ -146,13 +147,15 @@ export async function updateMemberRole(
     .update(workspaceMembers)
     .set({ role })
     .where(and(eq(workspaceMembers.workspaceId, workspaceId), eq(workspaceMembers.userId, userId)));
+  await revokeAllUserSessions(userId);
 }
 
-/** Remove a user from a workspace. */
+/** Remove a user from a workspace. Revokes sessions to prevent access with stale membership. */
 export async function removeMember(workspaceId: string, userId: string): Promise<void> {
   await db
     .delete(workspaceMembers)
     .where(and(eq(workspaceMembers.workspaceId, workspaceId), eq(workspaceMembers.userId, userId)));
+  await revokeAllUserSessions(userId);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Constant-time token comparison**: Added `crypto.timingSafeEqual` as a defense-in-depth measure after the database lookup in `validateSession()`. While SHA-256 hashing already prevents direct token leakage, the application-layer check ensures no timing side-channel from the comparison code itself.
- **Sliding-window session expiration**: Replaced the fixed 30-day TTL with a 7-day sliding window capped at 30 days from session creation. Active sessions are extended on each successful validation; inactive sessions expire after 7 days of disuse.
- **Session revocation on privilege changes**: `updateMemberRole()` and `removeMember()` in workspace-service now revoke all user sessions, eliminating the stale-privilege window where a user could operate with outdated workspace permissions.

## Changes

| File | What changed |
|------|-------------|
| `session-service.ts` | Added `timingSafeEqual` import, replaced `SESSION_TTL_MS` with `SESSION_MAX_TTL_MS` (30d) + `SESSION_SLIDING_WINDOW_MS` (7d), moved expiry check from DB WHERE clause to application code, added sliding-window update on validation |
| `workspace-service.ts` | Imported `revokeAllUserSessions`, called it after role update and member removal |
| `session-service.test.ts` | Added tests for timingSafeEqual rejection, post-fetch expiry check, sliding-window extension, and max TTL cap |
| `workspace-service.test.ts` | Added tests verifying session revocation on role change and member removal |

## Test plan

- [x] All 1131 existing tests pass (76 test files)
- [x] New tests verify timingSafeEqual rejects mismatched hashes
- [x] New tests verify expired sessions are rejected after fetch
- [x] New tests verify sliding-window extends expiry on use
- [x] New tests verify max TTL caps the sliding window
- [x] New tests verify sessions are revoked on role change
- [x] New tests verify sessions are revoked on member removal
- [x] Typecheck passes across all packages
- [x] Prettier formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)