### PR TITLE
fix(security): remove SYS_ADMIN/NET_ADMIN from DinD pods, require workspace opt-in

### DIFF
--- a/apps/api/src/db/migrations/0040_workspace_allow_dind.sql
+++ b/apps/api/src/db/migrations/0040_workspace_allow_dind.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workspaces" ADD COLUMN IF NOT EXISTS "allow_docker_in_docker" boolean NOT NULL DEFAULT false;

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1776441600000,
       "tag": "0039_cautious_mode",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1776528000000,
+      "tag": "0040_workspace_allow_dind",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -39,6 +39,7 @@ export const workspaces = pgTable("workspaces", {
   slug: text("slug").notNull().unique(),
   description: text("description"),
   createdBy: uuid("created_by"),
+  allowDockerInDocker: boolean("allow_docker_in_docker").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -21,6 +21,7 @@ const updateWorkspaceSchema = z.object({
     .regex(/^[a-z0-9-]+$/)
     .optional(),
   description: z.string().max(500).nullable().optional(),
+  allowDockerInDocker: z.boolean().optional(),
 });
 
 const addMemberSchema = z.object({

--- a/apps/api/src/services/repo-pool-service.test.ts
+++ b/apps/api/src/services/repo-pool-service.test.ts
@@ -43,6 +43,10 @@ vi.mock("../db/schema.js", () => ({
     state: "state",
     podId: "podId",
   },
+  workspaces: {
+    id: "id",
+    allowDockerInDocker: "allowDockerInDocker",
+  },
 }));
 
 const mockRuntimeCreate = vi.fn();
@@ -85,6 +89,7 @@ vi.mock("../logger.js", () => ({
 import { db } from "../db/client.js";
 import {
   resolveImage,
+  getOrCreateRepoPod,
   releaseRepoPodTask,
   cleanupIdleRepoPods,
   listRepoPods,
@@ -403,5 +408,187 @@ describe("deleteNetworkPolicy", () => {
   it("does not throw when deletion fails", async () => {
     // deleteNetworkPolicy has a try/catch that swallows errors
     await expect(deleteNetworkPolicy("nonexistent-pod")).resolves.toBeUndefined();
+  });
+});
+
+// ── Docker-in-Docker admission check ──────────────────────────────
+
+describe("getOrCreateRepoPod — DinD admission check", () => {
+  /**
+   * Helper: set up the db mock chain for getOrCreateRepoPod.
+   * The function chains: select().from().where().orderBy() which needs special handling
+   * because mockResolvedValueOnce on where() consumes the chain before orderBy() is called.
+   */
+  function mockGetOrCreateFlow(opts: {
+    existingPods?: any[];
+    podCount?: number;
+    workspaceLookup?: any[];
+    insertedPod?: any;
+  }) {
+    const dbMock = db as any;
+
+    // The main challenge: select().from(repoPods).where().orderBy() must be awaitable
+    // after the full chain. We use a thenable + orderBy combo.
+    const orderByResult = opts.existingPods ?? [];
+    const chainableWithOrderBy = {
+      orderBy: vi.fn().mockResolvedValue(orderByResult),
+    };
+
+    // Track call count to know which where() call we're on:
+    // 1st where: existing pods (needs .orderBy)
+    // 2nd where: pod count (terminal, returns [{count}])
+    // 3rd where: workspace lookup (terminal, returns workspace row)
+    // 4th+ where: update calls (terminal)
+    let whereCallCount = 0;
+    dbMock.where.mockImplementation(() => {
+      whereCallCount++;
+      if (whereCallCount === 1) {
+        // existing pods query → needs .orderBy()
+        return chainableWithOrderBy;
+      }
+      if (whereCallCount === 2) {
+        // pod count query
+        return Promise.resolve([{ count: opts.podCount ?? 0 }]);
+      }
+      if (whereCallCount === 3 && opts.workspaceLookup !== undefined) {
+        // workspace lookup
+        return Promise.resolve(opts.workspaceLookup);
+      }
+      // Remaining calls: update queries (e.g. state transitions)
+      return Promise.resolve([]);
+    });
+
+    if (opts.insertedPod) {
+      dbMock.returning.mockResolvedValueOnce([opts.insertedPod]);
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset where to default behavior
+    (db as any).where.mockReset().mockReturnThis();
+  });
+
+  it("rejects DinD when no workspaceId is provided", async () => {
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    await expect(
+      getOrCreateRepoPod("https://github.com/org/repo", "main", {}, undefined, {
+        dockerInDocker: true,
+      }),
+    ).rejects.toThrow("Docker-in-Docker requires a workspace with allowDockerInDocker enabled");
+  });
+
+  it("rejects DinD when workspace has allowDockerInDocker=false", async () => {
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      workspaceLookup: [{ allowDockerInDocker: false }],
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    await expect(
+      getOrCreateRepoPod("https://github.com/org/repo", "main", {}, undefined, {
+        dockerInDocker: true,
+        workspaceId: "ws-1",
+      }),
+    ).rejects.toThrow("Docker-in-Docker requires workspace admin opt-in");
+  });
+
+  it("rejects DinD when workspace is not found", async () => {
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      workspaceLookup: [],
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    await expect(
+      getOrCreateRepoPod("https://github.com/org/repo", "main", {}, undefined, {
+        dockerInDocker: true,
+        workspaceId: "nonexistent-ws",
+      }),
+    ).rejects.toThrow("Docker-in-Docker requires workspace admin opt-in");
+  });
+
+  it("allows DinD when workspace has allowDockerInDocker=true", async () => {
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      workspaceLookup: [{ allowDockerInDocker: true }],
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    mockRuntimeCreate.mockResolvedValueOnce({ id: "k8s-id", name: "optio-repo-abc" });
+
+    const pod = await getOrCreateRepoPod("https://github.com/org/repo", "main", {}, undefined, {
+      dockerInDocker: true,
+      workspaceId: "ws-1",
+    });
+
+    expect(pod.state).toBe("ready");
+    expect(mockRuntimeCreate).toHaveBeenCalled();
+
+    // Verify the ContainerSpec passed to create uses SYS_CHROOT, not SYS_ADMIN
+    const spec = mockRuntimeCreate.mock.calls[0][0];
+    expect(spec.capabilities).toEqual(["SYS_CHROOT"]);
+    expect(spec.capabilities).not.toContain("SYS_ADMIN");
+    expect(spec.capabilities).not.toContain("NET_ADMIN");
+    expect(spec.hostUsers).toBe(false);
+    expect(spec.tmpfsMounts).toEqual([{ mountPath: "/var/lib/docker", sizeLimit: "10Gi" }]);
+  });
+
+  it("does not add DinD capabilities when dockerInDocker is false", async () => {
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    mockRuntimeCreate.mockResolvedValueOnce({ id: "k8s-id", name: "optio-repo-abc" });
+
+    const pod = await getOrCreateRepoPod("https://github.com/org/repo", "main", {}, undefined, {
+      dockerInDocker: false,
+    });
+
+    expect(pod.state).toBe("ready");
+    const spec = mockRuntimeCreate.mock.calls[0][0];
+    expect(spec.capabilities).toBeUndefined();
+    expect(spec.hostUsers).toBeUndefined();
+    expect(spec.tmpfsMounts).toBeUndefined();
   });
 });

--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { eq, and, lt, sql, asc } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { repoPods, tasks, interactiveSessions } from "../db/schema.js";
+import { repoPods, tasks, interactiveSessions, workspaces } from "../db/schema.js";
 import { getRuntime } from "./container-service.js";
 import type { ContainerHandle, ContainerSpec, ExecSession, RepoImageConfig } from "@optio/shared";
 import {
@@ -60,6 +60,7 @@ export async function getOrCreateRepoPod(
     memoryLimit?: string | null;
     dockerInDocker?: boolean;
     secretProxy?: boolean;
+    workspaceId?: string | null;
   },
 ): Promise<RepoPod> {
   const repoUrl = normalizeRepoUrl(rawRepoUrl);
@@ -164,6 +165,7 @@ export async function getOrCreateRepoPod(
       },
       opts?.dockerInDocker,
       opts?.secretProxy,
+      opts?.workspaceId,
     );
   } catch (err: any) {
     if (err?.message?.includes("unique") || err?.code === "23505") {
@@ -197,7 +199,25 @@ async function createRepoPod(
   },
   dockerInDocker?: boolean,
   secretProxy?: boolean,
+  workspaceId?: string | null,
 ): Promise<RepoPod> {
+  // Admission check: Docker-in-Docker requires explicit workspace admin opt-in
+  if (dockerInDocker) {
+    if (!workspaceId) {
+      throw new Error("Docker-in-Docker requires a workspace with allowDockerInDocker enabled");
+    }
+    const [ws] = await db
+      .select({ allowDockerInDocker: workspaces.allowDockerInDocker })
+      .from(workspaces)
+      .where(eq(workspaces.id, workspaceId));
+    if (!ws?.allowDockerInDocker) {
+      throw new Error(
+        "Docker-in-Docker requires workspace admin opt-in. " +
+          "Enable allowDockerInDocker in workspace settings.",
+      );
+    }
+  }
+
   const [record] = await db
     .insert(repoPods)
     .values({ repoUrl, repoBranch, state: "provisioning", instanceIndex })
@@ -281,11 +301,13 @@ spec:
         "optio.secret-proxy": secretProxy ? "true" : "false",
         "managed-by": "optio",
       },
-      // Docker-in-Docker: user namespace isolation + capabilities + tmpfs for daemon storage
+      // Docker-in-Docker (rootless): user namespace isolation + minimal capabilities + tmpfs
+      // Uses rootless Docker (runc + fuse-overlayfs) so SYS_ADMIN is NOT required.
+      // SYS_CHROOT is the only extra capability needed for rootless container runtimes.
       ...(dockerInDocker
         ? {
             hostUsers: false,
-            capabilities: ["SYS_ADMIN", "NET_ADMIN"],
+            capabilities: ["SYS_CHROOT"],
             tmpfsMounts: [{ mountPath: "/var/lib/docker", sizeLimit: "10Gi" }],
           }
         : {}),

--- a/apps/api/src/services/workspace-service.ts
+++ b/apps/api/src/services/workspace-service.ts
@@ -52,12 +52,19 @@ export async function getWorkspaceBySlug(slug: string): Promise<Workspace | null
 
 export async function updateWorkspace(
   id: string,
-  data: { name?: string; slug?: string; description?: string | null },
+  data: {
+    name?: string;
+    slug?: string;
+    description?: string | null;
+    allowDockerInDocker?: boolean;
+  },
 ): Promise<Workspace | null> {
   const updates: Record<string, unknown> = { updatedAt: new Date() };
   if (data.name !== undefined) updates.name = data.name;
   if (data.slug !== undefined) updates.slug = data.slug.toLowerCase().replace(/[^a-z0-9-]/g, "-");
   if (data.description !== undefined) updates.description = data.description;
+  if (data.allowDockerInDocker !== undefined)
+    updates.allowDockerInDocker = data.allowDockerInDocker;
 
   const [ws] = await db.update(workspaces).set(updates).where(eq(workspaces.id, id)).returning();
   return (ws as Workspace) ?? null;

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -470,6 +470,7 @@ export function startTaskWorker() {
             memoryLimit: repoConfig?.memoryLimit,
             dockerInDocker: repoConfig?.dockerInDocker ?? false,
             secretProxy: repoConfig?.secretProxy ?? false,
+            workspaceId: taskWorkspaceId,
           },
         );
         repoPodId = pod.id;

--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -569,8 +569,9 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
             <span className="text-sm">Enable Docker-in-Docker</span>
             <p className="text-[10px] text-text-muted/60 mt-0.5">
               Allow agents to run <code>docker build</code> and <code>docker run</code> inside pods.
-              Uses K8s user namespace isolation (<code>hostUsers: false</code>) with SYS_ADMIN and
-              NET_ADMIN capabilities scoped to the user namespace &mdash; no privileged mode needed.
+              Uses rootless Docker with K8s user namespace isolation (<code>hostUsers: false</code>)
+              and minimal capabilities (SYS_CHROOT only) &mdash; no privileged mode needed. Requires
+              workspace admin opt-in via <code>allowDockerInDocker</code>.
             </p>
           </div>
         </label>

--- a/packages/shared/src/types/workspace.ts
+++ b/packages/shared/src/types/workspace.ts
@@ -6,6 +6,7 @@ export interface Workspace {
   slug: string;
   description?: string | null;
   createdBy?: string | null;
+  allowDockerInDocker: boolean;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary

- **Removes dangerous SYS_ADMIN and NET_ADMIN capabilities** from Docker-in-Docker pods, replacing them with rootless Docker using only `SYS_CHROOT` (already in the `ALLOWED_CAPABILITIES` whitelist)
- **Adds workspace-level `allowDockerInDocker` gate** (default `false`) — DinD pods are now rejected at admission time unless a workspace admin has explicitly opted in
- **Passes `workspaceId` through the pod creation flow** so the admission check can look up the workspace setting

## Motivation

When a repo enabled Docker-in-Docker, agent pods received `SYS_ADMIN` and `NET_ADMIN` capabilities. `SYS_ADMIN` is effectively root-on-host inside the container — untrusted code in `.optio/setup.sh` could mount the host filesystem, manipulate cgroups, and escape the container. `NET_ADMIN` allowed iptables reconfiguration and traffic interception. Combined with no default NetworkPolicy, this was a clean container escape vector.

## Changes

| File | Change |
|------|--------|
| `apps/api/src/db/schema.ts` | Add `allowDockerInDocker` boolean to `workspaces` table |
| `apps/api/src/db/migrations/0040_workspace_allow_dind.sql` | Migration for new column |
| `packages/shared/src/types/workspace.ts` | Add field to `Workspace` type |
| `apps/api/src/services/workspace-service.ts` | Support `allowDockerInDocker` in `updateWorkspace()` |
| `apps/api/src/routes/workspaces.ts` | Accept `allowDockerInDocker` in update schema (admin-only) |
| `apps/api/src/services/repo-pool-service.ts` | Admission check + replace capabilities with `SYS_CHROOT` |
| `apps/api/src/workers/task-worker.ts` | Pass `workspaceId` to `getOrCreateRepoPod()` |
| `apps/web/src/app/repos/[id]/page.tsx` | Update UI description to reflect rootless Docker |
| `apps/api/src/services/repo-pool-service.test.ts` | 5 new tests for admission check scenarios |

## Test plan

- [x] All 29 repo-pool-service tests pass (including 5 new admission check tests)
- [x] Full test suite passes (1131 tests across 76 files)
- [x] TypeScript typecheck passes across all packages
- [x] Prettier formatting passes
- [x] Next.js production build succeeds
- [ ] Verify DinD repos fail to create pods without workspace opt-in
- [ ] Verify DinD repos succeed after enabling `allowDockerInDocker` on workspace
- [ ] Verify non-DinD repos are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)