### PR TITLE
feat(observability): add TLS key-exchange group logging per upstream

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { startPrWatcherWorker } from "./workers/pr-watcher-worker.js";
 import { startWebhookWorker } from "./workers/webhook-worker.js";
 import { startScheduleWorker } from "./workers/schedule-worker.js";
 import { logger } from "./logger.js";
+import { logTlsStackInfo, initTlsObservability } from "./services/tls-observability.js";
 
 const redisConnection = {
   url: process.env.REDIS_URL ?? "redis://localhost:6379",
@@ -102,6 +103,10 @@ async function main() {
   // dev tasks (e.g. @optio/web never starting).
   await app.listen({ port: PORT, host: HOST });
   logger.info(`API server listening on ${HOST}:${PORT}`);
+
+  // Log TLS stack info and start observing negotiated key-exchange groups
+  logTlsStackInfo();
+  initTlsObservability();
 
   // --- Background initialization (after listen) ---
 

--- a/apps/api/src/services/tls-observability.test.ts
+++ b/apps/api/src/services/tls-observability.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the logger
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+// Track subscriptions registered via diagnostics_channel
+const subscribers = new Map<string, (...args: any[]) => void>();
+vi.mock("node:diagnostics_channel", () => ({
+  default: {
+    subscribe: vi.fn((name: string, handler: (...args: any[]) => void) => {
+      subscribers.set(name, handler);
+    }),
+  },
+}));
+
+import { logger } from "../logger.js";
+import {
+  initTlsObservability,
+  getTlsGroupCounts,
+  resetTlsGroupCounts,
+  logTlsStackInfo,
+} from "./tls-observability.js";
+
+describe("tls-observability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    subscribers.clear();
+    resetTlsGroupCounts();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("logTlsStackInfo", () => {
+    it("logs Node version, OpenSSL version, and PQ readiness", () => {
+      logTlsStackInfo();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeVersion: process.version,
+          opensslVersion: process.versions.openssl,
+          pqReady: expect.any(Boolean),
+        }),
+        "TLS stack",
+      );
+    });
+  });
+
+  describe("initTlsObservability", () => {
+    it("subscribes to undici:client:connected diagnostics channel", () => {
+      initTlsObservability();
+
+      expect(subscribers.has("undici:client:connected")).toBe(true);
+    });
+
+    it("records key-exchange group from connected socket", () => {
+      initTlsObservability();
+
+      const handler = subscribers.get("undici:client:connected")!;
+      handler({
+        socket: {
+          getEphemeralKeyInfo: () => ({ name: "X25519MLKEM768" }),
+        },
+        connectParams: { host: "api.github.com" },
+      });
+
+      const counts = getTlsGroupCounts();
+      expect(counts).toEqual([{ host: "api.github.com", group: "X25519MLKEM768", count: 1 }]);
+    });
+
+    it("increments count for repeated connections to same host+group", () => {
+      initTlsObservability();
+
+      const handler = subscribers.get("undici:client:connected")!;
+      const event = {
+        socket: {
+          getEphemeralKeyInfo: () => ({ name: "X25519" }),
+        },
+        connectParams: { host: "api.anthropic.com" },
+      };
+      handler(event);
+      handler(event);
+      handler(event);
+
+      const counts = getTlsGroupCounts();
+      expect(counts).toEqual([{ host: "api.anthropic.com", group: "X25519", count: 3 }]);
+    });
+
+    it("tracks different groups for the same host separately", () => {
+      initTlsObservability();
+
+      const handler = subscribers.get("undici:client:connected")!;
+      handler({
+        socket: { getEphemeralKeyInfo: () => ({ name: "X25519MLKEM768" }) },
+        connectParams: { host: "api.github.com" },
+      });
+      handler({
+        socket: { getEphemeralKeyInfo: () => ({ name: "X25519" }) },
+        connectParams: { host: "api.github.com" },
+      });
+
+      const counts = getTlsGroupCounts();
+      expect(counts).toHaveLength(2);
+      expect(counts).toContainEqual({ host: "api.github.com", group: "X25519MLKEM768", count: 1 });
+      expect(counts).toContainEqual({ host: "api.github.com", group: "X25519", count: 1 });
+    });
+
+    it("uses 'unknown' when getEphemeralKeyInfo is not available", () => {
+      initTlsObservability();
+
+      const handler = subscribers.get("undici:client:connected")!;
+      handler({
+        socket: {},
+        connectParams: { host: "example.com" },
+      });
+
+      const counts = getTlsGroupCounts();
+      expect(counts).toEqual([{ host: "example.com", group: "unknown", count: 1 }]);
+    });
+
+    it("uses 'unknown' when host is not available", () => {
+      initTlsObservability();
+
+      const handler = subscribers.get("undici:client:connected")!;
+      handler({
+        socket: { getEphemeralKeyInfo: () => ({ name: "X25519" }) },
+        connectParams: {},
+      });
+
+      const counts = getTlsGroupCounts();
+      expect(counts).toEqual([{ host: "unknown", group: "X25519", count: 1 }]);
+    });
+  });
+
+  describe("resetTlsGroupCounts", () => {
+    it("clears all recorded counts", () => {
+      initTlsObservability();
+
+      const handler = subscribers.get("undici:client:connected")!;
+      handler({
+        socket: { getEphemeralKeyInfo: () => ({ name: "X25519" }) },
+        connectParams: { host: "api.github.com" },
+      });
+
+      expect(getTlsGroupCounts()).toHaveLength(1);
+
+      resetTlsGroupCounts();
+      expect(getTlsGroupCounts()).toHaveLength(0);
+    });
+  });
+});

--- a/apps/api/src/services/tls-observability.ts
+++ b/apps/api/src/services/tls-observability.ts
@@ -1,0 +1,102 @@
+import diagnosticsChannel from "node:diagnostics_channel";
+import { logger } from "../logger.js";
+
+/**
+ * Per-connection TLS key-exchange group counter.
+ * Key format: "host|group"
+ */
+const counter = new Map<string, number>();
+
+let flushInterval: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * Log the TLS stack info at API startup: Node version, OpenSSL version,
+ * and whether the OpenSSL version supports post-quantum key exchange.
+ */
+export function logTlsStackInfo(): void {
+  const opensslVersion = process.versions.openssl ?? "unknown";
+  // OpenSSL >= 3.5.0 ships X25519MLKEM768 by default
+  const pqReady = compareVersions(opensslVersion, "3.5.0") >= 0;
+
+  logger.info(
+    {
+      nodeVersion: process.version,
+      opensslVersion,
+      pqReady,
+    },
+    "TLS stack",
+  );
+}
+
+/**
+ * Subscribe to undici's diagnostics channel to observe TLS key-exchange
+ * groups negotiated per upstream connection. Logs a periodic summary.
+ */
+export function initTlsObservability(): void {
+  diagnosticsChannel.subscribe("undici:client:connected", ({ socket, connectParams }: any) => {
+    const host: string = connectParams?.host ?? "unknown";
+    const group: string = (socket as any)?.getEphemeralKeyInfo?.()?.name ?? "unknown";
+    const key = `${host}|${group}`;
+    counter.set(key, (counter.get(key) ?? 0) + 1);
+  });
+
+  // Flush observed groups to structured logs every 60 seconds
+  flushInterval = setInterval(() => {
+    flushTlsGroupLogs();
+  }, 60_000);
+
+  // Allow the process to exit even if the interval is active
+  if (flushInterval.unref) {
+    flushInterval.unref();
+  }
+}
+
+/**
+ * Flush current TLS group observations to structured logs and clear counters.
+ */
+function flushTlsGroupLogs(): void {
+  for (const [key, count] of counter) {
+    const [host, group] = key.split("|");
+    logger.debug({ host, group, count }, "tls_group_observed");
+  }
+  counter.clear();
+}
+
+/**
+ * Return a snapshot of current TLS group counts (for testing and metrics).
+ */
+export function getTlsGroupCounts(): Array<{
+  host: string;
+  group: string;
+  count: number;
+}> {
+  const result: Array<{ host: string; group: string; count: number }> = [];
+  for (const [key, count] of counter) {
+    const [host, group] = key.split("|");
+    result.push({ host, group, count });
+  }
+  return result;
+}
+
+/**
+ * Clear all recorded TLS group counts.
+ */
+export function resetTlsGroupCounts(): void {
+  counter.clear();
+}
+
+/**
+ * Compare two semver-like version strings (e.g. "3.5.0" vs "3.4.1").
+ * Returns negative if a < b, 0 if equal, positive if a > b.
+ */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (na !== nb) return na - nb;
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Adds a TLS stack info log at API startup showing Node version, OpenSSL version, and post-quantum readiness (`pqReady` flag based on OpenSSL >= 3.5.0)
- Creates `tls-observability.ts` service that subscribes to undici's `diagnostics_channel` to count negotiated TLS key-exchange groups (e.g. `X25519MLKEM768` vs `X25519`) per upstream host
- Flushes observed group counts to structured debug logs every 60 seconds, providing visibility into which upstreams (GitHub, Anthropic, Slack, etc.) negotiate hybrid PQ key exchange
- Exposes `getTlsGroupCounts()` for future Prometheus metric integration

## Test plan

- [x] 8 unit tests covering: startup log output, diagnostics channel subscription, counter incrementing, multi-host/multi-group tracking, missing socket info fallbacks, and counter reset
- [x] All 1221 existing tests pass (78 test files)
- [x] TypeScript typecheck clean across all 11 packages
- [x] Prettier formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)