### PR TITLE
fix(security): prevent unauthenticated access to /api/auth/claude-token

### DIFF
--- a/apps/api/src/plugins/auth.test.ts
+++ b/apps/api/src/plugins/auth.test.ts
@@ -25,7 +25,7 @@ vi.mock("../services/secret-service.js", () => ({
   listSecrets: (...args: unknown[]) => mockListSecrets(...args),
 }));
 
-import { requireRole, isSetupComplete, resetSetupCompleteCache } from "./auth.js";
+import { requireRole, isSetupComplete, resetSetupCompleteCache, isPublicRoute } from "./auth.js";
 
 // ─── Helpers ───
 
@@ -156,6 +156,105 @@ describe("requireRole", () => {
       const res = await inject(await buildApp("viewer", null));
       expect(res.statusCode).toBe(403);
     });
+  });
+});
+
+describe("isPublicRoute", () => {
+  // ─── Non-auth public routes ───
+
+  it("allows /api/health", () => {
+    expect(isPublicRoute("/api/health")).toBe(true);
+  });
+
+  it("allows /api/setup/status", () => {
+    expect(isPublicRoute("/api/setup/status")).toBe(true);
+  });
+
+  it("allows /api/webhooks/ prefix", () => {
+    expect(isPublicRoute("/api/webhooks/some-id")).toBe(true);
+  });
+
+  it("allows /ws/ prefix", () => {
+    expect(isPublicRoute("/ws/events")).toBe(true);
+  });
+
+  it("allows /api/internal/git-credentials", () => {
+    expect(isPublicRoute("/api/internal/git-credentials")).toBe(true);
+  });
+
+  // ─── Public auth routes (OAuth flow) ───
+
+  it("allows /api/auth/providers", () => {
+    expect(isPublicRoute("/api/auth/providers")).toBe(true);
+  });
+
+  it("allows /api/auth/exchange-code", () => {
+    expect(isPublicRoute("/api/auth/exchange-code")).toBe(true);
+  });
+
+  it("allows /api/auth/github/login", () => {
+    expect(isPublicRoute("/api/auth/github/login")).toBe(true);
+  });
+
+  it("allows /api/auth/github/callback", () => {
+    expect(isPublicRoute("/api/auth/github/callback")).toBe(true);
+  });
+
+  it("allows /api/auth/google/login", () => {
+    expect(isPublicRoute("/api/auth/google/login")).toBe(true);
+  });
+
+  it("allows /api/auth/google/callback", () => {
+    expect(isPublicRoute("/api/auth/google/callback")).toBe(true);
+  });
+
+  it("allows /api/auth/gitlab/login", () => {
+    expect(isPublicRoute("/api/auth/gitlab/login")).toBe(true);
+  });
+
+  it("allows /api/auth/gitlab/callback", () => {
+    expect(isPublicRoute("/api/auth/gitlab/callback")).toBe(true);
+  });
+
+  // ─── Sensitive auth routes that must NOT be public ───
+
+  it("blocks /api/auth/claude-token", () => {
+    expect(isPublicRoute("/api/auth/claude-token")).toBe(false);
+  });
+
+  it("blocks /api/auth/status", () => {
+    expect(isPublicRoute("/api/auth/status")).toBe(false);
+  });
+
+  it("blocks /api/auth/usage", () => {
+    expect(isPublicRoute("/api/auth/usage")).toBe(false);
+  });
+
+  it("blocks /api/auth/me", () => {
+    expect(isPublicRoute("/api/auth/me")).toBe(false);
+  });
+
+  it("blocks /api/auth/ws-token", () => {
+    expect(isPublicRoute("/api/auth/ws-token")).toBe(false);
+  });
+
+  it("blocks /api/auth/refresh", () => {
+    expect(isPublicRoute("/api/auth/refresh")).toBe(false);
+  });
+
+  it("blocks /api/auth/logout", () => {
+    expect(isPublicRoute("/api/auth/logout")).toBe(false);
+  });
+
+  // ─── Edge cases ───
+
+  it("strips query parameters before matching", () => {
+    expect(isPublicRoute("/api/auth/providers?foo=bar")).toBe(true);
+    expect(isPublicRoute("/api/auth/claude-token?foo=bar")).toBe(false);
+  });
+
+  it("blocks unknown /api/auth/ subpaths", () => {
+    expect(isPublicRoute("/api/auth/something-new")).toBe(false);
   });
 });
 

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -42,15 +42,27 @@ export function requireRole(minimumRole: WorkspaceRole) {
 const SESSION_COOKIE_NAME = "optio_session";
 const WORKSPACE_HEADER = "x-workspace-id";
 
-/** Routes that never require authentication. */
-const PUBLIC_ROUTES = [
-  "/api/health",
-  "/api/auth/",
-  "/api/setup/status",
-  "/api/webhooks/",
-  "/ws/",
-  "/api/internal/git-credentials",
-];
+/** Exact routes that are always public. */
+const PUBLIC_ROUTES = new Set(["/api/health", "/api/setup/status"]);
+
+/** Prefix-matched routes that are always public. */
+const PUBLIC_PREFIXES = ["/api/webhooks/", "/ws/", "/api/internal/git-credentials"];
+
+/**
+ * Auth routes that are public (OAuth login/callback flows only).
+ * Sensitive endpoints like claude-token, status, usage, me are NOT listed
+ * here — they require authentication via the normal auth path.
+ */
+const PUBLIC_AUTH_ROUTES = new Set([
+  "/api/auth/providers",
+  "/api/auth/exchange-code",
+  "/api/auth/github/login",
+  "/api/auth/github/callback",
+  "/api/auth/google/login",
+  "/api/auth/google/callback",
+  "/api/auth/gitlab/login",
+  "/api/auth/gitlab/callback",
+]);
 
 /**
  * Secrets whose presence indicates that initial setup has been completed.
@@ -91,8 +103,10 @@ export function resetSetupCompleteCache(): void {
   _setupCompleteCache = null;
 }
 
-function isPublicRoute(url: string): boolean {
-  return PUBLIC_ROUTES.some((prefix) => url.startsWith(prefix));
+export function isPublicRoute(url: string): boolean {
+  const path = url.split("?")[0];
+  if (PUBLIC_ROUTES.has(path) || PUBLIC_AUTH_ROUTES.has(path)) return true;
+  return PUBLIC_PREFIXES.some((p) => path.startsWith(p));
 }
 
 function parseCookie(header: string | undefined, name: string): string | undefined {


### PR DESCRIPTION
## Summary

- **Fixed SSRF-like auth bypass** where `PUBLIC_ROUTES` used a prefix match on `/api/auth/`, causing _all_ endpoints under that path to skip authentication — including `/api/auth/claude-token` which returns the Claude OAuth token in plaintext.
- Replaced the blanket `/api/auth/` prefix with an explicit allow-list of OAuth login/callback routes (`providers`, `exchange-code`, `*/login`, `*/callback`).
- Sensitive endpoints (`claude-token`, `status`, `usage`, `me`, `ws-token`, `refresh`, `logout`) now require a valid session through the normal auth middleware.

## Changes

| File | What changed |
|------|-------------|
| `apps/api/src/plugins/auth.ts` | Split `PUBLIC_ROUTES` array (prefix-matched) into `PUBLIC_ROUTES` (exact Set), `PUBLIC_PREFIXES` (prefix array), and `PUBLIC_AUTH_ROUTES` (exact Set). Updated `isPublicRoute()` to use the new structure and strip query params. Exported `isPublicRoute` for testing. |
| `apps/api/src/plugins/auth.test.ts` | Added 22 tests covering every public and protected auth route, query-param stripping, and unknown-path blocking. |

## Test plan

- [x] All 22 new `isPublicRoute` tests pass (public OAuth routes allowed, sensitive routes blocked)
- [x] All 22 existing `requireRole` and `isSetupComplete` tests still pass
- [x] All 16 auth route tests (`/api/auth/me`, `/api/auth/exchange-code`, logout) still pass
- [x] Full test suite passes (76 files, 1148 tests)
- [x] Typecheck passes across all 11 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)