### PR TITLE
feat(security): tag encrypted blobs with algorithm version byte

### DIFF
--- a/apps/api/src/db/migrations/0041_encryption_alg_version.sql
+++ b/apps/api/src/db/migrations/0041_encryption_alg_version.sql
@@ -1,0 +1,6 @@
+-- Add algorithm version byte to all ciphertext-bearing tables for crypto-agility.
+-- Existing rows default to alg=1 (AES-256-GCM V1).
+
+ALTER TABLE "secrets" ADD COLUMN "alg" smallint NOT NULL DEFAULT 1;
+ALTER TABLE "webhooks" ADD COLUMN "secret_alg" smallint NOT NULL DEFAULT 1;
+ALTER TABLE "repos" ADD COLUMN "slack_webhook_url_alg" smallint NOT NULL DEFAULT 1;

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1776528000000,
       "tag": "0040_workspace_allow_dind",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1776614400000,
+      "tag": "0041_encryption_alg_version",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -4,6 +4,7 @@ import {
   text,
   timestamp,
   integer,
+  smallint,
   jsonb,
   pgEnum,
   boolean,
@@ -183,6 +184,7 @@ export const secrets = pgTable(
     encryptedValue: bytea("encrypted_value").notNull(),
     iv: bytea("iv").notNull(),
     authTag: bytea("auth_tag").notNull(),
+    alg: smallint("alg").notNull().default(1), // 1 = AES_256_GCM_V1
     workspaceId: uuid("workspace_id"), // nullable for backward compat
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
@@ -232,6 +234,7 @@ export const repos = pgTable(
     encryptedSlackWebhookUrl: bytea("encrypted_slack_webhook_url"), // AES-256-GCM encrypted Slack webhook URL
     slackWebhookUrlIv: bytea("slack_webhook_url_iv"),
     slackWebhookUrlAuthTag: bytea("slack_webhook_url_auth_tag"),
+    slackWebhookUrlAlg: smallint("slack_webhook_url_alg").notNull().default(1), // 1 = AES_256_GCM_V1
     slackChannel: text("slack_channel"), // override channel (optional)
     slackNotifyOn: jsonb("slack_notify_on").$type<string[]>(), // e.g. ["completed","failed","pr_opened","needs_attention"]
     slackEnabled: boolean("slack_enabled").notNull().default(false),
@@ -329,6 +332,7 @@ export const webhooks = pgTable(
     encryptedSecret: bytea("encrypted_secret"), // AES-256-GCM encrypted signing secret
     secretIv: bytea("secret_iv"),
     secretAuthTag: bytea("secret_auth_tag"),
+    secretAlg: smallint("secret_alg").notNull().default(1), // 1 = AES_256_GCM_V1
     description: text("description"),
     active: boolean("active").notNull().default(true),
     createdBy: uuid("created_by"),

--- a/apps/api/src/services/repo-service.test.ts
+++ b/apps/api/src/services/repo-service.test.ts
@@ -22,13 +22,15 @@ vi.mock("../db/schema.js", () => ({
 }));
 
 vi.mock("./secret-service.js", () => ({
+  ALG_AES_256_GCM_V1: 1,
   encrypt: vi.fn().mockImplementation((plaintext: string) => ({
-    encrypted: Buffer.from(`enc:${plaintext}`),
+    alg: 1,
+    ciphertext: Buffer.from(`enc:${plaintext}`),
     iv: Buffer.from("mock-iv-1234567"),
     authTag: Buffer.from("mock-auth-tag12"),
   })),
-  decrypt: vi.fn().mockImplementation((encrypted: Buffer) => {
-    const str = encrypted.toString();
+  decrypt: vi.fn().mockImplementation((blob: { ciphertext: Buffer }) => {
+    const str = blob.ciphertext.toString();
     return str.startsWith("enc:") ? str.slice(4) : str;
   }),
 }));

--- a/apps/api/src/services/repo-service.ts
+++ b/apps/api/src/services/repo-service.ts
@@ -1,7 +1,7 @@
 import { eq, and, isNull } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { repos, workspaces } from "../db/schema.js";
-import { encrypt, decrypt } from "./secret-service.js";
+import { encrypt, decrypt, ALG_AES_256_GCM_V1 } from "./secret-service.js";
 import { normalizeRepoUrl, parseRepoUrl } from "@optio/shared";
 
 export interface RepoRecord {
@@ -62,9 +62,12 @@ function decryptRepoRow(row: typeof repos.$inferSelect): RepoRecord {
   if (row.encryptedSlackWebhookUrl && row.slackWebhookUrlIv && row.slackWebhookUrlAuthTag) {
     const aad = Buffer.from(`repo:${row.id}:slackWebhookUrl`);
     slackWebhookUrl = decrypt(
-      row.encryptedSlackWebhookUrl,
-      row.slackWebhookUrlIv,
-      row.slackWebhookUrlAuthTag,
+      {
+        alg: row.slackWebhookUrlAlg ?? ALG_AES_256_GCM_V1,
+        iv: row.slackWebhookUrlIv,
+        ciphertext: row.encryptedSlackWebhookUrl,
+        authTag: row.slackWebhookUrlAuthTag,
+      },
       aad,
     );
   }
@@ -72,6 +75,7 @@ function decryptRepoRow(row: typeof repos.$inferSelect): RepoRecord {
     encryptedSlackWebhookUrl: _e,
     slackWebhookUrlIv: _iv,
     slackWebhookUrlAuthTag: _tag,
+    slackWebhookUrlAlg: _alg,
     ...rest
   } = row;
   return { ...rest, slackWebhookUrl } as RepoRecord;
@@ -215,10 +219,11 @@ export async function updateRepo(
       setData.slackWebhookUrlAuthTag = null;
     } else {
       const aad = Buffer.from(`repo:${id}:slackWebhookUrl`);
-      const { encrypted, iv, authTag } = encrypt(slackWebhookUrl, aad);
-      setData.encryptedSlackWebhookUrl = encrypted;
-      setData.slackWebhookUrlIv = iv;
-      setData.slackWebhookUrlAuthTag = authTag;
+      const blob = encrypt(slackWebhookUrl, aad);
+      setData.encryptedSlackWebhookUrl = blob.ciphertext;
+      setData.slackWebhookUrlIv = blob.iv;
+      setData.slackWebhookUrlAuthTag = blob.authTag;
+      setData.slackWebhookUrlAlg = blob.alg;
     }
   }
 

--- a/apps/api/src/services/secret-service.test.ts
+++ b/apps/api/src/services/secret-service.test.ts
@@ -50,6 +50,7 @@ describe("secret-service", () => {
   let listSecrets: typeof import("./secret-service.js").listSecrets;
   let deleteSecret: typeof import("./secret-service.js").deleteSecret;
   let resolveSecretsForTask: typeof import("./secret-service.js").resolveSecretsForTask;
+  let ALG_AES_256_GCM_V1: number;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -62,6 +63,7 @@ describe("secret-service", () => {
     listSecrets = mod.listSecrets;
     deleteSecret = mod.deleteSecret;
     resolveSecretsForTask = mod.resolveSecretsForTask;
+    ALG_AES_256_GCM_V1 = mod.ALG_AES_256_GCM_V1;
   });
 
   describe("encryption round-trip", () => {
@@ -70,6 +72,7 @@ describe("secret-service", () => {
       let capturedEncrypted: Buffer;
       let capturedIv: Buffer;
       let capturedAuthTag: Buffer;
+      let capturedAlg: number;
 
       const selectMock = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -83,6 +86,7 @@ describe("secret-service", () => {
           capturedEncrypted = vals.encryptedValue;
           capturedIv = vals.iv;
           capturedAuthTag = vals.authTag;
+          capturedAlg = vals.alg;
           return Promise.resolve();
         }),
       });
@@ -90,6 +94,7 @@ describe("secret-service", () => {
 
       await storeSecret("API_KEY", secretValue);
 
+      expect(capturedAlg!).toBe(ALG_AES_256_GCM_V1);
       expect(capturedEncrypted!).toBeInstanceOf(Buffer);
       expect(capturedIv!).toBeInstanceOf(Buffer);
       expect(capturedIv!.length).toBe(12); // NIST-recommended 12-byte IV
@@ -106,6 +111,7 @@ describe("secret-service", () => {
               encryptedValue: capturedEncrypted!,
               iv: capturedIv!,
               authTag: capturedAuthTag!,
+              alg: capturedAlg!,
               createdAt: new Date(),
               updatedAt: new Date(),
             },
@@ -184,7 +190,7 @@ describe("secret-service", () => {
 
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([{ encryptedValue: encrypted, iv, authTag }]),
+          where: vi.fn().mockResolvedValue([{ encryptedValue: encrypted, iv, authTag, alg: 1 }]),
         }),
       });
 
@@ -192,33 +198,52 @@ describe("secret-service", () => {
       const result = await retrieveSecret("OLD_KEY");
       expect(result).toBe("old-api-key");
     });
+
+    it("defaults to ALG_AES_256_GCM_V1 when alg is null in DB row", async () => {
+      // Encrypt with the same AAD that retrieveSecret("KEY", "global") will compute
+      const aad = buildSecretAAD("KEY", "global");
+      const blob = encrypt("new-secret", aad);
+
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi
+            .fn()
+            .mockResolvedValue([
+              { encryptedValue: blob.ciphertext, iv: blob.iv, authTag: blob.authTag, alg: null },
+            ]),
+        }),
+      });
+
+      const result = await retrieveSecret("KEY");
+      expect(result).toBe("new-secret");
+    });
   });
 
   describe("encrypt/decrypt IV and AAD", () => {
     it("uses 12-byte IV (NIST SP 800-38D recommended)", () => {
-      const { iv } = encrypt("test-value");
-      expect(iv.length).toBe(12);
+      const blob = encrypt("test-value");
+      expect(blob.iv.length).toBe(12);
     });
 
     it("encrypts and decrypts with AAD", () => {
       const aad = Buffer.from("API_KEY|global|global");
-      const { encrypted, iv, authTag } = encrypt("secret-value", aad);
-      const result = decrypt(encrypted, iv, authTag, aad);
+      const blob = encrypt("secret-value", aad);
+      const result = decrypt(blob, aad);
       expect(result).toBe("secret-value");
     });
 
     it("fails to decrypt with wrong AAD", () => {
       const aad = Buffer.from("API_KEY|global|ws-1");
       const wrongAad = Buffer.from("API_KEY|global|ws-2");
-      const { encrypted, iv, authTag } = encrypt("secret-value", aad);
-      expect(() => decrypt(encrypted, iv, authTag, wrongAad)).toThrow();
+      const blob = encrypt("secret-value", aad);
+      expect(() => decrypt(blob, wrongAad)).toThrow();
     });
 
     it("fails to decrypt when AAD is expected but missing", () => {
       const aad = Buffer.from("API_KEY|global|global");
-      const { encrypted, iv, authTag } = encrypt("secret-value", aad);
+      const blob = encrypt("secret-value", aad);
       // Decrypting without AAD on 12-byte IV data should fail
-      expect(() => decrypt(encrypted, iv, authTag)).toThrow();
+      expect(() => decrypt(blob)).toThrow();
     });
 
     it("handles legacy 16-byte IV data without AAD (backward compat)", () => {
@@ -226,20 +251,22 @@ describe("secret-service", () => {
       expect(iv.length).toBe(16);
       // decrypt with AAD provided should still work for 16-byte IV (legacy mode)
       const aad = Buffer.from("name|scope|global");
-      const result = decrypt(encrypted, iv, authTag, aad);
+      const blob = { alg: ALG_AES_256_GCM_V1, iv, ciphertext: encrypted, authTag };
+      const result = decrypt(blob, aad);
       expect(result).toBe("legacy-secret");
     });
 
     it("handles legacy 16-byte IV data without any AAD argument", () => {
       const { encrypted, iv, authTag } = legacyEncrypt("legacy-secret");
-      const result = decrypt(encrypted, iv, authTag);
+      const blob = { alg: ALG_AES_256_GCM_V1, iv, ciphertext: encrypted, authTag };
+      const result = decrypt(blob);
       expect(result).toBe("legacy-secret");
     });
 
     it("encrypts without AAD when none provided", () => {
-      const { encrypted, iv, authTag } = encrypt("no-aad-value");
-      expect(iv.length).toBe(12);
-      const result = decrypt(encrypted, iv, authTag);
+      const blob = encrypt("no-aad-value");
+      expect(blob.iv.length).toBe(12);
+      const result = decrypt(blob);
       expect(result).toBe("no-aad-value");
     });
   });
@@ -258,6 +285,65 @@ describe("secret-service", () => {
     it("uses 'global' when workspaceId is undefined", () => {
       const aad = buildSecretAAD("TOKEN", "repo-scope");
       expect(aad.toString()).toBe("TOKEN|repo-scope|global");
+    });
+  });
+
+  describe("EncryptedBlob and algorithm versioning", () => {
+    it("encrypt returns an EncryptedBlob with alg set to ALG_AES_256_GCM_V1", () => {
+      const blob = encrypt("test-value");
+      expect(blob.alg).toBe(ALG_AES_256_GCM_V1);
+      expect(blob.alg).toBe(0x01);
+    });
+
+    it("encrypt returns ciphertext (not encrypted) in the blob", () => {
+      const blob = encrypt("test-value");
+      expect(blob).toHaveProperty("ciphertext");
+      expect(blob.ciphertext).toBeInstanceOf(Buffer);
+      expect(blob).not.toHaveProperty("encrypted");
+    });
+
+    it("decrypt accepts an EncryptedBlob and returns plaintext", () => {
+      const blob = encrypt("round-trip-test");
+      const result = decrypt(blob);
+      expect(result).toBe("round-trip-test");
+    });
+
+    it("decrypt accepts an EncryptedBlob with AAD", () => {
+      const aad = Buffer.from("context");
+      const blob = encrypt("aad-test", aad);
+      const result = decrypt(blob, aad);
+      expect(result).toBe("aad-test");
+    });
+
+    it("decrypt rejects invalid alg < 1", () => {
+      const blob = encrypt("test");
+      blob.alg = 0;
+      expect(() => decrypt(blob)).toThrow("Invalid algorithm id");
+    });
+
+    it("decrypt rejects invalid alg > 255", () => {
+      const blob = encrypt("test");
+      blob.alg = 256;
+      expect(() => decrypt(blob)).toThrow("Invalid algorithm id");
+    });
+
+    it("decrypt rejects non-integer alg", () => {
+      const blob = encrypt("test");
+      blob.alg = 1.5;
+      expect(() => decrypt(blob)).toThrow("Invalid algorithm id");
+    });
+
+    it("decrypt rejects unsupported alg", () => {
+      const blob = encrypt("test");
+      blob.alg = 0x10;
+      expect(() => decrypt(blob)).toThrow("Unsupported encryption algorithm: 0x10");
+    });
+
+    it("handles legacy blobs with 16-byte IV via ALG_AES_256_GCM_V1", () => {
+      const { encrypted, iv, authTag } = legacyEncrypt("legacy-value");
+      const blob = { alg: ALG_AES_256_GCM_V1, iv, ciphertext: encrypted, authTag };
+      const result = decrypt(blob);
+      expect(result).toBe("legacy-value");
     });
   });
 
@@ -329,9 +415,13 @@ describe("secret-service", () => {
     it("applies isNull workspace filter for non-global scope without workspaceId", async () => {
       // Encrypt with appropriate AAD for this context
       const aad = buildSecretAAD("TOKEN", "repo-scope", null);
-      const { encrypted, iv, authTag } = encrypt("val", aad);
+      const blob = encrypt("val", aad);
 
-      const whereMock = vi.fn().mockResolvedValue([{ encryptedValue: encrypted, iv, authTag }]);
+      const whereMock = vi
+        .fn()
+        .mockResolvedValue([
+          { encryptedValue: blob.ciphertext, iv: blob.iv, authTag: blob.authTag, alg: blob.alg },
+        ]);
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({ where: whereMock }),
       });

--- a/apps/api/src/services/secret-service.ts
+++ b/apps/api/src/services/secret-service.ts
@@ -6,6 +6,19 @@ import type { SecretRef } from "@optio/shared";
 
 const ALGORITHM = "aes-256-gcm";
 
+// ── Algorithm version constants ─────────────────────────────────────────────
+export const ALG_AES_256_GCM_V1 = 0x01;
+export const ALG_AES_256_GCM_V2_AAD = 0x02; // future: adds AAD binding (see #302)
+// export const ALG_HYBRID_MLKEM_AESGCM = 0x10; // future: ML-KEM wraps the DEK
+// export const ALG_KMS_WRAPPED_AESGCM  = 0x20; // future: KMS-wrapped
+
+export interface EncryptedBlob {
+  alg: number; // 1 byte, identifies the encryption algorithm
+  iv: Buffer;
+  ciphertext: Buffer;
+  authTag: Buffer;
+}
+
 /** Values that must never be accepted as encryption keys. */
 const WEAK_KEY_VALUES = new Set([
   "change-me-in-production",
@@ -55,31 +68,39 @@ export function buildSecretAAD(name: string, scope: string, workspaceId?: string
   return Buffer.from(`${name}|${scope}|${workspaceId ?? "global"}`);
 }
 
-export function encrypt(
-  plaintext: string,
-  aad?: Buffer,
-): { encrypted: Buffer; iv: Buffer; authTag: Buffer } {
+export function encrypt(plaintext: string, aad?: Buffer): EncryptedBlob {
   const key = encryptionKey();
   const iv = randomBytes(12); // NIST SP 800-38D recommended 12-byte IV
   const cipher = createCipheriv(ALGORITHM, key, iv);
   if (aad) {
     cipher.setAAD(aad);
   }
-  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
-  const authTag = cipher.getAuthTag();
-  return { encrypted, iv, authTag };
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  return { alg: ALG_AES_256_GCM_V1, iv, ciphertext, authTag: cipher.getAuthTag() };
 }
 
-export function decrypt(encrypted: Buffer, iv: Buffer, authTag: Buffer, aad?: Buffer): string {
+export function decrypt(blob: EncryptedBlob, aad?: Buffer): string {
+  if (!Number.isInteger(blob.alg) || blob.alg < 1 || blob.alg > 255) {
+    throw new Error(`Invalid algorithm id: ${blob.alg}`);
+  }
+  switch (blob.alg) {
+    case ALG_AES_256_GCM_V1:
+      return decryptAesGcmV1(blob, aad);
+    default:
+      throw new Error(`Unsupported encryption algorithm: 0x${blob.alg.toString(16)}`);
+  }
+}
+
+function decryptAesGcmV1(blob: EncryptedBlob, aad?: Buffer): string {
   const key = encryptionKey();
-  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  const decipher = createDecipheriv(ALGORITHM, key, blob.iv);
   // Legacy rows use 16-byte IV without AAD; new rows use 12-byte IV with AAD.
   // Skip AAD for legacy data to maintain backward compatibility.
-  if (aad && iv.length !== 16) {
+  if (aad && blob.iv.length !== 16) {
     decipher.setAAD(aad);
   }
-  decipher.setAuthTag(authTag);
-  return decipher.update(encrypted).toString("utf8") + decipher.final("utf8");
+  decipher.setAuthTag(blob.authTag);
+  return decipher.update(blob.ciphertext).toString("utf8") + decipher.final("utf8");
 }
 
 export async function storeSecret(
@@ -89,7 +110,7 @@ export async function storeSecret(
   workspaceId?: string | null,
 ): Promise<void> {
   const aad = buildSecretAAD(name, scope, workspaceId);
-  const { encrypted, iv, authTag } = encrypt(value, aad);
+  const { alg, ciphertext, iv, authTag } = encrypt(value, aad);
 
   // Build conditions for lookup
   const conditions = [eq(secrets.name, name), eq(secrets.scope, scope)];
@@ -108,15 +129,16 @@ export async function storeSecret(
   if (existing.length > 0) {
     await db
       .update(secrets)
-      .set({ encryptedValue: encrypted, iv, authTag, updatedAt: new Date() })
+      .set({ encryptedValue: ciphertext, iv, authTag, alg, updatedAt: new Date() })
       .where(and(...conditions));
   } else {
     await db.insert(secrets).values({
       name,
       scope,
-      encryptedValue: encrypted,
+      encryptedValue: ciphertext,
       iv,
       authTag,
+      alg,
       workspaceId: workspaceId ?? undefined,
     });
   }
@@ -143,7 +165,15 @@ export async function retrieveSecret(
   if (!secret) throw new Error(`Secret not found: ${name} (scope: ${scope})`);
 
   const aad = buildSecretAAD(name, scope, workspaceId);
-  return decrypt(secret.encryptedValue, secret.iv, secret.authTag, aad);
+  return decrypt(
+    {
+      alg: secret.alg ?? ALG_AES_256_GCM_V1,
+      iv: secret.iv,
+      ciphertext: secret.encryptedValue,
+      authTag: secret.authTag,
+    },
+    aad,
+  );
 }
 
 export async function listSecrets(

--- a/apps/api/src/services/webhook-service.test.ts
+++ b/apps/api/src/services/webhook-service.test.ts
@@ -32,16 +32,18 @@ vi.mock("../logger.js", () => ({
 
 // Mock encrypt/decrypt from secret-service
 const mockEncrypt = vi.fn().mockImplementation((plaintext: string) => ({
-  encrypted: Buffer.from(`enc:${plaintext}`),
+  alg: 1,
+  ciphertext: Buffer.from(`enc:${plaintext}`),
   iv: Buffer.from("mock-iv-1234567"),
   authTag: Buffer.from("mock-auth-tag12"),
 }));
-const mockDecrypt = vi.fn().mockImplementation((encrypted: Buffer) => {
-  const str = encrypted.toString();
+const mockDecrypt = vi.fn().mockImplementation((blob: { ciphertext: Buffer }) => {
+  const str = blob.ciphertext.toString();
   return str.startsWith("enc:") ? str.slice(4) : str;
 });
 
 vi.mock("./secret-service.js", () => ({
+  ALG_AES_256_GCM_V1: 1,
   encrypt: (...args: unknown[]) => mockEncrypt(...args),
   decrypt: (...args: unknown[]) => mockDecrypt(...args),
 }));

--- a/apps/api/src/services/webhook-service.ts
+++ b/apps/api/src/services/webhook-service.ts
@@ -2,7 +2,7 @@ import { eq, desc } from "drizzle-orm";
 import { assertSsrfSafe } from "../utils/ssrf.js";
 import { db } from "../db/client.js";
 import { webhooks, webhookDeliveries } from "../db/schema.js";
-import { encrypt, decrypt } from "./secret-service.js";
+import { encrypt, decrypt, ALG_AES_256_GCM_V1 } from "./secret-service.js";
 import { HmacSha256Signer } from "./crypto/signer.js";
 import { logger } from "../logger.js";
 
@@ -41,7 +41,15 @@ function decryptWebhookRow(row: typeof webhooks.$inferSelect): WebhookRecord {
   let secret: string | null = null;
   if (row.encryptedSecret && row.secretIv && row.secretAuthTag) {
     const aad = Buffer.from(`webhook:${row.url}:secret`);
-    secret = decrypt(row.encryptedSecret, row.secretIv, row.secretAuthTag, aad);
+    secret = decrypt(
+      {
+        alg: row.secretAlg ?? ALG_AES_256_GCM_V1,
+        iv: row.secretIv,
+        ciphertext: row.encryptedSecret,
+        authTag: row.secretAuthTag,
+      },
+      aad,
+    );
   }
   return {
     id: row.id,
@@ -73,12 +81,15 @@ export async function createWebhook(
   let secretIv: Buffer | null = null;
   let secretAuthTag: Buffer | null = null;
 
+  let secretAlg: number = ALG_AES_256_GCM_V1;
+
   if (input.secret) {
     const aad = Buffer.from(`webhook:${input.url}:secret`);
-    const { encrypted, iv, authTag } = encrypt(input.secret, aad);
-    encryptedSecret = encrypted;
-    secretIv = iv;
-    secretAuthTag = authTag;
+    const blob = encrypt(input.secret, aad);
+    encryptedSecret = blob.ciphertext;
+    secretIv = blob.iv;
+    secretAuthTag = blob.authTag;
+    secretAlg = blob.alg;
   }
 
   const [webhook] = await db
@@ -89,6 +100,7 @@ export async function createWebhook(
       encryptedSecret,
       secretIv,
       secretAuthTag,
+      secretAlg,
       description: input.description ?? null,
       createdBy: createdBy ?? null,
       workspaceId: workspaceId ?? null,


### PR DESCRIPTION
## Summary

- Add crypto-agility to the encryption subsystem by tagging every encrypted blob with an `alg` version byte
- Introduce `ALG_AES_256_GCM_V1` (0x01) constant and `EncryptedBlob` interface (`{ alg, iv, ciphertext, authTag }`)
- Refactor `encrypt()` to return `EncryptedBlob` and `decrypt()` to dispatch on `blob.alg` with a `switch` statement
- Add runtime validation: rejects non-integer, out-of-range (< 1 or > 255), and unsupported `alg` values
- Add `alg` smallint column (default 1) to `secrets`, `webhooks` (`secret_alg`), and `repos` (`slack_webhook_url_alg`) tables via migration 0041
- Update all callers: `storeSecret`/`retrieveSecret`, `webhook-service`, and `repo-service` now persist and read `alg`
- Backward compatible: existing rows default to `alg=1`, null `alg` falls back to `ALG_AES_256_GCM_V1`

## Motivation

Without an algorithm identifier on each ciphertext blob, migrating to a new encryption scheme (AAD binding V2 per #302, ML-KEM-wrapped DEK, KMS integration) requires a coordinated rewrite of every call site. With this change, adding a new cipher becomes a single `case` in the `decrypt()` dispatch table plus a background migration to re-encrypt existing rows.

## Test plan

- [x] New tests for `EncryptedBlob` shape: `alg` field present, `ciphertext` property (not `encrypted`)
- [x] New tests for `decrypt()` validation: rejects invalid/unsupported alg values
- [x] New test for backward compat: null `alg` in DB row defaults to V1
- [x] Updated existing encrypt/decrypt round-trip tests for new API
- [x] Updated webhook-service and repo-service mock encrypt/decrypt to new shape
- [x] `storeSecret` test verifies `alg` is persisted to DB
- [x] All 1223 tests pass, typecheck clean, formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)