### PR TITLE
fix(security): enforce OpenSSL >= 3.5 for post-quantum TLS across all images

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -28,6 +28,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# Verify Node ships OpenSSL >= 3.5 for post-quantum TLS (X25519MLKEM768)
+RUN node -e 'const [maj,min] = process.versions.openssl.split(".").map(Number); if (maj < 3 || (maj === 3 && min < 5)) { console.error("OpenSSL " + process.versions.openssl + " too old; need >= 3.5"); process.exit(1); }'
+
 RUN npm install -g @anthropic-ai/claude-code
 
 # Allow sudo for extra package installation at runtime

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -26,6 +26,9 @@ FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091c
 ARG OPTIO_VERSION=dev
 ENV OPTIO_VERSION=${OPTIO_VERSION}
 
+# Verify Node ships OpenSSL >= 3.5 for post-quantum TLS (X25519MLKEM768)
+RUN node -e 'const [maj,min] = process.versions.openssl.split(".").map(Number); if (maj < 3 || (maj === 3 && min < 5)) { console.error("OpenSSL " + process.versions.openssl + " too old; need >= 3.5"); process.exit(1); }'
+
 # Install tsx globally for TypeScript execution at runtime
 # (workspace packages export .ts source, so the API runs via tsx)
 RUN npm install -g tsx

--- a/Dockerfile.optio
+++ b/Dockerfile.optio
@@ -15,6 +15,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# Verify Node ships OpenSSL >= 3.5 for post-quantum TLS (X25519MLKEM768)
+RUN node -e 'const [maj,min] = process.versions.openssl.split(".").map(Number); if (maj < 3 || (maj === 3 && min < 5)) { console.error("OpenSSL " + process.versions.openssl + " too old; need >= 3.5"); process.exit(1); }'
+
 # Claude Code
 RUN npm install -g @anthropic-ai/claude-code
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -41,6 +41,9 @@ ENV OPTIO_VERSION=${OPTIO_VERSION}
 
 WORKDIR /app
 
+# Verify Node ships OpenSSL >= 3.5 for post-quantum TLS (X25519MLKEM768)
+RUN node -e 'const [maj,min] = process.versions.openssl.split(".").map(Number); if (maj < 3 || (maj === 3 && min < 5)) { console.error("OpenSSL " + process.versions.openssl + " too old; need >= 3.5"); process.exit(1); }'
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 

--- a/apps/api/src/openssl-check.test.ts
+++ b/apps/api/src/openssl-check.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { assertMinOpenSSL } from "./openssl-check.js";
+
+describe("assertMinOpenSSL", () => {
+  it("throws for OpenSSL 1.x", () => {
+    expect(() => assertMinOpenSSL("1.1.1")).toThrow(
+      "OpenSSL 1.1.1 is too old for post-quantum TLS",
+    );
+  });
+
+  it("throws for OpenSSL 3.0.x", () => {
+    expect(() => assertMinOpenSSL("3.0.15")).toThrow(
+      "OpenSSL 3.0.15 is too old for post-quantum TLS",
+    );
+  });
+
+  it("throws for OpenSSL 3.4.x", () => {
+    expect(() => assertMinOpenSSL("3.4.1")).toThrow(
+      "OpenSSL 3.4.1 is too old for post-quantum TLS",
+    );
+  });
+
+  it("passes for OpenSSL 3.5.0", () => {
+    expect(() => assertMinOpenSSL("3.5.0")).not.toThrow();
+  });
+
+  it("passes for OpenSSL 3.5.4", () => {
+    expect(() => assertMinOpenSSL("3.5.4")).not.toThrow();
+  });
+
+  it("passes for OpenSSL 3.6.0", () => {
+    expect(() => assertMinOpenSSL("3.6.0")).not.toThrow();
+  });
+
+  it("passes for OpenSSL 4.0.0", () => {
+    expect(() => assertMinOpenSSL("4.0.0")).not.toThrow();
+  });
+
+  it("includes upgrade instructions in error message", () => {
+    expect(() => assertMinOpenSSL("3.0.0")).toThrow("Upgrade to Node 22+ with OpenSSL 3.5+");
+  });
+});

--- a/apps/api/src/openssl-check.ts
+++ b/apps/api/src/openssl-check.ts
@@ -1,0 +1,17 @@
+/**
+ * Assert that the runtime OpenSSL version is >= 3.5.0.
+ *
+ * Node 22+ bundles OpenSSL 3.5.x which negotiates hybrid post-quantum
+ * X25519MLKEM768 key agreement by default in TLS 1.3 handshakes.
+ * Refusing to start on older versions ensures all outbound fetch() calls
+ * (GitHub, Anthropic, Slack, etc.) benefit from PQ key agreement when
+ * the upstream supports it.
+ */
+export function assertMinOpenSSL(version: string): void {
+  const [maj, min] = version.split(".").map(Number);
+  if (maj < 3 || (maj === 3 && min < 5)) {
+    throw new Error(
+      `OpenSSL ${version} is too old for post-quantum TLS. Upgrade to Node 22+ with OpenSSL 3.5+.`,
+    );
+  }
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,3 +1,4 @@
+import { assertMinOpenSSL } from "./openssl-check.js";
 import Fastify, { type FastifyError } from "fastify";
 import { Redis } from "ioredis";
 import cors from "@fastify/cors";
@@ -50,6 +51,8 @@ const loggerConfig =
     : { level: process.env.LOG_LEVEL ?? "info" };
 
 export async function buildServer() {
+  assertMinOpenSSL(process.versions.openssl);
+
   const app = Fastify({ logger: loggerConfig });
 
   // Plugins

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -29,6 +29,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# Verify Node ships OpenSSL >= 3.5 for post-quantum TLS (X25519MLKEM768)
+RUN node -e 'const [maj,min] = process.versions.openssl.split(".").map(Number); if (maj < 3 || (maj === 3 && min < 5)) { console.error("OpenSSL " + process.versions.openssl + " too old; need >= 3.5"); process.exit(1); }'
+
 # pnpm (installed globally before switching to non-root user)
 RUN corepack enable && corepack prepare pnpm@10 --activate
 


### PR DESCRIPTION
## Summary

- Add **build-time assertions** to all container Dockerfiles (`Dockerfile.api`, `Dockerfile.web`, `Dockerfile.agent`, `Dockerfile.optio`, `images/base.Dockerfile`) that fail the build if the Node.js runtime ships OpenSSL < 3.5.0
- Add a **runtime assertion** in the API server (`openssl-check.ts` called from `server.ts`) that refuses to start on OpenSSL < 3.5
- Add **unit tests** for the OpenSSL version check logic (8 test cases covering edge cases)

Node 22+ bundles OpenSSL 3.5.x which negotiates hybrid post-quantum X25519MLKEM768 key agreement by default in TLS 1.3 handshakes. These guards ensure all outbound `fetch()` calls (GitHub, Anthropic, Slack, etc.) benefit from PQ key exchange when the upstream supports it.

The `images/base.Dockerfile` assertion also covers all derived agent images (`node`, `python`, `go`, `rust`, `full`, `dind`) since they inherit from the base image.

## Test plan

- [x] All 8 `openssl-check.test.ts` tests pass (covers OpenSSL 1.x, 3.0–3.4, 3.5, 3.6, 4.0)
- [x] Full test suite passes (1221 tests across 78 files)
- [x] Typecheck passes across all 11 packages
- [ ] Verify Docker builds succeed: `docker build -t optio-api:latest -f Dockerfile.api .`
- [ ] Verify assertion works: `docker run --rm optio-api:latest node -e 'console.log(process.versions.openssl, process.version)'` should show `3.5.x 22.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)