### PR TITLE
Allow to deploy in K8s without extra privileges

### DIFF
--- a/apps/api/src/routes/cluster.test.ts
+++ b/apps/api/src/routes/cluster.test.ts
@@ -106,13 +106,34 @@ describe("GET /api/cluster/overview", () => {
     app = await buildTestApp();
   });
 
-  it("returns 500 when K8s API fails", async () => {
-    mockListNode.mockRejectedValue(new Error("K8s API unavailable"));
+  it("returns 500 when namespace-scoped K8s API fails", async () => {
+    mockListNode.mockResolvedValue({ items: [] });
+    mockListNamespacedPod.mockRejectedValue(new Error("K8s API unavailable"));
+    mockListNamespacedService.mockRejectedValue(new Error("K8s API unavailable"));
+    mockListNamespacedEvent.mockRejectedValue(new Error("K8s API unavailable"));
 
     const res = await app.inject({ method: "GET", url: "/api/cluster/overview" });
 
     expect(res.statusCode).toBe(500);
     expect(res.json().error).toContain("K8s API unavailable");
+  });
+
+  it("returns 200 with empty nodes when listNode fails (no ClusterRole)", async () => {
+    mockListNode.mockRejectedValue(new Error("Forbidden: nodes is forbidden"));
+    mockListNamespacedPod.mockResolvedValue({ items: [] });
+    mockListNamespacedService.mockResolvedValue({ items: [] });
+    mockListNamespacedEvent.mockResolvedValue({ items: [] });
+    mockListClusterCustomObject.mockRejectedValue(new Error("Forbidden"));
+    mockListNamespacedCustomObject.mockResolvedValue({ items: [] });
+
+    const res = await app.inject({ method: "GET", url: "/api/cluster/overview" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.nodes).toEqual([]);
+    expect(body.summary.totalNodes).toBe(0);
+    expect(body.summary.readyNodes).toBe(0);
+    expect(body.pods).toBeDefined();
   });
 });
 

--- a/apps/api/src/routes/cluster.ts
+++ b/apps/api/src/routes/cluster.ts
@@ -105,14 +105,25 @@ export async function clusterRoutes(app: FastifyInstance) {
     try {
       const api = getK8sApi();
 
+      // listNode requires ClusterRole — gracefully return empty when unavailable
+      // (e.g. namespace-only RBAC with no cluster-wide permissions)
+      const listNodeSafe = async () => {
+        try {
+          return await api.listNode({ limit: 50 });
+        } catch {
+          return { items: [] };
+        }
+      };
+
       const [nodeList, podList, serviceList, eventList] = await Promise.all([
-        api.listNode({ limit: 50 }),
+        listNodeSafe(),
         api.listNamespacedPod({ namespace: NAMESPACE }),
         api.listNamespacedService({ namespace: NAMESPACE }),
         api.listNamespacedEvent({ namespace: NAMESPACE, limit: 30 }),
       ]);
 
-      // Fetch metrics (gracefully fail if metrics-server not installed)
+      // Fetch metrics (gracefully fail if metrics-server not installed or
+      // ClusterRole unavailable for node metrics)
       const [nodeMetricsItems, podMetricsItems] = await Promise.all([
         fetchNodeMetrics(),
         fetchPodMetrics(NAMESPACE),

--- a/helm/optio/templates/rbac.yaml
+++ b/helm/optio/templates/rbac.yaml
@@ -59,8 +59,10 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Values.namespace }}
+{{- if .Values.rbac.clusterRole.create }}
 ---
-# ClusterRole for node metrics (needed for cluster overview)
+# ClusterRole for node metrics (needed for cluster overview).
+# Disable with rbac.clusterRole.create=false for namespace-only deployments.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -92,4 +94,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Values.namespace }}
+{{- end }}
 {{- end }}

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -393,6 +393,17 @@ resourceQuota:
     persistentvolumeclaims: "30"
 
 # ──────────────────────────────────────────────────────────────────────────────
+# RBAC
+# ──────────────────────────────────────────────────────────────────────────────
+rbac:
+  clusterRole:
+    # Set to false for namespace-only deployments where cluster-wide
+    # permissions are not available (e.g. shared multitenant clusters).
+    # When disabled, the cluster overview page will not show node
+    # utilization, but all other functionality works normally.
+    create: true
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Service account
 # ──────────────────────────────────────────────────────────────────────────────
 serviceAccount:

--- a/packages/container-runtime/src/kubernetes.test.ts
+++ b/packages/container-runtime/src/kubernetes.test.ts
@@ -806,11 +806,38 @@ describe("KubernetesContainerRuntime", () => {
       expect(mockCoreApi.readNamespace).toHaveBeenCalledTimes(1);
     });
 
-    it("re-throws non-404 errors from readNamespace", async () => {
-      mockCoreApi.readNamespace.mockRejectedValue(new Error("forbidden"));
+    it("re-throws non-404/non-403 errors from readNamespace", async () => {
+      mockCoreApi.readNamespace.mockRejectedValue(new Error("internal server error"));
 
-      await expect(runtime.create(baseSpec())).rejects.toThrow("forbidden");
+      await expect(runtime.create(baseSpec())).rejects.toThrow("internal server error");
       expect(mockCoreApi.createNamespace).not.toHaveBeenCalled();
+    });
+
+    it("treats 403 Forbidden from readNamespace as namespace exists (no ClusterRole)", async () => {
+      mockCoreApi.readNamespace.mockRejectedValue({ statusCode: 403 });
+
+      // Should succeed — 403 means we lack cluster-level namespace read
+      // permission but the namespace must exist since we're running in it
+      await expect(runtime.create(baseSpec())).resolves.toBeDefined();
+      expect(mockCoreApi.createNamespace).not.toHaveBeenCalled();
+    });
+
+    it("treats 403 via response.httpStatusCode as namespace exists", async () => {
+      mockCoreApi.readNamespace.mockRejectedValue({
+        response: { httpStatusCode: 403 },
+      });
+
+      await expect(runtime.create(baseSpec())).resolves.toBeDefined();
+      expect(mockCoreApi.createNamespace).not.toHaveBeenCalled();
+    });
+
+    it("caches namespace check after 403 so second create skips readNamespace", async () => {
+      mockCoreApi.readNamespace.mockRejectedValue({ statusCode: 403 });
+
+      await runtime.create(baseSpec());
+      await runtime.create(baseSpec());
+
+      expect(mockCoreApi.readNamespace).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/container-runtime/src/kubernetes.ts
+++ b/packages/container-runtime/src/kubernetes.ts
@@ -482,6 +482,13 @@ export class KubernetesContainerRuntime implements ContainerRuntime {
       this.namespaceEnsured = true;
       return;
     } catch (err: unknown) {
+      // 403 Forbidden means we lack cluster-level namespace read permission
+      // (no ClusterRole). Since the pod is already running in this namespace,
+      // it must exist — skip namespace creation and cache the result.
+      if (this.isForbiddenError(err)) {
+        this.namespaceEnsured = true;
+        return;
+      }
       if (!this.isNotFoundError(err)) {
         throw err;
       }
@@ -615,6 +622,23 @@ export class KubernetesContainerRuntime implements ContainerRuntime {
         typeof err.response === "object" &&
         "httpStatusCode" in err.response &&
         (err.response as { httpStatusCode: number }).httpStatusCode === 404
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private isForbiddenError(err: unknown): boolean {
+    if (err && typeof err === "object") {
+      if ("statusCode" in err && (err as { statusCode: number }).statusCode === 403) return true;
+      if ("code" in err && (err as { code: number }).code === 403) return true;
+      if (
+        "response" in err &&
+        err.response &&
+        typeof err.response === "object" &&
+        "httpStatusCode" in err.response &&
+        (err.response as { httpStatusCode: number }).httpStatusCode === 403
       ) {
         return true;
       }


### PR DESCRIPTION
Closes #320

## What changed

In shared multitenant K8s clusters, users often don't have permission to create ClusterRole/ClusterRoleBinding resources. Previously, this blocked Helm deployment entirely and the system couldn't gracefully handle missing cluster-wide permissions at runtime.

This PR makes cluster-wide permissions optional:

1. **Helm chart**: Added `rbac.clusterRole.create` value (default `true`). Set to `false` to skip creating the ClusterRole and ClusterRoleBinding, enabling deployment with namespace-scoped RBAC only.

2. **Container runtime**: `ensureNamespace()` now handles 403 Forbidden gracefully. When the pod lacks cluster-level namespace read permission, it assumes the namespace exists (the pod is already running in it) instead of failing.

3. **Cluster overview**: `listNode()` now fails gracefully — returns an empty node list instead of a 500 error when ClusterRole is unavailable. Node utilization simply won't be displayed.

## How to test

### Namespace-only deployment
```bash
helm install optio helm/optio -n optio \
  --set rbac.clusterRole.create=false \
  --set encryption.key=$(openssl rand -hex 32)
```
- Verify the ClusterRole and ClusterRoleBinding are NOT created
- Verify `/api/health` returns 200 (healthy)
- Verify `/api/cluster/overview` returns 200 with empty `nodes` array
- Verify tasks can still be created and run normally

### Default deployment (backward compatible)
```bash
helm install optio helm/optio -n optio \
  --set encryption.key=$(openssl rand -hex 32)
```
- Verify ClusterRole/ClusterRoleBinding ARE created (default behavior unchanged)
- Verify cluster overview shows node info as before

### Unit tests
All existing tests pass, plus 4 new tests covering:
- 403 from `readNamespace` treated as "namespace exists" (3 tests)
- Cluster overview returning 200 with empty nodes on `listNode` failure (1 test)