### PR TITLE
feat: per-repo shared persistent cache directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,13 +307,14 @@ apps/
       routes/         health, tasks, subtasks, bulk, secrets, repos, issues, tickets, setup, auth,
                       cluster, resume, prompt-templates, analytics, webhooks, comments, schedules,
                       slack, task-templates, workspaces, dependencies, workflows, mcp-servers,
-                      sessions, skills
+                      sessions, skills, shared-directories
       services/       task-service, repo-pool-service, secret-service, auth-service, container-service,
                       prompt-template-service, repo-service, repo-detect-service, review-service,
                       subtask-service, ticket-sync-service, event-bus, agent-event-parser,
                       session-service, interactive-session-service, workspace-service, webhook-service,
                       comment-service, schedule-service, slack-service, task-template-service,
                       workflow-service, dependency-service, mcp-server-service, skill-service,
+                      shared-directory-service,
                       oauth/ (github, google, gitlab)
       plugins/        auth (session validation middleware)
       workers/        task-worker (main job processor), pr-watcher-worker, repo-cleanup-worker,
@@ -368,7 +369,8 @@ scripts/              setup-local.sh, update-local.sh, repo-init.sh, agent-entry
 **Infrastructure:**
 
 - **repos** — id, repoUrl, fullName, defaultBranch, isPrivate, imagePreset, autoMerge, claudeModel, claudeContextWindow, claudeThinking, claudeEffort, autoResume, maxConcurrentTasks, maxPodInstances, maxAgentsPerPod, reviewEnabled, reviewTrigger, slackEnabled, slackWebhookUrl, workspaceId, etc.
-- **repo_pods** — id, repoUrl, repoBranch, podName, podId, state, activeTaskCount, instanceIndex, workspaceId
+- **repo_pods** — id, repoUrl, repoBranch, podName, podId, state, activeTaskCount, instanceIndex, cachePvcName, cachePvcState, workspaceId
+- **repo_shared_directories** — id, repoId, workspaceId, name, description, mountLocation, mountSubPath, sizeGi, scope, createdBy, lastClearedAt, lastMountedAt, timestamps
 - **pod_health_events** — id, repoPodId, repoUrl, eventType, podName, message, createdAt
 - **secrets** — id, name, scope, encryptedValue (bytea), iv, authTag (AES-256-GCM), workspaceId
 
@@ -479,6 +481,44 @@ helm uninstall optio -n optio
 - **State transitions**: always go through `taskService.transitionTask()` which validates, updates DB, records event, and publishes to WebSocket
 - **Secrets**: never log or return secret values, only names/scopes. Encrypted at rest with AES-256-GCM
 - **Cost tracking**: stored as string (`costUsd`) to avoid float precision issues
+
+### Shared cache directories
+
+Per-repo persistent cache directories that survive across tasks and pod recreation. Backed by K8s PVCs with `ReadWriteOnce` access mode (works on any cluster).
+
+**Architecture**: one PVC per pod instance (`optio-cache-{repoSlug}-{instanceIndex}`), sized as the sum of all shared directory sizes. Each shared directory is a `subPath` mount within that PVC. This avoids per-node volume attach limits.
+
+**Schema**: `repo_shared_directories` table stores the logical directory entries. `repo_pods.cache_pvc_name` / `cache_pvc_state` track PVC bookkeeping.
+
+**Mount locations**:
+
+- `mountLocation: home` — mounts at `/home/agent/<mountSubPath>` (e.g., `.npm`, `.cache/pip`). Tool caches work automatically without env vars.
+- `mountLocation: workspace` — mounts at `/workspace/<mountSubPath>` (e.g., `.optio-cache/node-modules`). For build artifacts.
+
+**Routes**:
+
+- `GET /api/repos/:id/shared-directories` — list (member)
+- `POST /api/repos/:id/shared-directories` — create (admin)
+- `PATCH /api/repos/:id/shared-directories/:dirId` — update (admin)
+- `DELETE /api/repos/:id/shared-directories/:dirId` — delete + cleanup (admin)
+- `POST /api/repos/:id/shared-directories/:dirId/clear` — clear contents via exec (admin)
+- `POST /api/repos/:id/shared-directories/:dirId/usage` — check disk usage (member)
+- `POST /api/repos/:id/pods/recycle` — destroy idle pods so they recreate with new mounts (admin)
+
+**Common cache recipes**:
+
+| Tool        | Name           | Location | Sub-path                | Size |
+| ----------- | -------------- | -------- | ----------------------- | ---- |
+| npm         | npm-cache      | home     | .npm                    | 10Gi |
+| pnpm        | pnpm-store     | home     | .local/share/pnpm/store | 10Gi |
+| pip         | pip-cache      | home     | .cache/pip              | 10Gi |
+| cargo       | cargo-registry | home     | .cargo/registry         | 20Gi |
+| Go          | go-mod         | home     | go/pkg/mod              | 10Gi |
+| HuggingFace | huggingface    | home     | .cache/huggingface      | 50Gi |
+
+**Constraints**: name is a slug (1-40 chars, `^[a-z0-9](-?[a-z0-9])*$`), size 1-100Gi per dir, 200Gi total per repo. Only `per-pod` scope is supported in v1; `per-repo` (RWX) is reserved for a follow-up.
+
+**Helm config** (`values.yaml`): `agent.cache.enabled`, `agent.cache.storageClass`, `agent.cache.maxSizePerDirectoryGi`, `agent.cache.maxSizeTotalGi`, `agent.cache.defaultSizePerDirectoryGi`.
 
 ### Interactive sessions
 

--- a/apps/api/src/db/migrations/0046_repo_shared_directories.sql
+++ b/apps/api/src/db/migrations/0046_repo_shared_directories.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS "repo_shared_directories" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "repo_id" uuid NOT NULL REFERENCES "repos"("id") ON DELETE CASCADE,
+  "workspace_id" uuid,
+  "name" text NOT NULL,
+  "description" text,
+  "mount_location" text NOT NULL,
+  "mount_sub_path" text NOT NULL,
+  "size_gi" integer NOT NULL DEFAULT 10,
+  "scope" text NOT NULL DEFAULT 'per-pod',
+  "created_by" uuid,
+  "last_cleared_at" timestamp with time zone,
+  "last_mounted_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "repo_shared_dirs_repo_name_key" ON "repo_shared_directories" ("repo_id", "name");
+CREATE INDEX IF NOT EXISTS "repo_shared_dirs_repo_id_idx" ON "repo_shared_directories" ("repo_id");
+CREATE INDEX IF NOT EXISTS "repo_shared_dirs_workspace_idx" ON "repo_shared_directories" ("workspace_id");
+
+ALTER TABLE "repo_pods"
+  ADD COLUMN IF NOT EXISTS "cache_pvc_name" text,
+  ADD COLUMN IF NOT EXISTS "cache_pvc_state" text;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -300,6 +300,8 @@ export const repoPods = pgTable(
     activeTaskCount: integer("active_task_count").notNull().default(0),
     lastTaskAt: timestamp("last_task_at", { withTimezone: true }),
     errorMessage: text("error_message"),
+    cachePvcName: text("cache_pvc_name"),
+    cachePvcState: text("cache_pvc_state"), // "pending" | "bound" | "error"
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -766,4 +768,33 @@ export const promptTemplates = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [index("prompt_templates_workspace_id_idx").on(table.workspaceId)],
+);
+
+// ── Repo Shared Directories (persistent cache) ───────────────────────────────
+
+export const repoSharedDirectories = pgTable(
+  "repo_shared_directories",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    repoId: uuid("repo_id")
+      .notNull()
+      .references(() => repos.id, { onDelete: "cascade" }),
+    workspaceId: uuid("workspace_id"),
+    name: text("name").notNull(),
+    description: text("description"),
+    mountLocation: text("mount_location").notNull(), // "workspace" | "home"
+    mountSubPath: text("mount_sub_path").notNull(),
+    sizeGi: integer("size_gi").notNull().default(10),
+    scope: text("scope").notNull().default("per-pod"), // "per-pod" | "per-repo" (future)
+    createdBy: uuid("created_by"),
+    lastClearedAt: timestamp("last_cleared_at", { withTimezone: true }),
+    lastMountedAt: timestamp("last_mounted_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    unique("repo_shared_dirs_repo_name_key").on(table.repoId, table.name),
+    index("repo_shared_dirs_repo_id_idx").on(table.repoId),
+    index("repo_shared_dirs_workspace_idx").on(table.workspaceId),
+  ],
 );

--- a/apps/api/src/routes/shared-directories.test.ts
+++ b/apps/api/src/routes/shared-directories.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+
+// ─── Mocks ───
+
+const mockListSharedDirectories = vi.fn();
+const mockGetSharedDirectory = vi.fn();
+const mockCreateSharedDirectory = vi.fn();
+const mockUpdateSharedDirectory = vi.fn();
+const mockDeleteSharedDirectory = vi.fn();
+const mockClearSharedDirectory = vi.fn();
+const mockGetSharedDirectoryUsage = vi.fn();
+const mockValidateSharedDirectoryInput = vi.fn();
+
+vi.mock("../services/shared-directory-service.js", () => ({
+  listSharedDirectories: (...args: unknown[]) => mockListSharedDirectories(...args),
+  getSharedDirectory: (...args: unknown[]) => mockGetSharedDirectory(...args),
+  createSharedDirectory: (...args: unknown[]) => mockCreateSharedDirectory(...args),
+  updateSharedDirectory: (...args: unknown[]) => mockUpdateSharedDirectory(...args),
+  deleteSharedDirectory: (...args: unknown[]) => mockDeleteSharedDirectory(...args),
+  clearSharedDirectory: (...args: unknown[]) => mockClearSharedDirectory(...args),
+  getSharedDirectoryUsage: (...args: unknown[]) => mockGetSharedDirectoryUsage(...args),
+  validateSharedDirectoryInput: (...args: unknown[]) => mockValidateSharedDirectoryInput(...args),
+}));
+
+const mockGetRepo = vi.fn();
+vi.mock("../services/repo-service.js", () => ({
+  getRepo: (...args: unknown[]) => mockGetRepo(...args),
+}));
+
+const mockListRepoPodsForRepo = vi.fn();
+const mockDeleteNetworkPolicy = vi.fn();
+const mockDeleteEnvoyConfigMap = vi.fn();
+vi.mock("../services/repo-pool-service.js", () => ({
+  listRepoPodsForRepo: (...args: unknown[]) => mockListRepoPodsForRepo(...args),
+  deleteNetworkPolicy: (...args: unknown[]) => mockDeleteNetworkPolicy(...args),
+  deleteEnvoyConfigMap: (...args: unknown[]) => mockDeleteEnvoyConfigMap(...args),
+}));
+
+vi.mock("../services/container-service.js", () => ({
+  getRuntime: vi.fn().mockReturnValue({
+    destroy: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  repoPods: { id: "repo_pods.id" },
+}));
+
+import { sharedDirectoryRoutes } from "./shared-directories.js";
+
+// ─── Helpers ───
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.decorateRequest("user", undefined as any);
+  app.addHook("preHandler", (req, _reply, done) => {
+    (req as any).user = { id: "user-1", workspaceId: "ws-1", workspaceRole: "admin" };
+    done();
+  });
+  await sharedDirectoryRoutes(app);
+  await app.ready();
+  return app;
+}
+
+const mockRepoData = {
+  id: "repo-1",
+  repoUrl: "https://github.com/org/repo",
+  fullName: "org/repo",
+  workspaceId: "ws-1",
+};
+
+const mockDirData = {
+  id: "dir-1",
+  repoId: "repo-1",
+  name: "npm-cache",
+  mountLocation: "home",
+  mountSubPath: ".npm",
+  sizeGi: 10,
+  scope: "per-pod",
+};
+
+describe("GET /api/repos/:id/shared-directories", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("lists shared directories for a repo", async () => {
+    mockGetRepo.mockResolvedValue(mockRepoData);
+    mockListSharedDirectories.mockResolvedValue([mockDirData]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/repos/repo-1/shared-directories",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().directories).toHaveLength(1);
+    expect(mockListSharedDirectories).toHaveBeenCalledWith("repo-1");
+  });
+
+  it("returns 404 when repo not found", async () => {
+    mockGetRepo.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/repos/nonexistent/shared-directories",
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 when workspace mismatch", async () => {
+    mockGetRepo.mockResolvedValue({ ...mockRepoData, workspaceId: "other-ws" });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/repos/repo-1/shared-directories",
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("POST /api/repos/:id/shared-directories", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("creates a shared directory", async () => {
+    mockGetRepo.mockResolvedValue(mockRepoData);
+    mockValidateSharedDirectoryInput.mockReturnValue(null);
+    mockCreateSharedDirectory.mockResolvedValue(mockDirData);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/repos/repo-1/shared-directories",
+      payload: {
+        name: "npm-cache",
+        mountLocation: "home",
+        mountSubPath: ".npm",
+        sizeGi: 10,
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().directory.name).toBe("npm-cache");
+  });
+
+  it("returns 400 for validation error", async () => {
+    mockGetRepo.mockResolvedValue(mockRepoData);
+    mockValidateSharedDirectoryInput.mockReturnValue("Invalid name");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/repos/repo-1/shared-directories",
+      payload: {
+        name: "npm-cache",
+        mountLocation: "home",
+        mountSubPath: ".npm",
+        sizeGi: 10,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("Invalid name");
+  });
+
+  it("returns 409 for duplicate name", async () => {
+    mockGetRepo.mockResolvedValue(mockRepoData);
+    mockValidateSharedDirectoryInput.mockReturnValue(null);
+    mockCreateSharedDirectory.mockRejectedValue(
+      Object.assign(new Error("unique constraint"), { code: "23505" }),
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/repos/repo-1/shared-directories",
+      payload: {
+        name: "npm-cache",
+        mountLocation: "home",
+        mountSubPath: ".npm",
+        sizeGi: 10,
+      },
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+describe("PATCH /api/repos/:id/shared-directories/:dirId", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("updates a shared directory", async () => {
+    mockGetRepo.mockResolvedValue(mockRepoData);
+    mockGetSharedDirectory.mockResolvedValue(mockDirData);
+    mockUpdateSharedDirectory.mockResolvedValue({
+      ...mockDirData,
+      description: "Updated",
+    });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/repos/repo-1/shared-directories/dir-1",
+      payload: { description: "Updated" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().directory.description).toBe("Updated");
+  });
+
+  it("returns 404 when directory not found", async () => {
+    mockGetRepo.mockResolvedValue(mockRepoData);
+    mockGetSharedDirectory.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/repos/repo-1/shared-directories/nonexistent",
+      payload: { description: "Updated" },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("DELETE /api/repos/:id/shared-directories/:dirId", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("deletes a shared directory", async () => {
+    mockGetRepo.mockResolvedValue(mockRepoData);
+    mockGetSharedDirectory.mockResolvedValue(mockDirData);
+    mockDeleteSharedDirectory.mockResolvedValue(undefined);
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/api/repos/repo-1/shared-directories/dir-1",
+    });
+
+    expect(res.statusCode).toBe(204);
+  });
+});
+
+describe("POST /api/repos/:id/shared-directories/:dirId/clear", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("clears a shared directory", async () => {
+    mockGetRepo.mockResolvedValue(mockRepoData);
+    mockGetSharedDirectory.mockResolvedValue(mockDirData);
+    mockClearSharedDirectory.mockResolvedValue(undefined);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/repos/repo-1/shared-directories/dir-1/clear",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+  });
+});
+
+describe("POST /api/repos/:id/shared-directories/:dirId/usage", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns usage info", async () => {
+    mockGetRepo.mockResolvedValue(mockRepoData);
+    mockGetSharedDirectory.mockResolvedValue(mockDirData);
+    mockGetSharedDirectoryUsage.mockResolvedValue("1.5G");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/repos/repo-1/shared-directories/dir-1/usage",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().usage).toBe("1.5G");
+  });
+});
+
+describe("POST /api/repos/:id/pods/recycle", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("recycles idle pods", async () => {
+    mockGetRepo.mockResolvedValue(mockRepoData);
+    mockListRepoPodsForRepo.mockResolvedValue([
+      { id: "pod-1", podName: "test-pod", podId: "pod-1", state: "ready", activeTaskCount: 0 },
+    ]);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/repos/repo-1/pods/recycle",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(true);
+  });
+});

--- a/apps/api/src/routes/shared-directories.ts
+++ b/apps/api/src/routes/shared-directories.ts
@@ -1,0 +1,221 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import * as sharedDirService from "../services/shared-directory-service.js";
+
+const repoIdParamsSchema = z.object({ id: z.string() });
+const dirIdParamsSchema = z.object({ id: z.string(), dirId: z.string() });
+
+const createSharedDirectorySchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(40)
+    .regex(/^[a-z0-9](-?[a-z0-9])*$/, "lowercase alphanumeric with optional hyphens"),
+  description: z.string().optional(),
+  mountLocation: z.enum(["workspace", "home"]),
+  mountSubPath: z
+    .string()
+    .min(1)
+    .max(200)
+    .regex(/^[a-zA-Z0-9._/-]+$/, "alphanumeric with . _ / - only")
+    .refine((p) => !p.startsWith("/"), "must not start with /")
+    .refine((p) => !p.includes(".."), "must not contain path traversal"),
+  sizeGi: z.number().int().min(1).max(100).default(10),
+  scope: z.enum(["per-pod"]).default("per-pod"),
+});
+
+const updateSharedDirectorySchema = z.object({
+  description: z.string().nullable().optional(),
+  sizeGi: z.number().int().min(1).max(100).optional(),
+});
+
+export async function sharedDirectoryRoutes(app: FastifyInstance) {
+  // List shared directories for a repo
+  app.get("/api/repos/:id/shared-directories", async (req, reply) => {
+    const { id } = repoIdParamsSchema.parse(req.params);
+    const { getRepo } = await import("../services/repo-service.js");
+    const repo = await getRepo(id);
+    if (!repo) return reply.status(404).send({ error: "Repo not found" });
+
+    const wsId = req.user?.workspaceId;
+    if (wsId && repo.workspaceId && repo.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Repo not found" });
+    }
+
+    const directories = await sharedDirService.listSharedDirectories(id);
+    reply.send({ directories });
+  });
+
+  // Create a shared directory
+  app.post("/api/repos/:id/shared-directories", async (req, reply) => {
+    const { id } = repoIdParamsSchema.parse(req.params);
+    const { getRepo } = await import("../services/repo-service.js");
+    const repo = await getRepo(id);
+    if (!repo) return reply.status(404).send({ error: "Repo not found" });
+
+    const wsId = req.user?.workspaceId;
+    if (wsId && repo.workspaceId && repo.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Repo not found" });
+    }
+
+    const input = createSharedDirectorySchema.parse(req.body);
+
+    // Additional validation
+    const validationError = sharedDirService.validateSharedDirectoryInput(input);
+    if (validationError) {
+      return reply.status(400).send({ error: validationError });
+    }
+
+    try {
+      const directory = await sharedDirService.createSharedDirectory({
+        repoId: id,
+        workspaceId: repo.workspaceId,
+        name: input.name,
+        description: input.description,
+        mountLocation: input.mountLocation,
+        mountSubPath: input.mountSubPath,
+        sizeGi: input.sizeGi,
+        scope: input.scope,
+        createdBy: req.user?.id,
+      });
+      reply.status(201).send({ directory });
+    } catch (err: any) {
+      if (err?.message?.includes("unique") || err?.code === "23505") {
+        return reply.status(409).send({
+          error: `A shared directory named '${input.name}' already exists for this repo`,
+        });
+      }
+      if (err?.message?.includes("total cache size")) {
+        return reply.status(400).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  // Update a shared directory
+  app.patch("/api/repos/:id/shared-directories/:dirId", async (req, reply) => {
+    const { id, dirId } = dirIdParamsSchema.parse(req.params);
+    const { getRepo } = await import("../services/repo-service.js");
+    const repo = await getRepo(id);
+    if (!repo) return reply.status(404).send({ error: "Repo not found" });
+
+    const wsId = req.user?.workspaceId;
+    if (wsId && repo.workspaceId && repo.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Repo not found" });
+    }
+
+    const existing = await sharedDirService.getSharedDirectory(dirId);
+    if (!existing || existing.repoId !== id) {
+      return reply.status(404).send({ error: "Shared directory not found" });
+    }
+
+    const input = updateSharedDirectorySchema.parse(req.body);
+    const directory = await sharedDirService.updateSharedDirectory(dirId, input);
+    reply.send({ directory });
+  });
+
+  // Delete a shared directory
+  app.delete("/api/repos/:id/shared-directories/:dirId", async (req, reply) => {
+    const { id, dirId } = dirIdParamsSchema.parse(req.params);
+    const { getRepo } = await import("../services/repo-service.js");
+    const repo = await getRepo(id);
+    if (!repo) return reply.status(404).send({ error: "Repo not found" });
+
+    const wsId = req.user?.workspaceId;
+    if (wsId && repo.workspaceId && repo.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Repo not found" });
+    }
+
+    const existing = await sharedDirService.getSharedDirectory(dirId);
+    if (!existing || existing.repoId !== id) {
+      return reply.status(404).send({ error: "Shared directory not found" });
+    }
+
+    await sharedDirService.deleteSharedDirectory(dirId);
+    reply.status(204).send();
+  });
+
+  // Clear a shared directory's contents
+  app.post("/api/repos/:id/shared-directories/:dirId/clear", async (req, reply) => {
+    const { id, dirId } = dirIdParamsSchema.parse(req.params);
+    const { getRepo } = await import("../services/repo-service.js");
+    const repo = await getRepo(id);
+    if (!repo) return reply.status(404).send({ error: "Repo not found" });
+
+    const wsId = req.user?.workspaceId;
+    if (wsId && repo.workspaceId && repo.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Repo not found" });
+    }
+
+    const existing = await sharedDirService.getSharedDirectory(dirId);
+    if (!existing || existing.repoId !== id) {
+      return reply.status(404).send({ error: "Shared directory not found" });
+    }
+
+    await sharedDirService.clearSharedDirectory(existing, repo.repoUrl);
+    reply.send({ ok: true });
+  });
+
+  // Get usage of a shared directory
+  app.post("/api/repos/:id/shared-directories/:dirId/usage", async (req, reply) => {
+    const { id, dirId } = dirIdParamsSchema.parse(req.params);
+    const { getRepo } = await import("../services/repo-service.js");
+    const repo = await getRepo(id);
+    if (!repo) return reply.status(404).send({ error: "Repo not found" });
+
+    const wsId = req.user?.workspaceId;
+    if (wsId && repo.workspaceId && repo.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Repo not found" });
+    }
+
+    const existing = await sharedDirService.getSharedDirectory(dirId);
+    if (!existing || existing.repoId !== id) {
+      return reply.status(404).send({ error: "Shared directory not found" });
+    }
+
+    const usage = await sharedDirService.getSharedDirectoryUsage(existing, repo.repoUrl);
+    reply.send({ usage });
+  });
+
+  // Recycle (destroy) all ready pods for a repo so they get recreated with new mounts
+  app.post("/api/repos/:id/pods/recycle", async (req, reply) => {
+    const { id } = repoIdParamsSchema.parse(req.params);
+    const { getRepo } = await import("../services/repo-service.js");
+    const repo = await getRepo(id);
+    if (!repo) return reply.status(404).send({ error: "Repo not found" });
+
+    const wsId = req.user?.workspaceId;
+    if (wsId && repo.workspaceId && repo.workspaceId !== wsId) {
+      return reply.status(404).send({ error: "Repo not found" });
+    }
+
+    const { listRepoPodsForRepo } = await import("../services/repo-pool-service.js");
+    const { getRuntime } = await import("../services/container-service.js");
+    const { deleteNetworkPolicy, deleteEnvoyConfigMap } =
+      await import("../services/repo-pool-service.js");
+    const { db: dbClient } = await import("../db/client.js");
+    const { repoPods: repoPodsTable } = await import("../db/schema.js");
+    const { eq: eqOp } = await import("drizzle-orm");
+
+    const pods = await listRepoPodsForRepo(repo.repoUrl);
+    const rt = getRuntime();
+    let recycled = 0;
+
+    for (const pod of pods) {
+      if (pod.state !== "ready" || pod.activeTaskCount > 0) continue;
+      try {
+        if (pod.podName) {
+          await deleteNetworkPolicy(pod.podName).catch(() => {});
+          await deleteEnvoyConfigMap(pod.podName).catch(() => {});
+          await rt.destroy({ id: pod.podId ?? pod.podName, name: pod.podName });
+        }
+        await dbClient.delete(repoPodsTable).where(eqOp(repoPodsTable.id, pod.id));
+        recycled++;
+      } catch {
+        // Skip pods that can't be recycled
+      }
+    }
+
+    reply.send({ ok: true, recycled });
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -33,6 +33,7 @@ import { dependencyRoutes } from "./routes/dependencies.js";
 import { workflowRoutes } from "./routes/workflows.js";
 import { mcpServerRoutes } from "./routes/mcp-servers.js";
 import { skillRoutes } from "./routes/skills.js";
+import { sharedDirectoryRoutes } from "./routes/shared-directories.js";
 import { notificationRoutes } from "./routes/notifications.js";
 import { optioRoutes } from "./routes/optio.js";
 import { optioSettingsRoutes } from "./routes/optio-settings.js";
@@ -120,6 +121,7 @@ export async function buildServer() {
   await app.register(workflowRoutes);
   await app.register(mcpServerRoutes);
   await app.register(skillRoutes);
+  await app.register(sharedDirectoryRoutes);
   await app.register(notificationRoutes);
   await app.register(optioRoutes);
   await app.register(optioSettingsRoutes);

--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -262,6 +262,32 @@ spec:
     logger.warn({ err, pvcName }, "Failed to create PVC, pod will use ephemeral storage");
   }
 
+  // Load shared directories and ensure cache PVC exists
+  let cacheInfo: {
+    pvcName: string;
+    volumeMounts: Array<{ mountPath: string; subPath: string }>;
+  } | null = null;
+  try {
+    const { getSharedDirectoriesForRepo, ensureCachePvcForPod } =
+      await import("./shared-directory-service.js");
+    const sharedDirs = await getSharedDirectoriesForRepo(repoUrl, workspaceId);
+    if (sharedDirs.length > 0) {
+      cacheInfo = await ensureCachePvcForPod(repoUrl, instanceIndex, sharedDirs);
+      if (cacheInfo) {
+        await db
+          .update(repoPods)
+          .set({
+            cachePvcName: cacheInfo.pvcName,
+            cachePvcState: "bound",
+            updatedAt: new Date(),
+          })
+          .where(eq(repoPods.id, record.id));
+      }
+    }
+  } catch (err) {
+    logger.warn({ err, repoUrl }, "Failed to set up cache PVC — continuing without cache");
+  }
+
   let podNameForCleanup: string | undefined;
   try {
     const podName = generateRepoPodName(repoUrl);
@@ -280,6 +306,24 @@ spec:
       Object.assign(agentEnv, getAgentProxyEnv());
       agentEnv.OPTIO_SECRET_PROXY = "true";
     }
+
+    // Build cache volume and mounts for shared directories
+    const cacheVolumeName = "optio-cache";
+    const cacheExtraVolume = cacheInfo
+      ? {
+          raw: {
+            name: cacheVolumeName,
+            persistentVolumeClaim: { claimName: cacheInfo.pvcName },
+          },
+        }
+      : null;
+    const cacheVolumeMounts = cacheInfo
+      ? cacheInfo.volumeMounts.map((vm) => ({
+          name: cacheVolumeName,
+          mountPath: vm.mountPath,
+          subPath: vm.subPath,
+        }))
+      : [];
 
     const spec: ContainerSpec = {
       name: podName,
@@ -366,6 +410,12 @@ spec:
       }
 
       logger.info({ podName }, "Envoy secret proxy sidecar configured");
+    }
+
+    // Add cache volume and mounts for shared directories
+    if (cacheExtraVolume && cacheVolumeMounts.length > 0) {
+      spec.extraVolumes = [...(spec.extraVolumes ?? []), cacheExtraVolume];
+      spec.extraVolumeMounts = [...(spec.extraVolumeMounts ?? []), ...cacheVolumeMounts];
     }
 
     const handle = await rt.create(spec);
@@ -625,6 +675,7 @@ export async function execTaskInRepoPod(
     `mkdir -p "$(dirname "$EXCLUDE_FILE")"`,
     `grep -qxF '.optio/' "$EXCLUDE_FILE" 2>/dev/null || echo '.optio/' >> "$EXCLUDE_FILE"`,
     `grep -qxF '.optio-run-token' "$EXCLUDE_FILE" 2>/dev/null || echo '.optio-run-token' >> "$EXCLUDE_FILE"`,
+    `grep -qxF '.optio-cache/' "$EXCLUDE_FILE" 2>/dev/null || echo '.optio-cache/' >> "$EXCLUDE_FILE"`,
     // EXIT trap: preserve the worktree — cleanup is handled by the cleanup worker
     // based on task state. Only clean up Claude Code's internal worktrees (-wt suffix).
     `trap 'cd /workspace/repo 2>/dev/null; git worktree remove --force /workspace/tasks/${taskId}-wt 2>/dev/null || true; git worktree prune 2>/dev/null || true' EXIT`,

--- a/apps/api/src/services/repo-service.ts
+++ b/apps/api/src/services/repo-service.ts
@@ -238,5 +238,17 @@ export async function updateRepo(
 }
 
 export async function deleteRepo(id: string): Promise<void> {
+  // Look up the repo URL before deletion for PVC cleanup
+  const repo = await getRepo(id);
+  if (repo) {
+    try {
+      const { cleanupCachePvcsForRepo, cleanupHomePvcsForRepo } =
+        await import("./shared-directory-service.js");
+      await cleanupCachePvcsForRepo(repo.repoUrl);
+      await cleanupHomePvcsForRepo(repo.repoUrl);
+    } catch {
+      // PVC cleanup is best-effort — don't block repo deletion
+    }
+  }
   await db.delete(repos).where(eq(repos.id, id));
 }

--- a/apps/api/src/services/shared-directory-service.test.ts
+++ b/apps/api/src/services/shared-directory-service.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  repoSharedDirectories: {
+    id: "repo_shared_directories.id",
+    repoId: "repo_shared_directories.repo_id",
+    workspaceId: "repo_shared_directories.workspace_id",
+    name: "repo_shared_directories.name",
+    sizeGi: "repo_shared_directories.size_gi",
+    scope: "repo_shared_directories.scope",
+    mountLocation: "repo_shared_directories.mount_location",
+    mountSubPath: "repo_shared_directories.mount_sub_path",
+    createdAt: "repo_shared_directories.created_at",
+  },
+  repos: {
+    id: "repos.id",
+    repoUrl: "repos.repo_url",
+  },
+  repoPods: {
+    id: "repo_pods.id",
+    repoUrl: "repo_pods.repo_url",
+    state: "repo_pods.state",
+    cachePvcName: "repo_pods.cache_pvc_name",
+    cachePvcState: "repo_pods.cache_pvc_state",
+  },
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { db } from "../db/client.js";
+import {
+  listSharedDirectories,
+  createSharedDirectory,
+  deleteSharedDirectory,
+  getSharedDirectory,
+  updateSharedDirectory,
+  getMountPath,
+  validateSharedDirectoryInput,
+} from "./shared-directory-service.js";
+
+describe("shared-directory-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listSharedDirectories", () => {
+    it("lists all shared directories for a repo", async () => {
+      const dirs = [
+        {
+          id: "sd-1",
+          repoId: "r-1",
+          name: "npm-cache",
+          mountLocation: "home",
+          mountSubPath: ".npm",
+          sizeGi: 10,
+        },
+      ];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(dirs),
+        }),
+      });
+
+      const result = await listSharedDirectories("r-1");
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("npm-cache");
+    });
+
+    it("returns empty array when no directories exist", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await listSharedDirectories("r-1");
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("getSharedDirectory", () => {
+    it("returns directory when found", async () => {
+      const dir = { id: "sd-1", name: "npm-cache" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([dir]),
+        }),
+      });
+
+      const result = await getSharedDirectory("sd-1");
+      expect(result).toMatchObject(dir);
+    });
+
+    it("returns null when not found", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const result = await getSharedDirectory("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("createSharedDirectory", () => {
+    it("creates a shared directory", async () => {
+      const input = {
+        repoId: "r-1",
+        name: "npm-cache",
+        mountLocation: "home" as const,
+        mountSubPath: ".npm",
+        sizeGi: 10,
+      };
+      const created = { id: "sd-1", ...input, scope: "per-pod" };
+
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([created]),
+        }),
+      });
+
+      const result = await createSharedDirectory(input);
+      expect(result).toMatchObject({ id: "sd-1", name: "npm-cache" });
+    });
+
+    it("validates total size cap", async () => {
+      // Existing dirs take up 195Gi total
+      const existingDirs = [
+        { id: "sd-1", repoId: "r-1", sizeGi: 100 },
+        { id: "sd-2", repoId: "r-1", sizeGi: 95 },
+      ];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(existingDirs),
+        }),
+      });
+
+      await expect(
+        createSharedDirectory({
+          repoId: "r-1",
+          name: "big-cache",
+          mountLocation: "home",
+          mountSubPath: ".big",
+          sizeGi: 10,
+        }),
+      ).rejects.toThrow("total cache size");
+    });
+  });
+
+  describe("deleteSharedDirectory", () => {
+    it("deletes a shared directory", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await deleteSharedDirectory("sd-1");
+      expect(db.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe("updateSharedDirectory", () => {
+    it("updates directory fields", async () => {
+      const updated = { id: "sd-1", description: "Updated description" };
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([updated]),
+          }),
+        }),
+      });
+
+      const result = await updateSharedDirectory("sd-1", {
+        description: "Updated description",
+      });
+      expect(result).toMatchObject({ description: "Updated description" });
+    });
+
+    it("returns null when not found", async () => {
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const result = await updateSharedDirectory("nonexistent", {
+        description: "test",
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getMountPath", () => {
+    it("generates workspace mount path", () => {
+      expect(getMountPath("workspace", ".optio-cache/node-modules")).toBe(
+        "/workspace/.optio-cache/node-modules",
+      );
+    });
+
+    it("generates home mount path", () => {
+      expect(getMountPath("home", ".npm")).toBe("/home/agent/.npm");
+    });
+
+    it("handles nested home paths", () => {
+      expect(getMountPath("home", ".cache/huggingface")).toBe("/home/agent/.cache/huggingface");
+    });
+  });
+
+  describe("validateSharedDirectoryInput", () => {
+    it("accepts valid input", () => {
+      const result = validateSharedDirectoryInput({
+        name: "npm-cache",
+        mountLocation: "home",
+        mountSubPath: ".npm",
+        sizeGi: 10,
+      });
+      expect(result).toBeNull();
+    });
+
+    it("rejects invalid name format", () => {
+      const result = validateSharedDirectoryInput({
+        name: "INVALID_NAME!",
+        mountLocation: "home",
+        mountSubPath: ".npm",
+        sizeGi: 10,
+      });
+      expect(result).toContain("name");
+    });
+
+    it("rejects path traversal in mountSubPath", () => {
+      const result = validateSharedDirectoryInput({
+        name: "sneaky",
+        mountLocation: "home",
+        mountSubPath: "../etc/passwd",
+        sizeGi: 10,
+      });
+      expect(result).toContain("path traversal");
+    });
+
+    it("rejects absolute mountSubPath", () => {
+      const result = validateSharedDirectoryInput({
+        name: "sneaky",
+        mountLocation: "home",
+        mountSubPath: "/etc/passwd",
+        sizeGi: 10,
+      });
+      expect(result).toContain("must not start with /");
+    });
+
+    it("rejects size over max", () => {
+      const result = validateSharedDirectoryInput({
+        name: "big",
+        mountLocation: "home",
+        mountSubPath: ".big",
+        sizeGi: 200,
+      });
+      expect(result).toContain("100");
+    });
+
+    it("rejects size under 1", () => {
+      const result = validateSharedDirectoryInput({
+        name: "tiny",
+        mountLocation: "home",
+        mountSubPath: ".tiny",
+        sizeGi: 0,
+      });
+      expect(result).toContain("1");
+    });
+
+    it("rejects per-repo scope in v1", () => {
+      const result = validateSharedDirectoryInput({
+        name: "cache",
+        mountLocation: "home",
+        mountSubPath: ".cache",
+        sizeGi: 10,
+        scope: "per-repo",
+      });
+      expect(result).toContain("per-pod");
+    });
+
+    it("rejects invalid mount location", () => {
+      const result = validateSharedDirectoryInput({
+        name: "cache",
+        mountLocation: "invalid" as any,
+        mountSubPath: ".cache",
+        sizeGi: 10,
+      });
+      expect(result).toContain("mount location");
+    });
+  });
+});

--- a/apps/api/src/services/shared-directory-service.ts
+++ b/apps/api/src/services/shared-directory-service.ts
@@ -1,0 +1,455 @@
+import { eq, and, sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { repoSharedDirectories, repos, repoPods } from "../db/schema.js";
+import { logger } from "../logger.js";
+import { MAX_CACHE_SIZE_PER_DIR_GI, MAX_CACHE_SIZE_TOTAL_GI } from "@optio/shared";
+
+export type SharedDirectory = typeof repoSharedDirectories.$inferSelect;
+
+export interface CreateSharedDirectoryInput {
+  repoId: string;
+  workspaceId?: string | null;
+  name: string;
+  description?: string;
+  mountLocation: "workspace" | "home";
+  mountSubPath: string;
+  sizeGi: number;
+  scope?: string;
+  createdBy?: string;
+}
+
+export interface UpdateSharedDirectoryInput {
+  description?: string | null;
+  sizeGi?: number;
+}
+
+const NAME_REGEX = /^[a-z0-9](-?[a-z0-9])*$/;
+const SUBPATH_REGEX = /^[a-zA-Z0-9._/-]+$/;
+
+/**
+ * Validate shared directory input. Returns error message or null.
+ */
+export function validateSharedDirectoryInput(input: {
+  name: string;
+  mountLocation: string;
+  mountSubPath: string;
+  sizeGi: number;
+  scope?: string;
+}): string | null {
+  const maxSizePerDir = parseInt(
+    process.env.OPTIO_CACHE_MAX_SIZE_PER_DIR_GI ?? String(MAX_CACHE_SIZE_PER_DIR_GI),
+    10,
+  );
+
+  if (!NAME_REGEX.test(input.name) || input.name.length > 40) {
+    return "Invalid name: must be 1-40 lowercase alphanumeric characters with optional hyphens";
+  }
+
+  if (input.mountLocation !== "workspace" && input.mountLocation !== "home") {
+    return "Invalid mount location: must be 'workspace' or 'home'";
+  }
+
+  if (input.mountSubPath.startsWith("/")) {
+    return "mountSubPath must not start with /";
+  }
+
+  if (input.mountSubPath.includes("..")) {
+    return "mountSubPath must not contain path traversal (..)";
+  }
+
+  if (!SUBPATH_REGEX.test(input.mountSubPath) || input.mountSubPath.length > 200) {
+    return "mountSubPath must be 1-200 characters, alphanumeric with . _ / - only";
+  }
+
+  if (input.sizeGi < 1) {
+    return "sizeGi must be at least 1";
+  }
+
+  if (input.sizeGi > maxSizePerDir) {
+    return `sizeGi must be at most ${maxSizePerDir}`;
+  }
+
+  if (input.scope && input.scope !== "per-pod") {
+    return "Only 'per-pod' scope is supported in v1";
+  }
+
+  return null;
+}
+
+/**
+ * Generate the full mount path from location and subpath.
+ */
+export function getMountPath(mountLocation: string, mountSubPath: string): string {
+  if (mountLocation === "home") {
+    return `/home/agent/${mountSubPath}`;
+  }
+  return `/workspace/${mountSubPath}`;
+}
+
+/**
+ * Generate a PVC name for cache storage.
+ */
+export function generateCachePvcName(repoUrl: string, instanceIndex: number): string {
+  const slug = repoUrl.replace(/[^a-zA-Z0-9]/g, "-").slice(0, 40);
+  const suffix = instanceIndex > 0 ? `-${instanceIndex}` : "";
+  return `optio-cache-${slug}${suffix}`;
+}
+
+/**
+ * List all shared directories for a repo.
+ */
+export async function listSharedDirectories(repoId: string): Promise<SharedDirectory[]> {
+  return db.select().from(repoSharedDirectories).where(eq(repoSharedDirectories.repoId, repoId));
+}
+
+/**
+ * Get a single shared directory by ID.
+ */
+export async function getSharedDirectory(id: string): Promise<SharedDirectory | null> {
+  const [row] = await db
+    .select()
+    .from(repoSharedDirectories)
+    .where(eq(repoSharedDirectories.id, id));
+  return row ?? null;
+}
+
+/**
+ * Create a shared directory entry.
+ */
+export async function createSharedDirectory(
+  input: CreateSharedDirectoryInput,
+): Promise<SharedDirectory> {
+  const maxSizeTotal = parseInt(
+    process.env.OPTIO_CACHE_MAX_SIZE_TOTAL_GI ?? String(MAX_CACHE_SIZE_TOTAL_GI),
+    10,
+  );
+
+  // Check total size cap across all dirs for this repo
+  const existing = await db
+    .select()
+    .from(repoSharedDirectories)
+    .where(eq(repoSharedDirectories.repoId, input.repoId));
+
+  const currentTotalSize = existing.reduce((sum, d) => sum + d.sizeGi, 0);
+  if (currentTotalSize + input.sizeGi > maxSizeTotal) {
+    throw new Error(
+      `Adding ${input.sizeGi}Gi would exceed total cache size limit of ${maxSizeTotal}Gi ` +
+        `(current: ${currentTotalSize}Gi)`,
+    );
+  }
+
+  const [row] = await db
+    .insert(repoSharedDirectories)
+    .values({
+      repoId: input.repoId,
+      workspaceId: input.workspaceId ?? undefined,
+      name: input.name,
+      description: input.description ?? undefined,
+      mountLocation: input.mountLocation,
+      mountSubPath: input.mountSubPath,
+      sizeGi: input.sizeGi,
+      scope: input.scope ?? "per-pod",
+      createdBy: input.createdBy ?? undefined,
+    })
+    .returning();
+  return row;
+}
+
+/**
+ * Update a shared directory.
+ */
+export async function updateSharedDirectory(
+  id: string,
+  input: UpdateSharedDirectoryInput,
+): Promise<SharedDirectory | null> {
+  const updates: Record<string, unknown> = { updatedAt: new Date() };
+  if (input.description !== undefined) updates.description = input.description;
+  if (input.sizeGi !== undefined) updates.sizeGi = input.sizeGi;
+
+  const [row] = await db
+    .update(repoSharedDirectories)
+    .set(updates)
+    .where(eq(repoSharedDirectories.id, id))
+    .returning();
+  return row ?? null;
+}
+
+/**
+ * Delete a shared directory entry.
+ */
+export async function deleteSharedDirectory(id: string): Promise<void> {
+  await db.delete(repoSharedDirectories).where(eq(repoSharedDirectories.id, id));
+}
+
+/**
+ * Get shared directories for a repo by repo URL (used during pod creation).
+ */
+export async function getSharedDirectoriesForRepo(
+  repoUrl: string,
+  workspaceId?: string | null,
+): Promise<SharedDirectory[]> {
+  // Look up the repo to get the repoId
+  const conditions = [eq(repos.repoUrl, repoUrl)];
+  if (workspaceId) {
+    conditions.push(eq(repos.workspaceId, workspaceId));
+  }
+  const [repo] = await db
+    .select({ id: repos.id })
+    .from(repos)
+    .where(and(...conditions));
+
+  if (!repo) return [];
+
+  return db.select().from(repoSharedDirectories).where(eq(repoSharedDirectories.repoId, repo.id));
+}
+
+/**
+ * Ensure a cache PVC exists for a given repo pod instance.
+ * Creates the PVC if it doesn't exist. Returns the PVC name and volume mounts.
+ */
+export async function ensureCachePvcForPod(
+  repoUrl: string,
+  instanceIndex: number,
+  sharedDirs: SharedDirectory[],
+): Promise<{
+  pvcName: string;
+  volumeMounts: Array<{ mountPath: string; subPath: string }>;
+} | null> {
+  if (sharedDirs.length === 0) return null;
+
+  const pvcName = generateCachePvcName(repoUrl, instanceIndex);
+  const totalSizeGi = sharedDirs.reduce((sum, d) => sum + d.sizeGi, 0);
+  const storageClass = process.env.OPTIO_CACHE_STORAGE_CLASS || undefined;
+
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+    const namespace = process.env.OPTIO_NAMESPACE ?? "optio";
+
+    // Check if PVC already exists
+    try {
+      await execFileAsync("kubectl", ["get", "pvc", pvcName, "-n", namespace]);
+    } catch {
+      // PVC doesn't exist, create it
+      const storageClassLine = storageClass ? `\n  storageClassName: ${storageClass}` : "";
+      const pvcManifest = `apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${pvcName}
+  namespace: ${namespace}
+  labels:
+    managed-by: optio
+    optio.type: cache-pvc
+spec:
+  accessModes: [ReadWriteOnce]${storageClassLine}
+  resources:
+    requests:
+      storage: ${totalSizeGi}Gi`;
+
+      await execFileAsync("bash", [
+        "-c",
+        `echo '${pvcManifest}' | kubectl apply -f - -n ${namespace}`,
+      ]);
+      logger.info({ pvcName, totalSizeGi }, "Created cache PVC for repo pod");
+    }
+  } catch (err) {
+    logger.warn({ err, pvcName }, "Failed to create cache PVC");
+    return null;
+  }
+
+  // Build volume mounts — one per shared directory using subPath
+  const volumeMounts = sharedDirs.map((dir) => ({
+    mountPath: getMountPath(dir.mountLocation, dir.mountSubPath),
+    subPath: dir.name,
+  }));
+
+  return { pvcName, volumeMounts };
+}
+
+/**
+ * Clear the contents of a shared directory across all ready pods for a repo.
+ */
+export async function clearSharedDirectory(dir: SharedDirectory, repoUrl: string): Promise<void> {
+  const pods = await db
+    .select()
+    .from(repoPods)
+    .where(and(eq(repoPods.repoUrl, repoUrl), eq(repoPods.state, "ready")));
+
+  const mountPath = getMountPath(dir.mountLocation, dir.mountSubPath);
+
+  for (const pod of pods) {
+    if (!pod.podName) continue;
+    try {
+      const { execFile } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execFileAsync = promisify(execFile);
+      const namespace = process.env.OPTIO_NAMESPACE ?? "optio";
+
+      await execFileAsync("kubectl", [
+        "exec",
+        pod.podName,
+        "-n",
+        namespace,
+        "--",
+        "sh",
+        "-c",
+        `rm -rf ${mountPath}/* ${mountPath}/.[!.]* ${mountPath}/..?* 2>/dev/null || true`,
+      ]);
+      logger.info(
+        { podName: pod.podName, mountPath, dirName: dir.name },
+        "Cleared shared directory",
+      );
+    } catch (err) {
+      logger.warn(
+        { err, podName: pod.podName, dirName: dir.name },
+        "Failed to clear shared directory in pod",
+      );
+    }
+  }
+
+  // Update lastClearedAt
+  await db
+    .update(repoSharedDirectories)
+    .set({ lastClearedAt: new Date(), updatedAt: new Date() })
+    .where(eq(repoSharedDirectories.id, dir.id));
+}
+
+/**
+ * Get disk usage for a shared directory in a ready pod.
+ */
+export async function getSharedDirectoryUsage(
+  dir: SharedDirectory,
+  repoUrl: string,
+): Promise<string | null> {
+  const [pod] = await db
+    .select()
+    .from(repoPods)
+    .where(and(eq(repoPods.repoUrl, repoUrl), eq(repoPods.state, "ready")));
+
+  if (!pod?.podName) return null;
+
+  const mountPath = getMountPath(dir.mountLocation, dir.mountSubPath);
+
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+    const namespace = process.env.OPTIO_NAMESPACE ?? "optio";
+
+    const { stdout } = await execFileAsync("kubectl", [
+      "exec",
+      pod.podName,
+      "-n",
+      namespace,
+      "--",
+      "du",
+      "-sh",
+      mountPath,
+    ]);
+
+    return stdout.split("\t")[0]?.trim() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clean up all cache PVCs for a repo URL.
+ */
+export async function cleanupCachePvcsForRepo(repoUrl: string): Promise<void> {
+  const slug = repoUrl.replace(/[^a-zA-Z0-9]/g, "-").slice(0, 40);
+  const pvcPrefix = `optio-cache-${slug}`;
+  const namespace = process.env.OPTIO_NAMESPACE ?? "optio";
+
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+
+    // List PVCs matching the prefix
+    const { stdout } = await execFileAsync("kubectl", [
+      "get",
+      "pvc",
+      "-n",
+      namespace,
+      "-o",
+      "jsonpath={.items[*].metadata.name}",
+      "-l",
+      "optio.type=cache-pvc",
+    ]);
+
+    const pvcNames = stdout
+      .trim()
+      .split(/\s+/)
+      .filter((n: string) => n.startsWith(pvcPrefix));
+
+    for (const name of pvcNames) {
+      try {
+        await execFileAsync("kubectl", [
+          "delete",
+          "pvc",
+          name,
+          "-n",
+          namespace,
+          "--ignore-not-found",
+        ]);
+        logger.info({ pvcName: name }, "Deleted cache PVC");
+      } catch (err) {
+        logger.warn({ err, pvcName: name }, "Failed to delete cache PVC");
+      }
+    }
+  } catch (err) {
+    logger.warn({ err, repoUrl }, "Failed to cleanup cache PVCs");
+  }
+}
+
+/**
+ * Clean up home PVCs for a repo URL (fixes pre-existing leak).
+ */
+export async function cleanupHomePvcsForRepo(repoUrl: string): Promise<void> {
+  const slug = repoUrl.replace(/[^a-zA-Z0-9]/g, "-").slice(0, 40);
+  const pvcPrefix = `optio-home-${slug}`;
+  const namespace = process.env.OPTIO_NAMESPACE ?? "optio";
+
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+
+    // List PVCs matching the prefix
+    const { stdout } = await execFileAsync("kubectl", [
+      "get",
+      "pvc",
+      "-n",
+      namespace,
+      "-o",
+      "jsonpath={.items[*].metadata.name}",
+      "-l",
+      "optio.type=home-pvc",
+    ]);
+
+    const pvcNames = stdout
+      .trim()
+      .split(/\s+/)
+      .filter((n: string) => n.startsWith(pvcPrefix));
+
+    for (const name of pvcNames) {
+      try {
+        await execFileAsync("kubectl", [
+          "delete",
+          "pvc",
+          name,
+          "-n",
+          namespace,
+          "--ignore-not-found",
+        ]);
+        logger.info({ pvcName: name }, "Deleted home PVC");
+      } catch (err) {
+        logger.warn({ err, pvcName: name }, "Failed to delete home PVC");
+      }
+    }
+  } catch (err) {
+    logger.warn({ err, repoUrl }, "Failed to cleanup home PVCs");
+  }
+}

--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
 import { formatRelativeTime, formatDuration } from "@/lib/utils";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
+import { SharedDirectoriesSection } from "@/components/shared-directories-section";
 
 export default function RepoDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -1001,6 +1002,9 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
           </div>
         </div>
       </section>
+
+      {/* Cache Directories */}
+      {repo && <SharedDirectoriesSection repoId={repo.id} maxPodInstances={repo.maxPodInstances} />}
 
       {/* MCP Servers */}
       <section className="p-5 rounded-xl border border-border/50 bg-bg-card space-y-3">

--- a/apps/web/src/components/shared-directories-section.tsx
+++ b/apps/web/src/components/shared-directories-section.tsx
@@ -1,0 +1,464 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { api } from "@/lib/api-client";
+import { toast } from "sonner";
+import {
+  HardDrive,
+  Plus,
+  X,
+  Trash2,
+  RotateCcw,
+  RefreshCw,
+  AlertTriangle,
+  Loader2,
+} from "lucide-react";
+
+interface SharedDirectory {
+  id: string;
+  repoId: string;
+  name: string;
+  description: string | null;
+  mountLocation: string;
+  mountSubPath: string;
+  sizeGi: number;
+  scope: string;
+  lastClearedAt: string | null;
+  lastMountedAt: string | null;
+  createdAt: string;
+}
+
+interface CachePreset {
+  label: string;
+  name: string;
+  mountLocation: "workspace" | "home";
+  mountSubPath: string;
+  sizeGi: number;
+  description: string;
+}
+
+const CACHE_PRESETS: CachePreset[] = [
+  {
+    label: "npm",
+    name: "npm-cache",
+    mountLocation: "home",
+    mountSubPath: ".npm",
+    sizeGi: 10,
+    description: "npm global cache",
+  },
+  {
+    label: "pnpm",
+    name: "pnpm-store",
+    mountLocation: "home",
+    mountSubPath: ".local/share/pnpm/store",
+    sizeGi: 10,
+    description: "pnpm content-addressable store",
+  },
+  {
+    label: "pip",
+    name: "pip-cache",
+    mountLocation: "home",
+    mountSubPath: ".cache/pip",
+    sizeGi: 10,
+    description: "pip download cache",
+  },
+  {
+    label: "uv",
+    name: "uv-cache",
+    mountLocation: "home",
+    mountSubPath: ".cache/uv",
+    sizeGi: 10,
+    description: "uv package manager cache",
+  },
+  {
+    label: "cargo",
+    name: "cargo-registry",
+    mountLocation: "home",
+    mountSubPath: ".cargo/registry",
+    sizeGi: 20,
+    description: "Cargo crate registry",
+  },
+  {
+    label: "Go modules",
+    name: "go-mod",
+    mountLocation: "home",
+    mountSubPath: "go/pkg/mod",
+    sizeGi: 10,
+    description: "Go module download cache",
+  },
+  {
+    label: "Gradle",
+    name: "gradle-cache",
+    mountLocation: "home",
+    mountSubPath: ".gradle/caches",
+    sizeGi: 20,
+    description: "Gradle dependency caches",
+  },
+  {
+    label: "Maven",
+    name: "maven-repo",
+    mountLocation: "home",
+    mountSubPath: ".m2/repository",
+    sizeGi: 20,
+    description: "Maven local repository",
+  },
+  {
+    label: "HuggingFace",
+    name: "huggingface",
+    mountLocation: "home",
+    mountSubPath: ".cache/huggingface",
+    sizeGi: 50,
+    description: "HuggingFace model cache",
+  },
+  {
+    label: "Poetry",
+    name: "poetry-cache",
+    mountLocation: "home",
+    mountSubPath: ".cache/pypoetry",
+    sizeGi: 10,
+    description: "Poetry dependency cache",
+  },
+];
+
+export function SharedDirectoriesSection({
+  repoId,
+  maxPodInstances,
+}: {
+  repoId: string;
+  maxPodInstances?: number;
+}) {
+  const [directories, setDirectories] = useState<SharedDirectory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAdd, setShowAdd] = useState(false);
+  const [selectedPreset, setSelectedPreset] = useState<string>("custom");
+  const [newName, setNewName] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+  const [newMountLocation, setNewMountLocation] = useState<"workspace" | "home">("home");
+  const [newMountSubPath, setNewMountSubPath] = useState("");
+  const [newSizeGi, setNewSizeGi] = useState(10);
+  const [addingDir, setAddingDir] = useState(false);
+  const [clearingId, setClearingId] = useState<string | null>(null);
+  const [usageMap, setUsageMap] = useState<Record<string, string | null>>({});
+  const [recycling, setRecycling] = useState(false);
+
+  useEffect(() => {
+    api
+      .listRepoSharedDirectories(repoId)
+      .then((res) => setDirectories(res.directories))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [repoId]);
+
+  const applyPreset = (presetLabel: string) => {
+    setSelectedPreset(presetLabel);
+    if (presetLabel === "custom") {
+      setNewName("");
+      setNewDescription("");
+      setNewMountLocation("home");
+      setNewMountSubPath("");
+      setNewSizeGi(10);
+      return;
+    }
+    const preset = CACHE_PRESETS.find((p) => p.label === presetLabel);
+    if (preset) {
+      setNewName(preset.name);
+      setNewDescription(preset.description);
+      setNewMountLocation(preset.mountLocation);
+      setNewMountSubPath(preset.mountSubPath);
+      setNewSizeGi(preset.sizeGi);
+    }
+  };
+
+  const handleAdd = async () => {
+    if (!newName || !newMountSubPath) return;
+    setAddingDir(true);
+    try {
+      const res = await api.createRepoSharedDirectory(repoId, {
+        name: newName,
+        description: newDescription || undefined,
+        mountLocation: newMountLocation,
+        mountSubPath: newMountSubPath,
+        sizeGi: newSizeGi,
+      });
+      setDirectories((prev) => [...prev, res.directory]);
+      setShowAdd(false);
+      setSelectedPreset("custom");
+      setNewName("");
+      setNewDescription("");
+      setNewMountSubPath("");
+      setNewSizeGi(10);
+      toast.success(`Cache directory "${newName}" created`);
+    } catch (err: any) {
+      toast.error(err.message ?? "Failed to create cache directory");
+    } finally {
+      setAddingDir(false);
+    }
+  };
+
+  const handleDelete = async (dir: SharedDirectory) => {
+    try {
+      await api.deleteRepoSharedDirectory(repoId, dir.id);
+      setDirectories((prev) => prev.filter((d) => d.id !== dir.id));
+      toast.success(`Cache directory "${dir.name}" deleted`);
+    } catch (err: any) {
+      toast.error(err.message ?? "Failed to delete cache directory");
+    }
+  };
+
+  const handleClear = async (dir: SharedDirectory) => {
+    setClearingId(dir.id);
+    try {
+      await api.clearRepoSharedDirectory(repoId, dir.id);
+      toast.success(`Cache "${dir.name}" cleared`);
+    } catch (err: any) {
+      toast.error(err.message ?? "Failed to clear cache");
+    } finally {
+      setClearingId(null);
+    }
+  };
+
+  const handleRefreshUsage = async (dir: SharedDirectory) => {
+    try {
+      const res = await api.getRepoSharedDirectoryUsage(repoId, dir.id);
+      setUsageMap((prev) => ({ ...prev, [dir.id]: res.usage }));
+    } catch {
+      setUsageMap((prev) => ({ ...prev, [dir.id]: null }));
+    }
+  };
+
+  const handleRecyclePods = async () => {
+    setRecycling(true);
+    try {
+      const res = await api.recycleRepoPods(repoId);
+      toast.success(`Recycled ${res.recycled} pod(s). New pods will be created on next task.`);
+    } catch (err: any) {
+      toast.error(err.message ?? "Failed to recycle pods");
+    } finally {
+      setRecycling(false);
+    }
+  };
+
+  const getMountPathDisplay = (dir: SharedDirectory) => {
+    return dir.mountLocation === "home"
+      ? `/home/agent/${dir.mountSubPath}`
+      : `/workspace/${dir.mountSubPath}`;
+  };
+
+  if (loading) return null;
+
+  return (
+    <section className="p-5 rounded-xl border border-border/50 bg-bg-card space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <HardDrive className="w-4 h-4 text-text-muted" />
+          <h2 className="text-sm font-medium">Cache Directories</h2>
+        </div>
+        <button
+          onClick={() => setShowAdd(!showAdd)}
+          className="flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          Add Cache
+        </button>
+      </div>
+      <p className="text-xs text-text-muted">
+        Persistent storage that survives across tasks. Use for package caches, build artifacts,
+        model downloads, etc. Each pod instance gets its own copy.
+      </p>
+
+      {(maxPodInstances ?? 1) > 1 && (
+        <div className="flex items-start gap-2 p-2.5 rounded-lg border border-warning/30 bg-warning/5 text-xs text-warning">
+          <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+          <span>
+            This repo scales to {maxPodInstances} pod instances. Each instance gets its own cache
+            copy &mdash; the first task on each new instance will populate the cache from scratch.
+          </span>
+        </div>
+      )}
+
+      {directories.length > 0 && (
+        <div className="space-y-2">
+          {directories.map((dir) => (
+            <div
+              key={dir.id}
+              className="flex items-start gap-3 p-3 rounded-lg border border-border bg-bg"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{dir.name}</span>
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-hover text-text-muted">
+                    {dir.sizeGi}Gi
+                  </span>
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-hover text-text-muted">
+                    {dir.mountLocation}
+                  </span>
+                </div>
+                <p className="text-xs text-text-muted mt-0.5 font-mono truncate">
+                  {getMountPathDisplay(dir)}
+                </p>
+                {dir.description && (
+                  <p className="text-xs text-text-muted mt-0.5">{dir.description}</p>
+                )}
+                {usageMap[dir.id] !== undefined && (
+                  <p className="text-xs text-text-muted mt-0.5">
+                    Usage: {usageMap[dir.id] ?? "N/A"}
+                  </p>
+                )}
+              </div>
+              <div className="flex items-center gap-1.5 shrink-0">
+                <button
+                  onClick={() => handleRefreshUsage(dir)}
+                  className="text-text-muted hover:text-text p-1"
+                  title="Check usage"
+                >
+                  <RefreshCw className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  onClick={() => handleClear(dir)}
+                  disabled={clearingId === dir.id}
+                  className="text-text-muted hover:text-warning p-1"
+                  title="Clear cache contents"
+                >
+                  {clearingId === dir.id ? (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  ) : (
+                    <RotateCcw className="w-3.5 h-3.5" />
+                  )}
+                </button>
+                <button
+                  onClick={() => handleDelete(dir)}
+                  className="text-text-muted hover:text-error p-1"
+                  title="Delete cache directory"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {directories.length > 0 && (
+        <div className="flex items-center gap-2 pt-1">
+          <button
+            onClick={handleRecyclePods}
+            disabled={recycling}
+            className="flex items-center gap-1.5 text-xs text-text-muted hover:text-text"
+          >
+            {recycling ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <RotateCcw className="w-3.5 h-3.5" />
+            )}
+            Recycle idle pods
+          </button>
+          <span className="text-[10px] text-text-muted">
+            Force-recreate pods to pick up mount changes
+          </span>
+        </div>
+      )}
+
+      {showAdd && (
+        <div className="space-y-3 p-3 rounded-lg border border-primary/30 bg-primary/5">
+          <div>
+            <label className="block text-xs text-text-muted mb-1">Preset</label>
+            <select
+              value={selectedPreset}
+              onChange={(e) => applyPreset(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+            >
+              <option value="custom">Custom</option>
+              {CACHE_PRESETS.map((p) => (
+                <option key={p.label} value={p.label}>
+                  {p.label} &mdash; {p.mountSubPath}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Name (slug)</label>
+              <input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="npm-cache"
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Size (Gi)</label>
+              <input
+                type="number"
+                min={1}
+                max={100}
+                value={newSizeGi}
+                onChange={(e) => setNewSizeGi(parseInt(e.target.value) || 10)}
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs text-text-muted mb-1">Description (optional)</label>
+            <input
+              value={newDescription}
+              onChange={(e) => setNewDescription(e.target.value)}
+              placeholder="npm global cache"
+              className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Mount location</label>
+              <select
+                value={newMountLocation}
+                onChange={(e) => setNewMountLocation(e.target.value as "workspace" | "home")}
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+              >
+                <option value="home">Agent home (~)</option>
+                <option value="workspace">Workspace (/workspace)</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Sub-path</label>
+              <input
+                value={newMountSubPath}
+                onChange={(e) => setNewMountSubPath(e.target.value)}
+                placeholder=".npm"
+                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+              />
+            </div>
+          </div>
+
+          {newMountSubPath && (
+            <p className="text-xs text-text-muted font-mono">
+              Mount path:{" "}
+              {newMountLocation === "home"
+                ? `/home/agent/${newMountSubPath}`
+                : `/workspace/${newMountSubPath}`}
+            </p>
+          )}
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleAdd}
+              disabled={addingDir || !newName || !newMountSubPath}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg bg-primary text-white hover:bg-primary/90 disabled:opacity-40"
+            >
+              {addingDir && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+              Add
+            </button>
+            <button
+              onClick={() => setShowAdd(false)}
+              className="text-xs text-text-muted hover:text-text"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1090,4 +1090,68 @@ export const api = {
 
   testPushNotification: () =>
     request<{ sent: number }>("/api/notifications/test", { method: "POST" }),
+
+  // Shared Directories (Cache)
+  listRepoSharedDirectories: (repoId: string) =>
+    request<{
+      directories: Array<{
+        id: string;
+        repoId: string;
+        name: string;
+        description: string | null;
+        mountLocation: string;
+        mountSubPath: string;
+        sizeGi: number;
+        scope: string;
+        lastClearedAt: string | null;
+        lastMountedAt: string | null;
+        createdAt: string;
+        updatedAt: string;
+      }>;
+    }>(`/api/repos/${repoId}/shared-directories`),
+
+  createRepoSharedDirectory: (
+    repoId: string,
+    data: {
+      name: string;
+      description?: string;
+      mountLocation: "workspace" | "home";
+      mountSubPath: string;
+      sizeGi?: number;
+    },
+  ) =>
+    request<{ directory: any }>(`/api/repos/${repoId}/shared-directories`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+
+  updateRepoSharedDirectory: (
+    repoId: string,
+    dirId: string,
+    data: { description?: string | null; sizeGi?: number },
+  ) =>
+    request<{ directory: any }>(`/api/repos/${repoId}/shared-directories/${dirId}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    }),
+
+  deleteRepoSharedDirectory: (repoId: string, dirId: string) =>
+    request<void>(`/api/repos/${repoId}/shared-directories/${dirId}`, {
+      method: "DELETE",
+    }),
+
+  clearRepoSharedDirectory: (repoId: string, dirId: string) =>
+    request<{ ok: boolean }>(`/api/repos/${repoId}/shared-directories/${dirId}/clear`, {
+      method: "POST",
+    }),
+
+  getRepoSharedDirectoryUsage: (repoId: string, dirId: string) =>
+    request<{ usage: string | null }>(`/api/repos/${repoId}/shared-directories/${dirId}/usage`, {
+      method: "POST",
+    }),
+
+  recycleRepoPods: (repoId: string) =>
+    request<{ ok: boolean; recycled: number }>(`/api/repos/${repoId}/pods/recycle`, {
+      method: "POST",
+    }),
 };

--- a/helm/optio/templates/rbac.yaml
+++ b/helm/optio/templates/rbac.yaml
@@ -27,7 +27,7 @@ rules:
     verbs: ["get", "list", "create", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "create", "delete"]
+    verbs: ["get", "list", "create", "delete", "patch", "update"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list"]

--- a/helm/optio/templates/secrets.yaml
+++ b/helm/optio/templates/secrets.yaml
@@ -62,6 +62,12 @@ stringData:
   # Agent PVC configuration (read by API server at runtime)
   OPTIO_AGENT_PVC_STORAGE_CLASS: {{ .Values.agent.pvc.storageClass | quote }}
   OPTIO_AGENT_PVC_SIZE: {{ .Values.agent.pvc.size | quote }}
+  # Cache directory PVC configuration
+  OPTIO_CACHE_ENABLED: {{ .Values.agent.cache.enabled | quote }}
+  OPTIO_CACHE_STORAGE_CLASS: {{ .Values.agent.cache.storageClass | quote }}
+  OPTIO_CACHE_MAX_SIZE_PER_DIR_GI: {{ .Values.agent.cache.maxSizePerDirectoryGi | quote }}
+  OPTIO_CACHE_MAX_SIZE_TOTAL_GI: {{ .Values.agent.cache.maxSizeTotalGi | quote }}
+  OPTIO_CACHE_DEFAULT_SIZE_GI: {{ .Values.agent.cache.defaultSizePerDirectoryGi | quote }}
   {{- if .Values.notifications.vapid.publicKey }}
   OPTIO_VAPID_PUBLIC_KEY: {{ .Values.notifications.vapid.publicKey | quote }}
   OPTIO_VAPID_PRIVATE_KEY: {{ .Values.notifications.vapid.privateKey | quote }}

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -137,6 +137,14 @@ agent:
     size: 10Gi
     accessModes:
       - ReadWriteOnce
+  # Shared cache directory PVCs (opt-in per repo).
+  # Controls storage class and size limits for cache directories.
+  cache:
+    enabled: true                     # Set false to hard-disable the feature
+    storageClass: ""                  # Empty = cluster default storage class
+    maxSizePerDirectoryGi: 100        # Max size for a single cache directory
+    maxSizeTotalGi: 200               # Max total cache size across all dirs per repo
+    defaultSizePerDirectoryGi: 10     # Default size when creating a cache directory
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Network Policy

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -7,6 +7,11 @@ export const DEFAULT_MAX_TURNS_CODING = 250;
 export const DEFAULT_MAX_TURNS_REVIEW = 30;
 export const DEFAULT_MAX_TICKET_PAGES = 20;
 
+// ── Shared directory (cache) defaults ─────────────────────────────────────────
+export const DEFAULT_CACHE_SIZE_GI = 10;
+export const MAX_CACHE_SIZE_PER_DIR_GI = 100;
+export const MAX_CACHE_SIZE_TOTAL_GI = 200;
+
 /**
  * Default threshold (in ms) before a running task is flagged as "stalled".
  * Override per-repo via `repos.stallThresholdMs` or globally via


### PR DESCRIPTION
Closes #349

## What changed

Introduces a first-class "shared directories" feature that lets workspace admins define cache directories which persist across tasks in the same repository. These mount into every task pod at a configurable path inside `/workspace` or the agent's `$HOME`, are backed by K8s PVCs, and dramatically reduce per-task setup time for repositories with heavy install or model-download steps.

### New files
- **Migration**: `0046_repo_shared_directories.sql` — new `repo_shared_directories` table + `cache_pvc_name`/`cache_pvc_state` columns on `repo_pods`
- **Service**: `shared-directory-service.ts` — CRUD, PVC orchestration, clear/usage via kubectl exec, cleanup helpers
- **Routes**: `shared-directories.ts` — 7 endpoints: list, create, update, delete, clear, usage, pod recycle
- **UI**: `shared-directories-section.tsx` — Cache Directories section with 10 preset configs (npm, pnpm, pip, uv, cargo, go-mod, gradle, maven, huggingface, poetry)
- **Tests**: Service tests (validation, CRUD, mount path generation) + route tests (auth, 404, 409, CRUD)

### Modified files
- **Schema**: `repo_shared_directories` table definition + `cachePvcName`/`cachePvcState` on `repoPods`
- **Constants**: `DEFAULT_CACHE_SIZE_GI`, `MAX_CACHE_SIZE_PER_DIR_GI`, `MAX_CACHE_SIZE_TOTAL_GI`
- **repo-pool-service**: Loads shared dirs during pod creation, creates cache PVC, mounts via `extraVolumes` + `extraVolumeMounts` with subPath
- **repo-service**: `deleteRepo` now cleans up cache PVCs and home PVCs (fixes pre-existing leak)
- **server.ts**: Registers `sharedDirectoryRoutes`
- **API client**: 7 new methods for shared directory operations
- **Repo detail page**: Mounts `SharedDirectoriesSection` component
- **Helm chart**: `agent.cache.*` values, env vars in secrets template, PVC RBAC patch/update verbs
- **CLAUDE.md**: Full documentation including cache recipes table

### Design decisions
- **Option B (per-pod RWO PVC)**: Works on any K8s cluster without NFS/EFS. Each pod instance gets its own cache copy. Schema includes `scope` column for future RWX support but API rejects `per-repo` in v1.
- **Single PVC with subPaths**: All shared dirs share one PVC per pod instance, avoiding per-node attach limits (AWS: 16-28 volumes).
- **Home + workspace mount locations**: Home-relative mounts (e.g., `~/.npm`, `~/.cache/pip`) work automatically without env vars. Workspace mounts for build artifacts.
- **Eager PVC creation**: PVCs created at shared dir insert time for existing pods, and on-the-fly for new pod instances.

## How to test

1. **Create a shared directory**: Go to repo settings page > Cache Directories section > click "+ Add Cache" > select "npm" preset > click "Add"
2. **Verify PVC**: `kubectl get pvc -n optio -l optio.type=cache-pvc` should show the new PVC
3. **Run a task**: The next task on this repo should mount the cache at `/home/agent/.npm`
4. **Warm cache**: Run a second task — `npm ci` should be significantly faster
5. **Clear cache**: Click the rotate icon next to the cache entry
6. **Delete cache**: Click the trash icon next to the cache entry
7. **Pod recycle**: Click "Recycle idle pods" to force-recreate pods with new mount config
8. **Delete repo**: Verify cache PVCs are cleaned up: `kubectl get pvc -n optio -l optio.type=cache-pvc`