### PR TITLE
fix(security): enable TLS for in-cluster Postgres (sslmode=verify-full)

### DIFF
--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -1,10 +1,12 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema.js";
+import { parseSslConfig } from "./ssl.js";
 
 const connectionString =
   process.env.DATABASE_URL ?? "postgres://optio:optio_dev@localhost:5432/optio";
 
-const sql = postgres(connectionString);
+const sslConfig = parseSslConfig(connectionString);
+const sql = postgres(connectionString, sslConfig ? { ssl: sslConfig } : {});
 export const db = drizzle(sql, { schema });
 export type Database = typeof db;

--- a/apps/api/src/db/ssl.test.ts
+++ b/apps/api/src/db/ssl.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockReadFileSync = vi.fn();
+vi.mock("node:fs", () => ({
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+}));
+
+import { parseSslConfig } from "./ssl.js";
+
+describe("parseSslConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns undefined when sslmode is absent", () => {
+    expect(parseSslConfig("postgres://u:p@host:5432/db")).toBeUndefined();
+  });
+
+  it("returns undefined for sslmode=disable", () => {
+    expect(parseSslConfig("postgres://u:p@host:5432/db?sslmode=disable")).toBeUndefined();
+  });
+
+  it("returns undefined for sslmode=allow", () => {
+    expect(parseSslConfig("postgres://u:p@host:5432/db?sslmode=allow")).toBeUndefined();
+  });
+
+  it("returns rejectUnauthorized=false for sslmode=require", () => {
+    expect(parseSslConfig("postgres://u:p@host:5432/db?sslmode=require")).toEqual({
+      rejectUnauthorized: false,
+    });
+  });
+
+  it("returns rejectUnauthorized=false for sslmode=prefer", () => {
+    expect(parseSslConfig("postgres://u:p@host:5432/db?sslmode=prefer")).toEqual({
+      rejectUnauthorized: false,
+    });
+  });
+
+  it("returns rejectUnauthorized=true for sslmode=verify-full without sslrootcert", () => {
+    expect(parseSslConfig("postgres://u:p@host:5432/db?sslmode=verify-full")).toEqual({
+      rejectUnauthorized: true,
+    });
+  });
+
+  it("returns rejectUnauthorized=true for sslmode=verify-ca without sslrootcert", () => {
+    expect(parseSslConfig("postgres://u:p@host:5432/db?sslmode=verify-ca")).toEqual({
+      rejectUnauthorized: true,
+    });
+  });
+
+  it("reads CA cert file for sslmode=verify-full with sslrootcert", () => {
+    mockReadFileSync.mockReturnValue(
+      "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----",
+    );
+    const result = parseSslConfig(
+      "postgres://u:p@host:5432/db?sslmode=verify-full&sslrootcert=/etc/optio/pg-ca.crt",
+    );
+    expect(mockReadFileSync).toHaveBeenCalledWith("/etc/optio/pg-ca.crt", "utf-8");
+    expect(result).toEqual({
+      rejectUnauthorized: true,
+      ca: "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----",
+    });
+  });
+
+  it("reads CA cert file for sslmode=verify-ca with sslrootcert", () => {
+    mockReadFileSync.mockReturnValue("ca-cert-data");
+    const result = parseSslConfig(
+      "postgres://u:p@host:5432/db?sslmode=verify-ca&sslrootcert=/path/ca.crt",
+    );
+    expect(mockReadFileSync).toHaveBeenCalledWith("/path/ca.crt", "utf-8");
+    expect(result).toEqual({
+      rejectUnauthorized: true,
+      ca: "ca-cert-data",
+    });
+  });
+
+  it("returns undefined for unparseable URLs", () => {
+    expect(parseSslConfig("not-a-valid-url")).toBeUndefined();
+  });
+});

--- a/apps/api/src/db/ssl.ts
+++ b/apps/api/src/db/ssl.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import type { TlsOptions } from "node:tls";
+
+/**
+ * Parse SSL/TLS configuration from a PostgreSQL connection string.
+ *
+ * Reads `sslmode` and `sslrootcert` query parameters and returns
+ * TLS options suitable for the postgres driver's `ssl` option.
+ *
+ * - absent / `disable` / `allow` → undefined (no SSL)
+ * - `require` / `prefer`         → { rejectUnauthorized: false }
+ * - `verify-ca` / `verify-full`  → { rejectUnauthorized: true, ca? }
+ */
+export function parseSslConfig(connStr: string): TlsOptions | undefined {
+  let url: URL;
+  try {
+    url = new URL(connStr);
+  } catch {
+    return undefined;
+  }
+
+  const sslmode = url.searchParams.get("sslmode");
+  if (!sslmode || sslmode === "disable" || sslmode === "allow") {
+    return undefined;
+  }
+
+  if (sslmode === "verify-full" || sslmode === "verify-ca") {
+    const sslrootcert = url.searchParams.get("sslrootcert");
+    const opts: TlsOptions = { rejectUnauthorized: true };
+    if (sslrootcert) {
+      opts.ca = readFileSync(sslrootcert, "utf-8");
+    }
+    return opts;
+  }
+
+  // sslmode=require or sslmode=prefer — encrypted but no cert verification
+  return { rejectUnauthorized: false };
+}

--- a/helm/optio/templates/_helpers.tpl
+++ b/helm/optio/templates/_helpers.tpl
@@ -13,7 +13,12 @@ Database URL
 */}}
 {{- define "optio.databaseUrl" -}}
 {{- if .Values.postgresql.enabled -}}
-postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgres:5432/{{ .Values.postgresql.auth.database }}
+{{- $base := printf "postgres://%s:%s@%s-postgres:5432/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password .Release.Name .Values.postgresql.auth.database -}}
+{{- if .Values.postgresql.tls.enabled -}}
+{{- printf "%s?sslmode=verify-full&sslrootcert=/etc/optio/pg-ca.crt" $base -}}
+{{- else -}}
+{{- $base -}}
+{{- end -}}
 {{- else -}}
 {{- required "externalDatabase.url is required when postgresql.enabled=false" .Values.externalDatabase.url -}}
 {{- end -}}

--- a/helm/optio/templates/api-deployment.yaml
+++ b/helm/optio/templates/api-deployment.yaml
@@ -62,6 +62,11 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if and .Values.postgresql.enabled .Values.postgresql.tls.enabled }}
+            - name: pg-ca
+              mountPath: /etc/optio
+              readOnly: true
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ .Release.Name }}-config
@@ -99,6 +104,14 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if and .Values.postgresql.enabled .Values.postgresql.tls.enabled }}
+        - name: pg-ca
+          secret:
+            secretName: {{ .Release.Name }}-postgres-tls
+            items:
+              - key: ca.crt
+                path: pg-ca.crt
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/optio/templates/postgres-tls.yaml
+++ b/helm/optio/templates/postgres-tls.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.postgresql.enabled .Values.postgresql.tls.enabled }}
+{{/*
+  Generate a self-signed CA and server certificate for the in-cluster Postgres.
+  On first install genCA/genSignedCert create fresh certs.
+  On upgrade, existing certs are reused via lookup so connections are not broken.
+*/}}
+{{- $secretName := printf "%s-postgres-tls" .Release.Name -}}
+{{- $svcName := printf "%s-postgres" .Release.Name -}}
+{{- $svcFQDN := printf "%s-postgres.%s.svc.cluster.local" .Release.Name .Values.namespace -}}
+{{- $existing := lookup "v1" "Secret" .Values.namespace $secretName -}}
+{{- if $existing }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "optio.labels" . | nindent 4 }}
+type: Opaque
+data:
+  tls.crt: {{ index $existing.data "tls.crt" }}
+  tls.key: {{ index $existing.data "tls.key" }}
+  ca.crt: {{ index $existing.data "ca.crt" }}
+{{- else }}
+{{- $ca := genCA "optio-postgres-ca" 3650 -}}
+{{- $cert := genSignedCert $svcName (list "127.0.0.1") (list $svcName $svcFQDN "localhost") 3650 $ca -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "optio.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  tls.crt: |
+    {{ $cert.Cert | nindent 4 }}
+  tls.key: |
+    {{ $cert.Key | nindent 4 }}
+  ca.crt: |
+    {{ $ca.Cert | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/helm/optio/templates/postgres.yaml
+++ b/helm/optio/templates/postgres.yaml
@@ -46,6 +46,29 @@ spec:
         runAsUser: 999
         runAsGroup: 999
         fsGroup: 999
+      {{- if .Values.postgresql.tls.enabled }}
+      initContainers:
+        - name: init-tls
+          image: busybox:1.36
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command: ['sh', '-c']
+          args:
+            - |
+              cp /tls-secret/tls.crt /etc/postgres-tls/tls.crt
+              cp /tls-secret/tls.key /etc/postgres-tls/tls.key
+              chmod 600 /etc/postgres-tls/tls.key
+              chmod 644 /etc/postgres-tls/tls.crt
+          volumeMounts:
+            - name: tls-secret
+              mountPath: /tls-secret
+              readOnly: true
+            - name: postgres-tls
+              mountPath: /etc/postgres-tls
+      {{- end }}
       containers:
         - name: postgres
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
@@ -54,6 +77,17 @@ spec:
             capabilities:
               drop:
                 - ALL
+          {{- if .Values.postgresql.tls.enabled }}
+          args:
+            - "-c"
+            - "ssl=on"
+            - "-c"
+            - "ssl_cert_file=/etc/postgres-tls/tls.crt"
+            - "-c"
+            - "ssl_key_file=/etc/postgres-tls/tls.key"
+            - "-c"
+            - "ssl_min_protocol_version=TLSv1.3"
+          {{- end }}
           env:
             - name: POSTGRES_DB
               value: {{ .Values.postgresql.auth.database }}
@@ -69,12 +103,26 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+            {{- if .Values.postgresql.tls.enabled }}
+            - name: postgres-tls
+              mountPath: /etc/postgres-tls
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.postgresql.resources | nindent 12 }}
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-postgres-data
+        {{- if .Values.postgresql.tls.enabled }}
+        - name: tls-secret
+          secret:
+            secretName: {{ .Release.Name }}-postgres-tls
+        - name: postgres-tls
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -171,6 +171,11 @@ postgresql:
     username: optio
     # REQUIRED when auth is enabled. Override this in production.
     password: ""
+  # TLS encryption for the in-cluster Postgres connection.
+  # When enabled, a self-signed CA + server cert are generated at install time
+  # and the DATABASE_URL is configured with sslmode=verify-full.
+  tls:
+    enabled: true
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Redis (built-in)


### PR DESCRIPTION
## Summary

- **Enable TLS encryption** for the in-cluster Postgres deployment, closing the plaintext data-in-transit gap on the cluster network (including decrypted secret values from the `secrets` table)
- **Generate self-signed CA + server cert** at Helm install time via `genCA`/`genSignedCert`, with `lookup`-based reuse on upgrades to avoid breaking connections
- **Configure the API's DB client** to parse `sslmode` and `sslrootcert` from `DATABASE_URL` and pass proper TLS options to the postgres driver

## Changes

| File | What |
|------|------|
| `helm/optio/templates/postgres-tls.yaml` | New template: generates self-signed CA + server cert as a K8s Secret, reuses existing certs on upgrade |
| `helm/optio/templates/postgres.yaml` | Adds init container to copy certs with correct permissions (0600), enables `ssl=on` with TLS 1.3 minimum |
| `helm/optio/templates/api-deployment.yaml` | Mounts CA cert at `/etc/optio/pg-ca.crt` for verify-full validation |
| `helm/optio/templates/_helpers.tpl` | Appends `?sslmode=verify-full&sslrootcert=/etc/optio/pg-ca.crt` to DATABASE_URL when TLS is enabled |
| `helm/optio/values.yaml` | Adds `postgresql.tls.enabled: true` (on by default) |
| `apps/api/src/db/ssl.ts` | New utility: parses `sslmode`/`sslrootcert` from connection string, returns TLS options for the postgres driver |
| `apps/api/src/db/ssl.test.ts` | 10 tests covering all sslmode variants, CA cert reading, and edge cases |
| `apps/api/src/db/client.ts` | Uses `parseSslConfig()` to configure SSL when DATABASE_URL includes sslmode |

## Design decisions

- **Init container for key permissions**: Postgres requires the private key to be mode 0600. Since the pod runs as uid 999 (non-root) and K8s secret volume permissions don't allow this directly, an init container copies certs from the secret to a memory-backed emptyDir with correct ownership.
- **TLS 1.3 minimum**: Enforced via `ssl_min_protocol_version=TLSv1.3` — no reason to allow older protocols for an internal-only connection.
- **Backward compatible**: `postgresql.tls.enabled` can be set to `false` to disable TLS for local development. External databases (`postgresql.enabled=false`) are unaffected — users control sslmode in their own connection URL.
- **Cert reuse on upgrade**: Uses Helm `lookup` to check if the TLS secret already exists, preserving certs across `helm upgrade` to avoid connection disruption.

## Test plan

- [x] 10 unit tests for `parseSslConfig()` covering all sslmode values, CA cert file reading, and invalid URLs
- [x] All 1223 existing tests pass (78 test files)
- [x] Typecheck passes across all packages
- [ ] Deploy to a K8s cluster and verify TLS is active:
  ```bash
  kubectl exec -n optio deploy/optio-api -- openssl s_client \
    -connect optio-postgres:5432 -starttls postgres -tls1_3 </dev/null 2>&1 \
    | grep "Protocol\|Cipher"
  ```
- [ ] Verify API can connect to Postgres with verify-full by checking `/api/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)