### PR TITLE
feat(security): introduce Signer/Verifier interface for crypto-agility

### DIFF
--- a/apps/api/src/routes/tickets.test.ts
+++ b/apps/api/src/routes/tickets.test.ts
@@ -10,27 +10,27 @@ describe("verifyGitHubSignature", () => {
     return "sha256=" + createHmac("sha256", key).update(payload).digest("hex");
   }
 
-  it("accepts a valid signature", () => {
+  it("accepts a valid signature", async () => {
     const signature = sign(body, secret);
-    expect(verifyGitHubSignature(body, signature, secret)).toBe(true);
+    expect(await verifyGitHubSignature(body, signature, secret)).toBe(true);
   });
 
-  it("rejects a signature computed with the wrong secret", () => {
+  it("rejects a signature computed with the wrong secret", async () => {
     const signature = sign(body, "wrong-secret");
-    expect(verifyGitHubSignature(body, signature, secret)).toBe(false);
+    expect(await verifyGitHubSignature(body, signature, secret)).toBe(false);
   });
 
-  it("rejects a completely invalid signature string", () => {
-    expect(verifyGitHubSignature(body, "sha256=invalid", secret)).toBe(false);
+  it("rejects a completely invalid signature string", async () => {
+    expect(await verifyGitHubSignature(body, "sha256=invalid", secret)).toBe(false);
   });
 
-  it("rejects when body differs from what was signed", () => {
+  it("rejects when body differs from what was signed", async () => {
     const signature = sign(Buffer.from("different body"), secret);
-    expect(verifyGitHubSignature(body, signature, secret)).toBe(false);
+    expect(await verifyGitHubSignature(body, signature, secret)).toBe(false);
   });
 
-  it("rejects a signature with wrong length", () => {
-    expect(verifyGitHubSignature(body, "sha256=abc", secret)).toBe(false);
+  it("rejects a signature with wrong length", async () => {
+    expect(await verifyGitHubSignature(body, "sha256=abc", secret)).toBe(false);
   });
 });
 

--- a/apps/api/src/routes/tickets.ts
+++ b/apps/api/src/routes/tickets.ts
@@ -1,6 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { eq } from "drizzle-orm";
-import { createHmac, timingSafeEqual } from "node:crypto";
 import { Readable } from "node:stream";
 import { db } from "../db/client.js";
 import { ticketProviders } from "../db/schema.js";
@@ -8,6 +7,7 @@ import { TaskState } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
 import { syncAllTickets } from "../services/ticket-sync-service.js";
 import { storeSecret, deleteSecret } from "../services/secret-service.js";
+import { HmacSha256Verifier } from "../services/crypto/signer.js";
 import { logger } from "../logger.js";
 
 /** Fields per provider type that contain credentials and must be encrypted. */
@@ -23,11 +23,21 @@ const WEBHOOK_MAX_AGE_MINUTES = 5;
 /**
  * Verify the HMAC-SHA256 signature sent by GitHub in the X-Hub-Signature-256
  * header against the raw request body and the configured secret.
+ *
+ * Uses HmacSha256Verifier to centralize constant-time comparison.
  */
-export function verifyGitHubSignature(rawBody: Buffer, signature: string, secret: string): boolean {
-  const expected = "sha256=" + createHmac("sha256", secret).update(rawBody).digest("hex");
-  if (expected.length !== signature.length) return false;
-  return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+export async function verifyGitHubSignature(
+  rawBody: Buffer,
+  signature: string,
+  secret: string,
+): Promise<boolean> {
+  // GitHub sends "sha256=<hex>" — strip the prefix and decode the hex digest
+  const prefix = "sha256=";
+  if (!signature.startsWith(prefix)) return false;
+  const sigBytes = Buffer.from(signature.slice(prefix.length), "hex");
+
+  const verifier = new HmacSha256Verifier(secret);
+  return verifier.verify(rawBody, sigBytes);
 }
 
 /**
@@ -132,7 +142,7 @@ export async function ticketRoutes(app: FastifyInstance) {
       }
 
       const rawBody = (req as any).rawBody as Buffer;
-      if (!verifyGitHubSignature(rawBody, signature, webhookSecret)) {
+      if (!(await verifyGitHubSignature(rawBody, signature, webhookSecret))) {
         logger.warn("Webhook signature verification failed");
         return reply.status(401).send({ error: "Invalid signature" });
       }

--- a/apps/api/src/services/crypto/signer.test.ts
+++ b/apps/api/src/services/crypto/signer.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { createHmac, generateKeyPairSync, createSign, createVerify } from "node:crypto";
+import {
+  Rs256Signer,
+  HmacSha256Signer,
+  HmacSha256Verifier,
+  MlDsa65Signer,
+  NotImplementedError,
+} from "./signer.js";
+
+// ---------------------------------------------------------------------------
+// Test RSA key pair (generated once, used across RS256 tests)
+// ---------------------------------------------------------------------------
+const { privateKey: rsaPrivateKey, publicKey: rsaPublicKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+});
+const rsaPem = rsaPrivateKey.export({ type: "pkcs8", format: "pem" }) as string;
+
+// ---------------------------------------------------------------------------
+// Rs256Signer
+// ---------------------------------------------------------------------------
+describe("Rs256Signer", () => {
+  it("has kty 'rsa-sha256' and jwtAlg 'RS256'", () => {
+    const signer = new Rs256Signer(rsaPem);
+    expect(signer.kty).toBe("rsa-sha256");
+    expect(signer.jwtAlg).toBe("RS256");
+  });
+
+  it("produces a valid RSA-SHA256 signature", async () => {
+    const signer = new Rs256Signer(rsaPem);
+    const message = Buffer.from("header.payload");
+    const signature = await signer.sign(message);
+
+    // Verify with Node's built-in verifier
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(message);
+    expect(verifier.verify(rsaPublicKey, signature)).toBe(true);
+  });
+
+  it("produces different signatures for different messages", async () => {
+    const signer = new Rs256Signer(rsaPem);
+    const sig1 = await signer.sign(Buffer.from("message-1"));
+    const sig2 = await signer.sign(Buffer.from("message-2"));
+    expect(sig1.equals(sig2)).toBe(false);
+  });
+
+  it("accepts a PEM string", async () => {
+    const signer = new Rs256Signer(rsaPem);
+    const sig = await signer.sign(Buffer.from("test"));
+    expect(sig.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HmacSha256Signer
+// ---------------------------------------------------------------------------
+describe("HmacSha256Signer", () => {
+  const secret = "test-secret";
+
+  it("has kty 'hmac-sha256' and no jwtAlg", () => {
+    const signer = new HmacSha256Signer(secret);
+    expect(signer.kty).toBe("hmac-sha256");
+    expect(signer.jwtAlg).toBeUndefined();
+  });
+
+  it("produces the same output as createHmac", async () => {
+    const signer = new HmacSha256Signer(secret);
+    const message = Buffer.from("hello world");
+    const result = await signer.sign(message);
+
+    const expected = createHmac("sha256", secret).update(message).digest();
+    expect(result.equals(expected)).toBe(true);
+  });
+
+  it("produces a 32-byte digest", async () => {
+    const signer = new HmacSha256Signer(secret);
+    const result = await signer.sign(Buffer.from("data"));
+    expect(result.length).toBe(32);
+  });
+
+  it("produces different signatures for different secrets", async () => {
+    const signer1 = new HmacSha256Signer("secret-1");
+    const signer2 = new HmacSha256Signer("secret-2");
+    const message = Buffer.from("same message");
+    const sig1 = await signer1.sign(message);
+    const sig2 = await signer2.sign(message);
+    expect(sig1.equals(sig2)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HmacSha256Verifier
+// ---------------------------------------------------------------------------
+describe("HmacSha256Verifier", () => {
+  const secret = "verify-secret";
+
+  it("has kty 'hmac-sha256'", () => {
+    const verifier = new HmacSha256Verifier(secret);
+    expect(verifier.kty).toBe("hmac-sha256");
+  });
+
+  it("accepts a valid HMAC signature", async () => {
+    const message = Buffer.from("payload");
+    const signature = createHmac("sha256", secret).update(message).digest();
+    const verifier = new HmacSha256Verifier(secret);
+    expect(await verifier.verify(message, signature)).toBe(true);
+  });
+
+  it("rejects a signature from the wrong secret", async () => {
+    const message = Buffer.from("payload");
+    const signature = createHmac("sha256", "wrong-secret").update(message).digest();
+    const verifier = new HmacSha256Verifier(secret);
+    expect(await verifier.verify(message, signature)).toBe(false);
+  });
+
+  it("rejects a signature with wrong length", async () => {
+    const verifier = new HmacSha256Verifier(secret);
+    expect(await verifier.verify(Buffer.from("data"), Buffer.from("short"))).toBe(false);
+  });
+
+  it("rejects a tampered message", async () => {
+    const message = Buffer.from("original");
+    const signature = createHmac("sha256", secret).update(message).digest();
+    const verifier = new HmacSha256Verifier(secret);
+    expect(await verifier.verify(Buffer.from("tampered"), signature)).toBe(false);
+  });
+
+  it("round-trips with HmacSha256Signer", async () => {
+    const signer = new HmacSha256Signer(secret);
+    const verifier = new HmacSha256Verifier(secret);
+    const message = Buffer.from("round-trip test");
+    const signature = await signer.sign(message);
+    expect(await verifier.verify(message, signature)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MlDsa65Signer (stub)
+// ---------------------------------------------------------------------------
+describe("MlDsa65Signer", () => {
+  it("has kty 'ml-dsa-65' and jwtAlg 'ML-DSA-65'", () => {
+    const signer = new MlDsa65Signer();
+    expect(signer.kty).toBe("ml-dsa-65");
+    expect(signer.jwtAlg).toBe("ML-DSA-65");
+  });
+
+  it("throws NotImplementedError on sign", async () => {
+    const signer = new MlDsa65Signer();
+    await expect(signer.sign(Buffer.from("test"))).rejects.toThrow(NotImplementedError);
+    await expect(signer.sign(Buffer.from("test"))).rejects.toThrow(
+      "ML-DSA-65 is not yet supported",
+    );
+  });
+});

--- a/apps/api/src/services/crypto/signer.ts
+++ b/apps/api/src/services/crypto/signer.ts
@@ -1,0 +1,95 @@
+/**
+ * Crypto-agility: Signer / Verifier interfaces and concrete implementations.
+ *
+ * Today only RSA-SHA256 (for GitHub App JWTs) and HMAC-SHA256 (for webhooks)
+ * are wired in. The interface is designed so that adding ML-DSA-65 or a hybrid
+ * scheme later is a single-file change.
+ */
+import { createHmac, createPrivateKey, createSign, timingSafeEqual } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SignerKty = "rsa-sha256" | "hmac-sha256" | "ml-dsa-65" | "hybrid-rsa-mldsa";
+
+export interface Signer {
+  readonly kty: SignerKty;
+  /** JWT `alg` header value, e.g. "RS256". Undefined for MAC-only signers. */
+  readonly jwtAlg?: string;
+  sign(message: Buffer): Promise<Buffer>;
+}
+
+export interface Verifier {
+  readonly kty: SignerKty;
+  /** MUST use timingSafeEqual for MAC-based verification. */
+  verify(message: Buffer, signature: Buffer): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// RSA-SHA256 (GitHub App JWT)
+// ---------------------------------------------------------------------------
+
+export class Rs256Signer implements Signer {
+  readonly kty: SignerKty = "rsa-sha256";
+  readonly jwtAlg = "RS256";
+
+  private readonly key: ReturnType<typeof createPrivateKey>;
+
+  constructor(privateKey: string | Buffer) {
+    this.key = createPrivateKey(privateKey);
+  }
+
+  async sign(message: Buffer): Promise<Buffer> {
+    const signer = createSign("RSA-SHA256");
+    signer.update(message);
+    return signer.sign(this.key);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HMAC-SHA256 (webhooks)
+// ---------------------------------------------------------------------------
+
+export class HmacSha256Signer implements Signer {
+  readonly kty: SignerKty = "hmac-sha256";
+  readonly jwtAlg = undefined;
+
+  constructor(private readonly secret: string | Buffer) {}
+
+  async sign(message: Buffer): Promise<Buffer> {
+    return createHmac("sha256", this.secret).update(message).digest();
+  }
+}
+
+export class HmacSha256Verifier implements Verifier {
+  readonly kty: SignerKty = "hmac-sha256";
+
+  constructor(private readonly secret: string | Buffer) {}
+
+  async verify(message: Buffer, signature: Buffer): Promise<boolean> {
+    const expected = createHmac("sha256", this.secret).update(message).digest();
+    if (expected.length !== signature.length) return false;
+    return timingSafeEqual(expected, signature);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ML-DSA-65 stub (not yet available in Node's crypto)
+// ---------------------------------------------------------------------------
+
+export class NotImplementedError extends Error {
+  constructor(algorithm: string) {
+    super(`${algorithm} is not yet supported — waiting for Node.js crypto support`);
+    this.name = "NotImplementedError";
+  }
+}
+
+export class MlDsa65Signer implements Signer {
+  readonly kty: SignerKty = "ml-dsa-65";
+  readonly jwtAlg = "ML-DSA-65";
+
+  async sign(_message: Buffer): Promise<Buffer> {
+    throw new NotImplementedError("ML-DSA-65");
+  }
+}

--- a/apps/api/src/services/github-app-service.ts
+++ b/apps/api/src/services/github-app-service.ts
@@ -1,4 +1,6 @@
-import { createPrivateKey, createSign } from "node:crypto";
+import type { Signer } from "./crypto/signer.js";
+import { Rs256Signer, MlDsa65Signer } from "./crypto/signer.js";
+import { logger } from "../logger.js";
 
 let cachedToken: { token: string; expiresAt: number } | null = null;
 let installationTokenLock: Promise<string> | null = null;
@@ -13,25 +15,38 @@ export function isGitHubAppConfigured(): boolean {
   );
 }
 
-// Cache the parsed key object to avoid re-parsing on every JWT generation
-let _privateKeyObj: ReturnType<typeof createPrivateKey> | null = null;
+// Cache the signer instance so the private key is only parsed once
+let _appSigner: Signer | null = null;
 
-function getPrivateKey(): ReturnType<typeof createPrivateKey> {
-  if (!_privateKeyObj) {
-    const rawKey = process.env.GITHUB_APP_PRIVATE_KEY!;
-    // createPrivateKey handles PKCS#1 (BEGIN RSA PRIVATE KEY),
-    // PKCS#8 (BEGIN PRIVATE KEY), and OpenSSH (BEGIN OPENSSH PRIVATE KEY) formats
-    _privateKeyObj = createPrivateKey(rawKey);
+export function loadAppSigner(): Signer {
+  if (_appSigner) return _appSigner;
+
+  const alg = process.env.GITHUB_APP_JWT_ALG ?? "RS256";
+  switch (alg) {
+    case "RS256":
+      _appSigner = new Rs256Signer(process.env.GITHUB_APP_PRIVATE_KEY!);
+      break;
+    // Future: case "ML-DSA-65": _appSigner = new MlDsa65Signer(); break;
+    default:
+      throw new Error(`Unsupported GitHub App JWT algorithm: ${alg}`);
   }
-  return _privateKeyObj;
+
+  logger.info(
+    { githubAppJwtKty: _appSigner.kty, githubAppJwtAlg: _appSigner.jwtAlg },
+    "Signer configuration",
+  );
+
+  return _appSigner;
 }
 
-export function generateJwt(): string {
+export async function generateJwt(): Promise<string> {
   const appId = process.env.GITHUB_APP_ID!;
-  const key = getPrivateKey();
+  const signer = loadAppSigner();
 
   const now = Math.floor(Date.now() / 1000);
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const header = Buffer.from(
+    JSON.stringify({ alg: signer.jwtAlg ?? "RS256", typ: "JWT" }),
+  ).toString("base64url");
   const payload = Buffer.from(
     JSON.stringify({
       iss: appId,
@@ -40,9 +55,8 @@ export function generateJwt(): string {
     }),
   ).toString("base64url");
 
-  const signer = createSign("RSA-SHA256");
-  signer.update(`${header}.${payload}`);
-  const signature = signer.sign(key, "base64url");
+  const sigBuf = await signer.sign(Buffer.from(`${header}.${payload}`));
+  const signature = sigBuf.toString("base64url");
 
   return `${header}.${payload}.${signature}`;
 }
@@ -71,7 +85,7 @@ async function fetchInstallationToken(): Promise<string> {
   }
 
   const installationId = process.env.GITHUB_APP_INSTALLATION_ID!;
-  const jwt = generateJwt();
+  const jwt = await generateJwt();
 
   const res = await fetch(
     `https://api.github.com/app/installations/${installationId}/access_tokens`,
@@ -97,5 +111,5 @@ async function fetchInstallationToken(): Promise<string> {
 export function resetTokenCache(): void {
   cachedToken = null;
   installationTokenLock = null;
-  _privateKeyObj = null;
+  _appSigner = null;
 }

--- a/apps/api/src/services/github-token-service.test.ts
+++ b/apps/api/src/services/github-token-service.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { generateKeyPairSync, createVerify } from "node:crypto";
 
+vi.mock("../logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
 // Generate a test RSA key pair
 const { publicKey, privateKey } = generateKeyPairSync("rsa", {
   modulusLength: 2048,
@@ -60,22 +64,25 @@ describe("github-app-service", () => {
   });
 
   describe("generateJwt", () => {
-    it("produces a valid RS256 JWT with three parts", () => {
-      const jwt = generateJwt();
+    it("produces a valid RS256 JWT with three parts", async () => {
+      resetTokenCache();
+      const jwt = await generateJwt();
       const parts = jwt.split(".");
       expect(parts).toHaveLength(3);
     });
 
-    it("has correct header with RS256 algorithm", () => {
-      const jwt = generateJwt();
+    it("has correct header with RS256 algorithm", async () => {
+      resetTokenCache();
+      const jwt = await generateJwt();
       const [headerB64] = jwt.split(".");
       const header = JSON.parse(Buffer.from(headerB64, "base64url").toString());
       expect(header).toEqual({ alg: "RS256", typ: "JWT" });
     });
 
-    it("has correct payload claims", () => {
+    it("has correct payload claims", async () => {
+      resetTokenCache();
       const now = Math.floor(Date.now() / 1000);
-      const jwt = generateJwt();
+      const jwt = await generateJwt();
       const [, payloadB64] = jwt.split(".");
       const payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
 
@@ -88,8 +95,9 @@ describe("github-app-service", () => {
       expect(payload.exp).toBeLessThanOrEqual(now + 602);
     });
 
-    it("signature is verifiable with the public key", () => {
-      const jwt = generateJwt();
+    it("signature is verifiable with the public key", async () => {
+      resetTokenCache();
+      const jwt = await generateJwt();
       const [headerB64, payloadB64, signatureB64] = jwt.split(".");
       const verifier = createVerify("RSA-SHA256");
       verifier.update(`${headerB64}.${payloadB64}`);

--- a/apps/api/src/services/webhook-service.test.ts
+++ b/apps/api/src/services/webhook-service.test.ts
@@ -89,31 +89,31 @@ function makeDbRowWithSecret(secret: string, overrides: Record<string, unknown> 
 }
 
 describe("signPayload", () => {
-  it("produces a valid HMAC-SHA256 hex signature", () => {
+  it("produces a valid HMAC-SHA256 hex signature", async () => {
     const payload = JSON.stringify({ event: "task.completed", data: { taskId: "123" } });
     const secret = "test-secret-key";
-    const signature = signPayload(payload, secret);
+    const signature = await signPayload(payload, secret);
 
     const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
     expect(signature).toBe(expected);
   });
 
-  it("produces different signatures for different secrets", () => {
+  it("produces different signatures for different secrets", async () => {
     const payload = JSON.stringify({ event: "task.completed" });
-    const sig1 = signPayload(payload, "secret-1");
-    const sig2 = signPayload(payload, "secret-2");
+    const sig1 = await signPayload(payload, "secret-1");
+    const sig2 = await signPayload(payload, "secret-2");
     expect(sig1).not.toBe(sig2);
   });
 
-  it("produces different signatures for different payloads", () => {
+  it("produces different signatures for different payloads", async () => {
     const secret = "same-secret";
-    const sig1 = signPayload(JSON.stringify({ event: "task.completed" }), secret);
-    const sig2 = signPayload(JSON.stringify({ event: "task.failed" }), secret);
+    const sig1 = await signPayload(JSON.stringify({ event: "task.completed" }), secret);
+    const sig2 = await signPayload(JSON.stringify({ event: "task.failed" }), secret);
     expect(sig1).not.toBe(sig2);
   });
 
-  it("returns a 64-character hex string", () => {
-    const signature = signPayload("test", "secret");
+  it("returns a 64-character hex string", async () => {
+    const signature = await signPayload("test", "secret");
     expect(signature).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/apps/api/src/services/webhook-service.ts
+++ b/apps/api/src/services/webhook-service.ts
@@ -1,9 +1,9 @@
-import crypto from "node:crypto";
 import { eq, desc } from "drizzle-orm";
 import { assertSsrfSafe } from "../utils/ssrf.js";
 import { db } from "../db/client.js";
 import { webhooks, webhookDeliveries } from "../db/schema.js";
 import { encrypt, decrypt } from "./secret-service.js";
+import { HmacSha256Signer } from "./crypto/signer.js";
 import { logger } from "../logger.js";
 
 export type WebhookEvent =
@@ -134,8 +134,10 @@ export async function getWebhookDeliveries(webhookId: string, opts?: { limit?: n
 /**
  * Sign a payload using HMAC-SHA256 with the webhook's secret.
  */
-export function signPayload(payload: string, secret: string): string {
-  return crypto.createHmac("sha256", secret).update(payload).digest("hex");
+export async function signPayload(payload: string, secret: string): Promise<string> {
+  const signer = new HmacSha256Signer(secret);
+  const sig = await signer.sign(Buffer.from(payload));
+  return sig.toString("hex");
 }
 
 /**
@@ -247,7 +249,7 @@ export async function deliverWebhook(
   };
 
   if (webhook.secret) {
-    headers["X-Optio-Signature"] = signPayload(payloadStr, webhook.secret);
+    headers["X-Optio-Signature"] = await signPayload(payloadStr, webhook.secret);
   }
 
   let statusCode: number | undefined;


### PR DESCRIPTION
## Summary

- **Introduce `Signer` / `Verifier` interfaces** (`apps/api/src/services/crypto/signer.ts`) with four concrete implementations: `Rs256Signer`, `HmacSha256Signer`, `HmacSha256Verifier`, and `MlDsa65Signer` (stub for future PQ support)
- **Refactor `github-app-service.ts`** to use `Rs256Signer` via `loadAppSigner()`, with env-configurable algorithm (`GITHUB_APP_JWT_ALG`) and startup logging of active signer config
- **Refactor `tickets.ts`** webhook signature verification to use `HmacSha256Verifier`, centralizing constant-time comparison via `timingSafeEqual`
- **Refactor `webhook-service.ts`** `signPayload` to use `HmacSha256Signer` instead of direct `crypto.createHmac` calls

## Motivation

This is a zero-behavior-change refactor that decouples signature algorithms from call sites. When ML-DSA-65 or hybrid PQ schemes land in Node.js crypto (expected Node 26 LTS), swapping algorithms becomes a single-file change rather than a grep-and-replace across the codebase. Also centralizes `timingSafeEqual` usage for MAC verification, making it impossible to accidentally introduce non-constant-time comparisons in new webhook handlers (relates to #311).

## Test plan

- [x] 16 new unit tests for all signer/verifier implementations (`signer.test.ts`)
- [x] Updated existing tests for `github-token-service`, `tickets`, and `webhook-service` to work with now-async signature functions
- [x] Full test suite passes (1229 tests across 78 files)
- [x] Typecheck passes across all packages
- [x] Formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)