### PR TITLE
docs(security): document Kubernetes 1.33+ as minimum for PQ TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ You create a task          Optio runs the agent           Optio closes the loop
 
 ### Prerequisites
 
+- **Kubernetes v1.33+** — required for post-quantum TLS on the control plane. v1.33 is the first release built on Go 1.24, which enables hybrid X25519MLKEM768 key exchange automatically. Earlier versions run but do not negotiate post-quantum TLS between Optio and the Kubernetes API server.
 - **Docker Desktop** with Kubernetes enabled (Settings → Kubernetes → Enable)
 - **Node.js 22+** and **pnpm 10+**
 - **Helm** (`brew install helm`)

--- a/docs/pq-readiness.md
+++ b/docs/pq-readiness.md
@@ -1,0 +1,46 @@
+# Post-Quantum TLS Readiness
+
+Kubernetes v1.33 (April 2025) is the first release built on Go 1.24. Go 1.24's `crypto/tls` includes `X25519MLKEM768` as a default TLS 1.3 key share when `Config.CurvePreferences` is nil — which Kubernetes does not override. This means on K8s >= 1.33, every Go-based control plane component (API server, kubelet, controllers) negotiates hybrid post-quantum TLS automatically.
+
+Optio pins **Kubernetes >= 1.33** as the minimum supported version (enforced by the Helm chart's `kubeVersion` constraint) so that the Optio API pod's communication with `kube-apiserver` is PQ-hybrid by default.
+
+## PQ status by network leg
+
+| Leg                            | Protocol                                | PQ Status                                    | Notes                                                                                          |
+| ------------------------------ | --------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Optio API pod → kube-apiserver | TLS 1.3 (via `@kubernetes/client-node`) | **PQ-hybrid on K8s >= 1.33**                 | Go 1.24 enables X25519MLKEM768 automatically; the Node.js client connects to a Go-based server |
+| Web browser → Optio Web UI     | TLS 1.3 (via ingress/load balancer)     | Depends on ingress controller and client     | Configure your ingress controller and TLS termination to support PQ key exchange               |
+| Web browser → Optio API        | TLS 1.3 (via ingress/load balancer)     | Depends on ingress controller and client     | Same as above                                                                                  |
+| Optio API → PostgreSQL         | TLS (optional, per connection string)   | Not PQ by default                            | Requires PQ-capable PostgreSQL TLS configuration                                               |
+| Optio API → Redis              | TLS (optional, per connection string)   | Not PQ by default                            | Requires PQ-capable Redis TLS configuration                                                    |
+| Agent pod → GitHub API         | TLS 1.3                                 | Depends on GitHub server support             | GitHub controls server-side TLS negotiation                                                    |
+| kubelet → kube-apiserver       | mTLS 1.3                                | **PQ-hybrid on K8s >= 1.33**                 | Both sides are Go 1.24+ binaries                                                               |
+| kube-apiserver → etcd          | mTLS 1.3                                | **PQ-hybrid if etcd is built with Go 1.24+** | etcd v3.6+ ships with Go 1.24                                                                  |
+
+## Verification
+
+From inside the Optio API pod on a K8s 1.33+ cluster:
+
+```bash
+kubectl exec deploy/optio-api -- node -e '
+const https = require("https");
+const fs = require("fs");
+const req = https.get({
+  hostname: "kubernetes.default.svc",
+  port: 443,
+  path: "/version",
+  ca: fs.readFileSync("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"),
+  headers: { Authorization: "Bearer " + fs.readFileSync("/var/run/secrets/kubernetes.io/serviceaccount/token", "utf8") },
+}, (res) => {
+  console.log("TLS group:", res.socket.getEphemeralKeyInfo?.()?.name);
+  res.on("data", () => {});
+});
+req.on("error", console.error);
+'
+# Expected on K8s 1.33+: TLS group: x25519_mlkem768
+```
+
+## References
+
+- [Kubernetes Blog: Post-Quantum Cryptography in Kubernetes](https://kubernetes.io/blog/2025/07/18/pqc-in-k8s/)
+- [Go 1.24 release notes — crypto/tls](https://go.dev/doc/go1.24#cryptotls)

--- a/helm/optio/Chart.yaml
+++ b/helm/optio/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: optio
 description: AI Agent Workflow Orchestration
+kubeVersion: ">=1.33.0"
 type: application
 version: 0.1.0
 appVersion: "0.1.0"

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -21,6 +21,20 @@ if ! kubectl cluster-info >/dev/null 2>&1; then
   exit 1
 fi
 
+# Check Kubernetes version (v1.33+ required for post-quantum TLS)
+K8S_SERVER_VERSION=$(kubectl version --output=json 2>/dev/null | grep -o '"gitVersion":"v[0-9]*\.[0-9]*' | tail -1 | grep -o '[0-9]*\.[0-9]*')
+if [ -n "$K8S_SERVER_VERSION" ]; then
+  K8S_MAJOR=$(echo "$K8S_SERVER_VERSION" | cut -d. -f1)
+  K8S_MINOR=$(echo "$K8S_SERVER_VERSION" | cut -d. -f2)
+  if [ "$K8S_MAJOR" -lt 1 ] || { [ "$K8S_MAJOR" -eq 1 ] && [ "$K8S_MINOR" -lt 33 ]; }; then
+    echo "⚠ WARNING: Kubernetes v${K8S_SERVER_VERSION} detected. Optio requires v1.33+ for"
+    echo "  post-quantum TLS on the control plane. v1.33 is the first release built on"
+    echo "  Go 1.24, which enables hybrid X25519MLKEM768 key exchange automatically."
+    echo "  Update Docker Desktop or your cluster to Kubernetes v1.33+."
+    echo ""
+  fi
+fi
+
 echo "[1/6] Installing dependencies..."
 pnpm install
 


### PR DESCRIPTION
## Summary

- **Helm chart**: Added `kubeVersion: ">=1.33.0"` to `Chart.yaml` so `helm install` fails fast on older clusters that lack post-quantum TLS support
- **README**: Added Kubernetes v1.33+ as a prerequisite with explanation of why (Go 1.24's automatic X25519MLKEM768 key exchange)
- **docs/pq-readiness.md**: New document with a table of all network legs and their PQ TLS status, plus a verification command
- **setup-local.sh**: Added a runtime warning when the local cluster is below v1.33

## Context

Kubernetes v1.33 (April 2025) is the first release built on Go 1.24. Go 1.24's `crypto/tls` includes `X25519MLKEM768` as a default TLS 1.3 key share, meaning the Optio API pod's communication with `kube-apiserver` gets hybrid post-quantum TLS automatically on v1.33+ clusters. Pinning this as the minimum supported version makes the control plane leg defensibly PQ-ready.

## Test plan

- [x] `bash -n scripts/setup-local.sh` — shell syntax valid
- [x] `pnpm turbo typecheck` — all 11 packages pass
- [x] `pnpm turbo test` — all 1213 tests pass (77 test files)
- [x] Prettier formatting passes
- [ ] `helm lint helm/optio --set encryption.key=test` — verify kubeVersion constraint is valid (helm not available in CI container, but the YAML is straightforward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)