### PR TITLE
fix(security): stop leaking WebSocket auth tokens in URLs

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -122,11 +122,12 @@ async function authPlugin(app: FastifyInstance) {
       // Fall through to normal auth check
     }
 
-    // Token resolution order: Bearer header → session cookie → query param (WS)
+    // Token resolution order: Bearer header → session cookie
+    // Note: WebSocket auth is handled separately by authenticateWs() in ws-auth.ts
+    // using cookies and Sec-WebSocket-Protocol header (never URL query params).
     const token =
       parseBearer(req.headers.authorization) ??
-      parseCookie(req.headers.cookie, SESSION_COOKIE_NAME) ??
-      (req.query as Record<string, string>)?.token;
+      parseCookie(req.headers.cookie, SESSION_COOKIE_NAME);
 
     if (!token) {
       return reply.status(401).send({ error: "Authentication required" });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -68,7 +68,18 @@ export async function buildServer() {
     allowList: ["127.0.0.1", "::1"],
   });
   await app.register(formbody);
-  await app.register(websocket);
+  await app.register(websocket, {
+    options: {
+      // WebSocket auth tokens are sent via Sec-WebSocket-Protocol header to avoid
+      // leaking tokens in URLs. The client sends ["optio-ws-v1", "optio-auth-<TOKEN>"]
+      // and we select "optio-ws-v1" so the raw token is never echoed back.
+      handleProtocols: (protocols: Set<string>) => {
+        if (protocols.has("optio-ws-v1")) return "optio-ws-v1";
+        // No recognized protocol — select the first one offered (ws default behavior)
+        return protocols.values().next().value;
+      },
+    },
+  });
 
   // Auth plugin (validates session cookie on protected routes)
   await app.register(authPlugin);

--- a/apps/api/src/services/session-service.ts
+++ b/apps/api/src/services/session-service.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createHash } from "node:crypto";
+import { randomBytes, createHash, timingSafeEqual } from "node:crypto";
 import { db } from "../db/client.js";
 import { users, sessions } from "../db/schema.js";
 import { eq, and, gt, lt } from "drizzle-orm";
@@ -168,20 +168,40 @@ export async function createWsToken(userId: string): Promise<string> {
 }
 
 /**
+ * Find a WS upgrade token entry using timing-safe comparison.
+ *
+ * Iterates all entries and compares hashes with crypto.timingSafeEqual
+ * to prevent timing side-channel attacks. Returns the matching key and
+ * entry, or null if not found.
+ */
+function findWsTokenEntry(tokenHash: string): { key: string; entry: WsUpgradeEntry } | null {
+  const targetBuf = Buffer.from(tokenHash, "hex");
+  for (const [key, entry] of wsUpgradeTokens) {
+    const candidateBuf = Buffer.from(key, "hex");
+    if (candidateBuf.length === targetBuf.length && timingSafeEqual(candidateBuf, targetBuf)) {
+      return { key, entry };
+    }
+  }
+  return null;
+}
+
+/**
  * Validate and consume a single-use WebSocket upgrade token.
  * Returns the SessionUser on success (token is deleted), or null if
  * the token is invalid, expired, or already consumed.
+ *
+ * Uses timing-safe comparison and atomic delete-then-validate semantics.
  */
 export async function validateWsToken(token: string): Promise<SessionUser | null> {
   const tokenHash = hashToken(token);
-  const entry = wsUpgradeTokens.get(tokenHash);
+  const match = findWsTokenEntry(tokenHash);
 
-  if (!entry) return null;
+  if (!match) return null;
 
-  // Always delete — single use regardless of expiry check
-  wsUpgradeTokens.delete(tokenHash);
+  // Always delete — single use regardless of expiry check (atomic consume)
+  wsUpgradeTokens.delete(match.key);
 
-  if (entry.expiresAt <= Date.now()) return null;
+  if (match.entry.expiresAt <= Date.now()) return null;
 
   // Look up the user by ID
   const rows = await db
@@ -194,7 +214,7 @@ export async function validateWsToken(token: string): Promise<SessionUser | null
       defaultWorkspaceId: users.defaultWorkspaceId,
     })
     .from(users)
-    .where(eq(users.id, entry.userId))
+    .where(eq(users.id, match.entry.userId))
     .limit(1);
 
   if (rows.length === 0) return null;

--- a/apps/api/src/ws/optio-chat.ts
+++ b/apps/api/src/ws/optio-chat.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { getSettings } from "../services/optio-settings-service.js";
-import { authenticateWs } from "./ws-auth.js";
+import { authenticateWs, extractSessionToken } from "./ws-auth.js";
 import { logger } from "../logger.js";
 import {
   OPTIO_TOOL_SCHEMAS,
@@ -408,12 +408,10 @@ export async function optioChatWs(app: FastifyInstance) {
     activeConnections.set(userId, socket as unknown as WebSocket);
     log.info("Optio chat connected");
 
-    // Extract session token for tool execution (cookie or query param)
-    const cookieHeader = req.headers.cookie ?? "";
-    const sessionMatch = cookieHeader.match(/optio_session=([^;]+)/);
-    const sessionCookie = sessionMatch?.[1] ?? "";
-    const wsToken = (req.query as Record<string, string>)?.token ?? "";
-    const sessionToken = sessionCookie || wsToken;
+    // Extract session token for tool execution (cookie only — never URL query params).
+    // The upgrade token from Sec-WebSocket-Protocol is single-use and already consumed
+    // by authenticateWs(), so it cannot be reused for API passthrough.
+    const sessionToken = extractSessionToken(req) ?? "";
 
     let isProcessing = false;
     let abortController: AbortController | null = null;

--- a/apps/api/src/ws/ws-auth.test.ts
+++ b/apps/api/src/ws/ws-auth.test.ts
@@ -25,12 +25,21 @@ function createMockSocket() {
   };
 }
 
-function createMockRequest(opts: { cookie?: string; token?: string } = {}): FastifyRequest {
+function createMockRequest(
+  opts: { cookie?: string; token?: string; protocol?: string } = {},
+): FastifyRequest {
+  const headers: Record<string, string | undefined> = {
+    cookie: opts.cookie,
+  };
+  // Token via Sec-WebSocket-Protocol header (new secure approach)
+  if (opts.protocol) {
+    headers["sec-websocket-protocol"] = opts.protocol;
+  } else if (opts.token) {
+    headers["sec-websocket-protocol"] = `optio-ws-v1, optio-auth-${opts.token}`;
+  }
   return {
-    headers: {
-      cookie: opts.cookie,
-    },
-    query: opts.token ? { token: opts.token } : {},
+    headers,
+    query: {},
   } as unknown as FastifyRequest;
 }
 
@@ -91,7 +100,7 @@ describe("authenticateWs", () => {
     expect(socket.close).not.toHaveBeenCalled();
   });
 
-  it("validates query param token via validateWsToken (single-use)", async () => {
+  it("validates upgrade token from Sec-WebSocket-Protocol header via validateWsToken", async () => {
     const mockUser = {
       id: "user-2",
       provider: "google",
@@ -107,12 +116,27 @@ describe("authenticateWs", () => {
 
     expect(user).toEqual(mockUser);
     expect(mockValidateWsToken).toHaveBeenCalledWith("upgrade-token-456");
-    // Should NOT call validateSession for query param tokens (no cookie present)
+    // Should NOT call validateSession for protocol header tokens (no cookie present)
     expect(mockValidateSession).not.toHaveBeenCalled();
     expect(socket.close).not.toHaveBeenCalled();
   });
 
-  it("prefers cookie over query param", async () => {
+  it("does NOT read token from query param (security: tokens must not be in URLs)", async () => {
+    const socket = createMockSocket();
+    // Simulate old-style query param token — should be ignored
+    const req = {
+      headers: {},
+      query: { token: "leaked-token" },
+    } as unknown as FastifyRequest;
+
+    const user = await authenticateWs(socket as any, req);
+
+    expect(user).toBeNull();
+    expect(mockValidateWsToken).not.toHaveBeenCalled();
+    expect(socket.close).toHaveBeenCalledWith(4401, "Authentication required");
+  });
+
+  it("prefers cookie over protocol header token", async () => {
     const mockUser = {
       id: "user-3",
       provider: "github",
@@ -122,7 +146,7 @@ describe("authenticateWs", () => {
     };
     mockValidateSession.mockResolvedValue(mockUser);
     const socket = createMockSocket();
-    const req = createMockRequest({ cookie: "optio_session=fromcookie", token: "fromquery" });
+    const req = createMockRequest({ cookie: "optio_session=fromcookie", token: "fromprotocol" });
 
     await authenticateWs(socket as any, req);
 
@@ -131,7 +155,7 @@ describe("authenticateWs", () => {
     expect(mockValidateWsToken).not.toHaveBeenCalled();
   });
 
-  it("falls back to upgrade token when cookie is invalid", async () => {
+  it("falls back to protocol header token when cookie is invalid", async () => {
     const mockUser = {
       id: "user-4",
       provider: "github",
@@ -162,7 +186,7 @@ describe("authenticateWs", () => {
     expect(socket.close).toHaveBeenCalledWith(4401, "Invalid or expired session");
   });
 
-  it("closes socket when both cookie and upgrade token are invalid", async () => {
+  it("closes socket when both cookie and protocol header token are invalid", async () => {
     mockValidateSession.mockResolvedValue(null);
     mockValidateWsToken.mockResolvedValue(null);
     const socket = createMockSocket();
@@ -174,7 +198,7 @@ describe("authenticateWs", () => {
     expect(socket.close).toHaveBeenCalledWith(4401, "Invalid or expired session");
   });
 
-  it("closes socket when upgrade token alone is invalid", async () => {
+  it("closes socket when protocol header token alone is invalid", async () => {
     mockValidateWsToken.mockResolvedValue(null);
     const socket = createMockSocket();
     const req = createMockRequest({ token: "consumed-token" });
@@ -183,6 +207,39 @@ describe("authenticateWs", () => {
 
     expect(user).toBeNull();
     expect(socket.close).toHaveBeenCalledWith(4401, "Invalid or expired session");
+  });
+
+  it("extracts token from raw Sec-WebSocket-Protocol header with multiple protocols", async () => {
+    const mockUser = {
+      id: "user-5",
+      provider: "github",
+      email: "proto@example.com",
+      displayName: "Proto User",
+      avatarUrl: null,
+    };
+    mockValidateWsToken.mockResolvedValue(mockUser);
+    const socket = createMockSocket();
+    const req = createMockRequest({
+      protocol: "optio-ws-v1, optio-auth-abc123hex",
+    });
+
+    const user = await authenticateWs(socket as any, req);
+
+    expect(user).toEqual(mockUser);
+    expect(mockValidateWsToken).toHaveBeenCalledWith("abc123hex");
+  });
+
+  it("ignores Sec-WebSocket-Protocol header without optio-auth- prefix", async () => {
+    const socket = createMockSocket();
+    const req = createMockRequest({
+      protocol: "graphql-ws, some-other-protocol",
+    });
+
+    const user = await authenticateWs(socket as any, req);
+
+    expect(user).toBeNull();
+    expect(mockValidateWsToken).not.toHaveBeenCalled();
+    expect(socket.close).toHaveBeenCalledWith(4401, "Authentication required");
   });
 });
 
@@ -202,13 +259,16 @@ describe("extractSessionToken", () => {
     expect(extractSessionToken(req)).toBe("my-token");
   });
 
-  it("does NOT extract token from query param (security fix)", () => {
-    const req = createMockRequest({ token: "query-token" });
+  it("does NOT extract token from protocol header (cookie only)", () => {
+    const req = createMockRequest({ token: "protocol-token" });
     expect(extractSessionToken(req)).toBeUndefined();
   });
 
-  it("returns cookie token even when query param is present", () => {
-    const req = createMockRequest({ cookie: "optio_session=cookie-token", token: "query-token" });
+  it("returns cookie token even when protocol header is present", () => {
+    const req = createMockRequest({
+      cookie: "optio_session=cookie-token",
+      token: "protocol-token",
+    });
     expect(extractSessionToken(req)).toBe("cookie-token");
   });
 

--- a/apps/api/src/ws/ws-auth.ts
+++ b/apps/api/src/ws/ws-auth.ts
@@ -15,13 +15,49 @@ function parseCookie(header: string | undefined, name: string): string | undefin
   return match ? decodeURIComponent(match[1]) : undefined;
 }
 
+/** Prefix used in the Sec-WebSocket-Protocol header to carry upgrade tokens. */
+export const WS_AUTH_PROTOCOL_PREFIX = "optio-auth-";
+
+/** Fixed protocol name sent alongside the auth token during WebSocket upgrade. */
+export const WS_PROTOCOL_NAME = "optio-ws-v1";
+
+/**
+ * Extract a single-use upgrade token from the Sec-WebSocket-Protocol header.
+ *
+ * The client sends two subprotocols during the WebSocket upgrade:
+ *   ["optio-ws-v1", "optio-auth-<TOKEN>"]
+ *
+ * The server selects "optio-ws-v1" as the negotiated protocol (via handleProtocols
+ * in server.ts) so the raw token is never echoed back. This function extracts the
+ * token from the second subprotocol.
+ *
+ * This avoids putting tokens in URLs (which leak into logs, browser history, Referer
+ * headers, and proxy logs).
+ */
+function extractUpgradeTokenFromProtocol(req: FastifyRequest): string | undefined {
+  const protocolHeader = req.headers["sec-websocket-protocol"];
+  if (!protocolHeader || typeof protocolHeader !== "string") return undefined;
+
+  const protocols = protocolHeader.split(",").map((p) => p.trim());
+  for (const p of protocols) {
+    if (p.startsWith(WS_AUTH_PROTOCOL_PREFIX)) {
+      return p.slice(WS_AUTH_PROTOCOL_PREFIX.length);
+    }
+  }
+  return undefined;
+}
+
 /**
  * Authenticate a WebSocket connection.
  *
  * Two paths:
  *  1. Session cookie (`optio_session`) — validated against the sessions table.
- *  2. Single-use upgrade token (`?token=`) — validated and consumed from the
- *     in-memory WS token store (short-lived, ~30 s, one-time use).
+ *     Browsers send cookies on WebSocket upgrade requests automatically.
+ *  2. Single-use upgrade token via `Sec-WebSocket-Protocol` header — validated
+ *     and consumed from the in-memory WS token store (short-lived, ~30 s, one-time use).
+ *     Used for cross-origin setups where cookies are not available.
+ *
+ * Tokens are NEVER read from URL query params to prevent leaking into logs.
  *
  * Returns the session user on success, or null after closing the socket with code 4401.
  * When auth is disabled, returns a synthetic dev user.
@@ -47,11 +83,11 @@ export async function authenticateWs(
   if (cookieToken) {
     const user = await validateSession(cookieToken);
     if (user) return user;
-    // Cookie was present but invalid/expired — fall through to close
+    // Cookie was present but invalid/expired — fall through to protocol check
   }
 
-  // Path 2: single-use upgrade token via query param
-  const upgradeToken = (req.query as Record<string, string>)?.token;
+  // Path 2: single-use upgrade token via Sec-WebSocket-Protocol header
+  const upgradeToken = extractUpgradeTokenFromProtocol(req);
   if (upgradeToken) {
     const user = await validateWsToken(upgradeToken);
     if (user) return user;

--- a/apps/web/src/lib/ws-client.test.ts
+++ b/apps/web/src/lib/ws-client.test.ts
@@ -8,6 +8,7 @@ class MockWebSocket {
 
   readyState = MockWebSocket.OPEN;
   url: string;
+  protocols: string | string[] | undefined;
   onmessage: ((msg: { data: string }) => void) | null = null;
   onclose: ((ev: { code: number }) => void) | null = null;
   onerror: (() => void) | null = null;
@@ -17,8 +18,9 @@ class MockWebSocket {
   });
   send = vi.fn();
 
-  constructor(url: string) {
+  constructor(url: string, protocols?: string | string[]) {
     this.url = url;
+    this.protocols = protocols;
     MockWebSocket.instances.push(this);
   }
 }
@@ -151,7 +153,7 @@ describe("WsClient", () => {
     expect(ws.send).not.toHaveBeenCalled();
   });
 
-  it("uses token provider to build authenticated URL", async () => {
+  it("sends token via Sec-WebSocket-Protocol header, not URL", async () => {
     const tokenProvider = vi.fn().mockResolvedValue("test-token");
     const client = new WsClient("ws://localhost:4000/ws/events", tokenProvider);
     client.connect();
@@ -160,17 +162,23 @@ describe("WsClient", () => {
     await vi.runAllTimersAsync();
 
     expect(tokenProvider).toHaveBeenCalled();
-    expect(MockWebSocket.instances[0].url).toBe("ws://localhost:4000/ws/events?token=test-token");
+    const ws = MockWebSocket.instances[0];
+    // URL must NOT contain token (security: prevents token leaking into logs/history)
+    expect(ws.url).toBe("ws://localhost:4000/ws/events");
+    // Token must be sent via WebSocket subprotocol header
+    expect(ws.protocols).toEqual(["optio-ws-v1", "optio-auth-test-token"]);
   });
 
-  it("connects without token when provider returns null", async () => {
+  it("connects without protocols when provider returns null (cookie auth)", async () => {
     const tokenProvider = vi.fn().mockResolvedValue(null);
     const client = new WsClient("ws://localhost:4000/ws/events", tokenProvider);
     client.connect();
 
     await vi.runAllTimersAsync();
 
-    expect(MockWebSocket.instances[0].url).toBe("ws://localhost:4000/ws/events");
+    const ws = MockWebSocket.instances[0];
+    expect(ws.url).toBe("ws://localhost:4000/ws/events");
+    expect(ws.protocols).toBeUndefined();
   });
 
   it("retries connection when token provider fails", async () => {
@@ -187,6 +195,7 @@ describe("WsClient", () => {
     await vi.advanceTimersByTimeAsync(3000);
 
     expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].protocols).toEqual(["optio-ws-v1", "optio-auth-new-token"]);
   });
 
   it("closes socket on error event", () => {

--- a/apps/web/src/lib/ws-client.ts
+++ b/apps/web/src/lib/ws-client.ts
@@ -18,14 +18,13 @@ export class WsClient {
     if (this.ws?.readyState === WebSocket.OPEN) return;
 
     // If a token provider is set, fetch a token before connecting.
+    // Tokens are sent via the Sec-WebSocket-Protocol header (not URL query params)
+    // to prevent leaking into server logs, browser history, and Referer headers.
     if (this.tokenProvider) {
       this.tokenProvider()
         .then((token) => {
-          const sep = this.url.includes("?") ? "&" : "?";
-          const authedUrl = token
-            ? `${this.url}${sep}token=${encodeURIComponent(token)}`
-            : this.url;
-          this.openSocket(authedUrl);
+          const protocols = token ? ["optio-ws-v1", `optio-auth-${token}`] : undefined;
+          this.openSocket(this.url, protocols);
         })
         .catch(() => {
           // Token fetch failed — retry after delay
@@ -36,8 +35,8 @@ export class WsClient {
     }
   }
 
-  private openSocket(url: string): void {
-    this.ws = new WebSocket(url);
+  private openSocket(url: string, protocols?: string[]): void {
+    this.ws = protocols ? new WebSocket(url, protocols) : new WebSocket(url);
 
     this.ws.onmessage = (msg) => {
       try {


### PR DESCRIPTION
## Summary

- **Moved WebSocket auth tokens from URL query params to `Sec-WebSocket-Protocol` header** — tokens in URLs leak into nginx access logs, browser history, proxy logs, and Referer headers
- **Removed `req.query.token` fallback** from the global auth middleware and all WS handlers
- **Added `crypto.timingSafeEqual`** for WS upgrade token hash comparison to prevent timing side-channel attacks
- **Fixed optio-chat.ts** session token extraction to use cookie-only `extractSessionToken()` instead of reading from query params

## Details

### Token transport mechanism
The client now sends auth tokens via the WebSocket subprotocol negotiation:
```
Client: new WebSocket(url, ["optio-ws-v1", "optio-auth-<TOKEN>"])
Server: selects "optio-ws-v1" → raw token is never echoed back
```

The `handleProtocols` callback in `server.ts` ensures `optio-ws-v1` is selected as the negotiated protocol, so the auth token stays in the request headers only and is never included in the response.

### Auth flow (unchanged behavior, more secure transport)
1. **Primary**: Session cookie (`optio_session`) — browsers send it automatically on WS upgrade
2. **Fallback**: Single-use upgrade token via `Sec-WebSocket-Protocol` header — for cross-origin setups where cookies aren't available

### Files changed
| File | Change |
|------|--------|
| `apps/api/src/plugins/auth.ts` | Remove `req.query.token` from token resolution chain |
| `apps/api/src/ws/ws-auth.ts` | Extract token from `Sec-WebSocket-Protocol` header instead of query param |
| `apps/api/src/server.ts` | Configure `handleProtocols` to negotiate `optio-ws-v1` protocol |
| `apps/web/src/lib/ws-client.ts` | Send token via WebSocket protocols array, not URL |
| `apps/api/src/ws/optio-chat.ts` | Use `extractSessionToken()` (cookie only) for session passthrough |
| `apps/api/src/services/session-service.ts` | Add `crypto.timingSafeEqual` for WS token hash lookup |
| `apps/api/src/ws/ws-auth.test.ts` | Updated tests for protocol-based auth |
| `apps/web/src/lib/ws-client.test.ts` | Updated tests to verify tokens go via protocol, not URL |

## Test plan

- [x] All 1129 API tests pass (76 test files)
- [x] All web tests pass
- [x] TypeScript typecheck passes across all packages
- [x] Formatting passes (Prettier)
- [x] Pre-commit hooks pass (lint-staged, format, typecheck)
- [ ] Verify WebSocket connections work in local dev (cookie auth)
- [ ] Verify WebSocket connections work in cross-origin setup (protocol auth)
- [ ] Verify old clients with `?token=` in URL are properly rejected (not silently accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)