### PR TITLE
fix: stale-task re-queue spawns duplicate agents; API restart leaves orphaned processes

### DIFF
--- a/apps/api/src/services/repo-pool-service.test.ts
+++ b/apps/api/src/services/repo-pool-service.test.ts
@@ -95,6 +95,7 @@ import {
   listRepoPods,
   reconcileActiveTaskCounts,
   deleteNetworkPolicy,
+  killOrphanedAgentInPod,
 } from "./repo-pool-service.js";
 
 // ── resolveImage ────────────────────────────────────────────────────
@@ -590,5 +591,112 @@ describe("getOrCreateRepoPod — DinD admission check", () => {
     expect(spec.capabilities).toBeUndefined();
     expect(spec.hostUsers).toBeUndefined();
     expect(spec.tmpfsMounts).toBeUndefined();
+  });
+});
+
+// ── killOrphanedAgentInPod ───────────────────────────────────────
+
+describe("killOrphanedAgentInPod", () => {
+  function makeExecSession(output: string) {
+    return {
+      stdout: {
+        [Symbol.asyncIterator]: async function* () {
+          if (output) yield Buffer.from(output);
+        },
+      },
+      close: vi.fn(),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns false when pod is not found", async () => {
+    const dbMock = db as any;
+    dbMock.where.mockResolvedValueOnce([]); // pod lookup returns nothing
+
+    const result = await killOrphanedAgentInPod("nonexistent-pod", "task-1");
+    expect(result).toBe(false);
+  });
+
+  it("returns false when pod has no podName", async () => {
+    const dbMock = db as any;
+    dbMock.where.mockResolvedValueOnce([{ id: "pod-1", podName: null, state: "ready" }]);
+
+    const result = await killOrphanedAgentInPod("pod-1", "task-1");
+    expect(result).toBe(false);
+  });
+
+  it("returns false when pod is not in ready state", async () => {
+    const dbMock = db as any;
+    dbMock.where.mockResolvedValueOnce([
+      { id: "pod-1", podName: "p1", podId: "pid1", state: "error" },
+    ]);
+
+    const result = await killOrphanedAgentInPod("pod-1", "task-1");
+    expect(result).toBe(false);
+  });
+
+  it("returns false when pod is not reachable", async () => {
+    const dbMock = db as any;
+    dbMock.where.mockResolvedValueOnce([
+      { id: "pod-1", podName: "p1", podId: "pid1", state: "ready" },
+    ]);
+    mockRuntimeStatus.mockRejectedValueOnce(new Error("unreachable"));
+
+    const result = await killOrphanedAgentInPod("pod-1", "task-1");
+    expect(result).toBe(false);
+  });
+
+  it("returns true when orphaned processes are found and killed", async () => {
+    const dbMock = db as any;
+    dbMock.where.mockResolvedValueOnce([
+      { id: "pod-1", podName: "p1", podId: "pid1", state: "ready" },
+    ]);
+    mockRuntimeStatus.mockResolvedValueOnce({ state: "running" });
+
+    const killSession = makeExecSession("killed\n");
+    const cleanSession = makeExecSession("");
+    mockRuntimeExec.mockResolvedValueOnce(killSession).mockResolvedValueOnce(cleanSession);
+
+    const result = await killOrphanedAgentInPod("pod-1", "task-1");
+    expect(result).toBe(true);
+    expect(mockRuntimeExec).toHaveBeenCalledTimes(2); // kill + worktree cleanup
+  });
+
+  it("returns false when no orphaned processes are found but still cleans worktree", async () => {
+    const dbMock = db as any;
+    dbMock.where.mockResolvedValueOnce([
+      { id: "pod-1", podName: "p1", podId: "pid1", state: "ready" },
+    ]);
+    mockRuntimeStatus.mockResolvedValueOnce({ state: "running" });
+
+    const killSession = makeExecSession("none\n");
+    const cleanSession = makeExecSession("");
+    mockRuntimeExec.mockResolvedValueOnce(killSession).mockResolvedValueOnce(cleanSession);
+
+    const result = await killOrphanedAgentInPod("pod-1", "task-1");
+    expect(result).toBe(false);
+    // Should still clean up the worktree even if no processes found
+    expect(mockRuntimeExec).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles kill exec failure gracefully and still cleans worktree", async () => {
+    const dbMock = db as any;
+    dbMock.where.mockResolvedValueOnce([
+      { id: "pod-1", podName: "p1", podId: "pid1", state: "ready" },
+    ]);
+    mockRuntimeStatus.mockResolvedValueOnce({ state: "running" });
+
+    // Kill exec throws, but cleanup should still run
+    mockRuntimeExec
+      .mockRejectedValueOnce(new Error("exec failed"))
+      .mockResolvedValueOnce(makeExecSession(""));
+
+    const result = await killOrphanedAgentInPod("pod-1", "task-1");
+    expect(result).toBe(false);
+    // Should still attempt worktree cleanup
+    expect(mockRuntimeExec).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -676,9 +676,15 @@ export async function execTaskInRepoPod(
     `grep -qxF '.optio/' "$EXCLUDE_FILE" 2>/dev/null || echo '.optio/' >> "$EXCLUDE_FILE"`,
     `grep -qxF '.optio-run-token' "$EXCLUDE_FILE" 2>/dev/null || echo '.optio-run-token' >> "$EXCLUDE_FILE"`,
     `grep -qxF '.optio-cache/' "$EXCLUDE_FILE" 2>/dev/null || echo '.optio-cache/' >> "$EXCLUDE_FILE"`,
-    // EXIT trap: preserve the worktree — cleanup is handled by the cleanup worker
-    // based on task state. Only clean up Claude Code's internal worktrees (-wt suffix).
-    `trap 'cd /workspace/repo 2>/dev/null; git worktree remove --force /workspace/tasks/${taskId}-wt 2>/dev/null || true; git worktree prune 2>/dev/null || true' EXIT`,
+    // EXIT trap: kill child processes (agent + watchdog) then clean up internal worktrees.
+    // This ensures orphaned agent processes are killed when the exec stream is severed
+    // (e.g. API pod restart closes the SPDY connection but kubelet doesn't send SIGHUP).
+    `_optio_main_pid=$$`,
+    `trap 'kill $(jobs -p) 2>/dev/null; wait 2>/dev/null; cd /workspace/repo 2>/dev/null; git worktree remove --force /workspace/tasks/${taskId}-wt 2>/dev/null || true; git worktree prune 2>/dev/null || true' EXIT`,
+    // Background heartbeat: detect broken stdout pipe (EPIPE) from severed exec stream.
+    // Writes an empty line every 30s (skipped by the NDJSON parser). If stdout is broken
+    // (API pod died), sends SIGTERM to the main script which triggers the EXIT trap.
+    `(trap '' PIPE; while sleep 30; do printf '\\n' 2>/dev/null || { kill -TERM $_optio_main_pid 2>/dev/null; exit; }; done) &`,
     `set +e`,
     ...agentCommand,
     `AGENT_EXIT=$?`,
@@ -937,6 +943,82 @@ export async function deleteEnvoyConfigMap(podName: string): Promise<void> {
   } catch (err) {
     logger.warn({ err, configMapName }, "Failed to delete Envoy ConfigMap");
   }
+}
+
+/**
+ * Best-effort kill of orphaned agent processes inside a repo pod and worktree cleanup.
+ *
+ * Used before stale-task re-queue and during startup reconciliation to prevent
+ * duplicate agents running in the same worktree. Identifies processes by the
+ * OPTIO_TASK_ID env var that the exec script exports.
+ *
+ * Returns true if processes were found and killed, false otherwise.
+ */
+export async function killOrphanedAgentInPod(podId: string, taskId: string): Promise<boolean> {
+  const [pod] = await db.select().from(repoPods).where(eq(repoPods.id, podId));
+  if (!pod || !pod.podName || pod.state !== "ready") return false;
+
+  const rt = getRuntime();
+  const handle: ContainerHandle = { id: pod.podId ?? pod.podName, name: pod.podName };
+
+  try {
+    // Check pod is actually reachable
+    const status = await rt.status(handle);
+    if (status.state !== "running") return false;
+  } catch {
+    return false;
+  }
+
+  let killed = false;
+  try {
+    // Kill any processes whose environment contains OPTIO_TASK_ID=<taskId>.
+    // pgrep -f matches against the full command line; we also grep /proc/*/environ
+    // as a fallback since env vars aren't always visible in cmdline.
+    const killScript = [
+      `pids=$(grep -rl "OPTIO_TASK_ID=${taskId}" /proc/*/environ 2>/dev/null | cut -d/ -f3 | sort -u || true)`,
+      `if [ -n "$pids" ]; then`,
+      `  kill -TERM $pids 2>/dev/null || true`,
+      `  sleep 2`,
+      `  kill -9 $pids 2>/dev/null || true`,
+      `  echo "killed"`,
+      `else`,
+      `  echo "none"`,
+      `fi`,
+    ].join("\n");
+
+    const killSession = await rt.exec(handle, ["bash", "-c", killScript], { tty: false });
+    let output = "";
+    for await (const chunk of killSession.stdout as AsyncIterable<Buffer>) {
+      output += chunk.toString();
+    }
+    killSession.close();
+    killed = output.includes("killed");
+
+    if (killed) {
+      logger.info({ podId, taskId, podName: pod.podName }, "Killed orphaned agent processes");
+    }
+  } catch (err) {
+    logger.warn({ err, podId, taskId }, "Failed to kill orphaned agent processes");
+  }
+
+  // Clean up the worktree regardless of whether processes were found
+  try {
+    const cleanScript = [
+      `cd /workspace/repo`,
+      `git worktree remove --force /workspace/tasks/${taskId} 2>/dev/null || true`,
+      `rm -rf /workspace/tasks/${taskId}`,
+    ].join(" && ");
+
+    const cleanSession = await rt.exec(handle, ["bash", "-c", cleanScript], { tty: false });
+    for await (const _ of cleanSession.stdout as AsyncIterable<Buffer>) {
+      /* drain */
+    }
+    cleanSession.close();
+  } catch (err) {
+    logger.warn({ err, podId, taskId }, "Failed to clean up worktree for orphaned task");
+  }
+
+  return killed;
 }
 
 /**

--- a/apps/api/src/workers/repo-cleanup-worker.test.ts
+++ b/apps/api/src/workers/repo-cleanup-worker.test.ts
@@ -100,12 +100,14 @@ const mockCleanupIdle = vi.fn().mockResolvedValue(0);
 const mockUpdateWorktree = vi.fn().mockResolvedValue(undefined);
 const mockReconcile = vi.fn().mockResolvedValue(0);
 const mockDeleteNetPolicy = vi.fn().mockResolvedValue(undefined);
+const mockKillOrphanedAgent = vi.fn().mockResolvedValue(false);
 
 vi.mock("../services/repo-pool-service.js", () => ({
   cleanupIdleRepoPods: (...args: unknown[]) => mockCleanupIdle(...args),
   updateWorktreeState: (...args: unknown[]) => mockUpdateWorktree(...args),
   reconcileActiveTaskCounts: (...args: unknown[]) => mockReconcile(...args),
   deleteNetworkPolicy: (...args: unknown[]) => mockDeleteNetPolicy(...args),
+  killOrphanedAgentInPod: (...args: unknown[]) => mockKillOrphanedAgent(...args),
 }));
 
 const mockRtStatus = vi.fn();
@@ -241,6 +243,7 @@ beforeEach(() => {
   mockUpdateWorktree.mockReset().mockResolvedValue(undefined);
   mockReconcile.mockReset().mockResolvedValue(0);
   mockDeleteNetPolicy.mockReset().mockResolvedValue(undefined);
+  mockKillOrphanedAgent.mockReset().mockResolvedValue(false);
   mockCleanupExpiredSessions.mockReset().mockResolvedValue(0);
   mockTaskQueueAdd.mockReset().mockResolvedValue(undefined);
   mockPublishEvent.mockReset().mockResolvedValue(undefined);
@@ -780,6 +783,115 @@ describe("repo-cleanup-worker", () => {
       );
       // Should NOT re-queue
       expect(mockTaskQueueAdd).not.toHaveBeenCalled();
+    });
+
+    it("kills orphaned agent in pod before re-queueing stale task", async () => {
+      const staleTask = makeTask({
+        id: "stale-orphan",
+        state: "running",
+        lastPodId: "pod-abc",
+        updatedAt: new Date(Date.now() - 700_000).toISOString(),
+      });
+      selectResults = [
+        [], // repoPods
+        [], // soft stall detection: running tasks
+        [staleTask], // stale tasks
+        [{ count: 0 }], // staleRetryCount = 0 (first stale detection)
+      ];
+
+      mockKillOrphanedAgent.mockResolvedValue(true);
+
+      await processorFn();
+
+      // Should have called killOrphanedAgentInPod with the pod ID and task ID
+      expect(mockKillOrphanedAgent).toHaveBeenCalledWith("pod-abc", "stale-orphan");
+      // Should update worktree state to removed
+      expect(mockUpdateWorktree).toHaveBeenCalledWith("stale-orphan", "removed");
+      // Should still re-queue
+      expect(mockTaskQueueAdd).toHaveBeenCalled();
+    });
+
+    it("escalates to needs_attention when cleanup fails on repeated stale recovery", async () => {
+      const staleTask = makeTask({
+        id: "stale-stuck",
+        state: "running",
+        lastPodId: "pod-xyz",
+        updatedAt: new Date(Date.now() - 700_000).toISOString(),
+      });
+      selectResults = [
+        [], // repoPods
+        [], // soft stall detection: running tasks
+        [staleTask], // stale tasks
+        [{ count: 1 }], // staleRetryCount = 1 (already retried once)
+      ];
+
+      // Simulate cleanup failure
+      mockKillOrphanedAgent.mockRejectedValue(new Error("Pod not reachable"));
+
+      await processorFn();
+
+      // Should mark worktree as dirty
+      expect(mockUpdateWorktree).toHaveBeenCalledWith("stale-stuck", "dirty");
+      // Should transition to needs_attention (not re-queue)
+      expect(mockTransitionTask).toHaveBeenCalledWith(
+        "stale-stuck",
+        TaskState.NEEDS_ATTENTION,
+        "stale_recovery_failed",
+        expect.stringContaining("Manual intervention required"),
+      );
+      // Should NOT re-queue
+      expect(mockTaskQueueAdd).not.toHaveBeenCalled();
+    });
+
+    it("re-queues on first stale even if cleanup fails", async () => {
+      const staleTask = makeTask({
+        id: "stale-first",
+        state: "running",
+        lastPodId: "pod-first",
+        updatedAt: new Date(Date.now() - 700_000).toISOString(),
+      });
+      selectResults = [
+        [], // repoPods
+        [], // soft stall detection: running tasks
+        [staleTask], // stale tasks
+        [{ count: 0 }], // staleRetryCount = 0 (first time)
+      ];
+
+      // Cleanup fails but this is the first attempt, so we still re-queue
+      mockKillOrphanedAgent.mockRejectedValue(new Error("Pod not reachable"));
+
+      await processorFn();
+
+      // Should still re-queue (first attempt gets a pass even on cleanup failure)
+      expect(mockTaskQueueAdd).toHaveBeenCalledWith(
+        "process-task",
+        { taskId: "stale-first" },
+        expect.objectContaining({ priority: 100 }),
+      );
+    });
+
+    it("handles stale task with no lastPodId gracefully", async () => {
+      const staleTask = makeTask({
+        id: "stale-no-pod",
+        state: "running",
+        lastPodId: null,
+        updatedAt: new Date(Date.now() - 700_000).toISOString(),
+      });
+      selectResults = [
+        [], // repoPods
+        [], // soft stall detection: running tasks
+        [staleTask], // stale tasks
+        [{ count: 0 }], // staleRetryCount = 0
+      ];
+
+      await processorFn();
+
+      // Should NOT call killOrphanedAgent (no pod to clean up)
+      expect(mockKillOrphanedAgent).not.toHaveBeenCalled();
+      // Should still re-queue
+      expect(mockTaskQueueAdd).toHaveBeenCalled();
+      // Should update worktree state to removed
+      expect(mockUpdateWorktree).toHaveBeenCalledWith("stale-no-pod", "removed");
     });
   });
 

--- a/apps/api/src/workers/repo-cleanup-worker.ts
+++ b/apps/api/src/workers/repo-cleanup-worker.ts
@@ -7,6 +7,7 @@ import {
   updateWorktreeState,
   reconcileActiveTaskCounts,
   deleteNetworkPolicy,
+  killOrphanedAgentInPod,
 } from "../services/repo-pool-service.js";
 import { getRuntime } from "../services/container-service.js";
 import { TaskState, DEFAULT_STALL_THRESHOLD_MS } from "@optio/shared";
@@ -387,6 +388,46 @@ export function startRepoCleanupWorker() {
             );
             continue;
           }
+
+          // ── Kill orphaned agent before re-queue ──────────────────────
+          // The previous agent process may still be alive inside the pod
+          // (orphaned after an API restart). Launching a new agent in the
+          // same worktree would deadlock on git index lock / state files.
+          let cleanupSucceeded = false;
+          if (task.lastPodId) {
+            try {
+              await killOrphanedAgentInPod(task.lastPodId, task.id);
+              cleanupSucceeded = true;
+            } catch (err) {
+              logger.warn(
+                { err, taskId: task.id, podId: task.lastPodId },
+                "Failed to kill orphaned agent in pod",
+              );
+            }
+          } else {
+            cleanupSucceeded = true; // No pod to clean up
+          }
+
+          // If this is a repeated stale recovery (retried before but went
+          // stale again) AND cleanup failed, escalate to needs_attention
+          // rather than re-queueing — prevents infinite retry loops.
+          if (!cleanupSucceeded && Number(staleRetryCount) >= 1) {
+            logger.warn(
+              { taskId: task.id, staleRetryCount },
+              "Stale recovery cleanup failed on repeated attempt — escalating to needs_attention",
+            );
+            await updateWorktreeState(task.id, "dirty");
+            await taskService.transitionTask(
+              task.id,
+              TaskState.NEEDS_ATTENTION,
+              "stale_recovery_failed",
+              "Stale task recovery failed — orphaned processes could not be killed. Manual intervention required.",
+            );
+            continue;
+          }
+
+          // Mark worktree as removed (cleanup ran above) so the new agent creates a fresh one
+          await updateWorktreeState(task.id, "removed");
 
           await taskService.transitionTask(
             task.id,

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -1077,7 +1077,24 @@ export async function reconcileOrphanedTasks() {
     .where(eq(tasks.state, "running" as any));
 
   // Provisioning/running tasks lost their exec session.
-  // Before failing and re-queuing, check if a PR was already opened —
+  // Before failing and re-queuing, kill any orphaned agent processes
+  // left inside repo pods (the API restart severed the exec stream but
+  // kubelet doesn't send SIGHUP to in-pod processes).
+  for (const task of [...orphanedProvisioning, ...orphanedRunning]) {
+    if ((task as any).lastPodId) {
+      try {
+        await repoPool.killOrphanedAgentInPod((task as any).lastPodId, task.id);
+        await repoPool.updateWorktreeState(task.id, "removed");
+      } catch (err) {
+        logger.warn(
+          { err, taskId: task.id, podId: (task as any).lastPodId },
+          "Failed to kill orphaned agent during startup reconciliation",
+        );
+      }
+    }
+  }
+
+  // Check if a PR was already opened —
   // if so, transition directly to pr_opened to avoid redoing work.
   for (const task of [...orphanedProvisioning, ...orphanedRunning]) {
     const taskWsId = task.workspaceId ?? null;


### PR DESCRIPTION
Closes #356

## What changed

Fixed two interacting bugs that combined to produce duplicate `claude` processes in a single worktree after API restarts, causing deadlocks and silent task failures.

### Bug 1 — Stale re-queue now kills orphaned agents first

**`apps/api/src/workers/repo-cleanup-worker.ts`**: The stale task re-queue path now:
1. Calls `killOrphanedAgentInPod()` to find and kill any orphaned agent processes in the pod before re-queueing
2. Marks the worktree as `removed` so the next agent creates a fresh one (instead of sharing state with the dead agent)
3. Escalates to `needs_attention` (instead of re-queueing) when cleanup fails on a repeated stale recovery, preventing infinite retry loops

### Bug 2 — API restart cleans up orphaned in-pod processes

**`apps/api/src/workers/task-worker.ts`**: The `reconcileOrphanedTasks()` startup reconciliation now kills orphaned agent processes and cleans up worktrees for all tasks that were `running`/`provisioning` when the API died.

**`apps/api/src/services/repo-pool-service.ts`**:
- Added `killOrphanedAgentInPod()` — finds processes by `OPTIO_TASK_ID` env var in `/proc/*/environ`, sends SIGTERM+SIGKILL, then `git worktree remove --force`
- Made the in-pod exec script signal-aware:
  - EXIT trap now kills child process group (agent + watchdog)
  - Background heartbeat detects broken stdout pipe (EPIPE from severed SPDY stream) and sends SIGTERM to trigger cleanup

### Tests

- 7 test cases for `killOrphanedAgentInPod` (pod not found, no podName, error state, unreachable, successful kill, no processes found, exec failure)
- 4 test cases for stale detection with orphan cleanup (kill before re-queue, needs_attention escalation, first-attempt re-queue on failure, no lastPodId handling)

## How to test

1. **Stale re-queue safety**: Set `OPTIO_STALE_TASK_MS=10000`, start a task, suspend its agent process. The re-queue should call `killOrphanedAgentInPod` before spawning a new agent — no duplicate processes in the same worktree.
2. **API restart cleanup**: Start a long-running task, then `kubectl rollout restart deployment/optio-api -n optio`. Within ~60s the heartbeat should detect the broken pipe, the EXIT trap should kill the agent, and startup reconciliation should clean up any remaining orphans.
3. **Escalation on repeated failure**: If cleanup fails on a second stale recovery attempt, the task should be moved to `needs_attention` rather than retried again.
4. **Run tests**: `pnpm turbo test` — all 1495 tests pass.