### PR TITLE
fix(security): HMAC-SHA256 auth for internal credential endpoint

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -45,7 +45,14 @@ const WORKSPACE_HEADER = "x-workspace-id";
 /** Exact routes that are always public. */
 const PUBLIC_ROUTES = new Set(["/api/health", "/api/setup/status"]);
 
-/** Prefix-matched routes that are always public. */
+/**
+ * Prefix-matched routes that are always public.
+ *
+ * /api/internal/* routes are called by agent pods which don't have session
+ * cookies. They authenticate via HMAC-SHA256 signatures verified in the
+ * route handler itself (see hmac-auth-service.ts). The Helm ingress also
+ * blocks /api/internal/* from public traffic as defense in depth.
+ */
 const PUBLIC_PREFIXES = ["/api/webhooks/", "/ws/", "/api/internal/git-credentials"];
 
 /**

--- a/apps/api/src/routes/github-app.test.ts
+++ b/apps/api/src/routes/github-app.test.ts
@@ -19,6 +19,7 @@ import {
   getCredentialSecret,
   resetCredentialSecret,
 } from "../services/credential-secret-service.js";
+import { computeSignature } from "../services/hmac-auth-service.js";
 
 // ─── Helpers ───
 
@@ -26,7 +27,14 @@ import {
 // module load order in the test suite.
 process.env.OPTIO_ENCRYPTION_KEY = "test-encryption-key-for-unit-tests";
 resetCredentialSecret();
-const VALID_BEARER = `Bearer ${getCredentialSecret()}`;
+const SECRET = getCredentialSecret();
+const VALID_BEARER = `Bearer ${SECRET}`;
+
+function makeHmacHeaders(path: string, timestampOverride?: number): Record<string, string> {
+  const ts = timestampOverride ?? Math.floor(Date.now() / 1000);
+  const sig = computeSignature(SECRET, ts, path);
+  return { "x-optio-signature": `t=${ts},sig=${sig}` };
+}
 
 async function buildTestApp(): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
@@ -49,14 +57,88 @@ describe("GET /api/internal/git-credentials", () => {
     vi.unstubAllGlobals();
   });
 
-  it("returns 401 when no Authorization header", async () => {
+  // --- HMAC signature auth ---
+
+  it("returns token with valid HMAC signature", async () => {
+    mockGetGitHubToken.mockResolvedValue("ghp_server_token");
+    const path = "/api/internal/git-credentials";
+
+    const res = await app.inject({
+      method: "GET",
+      url: path,
+      headers: makeHmacHeaders(path),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ token: "ghp_server_token" });
+    expect(mockGetGitHubToken).toHaveBeenCalledWith({ server: true });
+  });
+
+  it("returns token with valid HMAC signature and taskId", async () => {
+    mockGetGitHubToken.mockResolvedValue("ghp_task_token");
+    const path = "/api/internal/git-credentials?taskId=task-123";
+
+    const res = await app.inject({
+      method: "GET",
+      url: path,
+      headers: makeHmacHeaders(path),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ token: "ghp_task_token" });
+    expect(mockGetGitHubToken).toHaveBeenCalledWith({ taskId: "task-123" });
+  });
+
+  it("returns 401 with expired HMAC signature", async () => {
+    const expiredTs = Math.floor(Date.now() / 1000) - 400; // beyond 5-min window
+    const path = "/api/internal/git-credentials";
+
+    const res = await app.inject({
+      method: "GET",
+      url: path,
+      headers: makeHmacHeaders(path, expiredTs),
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe("Signature expired");
+  });
+
+  it("returns 401 with invalid HMAC signature", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/internal/git-credentials",
+      headers: {
+        "x-optio-signature": `t=${Math.floor(Date.now() / 1000)},sig=bad_signature`,
+      },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe("Invalid signature");
+  });
+
+  it("returns 401 with HMAC signed for different path", async () => {
+    const path = "/api/internal/git-credentials";
+    const wrongPath = "/api/internal/other";
+
+    const res = await app.inject({
+      method: "GET",
+      url: path,
+      headers: makeHmacHeaders(wrongPath),
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toBe("Invalid signature");
+  });
+
+  // --- Legacy Bearer token auth (backward compatibility) ---
+
+  it("returns 401 when no auth headers", async () => {
     const res = await app.inject({
       method: "GET",
       url: "/api/internal/git-credentials",
     });
 
     expect(res.statusCode).toBe(401);
-    expect(res.json().error).toBe("Unauthorized");
   });
 
   it("returns 401 when incorrect bearer token", async () => {
@@ -70,7 +152,7 @@ describe("GET /api/internal/git-credentials", () => {
     expect(res.json().error).toBe("Unauthorized");
   });
 
-  it("returns token with valid bearer and taskId query param", async () => {
+  it("returns token with valid legacy bearer and taskId query param", async () => {
     mockGetGitHubToken.mockResolvedValue("ghp_task_token");
 
     const res = await app.inject({
@@ -84,7 +166,7 @@ describe("GET /api/internal/git-credentials", () => {
     expect(mockGetGitHubToken).toHaveBeenCalledWith({ taskId: "task-123" });
   });
 
-  it("returns token with valid bearer and no taskId", async () => {
+  it("returns token with valid legacy bearer and no taskId", async () => {
     mockGetGitHubToken.mockResolvedValue("ghp_server_token");
 
     const res = await app.inject({
@@ -97,6 +179,8 @@ describe("GET /api/internal/git-credentials", () => {
     expect(res.json()).toEqual({ token: "ghp_server_token" });
     expect(mockGetGitHubToken).toHaveBeenCalledWith({ server: true });
   });
+
+  // --- Error handling ---
 
   it("returns 500 when token service throws", async () => {
     mockGetGitHubToken.mockRejectedValue(new Error("Token fetch failed"));

--- a/apps/api/src/routes/github-app.ts
+++ b/apps/api/src/routes/github-app.ts
@@ -1,12 +1,11 @@
-import { timingSafeEqual } from "node:crypto";
 import type { FastifyInstance } from "fastify";
 import { getGitHubToken } from "../services/github-token-service.js";
 import { isGitHubAppConfigured } from "../services/github-app-service.js";
 import {
   getCredentialSecret,
-  getOrDeriveCredentialSecret,
   resetCredentialSecret,
 } from "../services/credential-secret-service.js";
+import { verifyInternalRequest } from "../services/hmac-auth-service.js";
 
 export { getCredentialSecret, resetCredentialSecret };
 
@@ -31,24 +30,23 @@ export default async function githubAppRoutes(app: FastifyInstance): Promise<voi
    * Cluster-internal only: the Helm ingress blocks /api/internal/* from public traffic.
    * Pods reach this via the K8s service DNS (optio-api.optio.svc.cluster.local).
    *
+   * Authentication: HMAC-SHA256 signature in X-Optio-Signature header.
+   * The agent computes HMAC(secret, "{timestamp}.{path}") and sends
+   * "t={timestamp},sig={hex}" — the raw secret never crosses the wire.
+   * Legacy Bearer token is still accepted for backward compatibility.
+   *
    * With taskId: returns the task creator's user token (for task-scoped operations).
    * Without taskId: returns an installation token (for pod-level operations like clone).
    */
   app.get<{ Querystring: { taskId?: string } }>(
     "/api/internal/git-credentials",
     async (req, reply) => {
-      const secret = getOrDeriveCredentialSecret();
-      if (!secret) {
-        return reply.status(503).send({ error: "Credential secret not configured" });
-      }
-
-      const authHeader = req.headers.authorization ?? "";
-      const expected = `Bearer ${secret}`;
-      const isValid =
-        authHeader.length === expected.length &&
-        timingSafeEqual(Buffer.from(authHeader), Buffer.from(expected));
-      if (!isValid) {
-        return reply.status(401).send({ error: "Unauthorized" });
+      const authResult = verifyInternalRequest(
+        req.headers as Record<string, string | string[] | undefined>,
+        req.url,
+      );
+      if (authResult) {
+        return reply.status(authResult.status).send({ error: authResult.error });
       }
 
       try {

--- a/apps/api/src/services/hmac-auth-service.test.ts
+++ b/apps/api/src/services/hmac-auth-service.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  parseSignatureHeader,
+  computeSignature,
+  verifyInternalRequest,
+  SIGNATURE_HEADER,
+  MAX_AGE_SECONDS,
+} from "./hmac-auth-service.js";
+import { getCredentialSecret, resetCredentialSecret } from "./credential-secret-service.js";
+
+// Set up a known encryption key for deterministic secret derivation
+process.env.OPTIO_ENCRYPTION_KEY = "test-encryption-key-for-unit-tests";
+resetCredentialSecret();
+const SECRET = getCredentialSecret();
+
+describe("parseSignatureHeader", () => {
+  it("parses valid header", () => {
+    const result = parseSignatureHeader("t=1712505600,sig=abc123");
+    expect(result).toEqual({ timestamp: 1712505600, signature: "abc123" });
+  });
+
+  it("returns null for missing timestamp", () => {
+    expect(parseSignatureHeader("sig=abc123")).toBeNull();
+  });
+
+  it("returns null for missing signature", () => {
+    expect(parseSignatureHeader("t=1712505600")).toBeNull();
+  });
+
+  it("returns null for non-numeric timestamp", () => {
+    expect(parseSignatureHeader("t=abc,sig=abc123")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseSignatureHeader("")).toBeNull();
+  });
+
+  it("handles signature values containing = characters", () => {
+    // base64-encoded values might contain =
+    const result = parseSignatureHeader("t=1712505600,sig=abc123def==");
+    expect(result).toEqual({ timestamp: 1712505600, signature: "abc123def==" });
+  });
+});
+
+describe("computeSignature", () => {
+  it("produces deterministic output", () => {
+    const sig1 = computeSignature("secret", 1000, "/api/test");
+    const sig2 = computeSignature("secret", 1000, "/api/test");
+    expect(sig1).toBe(sig2);
+  });
+
+  it("changes when timestamp changes", () => {
+    const sig1 = computeSignature("secret", 1000, "/api/test");
+    const sig2 = computeSignature("secret", 1001, "/api/test");
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it("changes when path changes", () => {
+    const sig1 = computeSignature("secret", 1000, "/api/a");
+    const sig2 = computeSignature("secret", 1000, "/api/b");
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it("changes when secret changes", () => {
+    const sig1 = computeSignature("secret1", 1000, "/api/test");
+    const sig2 = computeSignature("secret2", 1000, "/api/test");
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it("includes query string in the signed payload", () => {
+    const sig1 = computeSignature("secret", 1000, "/api/test");
+    const sig2 = computeSignature("secret", 1000, "/api/test?taskId=abc");
+    expect(sig1).not.toBe(sig2);
+  });
+});
+
+describe("verifyInternalRequest", () => {
+  const PATH = "/api/internal/git-credentials";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-04-07T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("accepts valid HMAC signature", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const sig = computeSignature(SECRET, now, PATH);
+    const headers = { [SIGNATURE_HEADER]: `t=${now},sig=${sig}` };
+
+    const result = verifyInternalRequest(headers, PATH);
+    expect(result).toBeNull();
+  });
+
+  it("accepts HMAC signature with query string", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const pathWithQuery = `${PATH}?taskId=task-123`;
+    const sig = computeSignature(SECRET, now, pathWithQuery);
+    const headers = { [SIGNATURE_HEADER]: `t=${now},sig=${sig}` };
+
+    const result = verifyInternalRequest(headers, pathWithQuery);
+    expect(result).toBeNull();
+  });
+
+  it("rejects expired HMAC signature", () => {
+    const expiredTime = Math.floor(Date.now() / 1000) - MAX_AGE_SECONDS - 1;
+    const sig = computeSignature(SECRET, expiredTime, PATH);
+    const headers = { [SIGNATURE_HEADER]: `t=${expiredTime},sig=${sig}` };
+
+    const result = verifyInternalRequest(headers, PATH);
+    expect(result).toEqual({ error: "Signature expired", status: 401 });
+  });
+
+  it("rejects future HMAC signature outside window", () => {
+    const futureTime = Math.floor(Date.now() / 1000) + MAX_AGE_SECONDS + 1;
+    const sig = computeSignature(SECRET, futureTime, PATH);
+    const headers = { [SIGNATURE_HEADER]: `t=${futureTime},sig=${sig}` };
+
+    const result = verifyInternalRequest(headers, PATH);
+    expect(result).toEqual({ error: "Signature expired", status: 401 });
+  });
+
+  it("rejects invalid HMAC signature", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const headers = { [SIGNATURE_HEADER]: `t=${now},sig=invalid_signature` };
+
+    const result = verifyInternalRequest(headers, PATH);
+    expect(result).toEqual({ error: "Invalid signature", status: 401 });
+  });
+
+  it("rejects malformed signature header", () => {
+    const headers = { [SIGNATURE_HEADER]: "garbage" };
+
+    const result = verifyInternalRequest(headers, PATH);
+    expect(result).toEqual({ error: "Malformed signature header", status: 401 });
+  });
+
+  it("rejects signature computed for a different path", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const sig = computeSignature(SECRET, now, "/api/other");
+    const headers = { [SIGNATURE_HEADER]: `t=${now},sig=${sig}` };
+
+    const result = verifyInternalRequest(headers, PATH);
+    expect(result).toEqual({ error: "Invalid signature", status: 401 });
+  });
+
+  // Legacy Bearer token support
+  it("accepts valid legacy Bearer token", () => {
+    const headers = { authorization: `Bearer ${SECRET}` };
+
+    const result = verifyInternalRequest(headers, PATH);
+    expect(result).toBeNull();
+  });
+
+  it("rejects invalid legacy Bearer token", () => {
+    const headers = { authorization: "Bearer wrong-token" };
+
+    const result = verifyInternalRequest(headers, PATH);
+    expect(result).toEqual({ error: "Unauthorized", status: 401 });
+  });
+
+  it("returns 401 when no auth headers present", () => {
+    const result = verifyInternalRequest({}, PATH);
+    expect(result).toEqual({ error: "Missing authentication", status: 401 });
+  });
+
+  it("returns 503 when credential secret is not configured", () => {
+    const origKey = process.env.OPTIO_ENCRYPTION_KEY;
+    const origSecret = process.env.OPTIO_CREDENTIAL_SECRET;
+    delete process.env.OPTIO_ENCRYPTION_KEY;
+    delete process.env.OPTIO_CREDENTIAL_SECRET;
+    resetCredentialSecret();
+
+    const now = Math.floor(Date.now() / 1000);
+    const sig = computeSignature("any", now, PATH);
+    const headers = { [SIGNATURE_HEADER]: `t=${now},sig=${sig}` };
+
+    const result = verifyInternalRequest(headers, PATH);
+    expect(result).toEqual({ error: "Credential secret not configured", status: 503 });
+
+    // Restore
+    process.env.OPTIO_ENCRYPTION_KEY = origKey;
+    if (origSecret) process.env.OPTIO_CREDENTIAL_SECRET = origSecret;
+    resetCredentialSecret();
+  });
+
+  it("prefers HMAC signature over Bearer token when both are present", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const sig = computeSignature(SECRET, now, PATH);
+    const headers = {
+      [SIGNATURE_HEADER]: `t=${now},sig=${sig}`,
+      authorization: "Bearer wrong-token", // Would fail if used
+    };
+
+    const result = verifyInternalRequest(headers, PATH);
+    expect(result).toBeNull(); // HMAC is preferred
+  });
+});

--- a/apps/api/src/services/hmac-auth-service.ts
+++ b/apps/api/src/services/hmac-auth-service.ts
@@ -1,0 +1,134 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { getOrDeriveCredentialSecret } from "./credential-secret-service.js";
+
+/**
+ * HMAC-based authentication for internal API endpoints.
+ *
+ * Instead of sending the raw credential secret as a Bearer token, agent pods
+ * compute an HMAC-SHA256 signature over a timestamp and request path, then
+ * send the signature in the X-Optio-Signature header.
+ *
+ * This provides:
+ * - Authentication (only someone with the secret can produce valid signatures)
+ * - Replay protection (timestamps expire after MAX_AGE_SECONDS)
+ * - The raw secret never crosses the wire
+ *
+ * Header format: X-Optio-Signature: t=<unix_seconds>,sig=<hex_hmac>
+ * Signed payload: "{timestamp}.{path}" where path includes the query string.
+ */
+
+const SIGNATURE_HEADER = "x-optio-signature";
+const MAX_AGE_SECONDS = 300; // 5 minutes
+
+export interface SignatureComponents {
+  timestamp: number;
+  signature: string;
+}
+
+/**
+ * Parse the X-Optio-Signature header.
+ * Format: t=<unix_seconds>,sig=<hex_hmac>
+ */
+export function parseSignatureHeader(header: string): SignatureComponents | null {
+  const parts: Record<string, string> = {};
+  for (const part of header.split(",")) {
+    const eqIdx = part.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = part.slice(0, eqIdx).trim();
+    const value = part.slice(eqIdx + 1).trim();
+    if (key) parts[key] = value;
+  }
+  const timestamp = parseInt(parts.t, 10);
+  const signature = parts.sig;
+  if (isNaN(timestamp) || !signature) return null;
+  return { timestamp, signature };
+}
+
+/**
+ * Compute the HMAC-SHA256 signature for a request.
+ */
+export function computeSignature(secret: string, timestamp: number, path: string): string {
+  return createHmac("sha256", secret).update(`${timestamp}.${path}`).digest("hex");
+}
+
+/**
+ * Verify an internal request's HMAC signature.
+ *
+ * Also accepts the legacy Bearer token format for backward compatibility
+ * during rollout (old agent images that haven't been rebuilt yet).
+ *
+ * Returns null if valid, or an error string if invalid.
+ */
+export function verifyInternalRequest(
+  headers: Record<string, string | string[] | undefined>,
+  requestPath: string,
+): { error: string; status: number } | null {
+  const secret = getOrDeriveCredentialSecret();
+  if (!secret) {
+    return { error: "Credential secret not configured", status: 503 };
+  }
+
+  // Prefer HMAC signature header
+  const sigHeader = headers[SIGNATURE_HEADER] as string | undefined;
+  if (sigHeader) {
+    return verifyHmacSignature(sigHeader, requestPath, secret);
+  }
+
+  // Fall back to legacy Bearer token for backward compatibility
+  const authHeader = (headers.authorization ?? "") as string;
+  if (authHeader.startsWith("Bearer ")) {
+    return verifyBearerToken(authHeader, secret);
+  }
+
+  return { error: "Missing authentication", status: 401 };
+}
+
+function verifyHmacSignature(
+  sigHeader: string,
+  requestPath: string,
+  secret: string,
+): { error: string; status: number } | null {
+  const parsed = parseSignatureHeader(sigHeader);
+  if (!parsed) {
+    return { error: "Malformed signature header", status: 401 };
+  }
+
+  // Replay protection: reject timestamps outside the allowed window
+  const now = Math.floor(Date.now() / 1000);
+  const age = Math.abs(now - parsed.timestamp);
+  if (age > MAX_AGE_SECONDS) {
+    return { error: "Signature expired", status: 401 };
+  }
+
+  const expected = computeSignature(secret, parsed.timestamp, requestPath);
+
+  const sigBuf = Buffer.from(parsed.signature, "utf8");
+  const expectedBuf = Buffer.from(expected, "utf8");
+
+  if (sigBuf.length !== expectedBuf.length || !timingSafeEqual(sigBuf, expectedBuf)) {
+    return { error: "Invalid signature", status: 401 };
+  }
+
+  return null; // Valid
+}
+
+function verifyBearerToken(
+  authHeader: string,
+  secret: string,
+): { error: string; status: number } | null {
+  const expected = `Bearer ${secret}`;
+
+  if (authHeader.length !== expected.length) {
+    return { error: "Unauthorized", status: 401 };
+  }
+
+  const isValid = timingSafeEqual(Buffer.from(authHeader), Buffer.from(expected));
+
+  if (!isValid) {
+    return { error: "Unauthorized", status: 401 };
+  }
+
+  return null; // Valid
+}
+
+export { SIGNATURE_HEADER, MAX_AGE_SECONDS };

--- a/helm/optio/templates/network-policy.yaml
+++ b/helm/optio/templates/network-policy.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.networkPolicy.enabled }}
+# Default-deny NetworkPolicy for agent (repo) pods.
+# Restricts cluster-internal traffic so a compromised agent pod cannot
+# reach PostgreSQL, Redis, or other services directly. Only the Optio
+# API service is reachable on the cluster network.
+#
+# External egress (GitHub, npm registries, AI providers) is allowed on
+# port 443. DNS resolution is allowed on port 53.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-repo-pod-policy
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "optio.labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      optio.type: repo-pod
+  policyTypes:
+    - Ingress
+    - Egress
+  # Deny all ingress — repo pods do not serve traffic.
+  # The API communicates with them via kubectl exec (through the K8s API
+  # server / kubelet), which is not subject to NetworkPolicy.
+  ingress: []
+  egress:
+    # Allow DNS resolution (kube-dns / CoreDNS)
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow access to the Optio API service (credential endpoint, callbacks)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: optio-api
+      ports:
+        - protocol: TCP
+          port: {{ .Values.api.port | default 4000 }}
+    # Allow HTTPS to external services (GitHub, npm, AI providers, etc.)
+    - ports:
+        - protocol: TCP
+          port: 443
+    # Allow HTTP to external services (some registries, mirrors)
+    - ports:
+        - protocol: TCP
+          port: 80
+{{- end }}

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -139,6 +139,16 @@ agent:
       - ReadWriteOnce
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Network Policy
+# Default-deny policy for agent (repo) pods. Restricts cluster-internal
+# traffic so compromised pods cannot reach PostgreSQL, Redis, or other
+# services directly. Requires a CNI plugin that supports NetworkPolicy
+# (e.g. Calico, Cilium, Weave Net). Not supported on Docker Desktop.
+# ──────────────────────────────────────────────────────────────────────────────
+networkPolicy:
+  enabled: false  # Set to true when your cluster supports NetworkPolicy
+
+# ──────────────────────────────────────────────────────────────────────────────
 # PostgreSQL (built-in)
 # Set enabled=false and configure externalDatabase.url for managed Postgres.
 # ──────────────────────────────────────────────────────────────────────────────

--- a/scripts/optio-gh-wrapper
+++ b/scripts/optio-gh-wrapper
@@ -1,7 +1,17 @@
 #!/bin/bash
 # Wrapper for gh CLI — fetches a fresh GitHub token before each invocation.
 # Intended to be called as an alias/function, not as a replacement binary.
-export GITHUB_TOKEN=$(curl -sf -H "Authorization: Bearer ${OPTIO_CREDENTIAL_SECRET}" "${OPTIO_GIT_CREDENTIAL_URL}" | jq -r '.token')
+#
+# Authentication: HMAC-SHA256 signature over timestamp + request path.
+# The raw OPTIO_CREDENTIAL_SECRET never crosses the wire.
+
+# Extract path from URL and compute HMAC signature
+_ts=$(date +%s)
+_path=$(echo "${OPTIO_GIT_CREDENTIAL_URL}" | sed 's|^[a-z]*://[^/]*||')
+_sig=$(printf '%s.%s' "$_ts" "$_path" | openssl dgst -sha256 -hmac "${OPTIO_CREDENTIAL_SECRET}" | awk '{print $NF}')
+export GITHUB_TOKEN=$(curl -sf -H "X-Optio-Signature: t=${_ts},sig=${_sig}" "${OPTIO_GIT_CREDENTIAL_URL}" | jq -r '.token')
+unset _ts _path _sig
+
 # Resolve a path to its real target, with fallback if realpath is unavailable
 resolve_path() {
   realpath "$1" 2>/dev/null || readlink -f "$1" 2>/dev/null || echo "$1"

--- a/scripts/optio-git-credential
+++ b/scripts/optio-git-credential
@@ -1,12 +1,32 @@
 #!/bin/bash
 # Git credential helper — called by git with "get" on stdin.
 # Supports GitHub (via Optio credential API) and GitLab (via GITLAB_TOKEN env var).
+#
+# Authentication: HMAC-SHA256 signature over timestamp + request path.
+# The raw OPTIO_CREDENTIAL_SECRET never crosses the wire.
+
+# Compute HMAC-SHA256 signature for an Optio internal API request.
+# Usage: _optio_sign <full_url>
+# Outputs: t=<timestamp>,sig=<hex_hmac>
+_optio_sign() {
+  local url="$1"
+  local ts
+  ts=$(date +%s)
+  # Extract path (+ query string) from URL: strip scheme://host[:port]
+  local path
+  path=$(echo "$url" | sed 's|^[a-z]*://[^/]*||')
+  local sig
+  sig=$(printf '%s.%s' "$ts" "$path" | openssl dgst -sha256 -hmac "${OPTIO_CREDENTIAL_SECRET}" | awk '{print $NF}')
+  echo "t=${ts},sig=${sig}"
+}
+
 while IFS= read -r line; do
   case "$line" in host=*) host="${line#host=}";; esac
   [ -z "$line" ] && break
 done
 if [ "$host" = "github.com" ]; then
-  TOKEN=$(curl -sf -H "Authorization: Bearer ${OPTIO_CREDENTIAL_SECRET}" "${OPTIO_GIT_CREDENTIAL_URL}" | jq -r '.token')
+  SIG=$(_optio_sign "${OPTIO_GIT_CREDENTIAL_URL}")
+  TOKEN=$(curl -sf -H "X-Optio-Signature: ${SIG}" "${OPTIO_GIT_CREDENTIAL_URL}" | jq -r '.token')
   if [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ]; then
     echo "protocol=https"
     echo "host=github.com"


### PR DESCRIPTION
## Summary

- **Replace bearer token with HMAC-SHA256 request signing** for the `/api/internal/git-credentials` endpoint. Agent pods now compute `HMAC(secret, "{timestamp}.{path}")` and send the signature in the `X-Optio-Signature` header. The raw `OPTIO_CREDENTIAL_SECRET` never crosses the wire.
- **Add replay protection** — signatures expire after 5 minutes, preventing captured signatures from being reused.
- **Add default-deny NetworkPolicy** (opt-in via `networkPolicy.enabled`) that restricts repo pod cluster-internal traffic to only the API service, preventing compromised pods from reaching PostgreSQL, Redis, or other cluster services.
- **Maintain backward compatibility** with legacy Bearer token auth for pods running older agent images that haven't been rebuilt yet.

## What changed

| File | Change |
|------|--------|
| `apps/api/src/services/hmac-auth-service.ts` | New HMAC-SHA256 verification service with timestamp validation and timing-safe comparison |
| `apps/api/src/services/hmac-auth-service.test.ts` | 23 tests covering signature parsing, computation, verification, expiry, and backward compat |
| `apps/api/src/routes/github-app.ts` | Route handler now uses `verifyInternalRequest()` instead of inline bearer check |
| `apps/api/src/routes/github-app.test.ts` | Extended from 7 to 12 tests covering both HMAC and legacy Bearer auth paths |
| `apps/api/src/plugins/auth.ts` | Added documentation explaining why `/api/internal/*` is in PUBLIC_ROUTES |
| `scripts/optio-git-credential` | Computes HMAC signature with `openssl dgst` instead of sending raw secret |
| `scripts/optio-gh-wrapper` | Same HMAC signing for gh CLI wrapper |
| `helm/optio/templates/network-policy.yaml` | Default-deny NetworkPolicy for repo pods (DNS + API + HTTPS egress only) |
| `helm/optio/values.yaml` | Added `networkPolicy.enabled` (default false) |

## Security improvements

1. **Secret never sent over the wire** — HMAC proves possession of the secret without transmitting it
2. **Replay protection** — 5-minute timestamp window prevents captured signatures from being reused
3. **Path binding** — signatures include the request path, preventing reuse across endpoints
4. **Network isolation** — optional NetworkPolicy restricts pod egress to only necessary services

## Test plan

- [x] All 23 HMAC auth service tests pass (parsing, signing, verification, expiry, backward compat)
- [x] All 12 route handler tests pass (HMAC auth, legacy Bearer, error handling)
- [x] Full test suite passes (1154 API tests, 178 web tests, 202 shared tests)
- [x] TypeScript typecheck passes across all 7 packages
- [x] Prettier formatting check passes
- [ ] Verify agent pods can authenticate with new HMAC signing (requires deployed environment)
- [ ] Verify NetworkPolicy works when enabled (requires CNI plugin like Calico/Cilium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)