### PR TITLE
feat: stalled task detection with activity heartbeats

### DIFF
--- a/apps/api/src/db/migrations/0045_stall_detection.sql
+++ b/apps/api/src/db/migrations/0045_stall_detection.sql
@@ -1,0 +1,21 @@
+-- Stall detection: activity heartbeats and per-repo threshold override
+
+-- Activity substate enum
+DO $$ BEGIN
+  CREATE TYPE "public"."task_activity_substate" AS ENUM('active', 'stalled', 'recovered');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Tasks: new columns for stall detection
+ALTER TABLE "tasks"
+  ADD COLUMN IF NOT EXISTS "last_activity_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "activity_substate" "public"."task_activity_substate" NOT NULL DEFAULT 'active';
+
+-- Repos: per-repo stall threshold override
+ALTER TABLE "repos"
+  ADD COLUMN IF NOT EXISTS "stall_threshold_ms" integer;
+
+-- Partial index for efficient stall detection scan (only running tasks)
+CREATE INDEX IF NOT EXISTS "tasks_running_last_activity_idx"
+  ON "tasks" ("last_activity_at")
+  WHERE "state" = 'running';

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1776873600000,
       "tag": "0043_gemini_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1776960000000,
+      "tag": "0045_stall_detection",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -67,6 +67,12 @@ export const workspaceMembers = pgTable(
 
 // ── Task enums ──────────────────────────────────────────────────────────────
 
+export const taskActivitySubstateEnum = pgEnum("task_activity_substate", [
+  "active",
+  "stalled",
+  "recovered",
+]);
+
 export const taskStateEnum = pgEnum("task_state", [
   "pending",
   "waiting_on_deps",
@@ -119,6 +125,8 @@ export const tasks = pgTable(
     workflowRunId: uuid("workflow_run_id"), // nullable FK to workflow_runs
     createdBy: uuid("created_by"), // nullable FK to users (null when auth is disabled)
     ignoreOffPeak: boolean("ignore_off_peak").notNull().default(false),
+    lastActivityAt: timestamp("last_activity_at", { withTimezone: true }), // stall detection: last parsed agent event
+    activitySubstate: taskActivitySubstateEnum("activity_substate").notNull().default("active"),
     workspaceId: uuid("workspace_id"), // nullable for backward compat; new tasks should always set this
     lastMessageAt: timestamp("last_message_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -246,6 +254,7 @@ export const repos = pgTable(
     slackEnabled: boolean("slack_enabled").notNull().default(false),
     networkPolicy: text("network_policy").notNull().default("unrestricted"), // "unrestricted" | "restricted"
     secretProxy: boolean("secret_proxy").notNull().default(false), // Envoy sidecar proxy for secret isolation
+    stallThresholdMs: integer("stall_threshold_ms"), // per-repo override for stall detection (null = use global default)
     offPeakOnly: boolean("off_peak_only").notNull().default(false),
     cpuRequest: text("cpu_request"), // e.g. "500m", "1000m", "2000m" — K8s CPU request
     cpuLimit: text("cpu_limit"), // e.g. "2000m", "4000m" — K8s CPU limit

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
-import { TaskState } from "@optio/shared";
+import { TaskState, isTaskStalled, getSilentDuration } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
 import * as dependencyService from "../services/dependency-service.js";
 import { taskQueue } from "../workers/task-worker.js";
@@ -81,7 +81,16 @@ export async function taskRoutes(app: FastifyInstance) {
       offset,
       workspaceId,
     });
-    reply.send({ tasks: taskList, limit, offset });
+
+    // Enrich running tasks with isStalled flag (lightweight — no lastLogSummary)
+    const globalThreshold = parseInt(process.env.OPTIO_STALL_THRESHOLD_MS ?? "300000", 10);
+    const now = new Date();
+    const enriched = taskList.map((t) => ({
+      ...t,
+      isStalled: isTaskStalled(t, now, globalThreshold),
+    }));
+
+    reply.send({ tasks: enriched, limit, offset });
   });
 
   // Search tasks with advanced filtering and cursor-based pagination
@@ -131,7 +140,27 @@ export async function taskRoutes(app: FastifyInstance) {
     const { getPipelineProgress } = await import("../services/subtask-service.js");
     pipelineProgress = await getPipelineProgress(id);
 
-    reply.send({ task, pendingReason, pipelineProgress });
+    // Compute stall info for running tasks
+    let stallInfo = null;
+    if (task.state === "running" && task.lastActivityAt) {
+      const repoConfig = await taskService.getRepoConfig(task.repoUrl);
+      const thresholdMs = taskService.getStallThresholdForRepo(repoConfig);
+      const now = new Date();
+      const stalled = isTaskStalled(task, now, thresholdMs);
+      const silentForMs = getSilentDuration(task, now);
+
+      // Only fetch last log summary for stalled tasks (expensive query)
+      const lastLogSummary = stalled ? await taskService.getLastLogSummary(id) : undefined;
+
+      stallInfo = {
+        isStalled: stalled,
+        silentForMs,
+        thresholdMs,
+        lastLogSummary,
+      };
+    }
+
+    reply.send({ task, pendingReason, pipelineProgress, stallInfo });
   });
 
   // Create task — member+

--- a/apps/api/src/services/task-service.test.ts
+++ b/apps/api/src/services/task-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TaskState } from "@optio/shared";
 
 vi.mock("../db/client.js", () => ({
@@ -20,10 +20,19 @@ vi.mock("../db/client.js", () => ({
 }));
 
 vi.mock("../db/schema.js", () => ({
-  tasks: { id: "id", state: "state", createdAt: "createdAt", taskId: "taskId" },
+  tasks: {
+    id: "id",
+    state: "state",
+    createdAt: "createdAt",
+    taskId: "taskId",
+    activitySubstate: "activitySubstate",
+    repoUrl: "repoUrl",
+  },
   taskEvents: { taskId: "taskId", createdAt: "createdAt", userId: "userId" },
-  taskLogs: { taskId: "taskId", timestamp: "timestamp" },
+  taskLogs: { taskId: "taskId", timestamp: "timestamp", logType: "logType", content: "content" },
   users: { id: "id", displayName: "display_name", avatarUrl: "avatar_url" },
+  repos: { repoUrl: "repoUrl" },
+  reviewDrafts: { taskId: "taskId" },
 }));
 
 vi.mock("./event-bus.js", () => ({ publishEvent: vi.fn() }));
@@ -40,6 +49,8 @@ import {
   tryTransitionTask,
   updateTaskPr,
   searchTasks,
+  updateTaskActivity,
+  getStallThresholdForRepo,
 } from "./task-service.js";
 
 describe("StateRaceError", () => {
@@ -240,5 +251,78 @@ describe("searchTasks", () => {
     await searchTasks({});
     // limit(51) = default 50 + 1
     expect(mockDb.limit).toHaveBeenCalledWith(51);
+  });
+});
+
+describe("getStallThresholdForRepo", () => {
+  const originalEnv = process.env.OPTIO_STALL_THRESHOLD_MS;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.OPTIO_STALL_THRESHOLD_MS = originalEnv;
+    } else {
+      delete process.env.OPTIO_STALL_THRESHOLD_MS;
+    }
+  });
+
+  it("returns per-repo override when set", () => {
+    expect(getStallThresholdForRepo({ stallThresholdMs: 900000 })).toBe(900000);
+  });
+
+  it("returns env var when repo has no override", () => {
+    process.env.OPTIO_STALL_THRESHOLD_MS = "60000";
+    expect(getStallThresholdForRepo({ stallThresholdMs: null })).toBe(60000);
+    expect(getStallThresholdForRepo(null)).toBe(60000);
+  });
+
+  it("returns default when no env var or repo override", () => {
+    delete process.env.OPTIO_STALL_THRESHOLD_MS;
+    expect(getStallThresholdForRepo(null)).toBe(300000);
+    expect(getStallThresholdForRepo({ stallThresholdMs: null })).toBe(300000);
+  });
+});
+
+describe("updateTaskActivity", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("updates lastActivityAt and checks for recovery", async () => {
+    const mockDb = db as any;
+    // Chain: update().set().where().returning()
+    mockDb.returning.mockResolvedValueOnce([
+      { activitySubstate: "active", lastActivityAt: new Date() },
+    ]);
+    // No recovery event expected for "active" substate
+    await updateTaskActivity("t1", new Date());
+    expect(db.update).toHaveBeenCalled();
+    expect(publishEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "task:recovered" }),
+    );
+  });
+
+  it("publishes task:recovered event when transitioning from stalled", async () => {
+    const at = new Date("2026-04-07T12:00:00Z");
+    const mockDb = db as any;
+    // update().set().where().returning() → recovered
+    mockDb.returning.mockResolvedValueOnce([{ activitySubstate: "recovered", lastActivityAt: at }]);
+    // getTask() → select().from().where() — use returning mock for second where chain
+    // We need where() to return db for the update chain, then resolve for getTask.
+    // Use returning mock for the first chain, and a fresh where mock for the second.
+    const origWhere = mockDb.where;
+    let whereCallCount = 0;
+    mockDb.where = vi.fn().mockImplementation((...args: unknown[]) => {
+      whereCallCount++;
+      if (whereCallCount <= 1) {
+        // First where() — part of update chain, return db so .returning() works
+        return mockDb;
+      }
+      // Second where() — getTask select, return task data
+      return Promise.resolve([{ id: "t1", lastActivityAt: new Date("2026-04-07T11:50:00Z") }]);
+    });
+    await updateTaskActivity("t1", at);
+    expect(publishEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "task:recovered", taskId: "t1" }),
+    );
+    // Restore original where mock
+    mockDb.where = origWhere;
   });
 });

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -1,7 +1,13 @@
 import { eq, desc, and, or, ilike, gte, lte, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { tasks, taskEvents, taskLogs, users, reviewDrafts } from "../db/schema.js";
-import { TaskState, transition, normalizeRepoUrl, type CreateTaskInput } from "@optio/shared";
+import { tasks, taskEvents, taskLogs, users, reviewDrafts, repos } from "../db/schema.js";
+import {
+  TaskState,
+  transition,
+  normalizeRepoUrl,
+  DEFAULT_STALL_THRESHOLD_MS,
+  type CreateTaskInput,
+} from "@optio/shared";
 import { publishEvent } from "./event-bus.js";
 import { logger } from "../logger.js";
 import { enqueueWebhookEvent } from "../workers/webhook-worker.js";
@@ -209,6 +215,14 @@ export async function transitionTask(
 
   if (toState === TaskState.RUNNING && !task.startedAt) {
     updateFields.startedAt = new Date();
+  }
+  // Stall detection: set lastActivityAt when entering running, reset substate when leaving
+  if (toState === TaskState.RUNNING) {
+    updateFields.lastActivityAt = new Date();
+    updateFields.activitySubstate = "active";
+  }
+  if (currentState === TaskState.RUNNING && toState !== TaskState.RUNNING) {
+    updateFields.activitySubstate = "active";
   }
   if (
     toState === TaskState.COMPLETED ||
@@ -592,6 +606,84 @@ async function sendSlackNotificationForTask(
   const { getRepoByUrl } = await import("./repo-service.js");
   const repoConfig = await getRepoByUrl(task.repoUrl);
   await notifySlackOnTransition({ ...task, state: toState }, toState, repoConfig);
+}
+
+/**
+ * Update the task's lastActivityAt timestamp and handle stall recovery.
+ * Called from the task-worker with debounced writes.
+ */
+export async function updateTaskActivity(taskId: string, at: Date) {
+  // Use a conditional update: if the task was stalled, flip to recovered
+  const updated = await db
+    .update(tasks)
+    .set({
+      lastActivityAt: at,
+      activitySubstate: sql`CASE WHEN ${tasks.activitySubstate} = 'stalled' THEN 'recovered' ELSE ${tasks.activitySubstate} END`,
+    })
+    .where(eq(tasks.id, taskId))
+    .returning({ activitySubstate: tasks.activitySubstate, lastActivityAt: tasks.lastActivityAt });
+
+  // If we just recovered from stalled, publish the event
+  if (updated.length > 0 && updated[0].activitySubstate === "recovered") {
+    const task = await getTask(taskId);
+    if (task) {
+      const silentWasMs = task.lastActivityAt
+        ? at.getTime() - new Date(task.lastActivityAt).getTime()
+        : 0;
+      await publishEvent({
+        type: "task:recovered",
+        taskId,
+        silentWasMs: Math.max(0, silentWasMs),
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+}
+
+/**
+ * Get the effective stall threshold for a repo.
+ * Priority: per-repo override → env var → hardcoded default.
+ */
+export function getStallThresholdForRepo(
+  repoConfig: {
+    stallThresholdMs?: number | null;
+  } | null,
+): number {
+  if (repoConfig?.stallThresholdMs != null) {
+    return repoConfig.stallThresholdMs;
+  }
+  return parseInt(process.env.OPTIO_STALL_THRESHOLD_MS ?? String(DEFAULT_STALL_THRESHOLD_MS), 10);
+}
+
+/**
+ * Get the last meaningful log entry summary for a stalled task.
+ * Returns a short string like "Bash $ npm test" or "Read file.ts".
+ */
+export async function getLastLogSummary(taskId: string): Promise<string | undefined> {
+  const [log] = await db
+    .select({ content: taskLogs.content, logType: taskLogs.logType })
+    .from(taskLogs)
+    .where(
+      and(
+        eq(taskLogs.taskId, taskId),
+        sql`${taskLogs.logType} IN ('tool_use', 'text', 'tool_result')`,
+      ),
+    )
+    .orderBy(desc(taskLogs.timestamp))
+    .limit(1);
+
+  if (!log) return undefined;
+  // Truncate to a reasonable summary length
+  const summary = log.content.trim().slice(0, 120);
+  return summary || undefined;
+}
+
+/**
+ * Get repo config for a given repo URL. Used by stall detector.
+ */
+export async function getRepoConfig(repoUrl: string) {
+  const [repo] = await db.select().from(repos).where(eq(repos.repoUrl, repoUrl));
+  return repo ?? null;
 }
 
 /** Fetch the most recent state-change events across all tasks. */

--- a/apps/api/src/workers/repo-cleanup-worker.test.ts
+++ b/apps/api/src/workers/repo-cleanup-worker.test.ts
@@ -79,11 +79,18 @@ vi.mock("../db/schema.js", () => ({
     worktreeState: "tasks.worktreeState",
     retryCount: "tasks.retryCount",
     maxRetries: "tasks.maxRetries",
+    lastActivityAt: "tasks.lastActivityAt",
+    activitySubstate: "tasks.activitySubstate",
+    workspaceId: "tasks.workspaceId",
   },
   taskEvents: {
     id: "taskEvents.id",
     taskId: "taskEvents.taskId",
     trigger: "taskEvents.trigger",
+  },
+  repos: {
+    repoUrl: "repos.repoUrl",
+    stallThresholdMs: "repos.stallThresholdMs",
   },
 }));
 
@@ -115,10 +122,20 @@ vi.mock("../services/container-service.js", () => ({
 
 const mockTransitionTask = vi.fn().mockResolvedValue(undefined);
 const mockUpdateTaskResult = vi.fn().mockResolvedValue(undefined);
+const mockGetStallThreshold = vi.fn().mockReturnValue(300_000);
+const mockGetLastLogSummary = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("../services/task-service.js", () => ({
   transitionTask: (...args: unknown[]) => mockTransitionTask(...args),
   updateTaskResult: (...args: unknown[]) => mockUpdateTaskResult(...args),
+  getStallThresholdForRepo: (...args: unknown[]) => mockGetStallThreshold(...args),
+  getLastLogSummary: (...args: unknown[]) => mockGetLastLogSummary(...args),
+}));
+
+const mockPublishEvent = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../services/event-bus.js", () => ({
+  publishEvent: (...args: unknown[]) => mockPublishEvent(...args),
 }));
 
 const mockCleanupExpiredSessions = vi.fn().mockResolvedValue(0);
@@ -226,6 +243,9 @@ beforeEach(() => {
   mockDeleteNetPolicy.mockReset().mockResolvedValue(undefined);
   mockCleanupExpiredSessions.mockReset().mockResolvedValue(0);
   mockTaskQueueAdd.mockReset().mockResolvedValue(undefined);
+  mockPublishEvent.mockReset().mockResolvedValue(undefined);
+  mockGetStallThreshold.mockReset().mockReturnValue(300_000);
+  mockGetLastLogSummary.mockReset().mockResolvedValue(undefined);
   selectCallIndex = 0;
   originalDateNow = Date.now;
 });
@@ -251,6 +271,7 @@ describe("repo-cleanup-worker", () => {
       // select #1: staleTasks returns empty
       selectResults = [
         [makePod({ state: "provisioning" })],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -262,6 +283,7 @@ describe("repo-cleanup-worker", () => {
     it("skips pods without podName", async () => {
       selectResults = [
         [makePod({ podName: null })],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -275,6 +297,7 @@ describe("repo-cleanup-worker", () => {
       selectResults = [
         [pod], // repoPods
         [], // active tasks on the dead pod
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -294,6 +317,7 @@ describe("repo-cleanup-worker", () => {
       selectResults = [
         [pod], // repoPods
         [], // active tasks
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -316,6 +340,7 @@ describe("repo-cleanup-worker", () => {
       selectResults = [
         [pod], // repoPods
         [task], // active tasks on the dead pod
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -343,6 +368,7 @@ describe("repo-cleanup-worker", () => {
       selectResults = [
         [pod], // repoPods
         [], // active tasks
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -363,6 +389,7 @@ describe("repo-cleanup-worker", () => {
       const pod = makePod({ state: "error" });
       selectResults = [
         [pod], // repoPods
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -389,6 +416,7 @@ describe("repo-cleanup-worker", () => {
       const pod = makePod();
       selectResults = [
         [pod], // repoPods
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -414,6 +442,7 @@ describe("repo-cleanup-worker", () => {
       const pod = makePod({ state: "error" });
       selectResults = [
         [pod], // repoPods
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -438,6 +467,7 @@ describe("repo-cleanup-worker", () => {
       selectResults = [
         [pod], // repoPods
         [], // task lookup for orphan worktree (no task found)
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -470,6 +500,7 @@ describe("repo-cleanup-worker", () => {
             maxRetries: 3,
           },
         ], // task lookup
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -497,6 +528,7 @@ describe("repo-cleanup-worker", () => {
             maxRetries: 3,
           },
         ],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -524,6 +556,7 @@ describe("repo-cleanup-worker", () => {
             maxRetries: 3,
           },
         ],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -550,6 +583,7 @@ describe("repo-cleanup-worker", () => {
             maxRetries: 3,
           },
         ],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -579,6 +613,7 @@ describe("repo-cleanup-worker", () => {
             maxRetries: 3,
           },
         ],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -610,6 +645,7 @@ describe("repo-cleanup-worker", () => {
             maxRetries: 3,
           },
         ],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -638,6 +674,7 @@ describe("repo-cleanup-worker", () => {
             maxRetries: 3,
           },
         ],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -664,6 +701,7 @@ describe("repo-cleanup-worker", () => {
             maxRetries: 3,
           },
         ],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -689,6 +727,7 @@ describe("repo-cleanup-worker", () => {
       });
       selectResults = [
         [], // repoPods — no pods
+        [], // soft stall detection: running tasks with lastActivityAt
         [staleTask], // stale tasks query
         [{ count: 1 }], // staleRetryCount < MAX_STALE_RETRIES (3)
       ];
@@ -725,6 +764,7 @@ describe("repo-cleanup-worker", () => {
       });
       selectResults = [
         [], // repoPods
+        [], // soft stall detection: running tasks
         [staleTask], // stale tasks
         [{ count: 3 }], // staleRetryCount >= MAX_STALE_RETRIES
       ];
@@ -749,6 +789,8 @@ describe("repo-cleanup-worker", () => {
     it("calls reconcileActiveTaskCounts", async () => {
       selectResults = [
         [], // repoPods
+        [], // soft stall detection: running tasks
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -760,6 +802,7 @@ describe("repo-cleanup-worker", () => {
     it("calls cleanupIdleRepoPods", async () => {
       selectResults = [
         [], // repoPods
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -771,6 +814,7 @@ describe("repo-cleanup-worker", () => {
     it("handles cleanupExpiredSessions error gracefully", async () => {
       selectResults = [
         [], // repoPods
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -783,6 +827,7 @@ describe("repo-cleanup-worker", () => {
     it("calls cleanupExpiredSessions", async () => {
       selectResults = [
         [], // repoPods
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -800,6 +845,7 @@ describe("repo-cleanup-worker", () => {
     it("handles empty pod list gracefully", async () => {
       selectResults = [
         [], // repoPods — no pods at all
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -813,6 +859,7 @@ describe("repo-cleanup-worker", () => {
 
       selectResults = [
         [provisioningPod, readyPod, noPodName], // repoPods
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -834,6 +881,7 @@ describe("repo-cleanup-worker", () => {
       selectResults = [
         [pod],
         [], // active tasks
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -861,6 +909,7 @@ describe("repo-cleanup-worker", () => {
             maxRetries: 3,
           },
         ],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -890,6 +939,7 @@ describe("repo-cleanup-worker", () => {
             maxRetries: 3,
           },
         ],
+        [], // soft stall detection: running tasks
         [], // stale tasks
       ];
 
@@ -903,6 +953,97 @@ describe("repo-cleanup-worker", () => {
 
       expect(mockRtExec).toHaveBeenCalledTimes(2);
       expect(mockUpdateWorktree).toHaveBeenCalledWith("task-noretry", "removed");
+    });
+  });
+
+  describe("soft stall detection", () => {
+    it("flags a running task as stalled when silent beyond threshold", async () => {
+      const stalledTask = {
+        id: "task-stalled",
+        repoUrl: "https://github.com/test/repo",
+        workspaceId: null,
+        lastActivityAt: new Date(Date.now() - 400_000), // 6.6 min ago
+        activitySubstate: "active",
+      };
+
+      selectResults = [
+        [], // pods
+        [stalledTask], // running tasks with lastActivityAt (stall detection query)
+        [], // repo config lookup
+        [], // soft stall detection: running tasks
+        [], // stale tasks
+      ];
+
+      mockRtStatus.mockResolvedValue({ state: "running" });
+      mockGetStallThreshold.mockReturnValue(300_000); // 5 min
+
+      await processorFn();
+
+      // Should have updated the task to stalled
+      expect(mockUpdate).toHaveBeenCalled();
+      // Should have published task:stalled event
+      expect(mockPublishEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "task:stalled",
+          taskId: "task-stalled",
+        }),
+      );
+    });
+
+    it("does NOT flag a task that is within threshold", async () => {
+      const activeTask = {
+        id: "task-active",
+        repoUrl: "https://github.com/test/repo",
+        workspaceId: null,
+        lastActivityAt: new Date(Date.now() - 60_000), // 1 min ago
+        activitySubstate: "active",
+      };
+
+      selectResults = [
+        [], // pods
+        [activeTask], // running tasks
+        [], // repo config
+        [], // soft stall detection: running tasks
+        [], // stale tasks
+      ];
+
+      mockRtStatus.mockResolvedValue({ state: "running" });
+      mockGetStallThreshold.mockReturnValue(300_000);
+
+      await processorFn();
+
+      // Should NOT have published stall event
+      expect(mockPublishEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "task:stalled" }),
+      );
+    });
+
+    it("does NOT re-flag an already stalled task", async () => {
+      const alreadyStalled = {
+        id: "task-already-stalled",
+        repoUrl: "https://github.com/test/repo",
+        workspaceId: null,
+        lastActivityAt: new Date(Date.now() - 600_000), // 10 min ago
+        activitySubstate: "stalled", // already flagged
+      };
+
+      selectResults = [
+        [], // pods
+        [alreadyStalled], // running tasks
+        [], // repo config
+        [], // soft stall detection: running tasks
+        [], // stale tasks
+      ];
+
+      mockRtStatus.mockResolvedValue({ state: "running" });
+      mockGetStallThreshold.mockReturnValue(300_000);
+
+      await processorFn();
+
+      // Should NOT publish duplicate stall event
+      expect(mockPublishEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "task:stalled" }),
+      );
     });
   });
 });

--- a/apps/api/src/workers/repo-cleanup-worker.ts
+++ b/apps/api/src/workers/repo-cleanup-worker.ts
@@ -1,7 +1,7 @@
 import { Queue, Worker } from "bullmq";
 import { eq, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { repoPods, podHealthEvents, tasks, taskEvents } from "../db/schema.js";
+import { repoPods, podHealthEvents, tasks, taskEvents, repos } from "../db/schema.js";
 import {
   cleanupIdleRepoPods,
   updateWorktreeState,
@@ -9,9 +9,10 @@ import {
   deleteNetworkPolicy,
 } from "../services/repo-pool-service.js";
 import { getRuntime } from "../services/container-service.js";
-import { TaskState } from "@optio/shared";
+import { TaskState, DEFAULT_STALL_THRESHOLD_MS } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
 import { cleanupExpiredSessions } from "../services/session-service.js";
+import { publishEvent } from "../services/event-bus.js";
 import { logger } from "../logger.js";
 
 import { getBullMQConnectionOptions } from "../services/redis-config.js";
@@ -44,6 +45,17 @@ export function startRepoCleanupWorker() {
     {
       repeat: {
         every: parseInt(process.env.OPTIO_HEALTH_CHECK_INTERVAL ?? "60000", 10),
+      },
+    },
+  );
+
+  // Dedicated stall-check cadence (30s) — more responsive than the 60s health-check
+  repoCleanupQueue.add(
+    "stall-check",
+    {},
+    {
+      repeat: {
+        every: parseInt(process.env.OPTIO_STALL_CHECK_INTERVAL ?? "30000", 10),
       },
     },
   );
@@ -257,6 +269,89 @@ export function startRepoCleanupWorker() {
         } catch {
           // Pod may not be accessible — skip
         }
+      }
+
+      // ── Soft stall detection ──────────────────────────────────────────────
+      // Flag running tasks that have been silent beyond their threshold.
+      // This does NOT fail/retry the task — it's an observable warning only.
+      try {
+        const globalThreshold = parseInt(
+          process.env.OPTIO_STALL_THRESHOLD_MS ?? String(DEFAULT_STALL_THRESHOLD_MS),
+          10,
+        );
+
+        // Fetch all running tasks with lastActivityAt set
+        const runningTasks = await db
+          .select({
+            id: tasks.id,
+            repoUrl: tasks.repoUrl,
+            workspaceId: tasks.workspaceId,
+            lastActivityAt: tasks.lastActivityAt,
+            activitySubstate: tasks.activitySubstate,
+          })
+          .from(tasks)
+          .where(sql`${tasks.state} = 'running' AND ${tasks.lastActivityAt} IS NOT NULL`);
+
+        // Cache repo configs to avoid repeated queries
+        const repoConfigCache = new Map<string, typeof repos.$inferSelect | null>();
+
+        for (const task of runningTasks) {
+          const now = Date.now();
+          const lastActivity = new Date(task.lastActivityAt!).getTime();
+          const silentForMs = now - lastActivity;
+
+          // Get per-repo threshold
+          let repoConfig = repoConfigCache.get(task.repoUrl);
+          if (repoConfig === undefined) {
+            const [rc] = await db.select().from(repos).where(eq(repos.repoUrl, task.repoUrl));
+            repoConfig = rc ?? null;
+            repoConfigCache.set(task.repoUrl, repoConfig);
+          }
+          const threshold = taskService.getStallThresholdForRepo(repoConfig);
+
+          if (silentForMs >= threshold && task.activitySubstate !== "stalled") {
+            // Mark as stalled
+            await db
+              .update(tasks)
+              .set({ activitySubstate: "stalled" })
+              .where(eq(tasks.id, task.id));
+
+            // Get last log summary for the stall event
+            const lastLogSummary = await taskService.getLastLogSummary(task.id);
+
+            await publishEvent({
+              type: "task:stalled",
+              taskId: task.id,
+              lastActivityAt: task.lastActivityAt!.toISOString(),
+              silentForMs,
+              lastLogSummary,
+              timestamp: new Date().toISOString(),
+            });
+
+            logger.info(
+              { taskId: task.id, silentForMs, threshold },
+              "Task flagged as stalled (soft)",
+            );
+          } else if (silentForMs < threshold && task.activitySubstate === "stalled") {
+            // Recovered — activity flush in task-worker already handles this,
+            // but catch edge cases here too
+            await db
+              .update(tasks)
+              .set({ activitySubstate: "recovered" })
+              .where(eq(tasks.id, task.id));
+
+            await publishEvent({
+              type: "task:recovered",
+              taskId: task.id,
+              silentWasMs: silentForMs,
+              timestamp: new Date().toISOString(),
+            });
+
+            logger.info({ taskId: task.id }, "Task recovered from stall");
+          }
+        }
+      } catch (err) {
+        logger.warn({ err }, "Soft stall detection pass failed");
       }
 
       // Detect stale running/provisioning tasks (agent exec died without updating state)

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -568,6 +568,10 @@ export function startTaskWorker() {
           : undefined;
         let lastHeartbeat = Date.now();
         const HEARTBEAT_INTERVAL_MS = 60_000;
+        // Stall detection: debounced activity timestamp flush
+        let pendingActivityAt: Date | null = null;
+        let lastActivityFlushAt = 0;
+        const ACTIVITY_FLUSH_INTERVAL_MS = 5_000;
         // Buffer for partial NDJSON lines split across chunks
         let lineBuf = "";
 
@@ -664,6 +668,11 @@ export function startTaskWorker() {
                 entry.metadata,
               );
 
+              // Stall detection: mark activity on meaningful parsed events
+              if (["text", "tool_use", "tool_result", "thinking", "system"].includes(entry.type)) {
+                pendingActivityAt = new Date();
+              }
+
               // Check for PR URL — only capture the first PR URL from agent output
               // that matches the task's own repo. Without repo validation, the
               // agent referencing another repo's PR (e.g. via gh pr list on a
@@ -706,6 +715,19 @@ export function startTaskWorker() {
               }
             }
           }
+
+          // Debounced flush of lastActivityAt to avoid per-event DB writes
+          if (pendingActivityAt && Date.now() - lastActivityFlushAt > ACTIVITY_FLUSH_INTERVAL_MS) {
+            await taskService.updateTaskActivity(taskId, pendingActivityAt);
+            lastActivityFlushAt = Date.now();
+            pendingActivityAt = null;
+          }
+        }
+
+        // Final flush of pending activity timestamp
+        if (pendingActivityAt) {
+          await taskService.updateTaskActivity(taskId, pendingActivityAt);
+          pendingActivityAt = null;
         }
 
         // Flush any remaining partial line in the buffer

--- a/apps/api/src/ws/log-stream.ts
+++ b/apps/api/src/ws/log-stream.ts
@@ -72,7 +72,9 @@ export async function logStreamWs(app: FastifyInstance) {
           event.type === "task:state_changed" ||
           event.type === "task:message" ||
           event.type === "task:message_delivered" ||
-          event.type === "task:message_acked"
+          event.type === "task:message_acked" ||
+          event.type === "task:stalled" ||
+          event.type === "task:recovered"
         ) {
           socket.send(message);
         }

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -26,6 +26,7 @@ import {
   Bot,
   Send,
   AlertCircle,
+  AlertTriangle,
   Eye,
   Key,
   Check,
@@ -42,7 +43,8 @@ import { AddDependencyDialog } from "@/components/add-dependency-dialog";
 
 export default function TaskDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { task, events, pendingReason, pipelineProgress, loading, error, refresh } = useTask(id);
+  const { task, events, pendingReason, pipelineProgress, stallInfo, loading, error, refresh } =
+    useTask(id);
   usePageTitle(task?.title ?? "Task");
   const [actionLoading, setActionLoading] = useState(false);
   const [resumePrompt, setResumePrompt] = useState("");
@@ -222,7 +224,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-3 flex-wrap">
                 <h1 className="text-lg font-bold tracking-tight">{task.title}</h1>
-                <StateBadge state={task.state} />
+                <StateBadge state={task.state} isStalled={stallInfo?.isStalled} />
               </div>
               <div className="flex items-center gap-4 mt-2 text-xs text-text-muted flex-wrap">
                 <span className="flex items-center gap-1">
@@ -357,6 +359,36 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
                 Run Now
               </button>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* Stall warning banner */}
+      {stallInfo?.isStalled && task?.state === "running" && (
+        <div className="shrink-0 border-b border-warning/20 bg-warning/5">
+          <div className="max-w-5xl mx-auto px-4 py-2.5 flex items-center gap-2 text-xs">
+            <AlertTriangle className="w-3.5 h-3.5 text-warning shrink-0" />
+            <span className="text-warning/80">
+              Agent looks stuck. No activity for{" "}
+              {stallInfo.silentForMs >= 60000
+                ? `${Math.floor(stallInfo.silentForMs / 60000)}m ${Math.floor((stallInfo.silentForMs % 60000) / 1000)}s`
+                : `${Math.floor(stallInfo.silentForMs / 1000)}s`}
+              .{stallInfo.lastLogSummary ? ` Last action: ${stallInfo.lastLogSummary}` : ""}
+            </span>
+            <span
+              className="ml-auto flex items-center gap-1 px-2 py-1 rounded-md bg-text-muted/10 text-text-muted/50 text-[10px] cursor-not-allowed"
+              title="Coming soon — depends on interactive messaging feature"
+            >
+              Send a nudge
+            </span>
+            <button
+              disabled={actionLoading}
+              onClick={handleCancel}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-error/10 text-error hover:bg-error/20 transition-all shrink-0"
+            >
+              <XCircle className="w-3 h-3" />
+              Force fail
+            </button>
           </div>
         </div>
       )}

--- a/apps/web/src/components/state-badge.test.tsx
+++ b/apps/web/src/components/state-badge.test.tsx
@@ -1,6 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
 import { StateBadge } from "./state-badge";
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("StateBadge", () => {
   it("renders the correct label for known states", () => {
@@ -59,5 +63,21 @@ describe("StateBadge", () => {
     const { container } = render(<StateBadge state="completed" />);
     const dot = container.querySelector(".rounded-full");
     expect(dot?.className).not.toContain("glow-dot");
+  });
+
+  it("renders Stuck pill when isStalled is true", () => {
+    const { rerender } = render(<StateBadge state="running" isStalled={true} />);
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.getByText("Stuck")).toBeInTheDocument();
+
+    // does not render Stuck pill when isStalled is false
+    rerender(<StateBadge state="running" isStalled={false} />);
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.queryByText("Stuck")).not.toBeInTheDocument();
+
+    // does not render Stuck pill when isStalled is undefined
+    rerender(<StateBadge state="running" />);
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.queryByText("Stuck")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/state-badge.tsx
+++ b/apps/web/src/components/state-badge.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { AlertTriangle } from "lucide-react";
 
 const STATE_CONFIG: Record<
   string,
@@ -76,7 +77,15 @@ const STATE_CONFIG: Record<
   },
 };
 
-export function StateBadge({ state, showDot = true }: { state: string; showDot?: boolean }) {
+export function StateBadge({
+  state,
+  showDot = true,
+  isStalled,
+}: {
+  state: string;
+  showDot?: boolean;
+  isStalled?: boolean;
+}) {
   const config = STATE_CONFIG[state] ?? {
     label: state,
     color: "text-text-muted",
@@ -84,20 +93,28 @@ export function StateBadge({ state, showDot = true }: { state: string; showDot?:
     glowClass: "badge-glow-muted",
   };
   return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[11px] font-medium tracking-wide uppercase transition-all duration-200",
-        config.color,
-        config.glowClass,
-        config.emphasis && "border border-warning/20",
+    <span className="inline-flex items-center gap-1">
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[11px] font-medium tracking-wide uppercase transition-all duration-200",
+          config.color,
+          config.glowClass,
+          config.emphasis && "border border-warning/20",
+        )}
+      >
+        {showDot && (
+          <span
+            className={cn("w-1.5 h-1.5 rounded-full", config.dotColor, config.pulse && "glow-dot")}
+          />
+        )}
+        {config.label}
+      </span>
+      {isStalled && (
+        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-medium tracking-wide uppercase text-warning bg-warning/10 border border-warning/20">
+          <AlertTriangle className="w-3 h-3" />
+          Stuck
+        </span>
       )}
-    >
-      {showDot && (
-        <span
-          className={cn("w-1.5 h-1.5 rounded-full", config.dotColor, config.pulse && "glow-dot")}
-        />
-      )}
-      {config.label}
     </span>
   );
 }

--- a/apps/web/src/components/task-card.tsx
+++ b/apps/web/src/components/task-card.tsx
@@ -7,7 +7,16 @@ import { StateBadge } from "./state-badge";
 import { classifyError } from "@optio/shared";
 import { api } from "@/lib/api-client";
 import { formatRelativeTime } from "@/lib/utils";
-import { ExternalLink, RotateCcw, Bot, Link2, Clock, Moon, Play } from "lucide-react";
+import {
+  ExternalLink,
+  RotateCcw,
+  Bot,
+  Link2,
+  Clock,
+  Moon,
+  Play,
+  AlertTriangle,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useOptioChatStore } from "@/hooks/use-optio-chat";
 
@@ -32,6 +41,9 @@ interface TaskSummary {
   taskType?: string;
   parentTaskId?: string;
   pendingReason?: string | null;
+  lastActivityAt?: string;
+  activitySubstate?: string;
+  isStalled?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -88,7 +100,7 @@ export const TaskCard = React.memo(function TaskCard({ task, subtasks }: TaskCar
                 ${parseFloat(task.costUsd).toFixed(2)}
               </span>
             )}
-            <StateBadge state={task.state} />
+            <StateBadge state={task.state} isStalled={task.isStalled} />
           </div>
         </div>
 
@@ -137,6 +149,17 @@ export const TaskCard = React.memo(function TaskCard({ task, subtasks }: TaskCar
               <Play className="w-3 h-3" />
               Run Now
             </button>
+          </div>
+        )}
+
+        {/* Stall indicator */}
+        {task.state === "running" && task.isStalled && (
+          <div className="mt-3 px-3 py-2 rounded-lg bg-warning/5 border border-warning/10 flex items-center gap-2">
+            <AlertTriangle className="w-3 h-3 text-warning/60 shrink-0" />
+            <span className="text-xs text-warning/70">
+              No activity for{" "}
+              {task.lastActivityAt ? formatRelativeTime(task.lastActivityAt) : "a while"}
+            </span>
           </div>
         )}
 

--- a/apps/web/src/hooks/use-store.ts
+++ b/apps/web/src/hooks/use-store.ts
@@ -15,6 +15,9 @@ export interface TaskSummary {
   parentTaskId?: string;
   ticketExternalId?: string;
   pendingReason?: string | null;
+  lastActivityAt?: string;
+  activitySubstate?: string;
+  isStalled?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/apps/web/src/hooks/use-task.ts
+++ b/apps/web/src/hooks/use-task.ts
@@ -8,6 +8,7 @@ export function useTask(id: string) {
   const [events, setEvents] = useState<any[]>([]);
   const [pendingReason, setPendingReason] = useState<string | null>(null);
   const [pipelineProgress, setPipelineProgress] = useState<any>(null);
+  const [stallInfo, setStallInfo] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -17,6 +18,7 @@ export function useTask(id: string) {
       setTask(taskRes.task);
       setPendingReason(taskRes.pendingReason ?? null);
       setPipelineProgress(taskRes.pipelineProgress ?? null);
+      setStallInfo(taskRes.stallInfo ?? null);
       setEvents(eventsRes.events);
       setError(null);
     } catch (err) {
@@ -30,5 +32,5 @@ export function useTask(id: string) {
     refresh();
   }, [refresh]);
 
-  return { task, events, pendingReason, pipelineProgress, loading, error, refresh };
+  return { task, events, pendingReason, pipelineProgress, stallInfo, loading, error, refresh };
 }

--- a/apps/web/src/hooks/use-websocket.ts
+++ b/apps/web/src/hooks/use-websocket.ts
@@ -63,6 +63,21 @@ export function useGlobalWebSocket() {
         .updateTask(event.taskId, { pendingReason: event.data?.pendingReason ?? null });
     });
 
+    client.on("task:stalled", (event) => {
+      useStore.getState().updateTask(event.taskId, {
+        activitySubstate: "stalled",
+        isStalled: true,
+        lastActivityAt: event.lastActivityAt,
+      });
+    });
+
+    client.on("task:recovered", (event) => {
+      useStore.getState().updateTask(event.taskId, {
+        activitySubstate: "recovered",
+        isStalled: false,
+      });
+    });
+
     client.on("task:created", (event) => {
       useStore.getState().addTask({
         id: event.taskId,

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -69,9 +69,17 @@ export const api = {
   },
 
   getTask: (id: string) =>
-    request<{ task: any; pendingReason?: string | null; pipelineProgress?: any | null }>(
-      `/api/tasks/${id}`,
-    ),
+    request<{
+      task: any;
+      pendingReason?: string | null;
+      pipelineProgress?: any | null;
+      stallInfo?: {
+        isStalled: boolean;
+        silentForMs: number;
+        thresholdMs: number;
+        lastLogSummary?: string;
+      } | null;
+    }>(`/api/tasks/${id}`),
 
   createTask: (data: {
     title: string;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -8,6 +8,13 @@ export const DEFAULT_MAX_TURNS_REVIEW = 30;
 export const DEFAULT_MAX_TICKET_PAGES = 20;
 
 /**
+ * Default threshold (in ms) before a running task is flagged as "stalled".
+ * Override per-repo via `repos.stallThresholdMs` or globally via
+ * `OPTIO_STALL_THRESHOLD_MS` env var.
+ */
+export const DEFAULT_STALL_THRESHOLD_MS = 300_000; // 5 minutes
+
+/**
  * Max length for K8s resource names.
  */
 const K8S_NAME_MAX = 63;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,4 +21,5 @@ export * from "./types/optio-settings.js";
 export * from "./types/optio-action.js";
 export * from "./types/git-platform.js";
 export * from "./utils/parse-repo-url.js";
+export * from "./utils/is-stalled.js";
 export * from "./optio-tools.js";

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -6,6 +6,8 @@ export type WsEvent =
   | TaskLogEvent
   | TaskCreatedEvent
   | TaskPendingReasonEvent
+  | TaskStalledEvent
+  | TaskRecoveredEvent
   | AuthFailedEvent
   | SessionCreatedEvent
   | SessionEndedEvent
@@ -66,6 +68,22 @@ export interface SessionCreatedEvent {
 export interface SessionEndedEvent {
   type: "session:ended";
   sessionId: string;
+  timestamp: string;
+}
+
+export interface TaskStalledEvent {
+  type: "task:stalled";
+  taskId: string;
+  lastActivityAt: string; // ISO
+  silentForMs: number;
+  lastLogSummary?: string; // e.g. "Bash $ npm test"
+  timestamp: string;
+}
+
+export interface TaskRecoveredEvent {
+  type: "task:recovered";
+  taskId: string;
+  silentWasMs: number;
   timestamp: string;
 }
 

--- a/packages/shared/src/types/task.ts
+++ b/packages/shared/src/types/task.ts
@@ -11,6 +11,8 @@ export enum TaskState {
   CANCELLED = "cancelled",
 }
 
+export type TaskActivitySubstate = "active" | "stalled" | "recovered";
+
 export interface Task {
   id: string;
   title: string;
@@ -28,10 +30,19 @@ export interface Task {
   metadata?: Record<string, unknown>;
   retryCount: number;
   maxRetries: number;
+  lastActivityAt?: Date;
+  activitySubstate?: TaskActivitySubstate;
   createdAt: Date;
   updatedAt: Date;
   startedAt?: Date;
   completedAt?: Date;
+}
+
+export interface StallInfo {
+  isStalled: boolean;
+  silentForMs: number;
+  thresholdMs: number;
+  lastLogSummary?: string;
 }
 
 export interface TaskEvent {

--- a/packages/shared/src/utils/is-stalled.test.ts
+++ b/packages/shared/src/utils/is-stalled.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { isTaskStalled, getSilentDuration } from "./is-stalled.js";
+
+describe("isTaskStalled", () => {
+  const now = new Date("2026-04-07T12:00:00Z");
+
+  it("returns false for non-running tasks", () => {
+    expect(
+      isTaskStalled({ state: "completed", lastActivityAt: new Date("2026-04-07T11:00:00Z") }, now),
+    ).toBe(false);
+  });
+
+  it("returns false when lastActivityAt is not set", () => {
+    expect(isTaskStalled({ state: "running", lastActivityAt: null }, now)).toBe(false);
+    expect(isTaskStalled({ state: "running" }, now)).toBe(false);
+  });
+
+  it("returns false when within threshold", () => {
+    // 4 minutes silent, 5 min threshold
+    const lastActivity = new Date("2026-04-07T11:56:00Z");
+    expect(isTaskStalled({ state: "running", lastActivityAt: lastActivity }, now, 300_000)).toBe(
+      false,
+    );
+  });
+
+  it("returns true when past threshold", () => {
+    // 6 minutes silent, 5 min threshold
+    const lastActivity = new Date("2026-04-07T11:54:00Z");
+    expect(isTaskStalled({ state: "running", lastActivityAt: lastActivity }, now, 300_000)).toBe(
+      true,
+    );
+  });
+
+  it("returns true when exactly at threshold", () => {
+    // Exactly 5 minutes
+    const lastActivity = new Date("2026-04-07T11:55:00Z");
+    expect(isTaskStalled({ state: "running", lastActivityAt: lastActivity }, now, 300_000)).toBe(
+      true,
+    );
+  });
+
+  it("accepts string dates", () => {
+    const lastActivity = "2026-04-07T11:54:00Z";
+    expect(isTaskStalled({ state: "running", lastActivityAt: lastActivity }, now, 300_000)).toBe(
+      true,
+    );
+  });
+
+  it("uses default threshold when not provided", () => {
+    // 4 minutes silent — should not be stalled (default is 5 min)
+    const lastActivity = new Date("2026-04-07T11:56:00Z");
+    expect(isTaskStalled({ state: "running", lastActivityAt: lastActivity }, now)).toBe(false);
+
+    // 6 minutes silent — should be stalled
+    const staleActivity = new Date("2026-04-07T11:54:00Z");
+    expect(isTaskStalled({ state: "running", lastActivityAt: staleActivity }, now)).toBe(true);
+  });
+
+  it("respects custom threshold", () => {
+    // 2 minutes silent, 1 min threshold → stalled
+    const lastActivity = new Date("2026-04-07T11:58:00Z");
+    expect(isTaskStalled({ state: "running", lastActivityAt: lastActivity }, now, 60_000)).toBe(
+      true,
+    );
+  });
+
+  it("handles per-repo 15-minute threshold", () => {
+    // 10 minutes silent, 15 min threshold → NOT stalled
+    const lastActivity = new Date("2026-04-07T11:50:00Z");
+    expect(isTaskStalled({ state: "running", lastActivityAt: lastActivity }, now, 900_000)).toBe(
+      false,
+    );
+
+    // 16 minutes silent, 15 min threshold → stalled
+    const veryStale = new Date("2026-04-07T11:44:00Z");
+    expect(isTaskStalled({ state: "running", lastActivityAt: veryStale }, now, 900_000)).toBe(true);
+  });
+});
+
+describe("getSilentDuration", () => {
+  const now = new Date("2026-04-07T12:00:00Z");
+
+  it("returns 0 for non-running tasks", () => {
+    expect(
+      getSilentDuration(
+        { state: "completed", lastActivityAt: new Date("2026-04-07T11:50:00Z") },
+        now,
+      ),
+    ).toBe(0);
+  });
+
+  it("returns 0 when lastActivityAt is not set", () => {
+    expect(getSilentDuration({ state: "running" }, now)).toBe(0);
+  });
+
+  it("returns correct duration", () => {
+    const lastActivity = new Date("2026-04-07T11:55:00Z");
+    expect(getSilentDuration({ state: "running", lastActivityAt: lastActivity }, now)).toBe(
+      300_000,
+    );
+  });
+
+  it("never returns negative", () => {
+    // lastActivityAt in the future (clock skew)
+    const future = new Date("2026-04-07T12:05:00Z");
+    expect(getSilentDuration({ state: "running", lastActivityAt: future }, now)).toBe(0);
+  });
+});

--- a/packages/shared/src/utils/is-stalled.ts
+++ b/packages/shared/src/utils/is-stalled.ts
@@ -1,0 +1,35 @@
+import { DEFAULT_STALL_THRESHOLD_MS } from "../constants.js";
+
+/**
+ * Pure function to check if a task is stalled based on its lastActivityAt
+ * timestamp and a configurable threshold.
+ */
+export function isTaskStalled(
+  task: { state: string; lastActivityAt?: Date | string | null },
+  now: Date = new Date(),
+  thresholdMs: number = DEFAULT_STALL_THRESHOLD_MS,
+): boolean {
+  if (task.state !== "running") return false;
+  if (!task.lastActivityAt) return false;
+
+  const lastActivity =
+    task.lastActivityAt instanceof Date ? task.lastActivityAt : new Date(task.lastActivityAt);
+  const silentForMs = now.getTime() - lastActivity.getTime();
+  return silentForMs >= thresholdMs;
+}
+
+/**
+ * Compute how long a task has been silent (in ms).
+ * Returns 0 if lastActivityAt is not set or the task is not running.
+ */
+export function getSilentDuration(
+  task: { state: string; lastActivityAt?: Date | string | null },
+  now: Date = new Date(),
+): number {
+  if (task.state !== "running") return 0;
+  if (!task.lastActivityAt) return 0;
+
+  const lastActivity =
+    task.lastActivityAt instanceof Date ? task.lastActivityAt : new Date(task.lastActivityAt);
+  return Math.max(0, now.getTime() - lastActivity.getTime());
+}


### PR DESCRIPTION
## Summary

- Add soft stall detection for running tasks whose agent has gone silent beyond a configurable threshold (default 5 min)
- Surface a yellow "Looks stuck" warning in the UI via new `lastActivityAt` field, `activitySubstate` enum, and dedicated stall-detector tick
- Coexists with the existing hard stale-task fallback (10 min → fail + retry) as a safety net

## Changes

### Backend
- **Schema**: New `lastActivityAt` (timestamptz) and `activitySubstate` (enum: active/stalled/recovered) columns on `tasks`; new `stallThresholdMs` column on `repos` for per-repo threshold override; partial index on running tasks for efficient detection queries
- **Task worker**: Debounced (5s) `lastActivityAt` flush during agent log streaming — only updates on meaningful parsed events (text, tool_use, tool_result, thinking, system)
- **Repo cleanup worker**: New soft stall detection pass (30s cadence) that flags silent tasks as stalled and emits `task:stalled` / `task:recovered` WebSocket events
- **Task service**: `updateTaskActivity()` with stall→recovered transition detection; `getStallThresholdForRepo()` with per-repo → env → default resolution; `getLastLogSummary()` for stall banner context; transition hooks to reset substate on state changes
- **Routes**: `stallInfo` object in GET /api/tasks/:id; `isStalled` boolean enrichment on task list
- **WebSocket**: `task:stalled` and `task:recovered` events forwarded on per-task log channel

### Frontend
- **StateBadge**: Yellow "Stuck" pill overlay when `isStalled` is true
- **TaskCard**: Stall indicator row showing time since last activity
- **Task detail page**: Warning banner with silent duration, last action, disabled "Send a nudge" button (pending messaging feature), and "Force fail" button
- **Zustand store**: New `lastActivityAt`, `activitySubstate`, `isStalled` fields on TaskSummary
- **WebSocket handlers**: Real-time stall/recovery updates via event bus

### Shared
- `DEFAULT_STALL_THRESHOLD_MS` constant (300,000 = 5 min)
- `isTaskStalled()` and `getSilentDuration()` pure utility functions
- `TaskStalledEvent` and `TaskRecoveredEvent` types added to WsEvent union
- `TaskActivitySubstate` and `StallInfo` types on Task interface

## Configuration

| Setting | Default | Description |
|---------|---------|-------------|
| `OPTIO_STALL_THRESHOLD_MS` | `300000` (5 min) | Global stall threshold |
| `repos.stallThresholdMs` | `null` (use global) | Per-repo override |
| `OPTIO_STALL_CHECK_INTERVAL` | `30000` (30s) | Stall detection cadence |

## Test plan

- [x] `packages/shared/src/utils/is-stalled.test.ts` — 13 tests for pure stall detection logic
- [x] `apps/api/src/services/task-service.test.ts` — Tests for `getStallThresholdForRepo` and `updateTaskActivity`
- [x] `apps/api/src/workers/repo-cleanup-worker.test.ts` — Tests for soft stall detection (flags stalled, skips active, no re-flag)
- [x] `apps/web/src/components/state-badge.test.tsx` — Tests for Stuck pill rendering
- [x] All existing tests pass (1301 API + 189 web + 215 shared)
- [x] TypeCheck passes across all 7 packages
- [x] Next.js production build succeeds
- [x] Prettier formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)