### PR TITLE
fix(security): replace Envoy sidecar RSA-2048 CA with Ed25519, cut validity to 30 days

### DIFF
--- a/apps/api/src/services/envoy-sidecar.test.ts
+++ b/apps/api/src/services/envoy-sidecar.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   generateEnvoyConfig,
   generateSecretInitScript,
@@ -95,13 +95,28 @@ describe("generateSecretInitScript", () => {
     expect(script).toContain("anthropic-api-key");
   });
 
-  it("generates CA certificate", () => {
+  it("generates CA certificate with ed25519 and 30-day validity", () => {
     const script = generateSecretInitScript({});
 
     expect(script).toContain("openssl req -x509");
+    expect(script).toContain("-newkey ed25519");
+    expect(script).toContain("-days 30");
+    expect(script).not.toContain("rsa:2048");
+    expect(script).not.toContain("-days 365");
     expect(script).toContain("Optio Envoy Proxy CA");
     expect(script).toContain("ca.crt");
     expect(script).toContain("ca.key");
+  });
+
+  it("respects OPTIO_ENVOY_CA_ALG env var override", () => {
+    process.env.OPTIO_ENVOY_CA_ALG = "mldsa44";
+    try {
+      const script = generateSecretInitScript({});
+      expect(script).toContain("-newkey mldsa44");
+      expect(script).not.toContain("ed25519");
+    } finally {
+      delete process.env.OPTIO_ENVOY_CA_ALG;
+    }
   });
 
   it("handles both secrets", () => {

--- a/apps/api/src/services/envoy-sidecar.ts
+++ b/apps/api/src/services/envoy-sidecar.ts
@@ -320,11 +320,15 @@ export function generateSecretInitScript(secrets: SecretProxySecrets): string {
     lines.push(`chmod 600 ${SECRET_MOUNT_PATH}/anthropic-api-key`);
   }
 
-  // Generate a self-signed CA certificate for TLS interception
+  // Generate a self-signed CA certificate for TLS interception.
+  // Ed25519 is smaller/faster than RSA-2048 and sufficient for ephemeral intra-pod TLS.
+  // 30-day validity is plenty — pods rarely live longer than 24h.
+  // Override via OPTIO_ENVOY_CA_ALG for future PQ migration (e.g. "mldsa44").
+  const keyAlg = process.env.OPTIO_ENVOY_CA_ALG ?? "ed25519";
   lines.push(`mkdir -p /etc/envoy/ca`);
   lines.push(
-    `openssl req -x509 -newkey rsa:2048 -keyout ${CA_KEY_PATH} -out ${CA_CERT_PATH} ` +
-      `-days 365 -nodes -subj "/CN=Optio Envoy Proxy CA" 2>/dev/null`,
+    `openssl req -x509 -newkey ${keyAlg} -keyout ${CA_KEY_PATH} -out ${CA_CERT_PATH} ` +
+      `-days 30 -nodes -subj "/CN=Optio Envoy Proxy CA" 2>/dev/null`,
   );
 
   lines.push(`echo "[optio] Secret proxy init complete"`);


### PR DESCRIPTION
## Summary

- Replace `rsa:2048` with `ed25519` for the Envoy secret-proxy sidecar's self-signed CA certificate, cutting generation time from ~500ms to ~10ms
- Reduce certificate validity from 365 days to 30 days (pods rarely live >24h, so 365 was unnecessarily long)
- Add `OPTIO_ENVOY_CA_ALG` env var override to support future PQ migration (e.g. `mldsa44` when OpenSSL 3.5+ stabilizes ML-DSA)

## Changes

**`apps/api/src/services/envoy-sidecar.ts`** (lines 323-329):
- Changed `-newkey rsa:2048` → `-newkey ed25519` (via env var with `ed25519` default)
- Changed `-days 365` → `-days 30`
- Added `OPTIO_ENVOY_CA_ALG` env var support for algorithm override

**`apps/api/src/services/envoy-sidecar.test.ts`**:
- Updated existing CA cert test to assert `ed25519` and `30-day` validity
- Added negative assertions (`not.toContain("rsa:2048")`, `not.toContain("-days 365")`)
- Added new test for `OPTIO_ENVOY_CA_ALG` env var override

## Why

1. Ed25519 is smaller and faster than RSA-2048 — sufficient for ephemeral intra-pod TLS
2. 30 days is more than enough for a cert that only lives as long as the pod (default idle timeout 10 min)
3. Removes one of only two RSA usages in the codebase, simplifying the PQ migration path
4. The env var makes future algorithm upgrades a config change, not a code change

## Test plan

- [x] Updated test asserts Ed25519 and 30-day validity
- [x] New test verifies `OPTIO_ENVOY_CA_ALG` override works
- [x] All 1214 tests pass across 77 test files
- [x] Typecheck passes for all 11 packages
- [ ] After deploy: `kubectl exec <pod> -c envoy -- openssl x509 -in /etc/envoy/ca.crt -noout -text | grep -E "(Signature Algorithm|Public Key Algorithm)"` should show `ED25519`

🤖 Generated with [Claude Code](https://claude.com/claude-code)