### PR TITLE
feat(workflows): replace workflow tables with new Workflows data model

### DIFF
--- a/apps/api/src/db/migrations/1775791878_replace_workflow_tables.sql
+++ b/apps/api/src/db/migrations/1775791878_replace_workflow_tables.sql
@@ -1,0 +1,100 @@
+-- Drop old workflow tables and references
+ALTER TABLE "tasks" DROP COLUMN IF EXISTS "workflow_run_id";
+--> statement-breakpoint
+DROP TABLE IF EXISTS "workflow_runs";
+--> statement-breakpoint
+DROP TABLE IF EXISTS "workflow_templates";
+--> statement-breakpoint
+
+-- Create new workflow enums
+DO $$ BEGIN
+  CREATE TYPE "public"."workflow_run_state" AS ENUM('queued', 'running', 'completed', 'failed');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  CREATE TYPE "public"."workflow_trigger_type" AS ENUM('manual', 'schedule', 'webhook');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  CREATE TYPE "public"."workflow_pod_state" AS ENUM('provisioning', 'ready', 'error', 'terminating');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+
+-- Create workflows table
+CREATE TABLE IF NOT EXISTS "workflows" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" text NOT NULL,
+  "workspace_id" uuid,
+  "environment_spec" jsonb,
+  "prompt_template" text NOT NULL,
+  "params_schema" jsonb,
+  "agent_runtime" text DEFAULT 'claude-code' NOT NULL,
+  "model" text,
+  "max_turns" integer,
+  "budget_usd" text,
+  "max_concurrent" integer DEFAULT 1 NOT NULL,
+  "max_retries" integer DEFAULT 3 NOT NULL,
+  "warm_pool_size" integer DEFAULT 0 NOT NULL,
+  "enabled" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workflows_workspace_id_idx" ON "workflows" USING btree ("workspace_id");
+--> statement-breakpoint
+
+-- Create workflow_triggers table
+CREATE TABLE IF NOT EXISTS "workflow_triggers" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "workflow_id" uuid NOT NULL REFERENCES "workflows"("id") ON DELETE CASCADE,
+  "type" "workflow_trigger_type" NOT NULL,
+  "config" jsonb,
+  "param_mapping" jsonb,
+  "enabled" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workflow_triggers_workflow_id_idx" ON "workflow_triggers" USING btree ("workflow_id");
+--> statement-breakpoint
+
+-- Create workflow_runs table (new schema)
+CREATE TABLE IF NOT EXISTS "workflow_runs" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "workflow_id" uuid NOT NULL REFERENCES "workflows"("id") ON DELETE CASCADE,
+  "trigger_id" uuid REFERENCES "workflow_triggers"("id"),
+  "params" jsonb,
+  "state" "workflow_run_state" DEFAULT 'queued' NOT NULL,
+  "output" jsonb,
+  "cost_usd" text,
+  "input_tokens" integer,
+  "output_tokens" integer,
+  "model_used" text,
+  "error_message" text,
+  "session_id" text,
+  "pod_name" text,
+  "retry_count" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workflow_runs_workflow_id_idx" ON "workflow_runs" USING btree ("workflow_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workflow_runs_state_idx" ON "workflow_runs" USING btree ("state");
+--> statement-breakpoint
+
+-- Create workflow_pods table
+CREATE TABLE IF NOT EXISTS "workflow_pods" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "workflow_id" uuid NOT NULL REFERENCES "workflows"("id") ON DELETE CASCADE,
+  "pod_name" text,
+  "state" "workflow_pod_state" DEFAULT 'provisioning' NOT NULL,
+  "active_run_count" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "workflow_pods_workflow_id_idx" ON "workflow_pods" USING btree ("workflow_id");

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1775627754000,
       "tag": "1775627754_api_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1775791878000,
+      "tag": "1775791878_replace_workflow_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -122,7 +122,6 @@ export const tasks = pgTable(
     blocksParent: boolean("blocks_parent").notNull().default(false), // if true, parent waits for this
     worktreeState: text("worktree_state"), // "active" | "dirty" | "reset" | "preserved" | "removed"
     lastPodId: uuid("last_pod_id"), // last pod this task ran on (for same-pod retry affinity)
-    workflowRunId: uuid("workflow_run_id"), // nullable FK to workflow_runs
     createdBy: uuid("created_by"), // nullable FK to users (null when auth is disabled)
     ignoreOffPeak: boolean("ignore_off_peak").notNull().default(false),
     lastActivityAt: timestamp("last_activity_at", { withTimezone: true }), // stall detection: last parsed agent event
@@ -543,48 +542,110 @@ export const taskDependencies = pgTable(
   ],
 );
 
-// ── Workflow Templates & Runs ────────────────────────────────────────────────
+// ── Workflows (new data model) ───────────────────────────────────────────────
 
-export const workflowTemplates = pgTable("workflow_templates", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  name: text("name").notNull(),
-  description: text("description"),
-  workspaceId: uuid("workspace_id"),
-  steps: jsonb("steps")
-    .$type<
-      Array<{
-        id: string;
-        title: string;
-        prompt: string;
-        repoUrl?: string;
-        agentType?: string;
-        dependsOn?: string[];
-        condition?: { type: string; value?: string };
-      }>
-    >()
-    .notNull(),
-  status: text("status").notNull().default("draft"), // "draft" | "active" | "archived"
-  createdBy: uuid("created_by"),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+export const workflowRunStateEnum = pgEnum("workflow_run_state", [
+  "queued",
+  "running",
+  "completed",
+  "failed",
+]);
+
+export const workflowTriggerTypeEnum = pgEnum("workflow_trigger_type", [
+  "manual",
+  "schedule",
+  "webhook",
+]);
+
+export const workflowPodStateEnum = pgEnum("workflow_pod_state", [
+  "provisioning",
+  "ready",
+  "error",
+  "terminating",
+]);
+
+export const workflows = pgTable(
+  "workflows",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: text("name").notNull(),
+    workspaceId: uuid("workspace_id"),
+    environmentSpec: jsonb("environment_spec").$type<Record<string, unknown>>(),
+    promptTemplate: text("prompt_template").notNull(),
+    paramsSchema: jsonb("params_schema").$type<Record<string, unknown>>(),
+    agentRuntime: text("agent_runtime").notNull().default("claude-code"),
+    model: text("model"),
+    maxTurns: integer("max_turns"),
+    budgetUsd: text("budget_usd"),
+    maxConcurrent: integer("max_concurrent").notNull().default(1),
+    maxRetries: integer("max_retries").notNull().default(3),
+    warmPoolSize: integer("warm_pool_size").notNull().default(0),
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("workflows_workspace_id_idx").on(table.workspaceId)],
+);
+
+export const workflowTriggers = pgTable(
+  "workflow_triggers",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    workflowId: uuid("workflow_id")
+      .notNull()
+      .references(() => workflows.id, { onDelete: "cascade" }),
+    type: workflowTriggerTypeEnum("type").notNull(),
+    config: jsonb("config").$type<Record<string, unknown>>(),
+    paramMapping: jsonb("param_mapping").$type<Record<string, unknown>>(),
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("workflow_triggers_workflow_id_idx").on(table.workflowId)],
+);
 
 export const workflowRuns = pgTable(
   "workflow_runs",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    workflowTemplateId: uuid("workflow_template_id")
+    workflowId: uuid("workflow_id")
       .notNull()
-      .references(() => workflowTemplates.id, { onDelete: "cascade" }),
-    workspaceId: uuid("workspace_id"),
-    status: text("status").notNull().default("running"), // "running" | "paused" | "completed" | "failed" | "cancelled"
-    taskMapping: jsonb("task_mapping").$type<Record<string, string>>(), // stepId → taskId
-    createdBy: uuid("created_by"),
+      .references(() => workflows.id, { onDelete: "cascade" }),
+    triggerId: uuid("trigger_id").references(() => workflowTriggers.id),
+    params: jsonb("params").$type<Record<string, unknown>>(),
+    state: workflowRunStateEnum("state").notNull().default("queued"),
+    output: jsonb("output").$type<Record<string, unknown>>(),
+    costUsd: text("cost_usd"),
+    inputTokens: integer("input_tokens"),
+    outputTokens: integer("output_tokens"),
+    modelUsed: text("model_used"),
+    errorMessage: text("error_message"),
+    sessionId: text("session_id"),
+    podName: text("pod_name"),
+    retryCount: integer("retry_count").notNull().default(0),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-    completedAt: timestamp("completed_at", { withTimezone: true }),
   },
-  (table) => [index("workflow_runs_template_id_idx").on(table.workflowTemplateId)],
+  (table) => [
+    index("workflow_runs_workflow_id_idx").on(table.workflowId),
+    index("workflow_runs_state_idx").on(table.state),
+  ],
+);
+
+export const workflowPods = pgTable(
+  "workflow_pods",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    workflowId: uuid("workflow_id")
+      .notNull()
+      .references(() => workflows.id, { onDelete: "cascade" }),
+    podName: text("pod_name"),
+    state: workflowPodStateEnum("state").notNull().default("provisioning"),
+    activeRunCount: integer("active_run_count").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("workflow_pods_workflow_id_idx").on(table.workflowId)],
 );
 
 // ── MCP Servers ──────────────────────────────────────────────────────────────

--- a/apps/api/src/routes/request-input-validation.test.ts
+++ b/apps/api/src/routes/request-input-validation.test.ts
@@ -105,16 +105,19 @@ vi.mock("../services/interactive-session-service.js", () => ({
 }));
 
 // workflows.ts mocks
-const mockRunWorkflow = vi.fn();
+const mockCreateWorkflowRun = vi.fn();
 vi.mock("../services/workflow-service.js", () => ({
-  listWorkflowTemplates: vi.fn().mockResolvedValue([]),
-  getWorkflowTemplate: vi.fn().mockResolvedValue(null),
-  createWorkflowTemplate: vi.fn(),
-  updateWorkflowTemplate: vi.fn(),
-  deleteWorkflowTemplate: vi.fn(),
-  runWorkflow: (...args: unknown[]) => mockRunWorkflow(...args),
+  listWorkflows: vi.fn().mockResolvedValue([]),
+  getWorkflow: vi.fn().mockResolvedValue(null),
+  createWorkflow: vi.fn(),
+  updateWorkflow: vi.fn(),
+  deleteWorkflow: vi.fn(),
+  listWorkflowTriggers: vi.fn().mockResolvedValue([]),
+  createWorkflowTrigger: vi.fn(),
+  deleteWorkflowTrigger: vi.fn(),
   listWorkflowRuns: vi.fn().mockResolvedValue([]),
   getWorkflowRun: vi.fn().mockResolvedValue(null),
+  createWorkflowRun: (...args: unknown[]) => mockCreateWorkflowRun(...args),
 }));
 
 // tasks.ts mocks
@@ -322,30 +325,30 @@ describe("workflows route body validation", () => {
     await app.ready();
   });
 
-  it("rejects POST /api/workflow-templates/:id/run with wrong type for repoUrl", async () => {
+  it("rejects POST /api/workflows/:id/runs with wrong type for triggerId", async () => {
     const res = await app.inject({
       method: "POST",
-      url: "/api/workflow-templates/t1/run",
-      payload: { repoUrl: 42 },
+      url: "/api/workflows/t1/runs",
+      payload: { triggerId: 42 },
     });
     expect(res.statusCode).toBe(400);
   });
 
-  it("accepts POST /api/workflow-templates/:id/run with valid optional body", async () => {
-    mockRunWorkflow.mockResolvedValue({ id: "run-1" });
+  it("accepts POST /api/workflows/:id/runs with valid optional body", async () => {
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-1", state: "queued" });
     const res = await app.inject({
       method: "POST",
-      url: "/api/workflow-templates/t1/run",
-      payload: { repoUrl: "https://github.com/org/repo" },
+      url: "/api/workflows/t1/runs",
+      payload: { triggerId: "tr-1" },
     });
     expect(res.statusCode).toBe(201);
   });
 
-  it("accepts POST /api/workflow-templates/:id/run with empty body", async () => {
-    mockRunWorkflow.mockResolvedValue({ id: "run-1" });
+  it("accepts POST /api/workflows/:id/runs with empty body", async () => {
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-1", state: "queued" });
     const res = await app.inject({
       method: "POST",
-      url: "/api/workflow-templates/t1/run",
+      url: "/api/workflows/t1/runs",
       payload: {},
     });
     expect(res.statusCode).toBe(201);

--- a/apps/api/src/routes/workflows.test.ts
+++ b/apps/api/src/routes/workflows.test.ts
@@ -4,24 +4,30 @@ import type { FastifyInstance } from "fastify";
 
 // ─── Mocks ───
 
-const mockListWorkflowTemplates = vi.fn();
-const mockGetWorkflowTemplate = vi.fn();
-const mockCreateWorkflowTemplate = vi.fn();
-const mockUpdateWorkflowTemplate = vi.fn();
-const mockDeleteWorkflowTemplate = vi.fn();
-const mockRunWorkflow = vi.fn();
+const mockListWorkflows = vi.fn();
+const mockGetWorkflow = vi.fn();
+const mockCreateWorkflow = vi.fn();
+const mockUpdateWorkflow = vi.fn();
+const mockDeleteWorkflow = vi.fn();
+const mockListWorkflowTriggers = vi.fn();
+const mockCreateWorkflowTrigger = vi.fn();
+const mockDeleteWorkflowTrigger = vi.fn();
 const mockListWorkflowRuns = vi.fn();
 const mockGetWorkflowRun = vi.fn();
+const mockCreateWorkflowRun = vi.fn();
 
 vi.mock("../services/workflow-service.js", () => ({
-  listWorkflowTemplates: (...args: unknown[]) => mockListWorkflowTemplates(...args),
-  getWorkflowTemplate: (...args: unknown[]) => mockGetWorkflowTemplate(...args),
-  createWorkflowTemplate: (...args: unknown[]) => mockCreateWorkflowTemplate(...args),
-  updateWorkflowTemplate: (...args: unknown[]) => mockUpdateWorkflowTemplate(...args),
-  deleteWorkflowTemplate: (...args: unknown[]) => mockDeleteWorkflowTemplate(...args),
-  runWorkflow: (...args: unknown[]) => mockRunWorkflow(...args),
+  listWorkflows: (...args: unknown[]) => mockListWorkflows(...args),
+  getWorkflow: (...args: unknown[]) => mockGetWorkflow(...args),
+  createWorkflow: (...args: unknown[]) => mockCreateWorkflow(...args),
+  updateWorkflow: (...args: unknown[]) => mockUpdateWorkflow(...args),
+  deleteWorkflow: (...args: unknown[]) => mockDeleteWorkflow(...args),
+  listWorkflowTriggers: (...args: unknown[]) => mockListWorkflowTriggers(...args),
+  createWorkflowTrigger: (...args: unknown[]) => mockCreateWorkflowTrigger(...args),
+  deleteWorkflowTrigger: (...args: unknown[]) => mockDeleteWorkflowTrigger(...args),
   listWorkflowRuns: (...args: unknown[]) => mockListWorkflowRuns(...args),
   getWorkflowRun: (...args: unknown[]) => mockGetWorkflowRun(...args),
+  createWorkflowRun: (...args: unknown[]) => mockCreateWorkflowRun(...args),
 }));
 
 import { workflowRoutes } from "./workflows.js";
@@ -40,9 +46,7 @@ async function buildTestApp(): Promise<FastifyInstance> {
   return app;
 }
 
-const mockStep = { id: "step-1", title: "Step 1", prompt: "Do step 1" };
-
-describe("GET /api/workflow-templates", () => {
+describe("GET /api/workflows", () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {
@@ -50,18 +54,18 @@ describe("GET /api/workflow-templates", () => {
     app = await buildTestApp();
   });
 
-  it("lists templates scoped to workspace", async () => {
-    mockListWorkflowTemplates.mockResolvedValue([{ id: "wf-1", name: "Deploy" }]);
+  it("lists workflows scoped to workspace", async () => {
+    mockListWorkflows.mockResolvedValue([{ id: "wf-1", name: "Deploy" }]);
 
-    const res = await app.inject({ method: "GET", url: "/api/workflow-templates" });
+    const res = await app.inject({ method: "GET", url: "/api/workflows" });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().templates).toHaveLength(1);
-    expect(mockListWorkflowTemplates).toHaveBeenCalledWith("ws-1");
+    expect(res.json().workflows).toHaveLength(1);
+    expect(mockListWorkflows).toHaveBeenCalledWith("ws-1");
   });
 });
 
-describe("POST /api/workflow-templates", () => {
+describe("POST /api/workflows", () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {
@@ -69,33 +73,34 @@ describe("POST /api/workflow-templates", () => {
     app = await buildTestApp();
   });
 
-  it("creates a workflow template", async () => {
-    mockCreateWorkflowTemplate.mockResolvedValue({ id: "wf-1", name: "Deploy" });
+  it("creates a workflow", async () => {
+    mockCreateWorkflow.mockResolvedValue({ id: "wf-1", name: "Deploy" });
 
     const res = await app.inject({
       method: "POST",
-      url: "/api/workflow-templates",
-      payload: { name: "Deploy", steps: [mockStep] },
+      url: "/api/workflows",
+      payload: { name: "Deploy", promptTemplate: "Do the deploy" },
     });
 
     expect(res.statusCode).toBe(201);
-    expect(mockCreateWorkflowTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({ name: "Deploy", workspaceId: "ws-1", createdBy: "user-1" }),
+    expect(mockCreateWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Deploy", workspaceId: "ws-1" }),
     );
   });
 
-  it("rejects empty steps array (Zod throws)", async () => {
+  it("rejects missing promptTemplate", async () => {
     const res = await app.inject({
       method: "POST",
-      url: "/api/workflow-templates",
-      payload: { name: "Empty", steps: [] },
+      url: "/api/workflows",
+      payload: { name: "Deploy" },
     });
 
+    // Zod validation error
     expect(res.statusCode).toBe(500);
   });
 });
 
-describe("POST /api/workflow-templates/:id/run", () => {
+describe("POST /api/workflows/:id/runs", () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {
@@ -103,28 +108,27 @@ describe("POST /api/workflow-templates/:id/run", () => {
     app = await buildTestApp();
   });
 
-  it("runs a workflow", async () => {
-    mockRunWorkflow.mockResolvedValue({ id: "run-1", status: "running" });
+  it("creates a workflow run", async () => {
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-1", state: "queued" });
 
     const res = await app.inject({
       method: "POST",
-      url: "/api/workflow-templates/wf-1/run",
+      url: "/api/workflows/wf-1/runs",
       payload: {},
     });
 
     expect(res.statusCode).toBe(201);
-    expect(mockRunWorkflow).toHaveBeenCalledWith(
-      "wf-1",
-      expect.objectContaining({ workspaceId: "ws-1" }),
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: "wf-1" }),
     );
   });
 
-  it("returns 400 when run fails", async () => {
-    mockRunWorkflow.mockRejectedValue(new Error("Template not found"));
+  it("returns 400 when run creation fails", async () => {
+    mockCreateWorkflowRun.mockRejectedValue(new Error("Workflow not found"));
 
     const res = await app.inject({
       method: "POST",
-      url: "/api/workflow-templates/nonexistent/run",
+      url: "/api/workflows/nonexistent/runs",
       payload: {},
     });
 
@@ -152,6 +156,31 @@ describe("GET /api/workflow-runs/:id", () => {
     mockGetWorkflowRun.mockResolvedValue(null);
 
     const res = await app.inject({ method: "GET", url: "/api/workflow-runs/nonexistent" });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("DELETE /api/workflows/:id", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("deletes a workflow", async () => {
+    mockDeleteWorkflow.mockResolvedValue(true);
+
+    const res = await app.inject({ method: "DELETE", url: "/api/workflows/wf-1" });
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("returns 404 for nonexistent workflow", async () => {
+    mockDeleteWorkflow.mockResolvedValue(false);
+
+    const res = await app.inject({ method: "DELETE", url: "/api/workflows/nonexistent" });
 
     expect(res.statusCode).toBe(404);
   });

--- a/apps/api/src/routes/workflows.ts
+++ b/apps/api/src/routes/workflows.ts
@@ -2,122 +2,155 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import * as workflowService from "../services/workflow-service.js";
 
-const stepSchema = z.object({
-  id: z.string().min(1),
-  title: z.string().min(1),
-  prompt: z.string().min(1),
-  repoUrl: z.string().optional(),
-  agentType: z.string().optional(),
-  dependsOn: z.array(z.string()).optional(),
-  condition: z
-    .object({
-      type: z.enum(["always", "if_pr_opened", "if_ci_passes", "if_cost_under"]),
-      value: z.string().optional(),
-    })
-    .optional(),
-});
+const idParamsSchema = z.object({ id: z.string() });
 
-const createTemplateSchema = z.object({
+const createWorkflowSchema = z.object({
   name: z.string().min(1),
-  description: z.string().optional(),
-  steps: z.array(stepSchema).min(1),
-  status: z.enum(["draft", "active", "archived"]).optional(),
+  environmentSpec: z.record(z.unknown()).optional(),
+  promptTemplate: z.string().min(1),
+  paramsSchema: z.record(z.unknown()).optional(),
+  agentRuntime: z.string().optional(),
+  model: z.string().optional(),
+  maxTurns: z.number().int().positive().optional(),
+  budgetUsd: z.string().optional(),
+  maxConcurrent: z.number().int().positive().optional(),
+  maxRetries: z.number().int().min(0).optional(),
+  warmPoolSize: z.number().int().min(0).optional(),
+  enabled: z.boolean().optional(),
 });
 
-const updateTemplateSchema = z.object({
+const updateWorkflowSchema = z.object({
   name: z.string().min(1).optional(),
-  description: z.string().optional(),
-  steps: z.array(stepSchema).min(1).optional(),
-  status: z.enum(["draft", "active", "archived"]).optional(),
+  environmentSpec: z.record(z.unknown()).optional(),
+  promptTemplate: z.string().min(1).optional(),
+  paramsSchema: z.record(z.unknown()).optional(),
+  agentRuntime: z.string().optional(),
+  model: z.string().optional(),
+  maxTurns: z.number().int().positive().optional(),
+  budgetUsd: z.string().optional(),
+  maxConcurrent: z.number().int().positive().optional(),
+  maxRetries: z.number().int().min(0).optional(),
+  warmPoolSize: z.number().int().min(0).optional(),
+  enabled: z.boolean().optional(),
 });
 
-const runWorkflowBodySchema = z
+const createTriggerSchema = z.object({
+  type: z.enum(["manual", "schedule", "webhook"]),
+  config: z.record(z.unknown()).optional(),
+  paramMapping: z.record(z.unknown()).optional(),
+  enabled: z.boolean().optional(),
+});
+
+const createRunSchema = z
   .object({
-    repoUrl: z.string().optional(),
+    triggerId: z.string().optional(),
+    params: z.record(z.unknown()).optional(),
   })
   .optional()
   .default({});
 
-const idParamsSchema = z.object({ id: z.string() });
-
 export async function workflowRoutes(app: FastifyInstance) {
-  // List workflow templates
-  app.get("/api/workflow-templates", async (req, reply) => {
-    const templates = await workflowService.listWorkflowTemplates(
-      req.user?.workspaceId ?? undefined,
-    );
-    reply.send({ templates });
+  // ── Workflows ──────────────────────────────────────────────────────────────
+
+  // List workflows
+  app.get("/api/workflows", async (req, reply) => {
+    const list = await workflowService.listWorkflows(req.user?.workspaceId ?? undefined);
+    reply.send({ workflows: list });
   });
 
-  // Get a workflow template
-  app.get("/api/workflow-templates/:id", async (req, reply) => {
+  // Get a workflow
+  app.get("/api/workflows/:id", async (req, reply) => {
     const { id } = idParamsSchema.parse(req.params);
-    const template = await workflowService.getWorkflowTemplate(id);
-    if (!template) return reply.status(404).send({ error: "Workflow template not found" });
-    reply.send({ template });
+    const workflow = await workflowService.getWorkflow(id);
+    if (!workflow) return reply.status(404).send({ error: "Workflow not found" });
+    reply.send({ workflow });
   });
 
-  // Create a workflow template
-  app.post("/api/workflow-templates", async (req, reply) => {
-    const input = createTemplateSchema.parse(req.body);
-    try {
-      const template = await workflowService.createWorkflowTemplate({
-        ...input,
-        workspaceId: req.user?.workspaceId ?? undefined,
-        createdBy: req.user?.id,
-      });
-      reply.status(201).send({ template });
-    } catch (err) {
-      reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
-    }
+  // Create a workflow
+  app.post("/api/workflows", async (req, reply) => {
+    const input = createWorkflowSchema.parse(req.body);
+    const workflow = await workflowService.createWorkflow({
+      ...input,
+      workspaceId: req.user?.workspaceId ?? undefined,
+    });
+    reply.status(201).send({ workflow });
   });
 
-  // Update a workflow template
-  app.patch("/api/workflow-templates/:id", async (req, reply) => {
+  // Update a workflow
+  app.patch("/api/workflows/:id", async (req, reply) => {
     const { id } = idParamsSchema.parse(req.params);
-    const input = updateTemplateSchema.parse(req.body);
-    try {
-      const template = await workflowService.updateWorkflowTemplate(id, input);
-      if (!template) return reply.status(404).send({ error: "Workflow template not found" });
-      reply.send({ template });
-    } catch (err) {
-      reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
-    }
+    const input = updateWorkflowSchema.parse(req.body);
+    const workflow = await workflowService.updateWorkflow(id, input);
+    if (!workflow) return reply.status(404).send({ error: "Workflow not found" });
+    reply.send({ workflow });
   });
 
-  // Delete a workflow template
-  app.delete("/api/workflow-templates/:id", async (req, reply) => {
+  // Delete a workflow
+  app.delete("/api/workflows/:id", async (req, reply) => {
     const { id } = idParamsSchema.parse(req.params);
-    const deleted = await workflowService.deleteWorkflowTemplate(id);
-    if (!deleted) return reply.status(404).send({ error: "Workflow template not found" });
+    const deleted = await workflowService.deleteWorkflow(id);
+    if (!deleted) return reply.status(404).send({ error: "Workflow not found" });
     reply.status(204).send();
   });
 
-  // Run a workflow template (instantiate)
-  app.post("/api/workflow-templates/:id/run", async (req, reply) => {
+  // ── Workflow Triggers ──────────────────────────────────────────────────────
+
+  // List triggers for a workflow
+  app.get("/api/workflows/:id/triggers", async (req, reply) => {
     const { id } = idParamsSchema.parse(req.params);
-    const parsed = runWorkflowBodySchema.safeParse(req.body);
+    const triggers = await workflowService.listWorkflowTriggers(id);
+    reply.send({ triggers });
+  });
+
+  // Create a trigger
+  app.post("/api/workflows/:id/triggers", async (req, reply) => {
+    const { id } = idParamsSchema.parse(req.params);
+    const input = createTriggerSchema.parse(req.body);
+    try {
+      const trigger = await workflowService.createWorkflowTrigger({
+        workflowId: id,
+        ...input,
+      });
+      reply.status(201).send({ trigger });
+    } catch (err) {
+      reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  // Delete a trigger
+  app.delete("/api/workflows/:id/triggers/:triggerId", async (req, reply) => {
+    const params = z.object({ id: z.string(), triggerId: z.string() }).parse(req.params);
+    const deleted = await workflowService.deleteWorkflowTrigger(params.triggerId);
+    if (!deleted) return reply.status(404).send({ error: "Trigger not found" });
+    reply.status(204).send();
+  });
+
+  // ── Workflow Runs ──────────────────────────────────────────────────────────
+
+  // List runs for a workflow
+  app.get("/api/workflows/:id/runs", async (req, reply) => {
+    const { id } = idParamsSchema.parse(req.params);
+    const runs = await workflowService.listWorkflowRuns(id);
+    reply.send({ runs });
+  });
+
+  // Create a run (trigger a workflow)
+  app.post("/api/workflows/:id/runs", async (req, reply) => {
+    const { id } = idParamsSchema.parse(req.params);
+    const parsed = createRunSchema.safeParse(req.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: parsed.error.issues[0].message });
     }
-    const body = parsed.data;
     try {
-      const run = await workflowService.runWorkflow(id, {
-        workspaceId: req.user?.workspaceId ?? undefined,
-        createdBy: req.user?.id,
-        repoUrlOverride: body.repoUrl,
+      const run = await workflowService.createWorkflowRun({
+        workflowId: id,
+        triggerId: parsed.data.triggerId,
+        params: parsed.data.params,
       });
       reply.status(201).send({ run });
     } catch (err) {
       reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
     }
-  });
-
-  // List workflow runs for a template
-  app.get("/api/workflow-templates/:id/runs", async (req, reply) => {
-    const { id } = idParamsSchema.parse(req.params);
-    const runs = await workflowService.listWorkflowRuns(id);
-    reply.send({ runs });
   });
 
   // Get a workflow run

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -350,15 +350,6 @@ export async function transitionTask(
       .catch((err) => logger.warn({ err, taskId: id }, "Failed to cascade failure to dependents"));
   }
 
-  // Update workflow run status if this task is part of a workflow
-  if (updated[0].workflowRunId) {
-    import("./workflow-service.js")
-      .then(({ checkWorkflowRunCompletion }) =>
-        checkWorkflowRunCompletion(updated[0].workflowRunId!),
-      )
-      .catch((err) => logger.warn({ err, taskId: id }, "Failed to update workflow run status"));
-  }
-
   return updated[0];
 }
 

--- a/apps/api/src/services/workflow-service.test.ts
+++ b/apps/api/src/services/workflow-service.test.ts
@@ -10,35 +10,26 @@ vi.mock("../db/client.js", () => ({
 }));
 
 vi.mock("../db/schema.js", () => ({
-  workflowTemplates: {
-    id: "workflow_templates.id",
-    workspaceId: "workflow_templates.workspace_id",
-    createdAt: "workflow_templates.created_at",
+  workflows: {
+    id: "workflows.id",
+    workspaceId: "workflows.workspace_id",
+    createdAt: "workflows.created_at",
+  },
+  workflowTriggers: {
+    id: "workflow_triggers.id",
+    workflowId: "workflow_triggers.workflow_id",
+    createdAt: "workflow_triggers.created_at",
   },
   workflowRuns: {
     id: "workflow_runs.id",
-    workflowTemplateId: "workflow_runs.workflow_template_id",
+    workflowId: "workflow_runs.workflow_id",
+    state: "workflow_runs.state",
     createdAt: "workflow_runs.created_at",
   },
-  tasks: {
-    id: "tasks.id",
-    workflowRunId: "tasks.workflow_run_id",
-  },
-}));
-
-vi.mock("./task-service.js", () => ({
-  getTask: vi.fn(),
-  createTask: vi.fn(),
-  transitionTask: vi.fn(),
-}));
-
-vi.mock("./dependency-service.js", () => ({
-  addDependencies: vi.fn(),
-}));
-
-vi.mock("../workers/task-worker.js", () => ({
-  taskQueue: {
-    add: vi.fn(),
+  workflowPods: {
+    id: "workflow_pods.id",
+    workflowId: "workflow_pods.workflow_id",
+    createdAt: "workflow_pods.created_at",
   },
 }));
 
@@ -55,28 +46,29 @@ vi.mock("../logger.js", () => ({
   },
 }));
 
-// Must mock @optio/shared detectCycle
 vi.mock("@optio/shared", async () => {
   const actual = await vi.importActual("@optio/shared");
-  return {
-    ...actual,
-  };
+  return { ...actual };
 });
 
 import { db } from "../db/client.js";
-import * as taskService from "./task-service.js";
-import * as dependencyService from "./dependency-service.js";
-import { taskQueue } from "../workers/task-worker.js";
 import {
-  listWorkflowTemplates,
-  getWorkflowTemplate,
-  createWorkflowTemplate,
-  updateWorkflowTemplate,
-  deleteWorkflowTemplate,
+  listWorkflows,
+  getWorkflow,
+  createWorkflow,
+  updateWorkflow,
+  deleteWorkflow,
+  listWorkflowTriggers,
+  createWorkflowTrigger,
+  deleteWorkflowTrigger,
   listWorkflowRuns,
   getWorkflowRun,
-  runWorkflow,
-  checkWorkflowRunCompletion,
+  createWorkflowRun,
+  transitionWorkflowRun,
+  listWorkflowPods,
+  getWorkflowPod,
+  createWorkflowPod,
+  deleteWorkflowPod,
 } from "./workflow-service.js";
 
 describe("workflow-service", () => {
@@ -84,43 +76,44 @@ describe("workflow-service", () => {
     vi.clearAllMocks();
   });
 
-  describe("listWorkflowTemplates", () => {
-    it("lists all templates ordered by createdAt", async () => {
-      const templates = [{ id: "wt-1", name: "Deploy" }];
-      const mockWhere = vi.fn().mockResolvedValue(templates);
+  // ── Workflow CRUD ──────────────────────────────────────────────────────────
+
+  describe("listWorkflows", () => {
+    it("lists all workflows ordered by createdAt", async () => {
+      const items = [{ id: "wf-1", name: "Deploy" }];
+      const mockWhere = vi.fn().mockResolvedValue(items);
       const mockOrderBy = vi.fn().mockReturnValue({ where: mockWhere });
       const mockFrom = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
       (db.select as any) = vi.fn().mockReturnValue({ from: mockFrom });
 
-      // Without workspaceId, should not call where
-      mockOrderBy.mockResolvedValue(templates);
-      const result = await listWorkflowTemplates();
-      expect(result).toEqual(templates);
+      mockOrderBy.mockResolvedValue(items);
+      const result = await listWorkflows();
+      expect(result).toEqual(items);
     });
 
     it("filters by workspaceId when provided", async () => {
-      const templates = [{ id: "wt-1", name: "Deploy" }];
-      const mockWhere = vi.fn().mockResolvedValue(templates);
+      const items = [{ id: "wf-1", name: "Deploy" }];
+      const mockWhere = vi.fn().mockResolvedValue(items);
       const mockOrderBy = vi.fn().mockReturnValue({ where: mockWhere });
       const mockFrom = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
       (db.select as any) = vi.fn().mockReturnValue({ from: mockFrom });
 
-      const result = await listWorkflowTemplates("ws-1");
+      const result = await listWorkflows("ws-1");
       expect(mockWhere).toHaveBeenCalled();
     });
   });
 
-  describe("getWorkflowTemplate", () => {
-    it("returns template when found", async () => {
-      const template = { id: "wt-1", name: "Deploy" };
+  describe("getWorkflow", () => {
+    it("returns workflow when found", async () => {
+      const workflow = { id: "wf-1", name: "Deploy" };
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([template]),
+          where: vi.fn().mockResolvedValue([workflow]),
         }),
       });
 
-      const result = await getWorkflowTemplate("wt-1");
-      expect(result).toEqual(template);
+      const result = await getWorkflow("wf-1");
+      expect(result).toEqual(workflow);
     });
 
     it("returns null when not found", async () => {
@@ -130,73 +123,53 @@ describe("workflow-service", () => {
         }),
       });
 
-      const result = await getWorkflowTemplate("nonexistent");
+      const result = await getWorkflow("nonexistent");
       expect(result).toBeNull();
     });
   });
 
-  describe("createWorkflowTemplate", () => {
-    it("creates a template with valid DAG", async () => {
-      const created = { id: "wt-1", name: "Pipeline", steps: [] };
+  describe("createWorkflow", () => {
+    it("creates a workflow with required fields", async () => {
+      const created = { id: "wf-1", name: "Pipeline", promptTemplate: "Do stuff" };
       (db.insert as any) = vi.fn().mockReturnValue({
         values: vi.fn().mockReturnValue({
           returning: vi.fn().mockResolvedValue([created]),
         }),
       });
 
-      const result = await createWorkflowTemplate({
+      const result = await createWorkflow({
         name: "Pipeline",
-        steps: [
-          { id: "step-a", title: "Build", prompt: "Build the app" },
-          { id: "step-b", title: "Test", prompt: "Run tests", dependsOn: ["step-a"] },
-        ],
+        promptTemplate: "Do stuff",
       });
 
       expect(result).toEqual(created);
     });
 
-    it("throws on circular dependency", async () => {
-      await expect(
-        createWorkflowTemplate({
-          name: "Bad",
-          steps: [
-            { id: "a", title: "A", prompt: "...", dependsOn: ["b"] },
-            { id: "b", title: "B", prompt: "...", dependsOn: ["a"] },
-          ],
-        }),
-      ).rejects.toThrow(/[Cc]ircular dependency/);
-    });
-
-    it("throws on unknown step reference", async () => {
-      await expect(
-        createWorkflowTemplate({
-          name: "Bad",
-          steps: [{ id: "a", title: "A", prompt: "...", dependsOn: ["nonexistent"] }],
-        }),
-      ).rejects.toThrow(/unknown step/);
-    });
-
-    it("uses default status 'draft' when not specified", async () => {
+    it("uses default values for optional fields", async () => {
       let capturedValues: any;
       (db.insert as any) = vi.fn().mockReturnValue({
         values: vi.fn().mockImplementation((vals: any) => {
           capturedValues = vals;
-          return { returning: vi.fn().mockResolvedValue([{ id: "wt-1", ...vals }]) };
+          return { returning: vi.fn().mockResolvedValue([{ id: "wf-1", ...vals }]) };
         }),
       });
 
-      await createWorkflowTemplate({
+      await createWorkflow({
         name: "Test",
-        steps: [{ id: "a", title: "A", prompt: "Do it" }],
+        promptTemplate: "Do it",
       });
 
-      expect(capturedValues.status).toBe("draft");
+      expect(capturedValues.agentRuntime).toBe("claude-code");
+      expect(capturedValues.maxConcurrent).toBe(1);
+      expect(capturedValues.maxRetries).toBe(3);
+      expect(capturedValues.warmPoolSize).toBe(0);
+      expect(capturedValues.enabled).toBe(true);
     });
   });
 
-  describe("updateWorkflowTemplate", () => {
-    it("updates template fields", async () => {
-      const updated = { id: "wt-1", name: "Updated" };
+  describe("updateWorkflow", () => {
+    it("updates workflow fields", async () => {
+      const updated = { id: "wf-1", name: "Updated" };
       (db.update as any) = vi.fn().mockReturnValue({
         set: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -205,22 +178,11 @@ describe("workflow-service", () => {
         }),
       });
 
-      const result = await updateWorkflowTemplate("wt-1", { name: "Updated" });
+      const result = await updateWorkflow("wf-1", { name: "Updated" });
       expect(result).toEqual(updated);
     });
 
-    it("validates DAG when steps are updated", async () => {
-      await expect(
-        updateWorkflowTemplate("wt-1", {
-          steps: [
-            { id: "a", title: "A", prompt: "...", dependsOn: ["b"] },
-            { id: "b", title: "B", prompt: "...", dependsOn: ["a"] },
-          ],
-        }),
-      ).rejects.toThrow(/[Cc]ircular dependency/);
-    });
-
-    it("returns null when template not found", async () => {
+    it("returns null when workflow not found", async () => {
       (db.update as any) = vi.fn().mockReturnValue({
         set: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -229,37 +191,71 @@ describe("workflow-service", () => {
         }),
       });
 
-      const result = await updateWorkflowTemplate("nonexistent", { name: "X" });
+      const result = await updateWorkflow("nonexistent", { name: "X" });
       expect(result).toBeNull();
     });
   });
 
-  describe("deleteWorkflowTemplate", () => {
-    it("returns true when template is deleted", async () => {
+  describe("deleteWorkflow", () => {
+    it("returns true when deleted", async () => {
       (db.delete as any) = vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{ id: "wt-1" }]),
+          returning: vi.fn().mockResolvedValue([{ id: "wf-1" }]),
         }),
       });
 
-      const result = await deleteWorkflowTemplate("wt-1");
+      const result = await deleteWorkflow("wf-1");
       expect(result).toBe(true);
     });
 
-    it("returns false when template not found", async () => {
+    it("returns false when not found", async () => {
       (db.delete as any) = vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           returning: vi.fn().mockResolvedValue([]),
         }),
       });
 
-      const result = await deleteWorkflowTemplate("nonexistent");
+      const result = await deleteWorkflow("nonexistent");
       expect(result).toBe(false);
     });
   });
 
+  // ── Workflow Triggers ──────────────────────────────────────────────────────
+
+  describe("createWorkflowTrigger", () => {
+    it("creates a trigger", async () => {
+      const created = { id: "tr-1", workflowId: "wf-1", type: "manual" };
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([created]),
+        }),
+      });
+
+      const result = await createWorkflowTrigger({
+        workflowId: "wf-1",
+        type: "manual",
+      });
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe("deleteWorkflowTrigger", () => {
+    it("returns true when deleted", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "tr-1" }]),
+        }),
+      });
+
+      const result = await deleteWorkflowTrigger("tr-1");
+      expect(result).toBe(true);
+    });
+  });
+
+  // ── Workflow Runs ──────────────────────────────────────────────────────────
+
   describe("listWorkflowRuns", () => {
-    it("lists runs for a template", async () => {
+    it("lists runs for a workflow", async () => {
       const runs = [{ id: "wr-1" }, { id: "wr-2" }];
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
@@ -269,14 +265,14 @@ describe("workflow-service", () => {
         }),
       });
 
-      const result = await listWorkflowRuns("wt-1");
+      const result = await listWorkflowRuns("wf-1");
       expect(result).toEqual(runs);
     });
   });
 
   describe("getWorkflowRun", () => {
     it("returns run when found", async () => {
-      const run = { id: "wr-1", status: "running" };
+      const run = { id: "wr-1", state: "queued" };
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([run]),
@@ -299,159 +295,61 @@ describe("workflow-service", () => {
     });
   });
 
-  describe("runWorkflow", () => {
-    it("creates tasks and wires dependencies for a workflow", async () => {
-      // Mock getWorkflowTemplate
+  describe("createWorkflowRun", () => {
+    it("creates a run for an enabled workflow", async () => {
+      // Mock getWorkflow
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([
-            {
-              id: "wt-1",
-              status: "active",
-              steps: [
-                {
-                  id: "build",
-                  title: "Build",
-                  prompt: "Build it",
-                  repoUrl: "https://github.com/o/r",
-                },
-                {
-                  id: "test",
-                  title: "Test",
-                  prompt: "Test it",
-                  repoUrl: "https://github.com/o/r",
-                  dependsOn: ["build"],
-                },
-              ],
-            },
-          ]),
+          where: vi.fn().mockResolvedValue([{ id: "wf-1", enabled: true }]),
         }),
       });
 
-      // Mock insert for workflow run
+      // Mock insert
       (db.insert as any) = vi.fn().mockReturnValue({
         values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{ id: "wr-1", taskMapping: {} }]),
+          returning: vi
+            .fn()
+            .mockResolvedValue([{ id: "wr-1", workflowId: "wf-1", state: "queued" }]),
         }),
       });
 
-      // Mock update for tasks and workflow run
-      (db.update as any) = vi.fn().mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined),
-        }),
-      });
-
-      let taskCount = 0;
-      vi.mocked(taskService.createTask).mockImplementation(async () => {
-        taskCount++;
-        return { id: `task-${taskCount}`, maxRetries: 3 } as any;
-      });
-
-      const result = await runWorkflow("wt-1");
-
-      expect(taskService.createTask).toHaveBeenCalledTimes(2);
-      expect(dependencyService.addDependencies).toHaveBeenCalledWith("task-2", ["task-1"]);
-      // Build step has no deps → queued
-      expect(taskService.transitionTask).toHaveBeenCalledWith("task-1", "queued", "workflow_start");
-      // Test step has deps → waiting_on_deps
-      expect(taskService.transitionTask).toHaveBeenCalledWith(
-        "task-2",
-        "waiting_on_deps",
-        "workflow_start",
-      );
-      expect(taskQueue.add).toHaveBeenCalledTimes(1); // Only root task queued
+      const result = await createWorkflowRun({ workflowId: "wf-1" });
+      expect(result.state).toBe("queued");
     });
 
-    it("throws when template not found", async () => {
+    it("throws when workflow not found", async () => {
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([]),
         }),
       });
 
-      await expect(runWorkflow("nonexistent")).rejects.toThrow("Workflow template not found");
+      await expect(createWorkflowRun({ workflowId: "nonexistent" })).rejects.toThrow(
+        "Workflow not found",
+      );
     });
 
-    it("throws when template is archived", async () => {
+    it("throws when workflow is disabled", async () => {
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([{ id: "wt-1", status: "archived", steps: [] }]),
+          where: vi.fn().mockResolvedValue([{ id: "wf-1", enabled: false }]),
         }),
       });
 
-      await expect(runWorkflow("wt-1")).rejects.toThrow("Cannot run an archived workflow");
-    });
-
-    it("throws when step has no repoUrl and no override", async () => {
-      (db.select as any) = vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([
-            {
-              id: "wt-1",
-              status: "active",
-              steps: [{ id: "s1", title: "S1", prompt: "..." }],
-            },
-          ]),
-        }),
-      });
-
-      (db.insert as any) = vi.fn().mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{ id: "wr-1", taskMapping: {} }]),
-        }),
-      });
-
-      await expect(runWorkflow("wt-1")).rejects.toThrow(/no repoUrl/);
+      await expect(createWorkflowRun({ workflowId: "wf-1" })).rejects.toThrow(
+        "Workflow is disabled",
+      );
     });
   });
 
-  describe("checkWorkflowRunCompletion", () => {
-    it("marks run as completed when all tasks completed", async () => {
-      let selectCallCount = 0;
-      (db.select as any) = vi.fn().mockImplementation(() => ({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockImplementation(() => {
-            selectCallCount++;
-            if (selectCallCount === 1) {
-              return Promise.resolve([
-                { id: "wr-1", status: "running", taskMapping: { a: "t-1", b: "t-2" } },
-              ]);
-            }
-            return Promise.resolve([]);
-          }),
-        }),
-      }));
-
-      vi.mocked(taskService.getTask)
-        .mockResolvedValueOnce({ id: "t-1", state: "completed" } as any)
-        .mockResolvedValueOnce({ id: "t-2", state: "completed" } as any);
-
-      (db.update as any) = vi.fn().mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined),
-        }),
-      });
-
-      await checkWorkflowRunCompletion("wr-1");
-
-      expect(db.update).toHaveBeenCalled();
-    });
-
-    it("marks run as failed when all terminal but some failed", async () => {
+  describe("transitionWorkflowRun", () => {
+    it("transitions from queued to running", async () => {
+      // Mock getWorkflowRun
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
-          where: vi
-            .fn()
-            .mockResolvedValue([
-              { id: "wr-1", status: "running", taskMapping: { a: "t-1", b: "t-2" } },
-            ]),
+          where: vi.fn().mockResolvedValue([{ id: "wr-1", state: "queued", retryCount: 0 }]),
         }),
       });
-
-      vi.mocked(taskService.getTask)
-        .mockResolvedValueOnce({ id: "t-1", state: "completed" } as any)
-        .mockResolvedValueOnce({ id: "t-2", state: "failed" } as any);
 
       (db.update as any) = vi.fn().mockReturnValue({
         set: vi.fn().mockReturnValue({
@@ -459,43 +357,61 @@ describe("workflow-service", () => {
         }),
       });
 
-      await checkWorkflowRunCompletion("wr-1");
-
+      await expect(transitionWorkflowRun("wr-1", "running" as any)).resolves.not.toThrow();
       expect(db.update).toHaveBeenCalled();
     });
 
-    it("does nothing when run is not found", async () => {
+    it("throws on invalid transition", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "wr-1", state: "completed", retryCount: 0 }]),
+        }),
+      });
+
+      await expect(transitionWorkflowRun("wr-1", "running" as any)).rejects.toThrow(
+        /Invalid workflow state transition/,
+      );
+    });
+
+    it("throws when run not found", async () => {
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([]),
         }),
       });
 
-      await checkWorkflowRunCompletion("nonexistent");
-
-      expect(db.update).not.toHaveBeenCalled();
+      await expect(transitionWorkflowRun("nonexistent", "running" as any)).rejects.toThrow(
+        "Workflow run not found",
+      );
     });
+  });
 
-    it("does nothing when tasks are still running", async () => {
-      (db.select as any) = vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi
-            .fn()
-            .mockResolvedValue([
-              { id: "wr-1", status: "running", taskMapping: { a: "t-1", b: "t-2" } },
-            ]),
+  // ── Workflow Pods ──────────────────────────────────────────────────────────
+
+  describe("createWorkflowPod", () => {
+    it("creates a pod", async () => {
+      const created = { id: "wp-1", workflowId: "wf-1", state: "provisioning" };
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([created]),
         }),
       });
 
-      vi.mocked(taskService.getTask)
-        .mockResolvedValueOnce({ id: "t-1", state: "completed" } as any)
-        .mockResolvedValueOnce({ id: "t-2", state: "running" } as any);
+      const result = await createWorkflowPod({ workflowId: "wf-1" });
+      expect(result).toEqual(created);
+    });
+  });
 
-      (db.update as any) = vi.fn();
+  describe("deleteWorkflowPod", () => {
+    it("returns true when deleted", async () => {
+      (db.delete as any) = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "wp-1" }]),
+        }),
+      });
 
-      await checkWorkflowRunCompletion("wr-1");
-
-      expect(db.update).not.toHaveBeenCalled();
+      const result = await deleteWorkflowPod("wp-1");
+      expect(result).toBe(true);
     });
   });
 });

--- a/apps/api/src/services/workflow-service.ts
+++ b/apps/api/src/services/workflow-service.ts
@@ -1,147 +1,146 @@
 import { eq, desc } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { workflowTemplates, workflowRuns, tasks } from "../db/schema.js";
-import { TaskState, detectCycle, type DagEdge } from "@optio/shared";
-import * as taskService from "./task-service.js";
-import * as dependencyService from "./dependency-service.js";
-import { taskQueue } from "../workers/task-worker.js";
+import { workflows, workflowTriggers, workflowRuns, workflowPods } from "../db/schema.js";
+import {
+  WorkflowState,
+  canTransitionWorkflow,
+  InvalidWorkflowTransitionError,
+} from "@optio/shared";
 import { logger } from "../logger.js";
 
-// ── Workflow Template CRUD ───────────────────────────────────────────────────
+// ── Workflow CRUD ────────────────────────────────────────────────────────────
 
-export async function listWorkflowTemplates(workspaceId?: string) {
-  let query = db.select().from(workflowTemplates).orderBy(desc(workflowTemplates.createdAt));
+export async function listWorkflows(workspaceId?: string) {
+  let query = db.select().from(workflows).orderBy(desc(workflows.createdAt));
   if (workspaceId) {
-    query = query.where(eq(workflowTemplates.workspaceId, workspaceId)) as typeof query;
+    query = query.where(eq(workflows.workspaceId, workspaceId)) as typeof query;
   }
   return query;
 }
 
-export async function getWorkflowTemplate(id: string) {
-  const [template] = await db.select().from(workflowTemplates).where(eq(workflowTemplates.id, id));
-  return template ?? null;
+export async function getWorkflow(id: string) {
+  const [workflow] = await db.select().from(workflows).where(eq(workflows.id, id));
+  return workflow ?? null;
 }
 
-export async function createWorkflowTemplate(input: {
+export async function createWorkflow(input: {
   name: string;
-  description?: string;
-  steps: Array<{
-    id: string;
-    title: string;
-    prompt: string;
-    repoUrl?: string;
-    agentType?: string;
-    dependsOn?: string[];
-    condition?: { type: string; value?: string };
-  }>;
-  status?: string;
   workspaceId?: string;
-  createdBy?: string;
+  environmentSpec?: Record<string, unknown>;
+  promptTemplate: string;
+  paramsSchema?: Record<string, unknown>;
+  agentRuntime?: string;
+  model?: string;
+  maxTurns?: number;
+  budgetUsd?: string;
+  maxConcurrent?: number;
+  maxRetries?: number;
+  warmPoolSize?: number;
+  enabled?: boolean;
 }) {
-  // Validate DAG — no cycles in step dependencies
-  const edges: DagEdge[] = [];
-  for (const step of input.steps) {
-    for (const dep of step.dependsOn ?? []) {
-      edges.push({ from: step.id, to: dep });
-    }
-  }
-  const cycle = detectCycle(edges);
-  if (cycle) {
-    throw new Error(`Circular dependency in workflow steps: ${cycle.join(" → ")}`);
-  }
-
-  // Validate all dependsOn references point to valid step IDs
-  const stepIds = new Set(input.steps.map((s) => s.id));
-  for (const step of input.steps) {
-    for (const dep of step.dependsOn ?? []) {
-      if (!stepIds.has(dep)) {
-        throw new Error(`Step "${step.id}" depends on unknown step "${dep}"`);
-      }
-    }
-  }
-
-  const [template] = await db
-    .insert(workflowTemplates)
+  const [workflow] = await db
+    .insert(workflows)
     .values({
       name: input.name,
-      description: input.description,
-      steps: input.steps,
-      status: input.status ?? "draft",
       workspaceId: input.workspaceId,
-      createdBy: input.createdBy,
+      environmentSpec: input.environmentSpec,
+      promptTemplate: input.promptTemplate,
+      paramsSchema: input.paramsSchema,
+      agentRuntime: input.agentRuntime ?? "claude-code",
+      model: input.model,
+      maxTurns: input.maxTurns,
+      budgetUsd: input.budgetUsd,
+      maxConcurrent: input.maxConcurrent ?? 1,
+      maxRetries: input.maxRetries ?? 3,
+      warmPoolSize: input.warmPoolSize ?? 0,
+      enabled: input.enabled ?? true,
     })
     .returning();
-  return template;
+  return workflow;
 }
 
-export async function updateWorkflowTemplate(
+export async function updateWorkflow(
   id: string,
   input: {
     name?: string;
-    description?: string;
-    steps?: Array<{
-      id: string;
-      title: string;
-      prompt: string;
-      repoUrl?: string;
-      agentType?: string;
-      dependsOn?: string[];
-      condition?: { type: string; value?: string };
-    }>;
-    status?: string;
+    environmentSpec?: Record<string, unknown>;
+    promptTemplate?: string;
+    paramsSchema?: Record<string, unknown>;
+    agentRuntime?: string;
+    model?: string;
+    maxTurns?: number;
+    budgetUsd?: string;
+    maxConcurrent?: number;
+    maxRetries?: number;
+    warmPoolSize?: number;
+    enabled?: boolean;
   },
 ) {
-  // Validate DAG if steps are being updated
-  if (input.steps) {
-    const edges: DagEdge[] = [];
-    for (const step of input.steps) {
-      for (const dep of step.dependsOn ?? []) {
-        edges.push({ from: step.id, to: dep });
-      }
-    }
-    const cycle = detectCycle(edges);
-    if (cycle) {
-      throw new Error(`Circular dependency in workflow steps: ${cycle.join(" → ")}`);
-    }
-    const stepIds = new Set(input.steps.map((s) => s.id));
-    for (const step of input.steps) {
-      for (const dep of step.dependsOn ?? []) {
-        if (!stepIds.has(dep)) {
-          throw new Error(`Step "${step.id}" depends on unknown step "${dep}"`);
-        }
-      }
-    }
-  }
-
   const updates: Record<string, unknown> = { updatedAt: new Date() };
   if (input.name !== undefined) updates.name = input.name;
-  if (input.description !== undefined) updates.description = input.description;
-  if (input.steps !== undefined) updates.steps = input.steps;
-  if (input.status !== undefined) updates.status = input.status;
+  if (input.environmentSpec !== undefined) updates.environmentSpec = input.environmentSpec;
+  if (input.promptTemplate !== undefined) updates.promptTemplate = input.promptTemplate;
+  if (input.paramsSchema !== undefined) updates.paramsSchema = input.paramsSchema;
+  if (input.agentRuntime !== undefined) updates.agentRuntime = input.agentRuntime;
+  if (input.model !== undefined) updates.model = input.model;
+  if (input.maxTurns !== undefined) updates.maxTurns = input.maxTurns;
+  if (input.budgetUsd !== undefined) updates.budgetUsd = input.budgetUsd;
+  if (input.maxConcurrent !== undefined) updates.maxConcurrent = input.maxConcurrent;
+  if (input.maxRetries !== undefined) updates.maxRetries = input.maxRetries;
+  if (input.warmPoolSize !== undefined) updates.warmPoolSize = input.warmPoolSize;
+  if (input.enabled !== undefined) updates.enabled = input.enabled;
 
-  const [updated] = await db
-    .update(workflowTemplates)
-    .set(updates)
-    .where(eq(workflowTemplates.id, id))
-    .returning();
+  const [updated] = await db.update(workflows).set(updates).where(eq(workflows.id, id)).returning();
   return updated ?? null;
 }
 
-export async function deleteWorkflowTemplate(id: string): Promise<boolean> {
-  const deleted = await db
-    .delete(workflowTemplates)
-    .where(eq(workflowTemplates.id, id))
+export async function deleteWorkflow(id: string): Promise<boolean> {
+  const deleted = await db.delete(workflows).where(eq(workflows.id, id)).returning();
+  return deleted.length > 0;
+}
+
+// ── Workflow Triggers ────────────────────────────────────────────────────────
+
+export async function listWorkflowTriggers(workflowId: string) {
+  return db
+    .select()
+    .from(workflowTriggers)
+    .where(eq(workflowTriggers.workflowId, workflowId))
+    .orderBy(desc(workflowTriggers.createdAt));
+}
+
+export async function createWorkflowTrigger(input: {
+  workflowId: string;
+  type: "manual" | "schedule" | "webhook";
+  config?: Record<string, unknown>;
+  paramMapping?: Record<string, unknown>;
+  enabled?: boolean;
+}) {
+  const [trigger] = await db
+    .insert(workflowTriggers)
+    .values({
+      workflowId: input.workflowId,
+      type: input.type,
+      config: input.config,
+      paramMapping: input.paramMapping,
+      enabled: input.enabled ?? true,
+    })
     .returning();
+  return trigger;
+}
+
+export async function deleteWorkflowTrigger(id: string): Promise<boolean> {
+  const deleted = await db.delete(workflowTriggers).where(eq(workflowTriggers.id, id)).returning();
   return deleted.length > 0;
 }
 
 // ── Workflow Runs ────────────────────────────────────────────────────────────
 
-export async function listWorkflowRuns(templateId: string) {
+export async function listWorkflowRuns(workflowId: string) {
   return db
     .select()
     .from(workflowRuns)
-    .where(eq(workflowRuns.workflowTemplateId, templateId))
+    .where(eq(workflowRuns.workflowId, workflowId))
     .orderBy(desc(workflowRuns.createdAt));
 }
 
@@ -150,144 +149,102 @@ export async function getWorkflowRun(id: string) {
   return run ?? null;
 }
 
-/**
- * Instantiate and run a workflow from a template.
- * Creates tasks for each step and wires up dependencies between them.
- */
-export async function runWorkflow(
-  templateId: string,
-  opts?: { workspaceId?: string; createdBy?: string; repoUrlOverride?: string },
-) {
-  const template = await getWorkflowTemplate(templateId);
-  if (!template) throw new Error("Workflow template not found");
-  if (template.status === "archived") throw new Error("Cannot run an archived workflow");
+export async function createWorkflowRun(input: {
+  workflowId: string;
+  triggerId?: string;
+  params?: Record<string, unknown>;
+}) {
+  const workflow = await getWorkflow(input.workflowId);
+  if (!workflow) throw new Error("Workflow not found");
+  if (!workflow.enabled) throw new Error("Workflow is disabled");
 
-  const steps = template.steps as Array<{
-    id: string;
-    title: string;
-    prompt: string;
-    repoUrl?: string;
-    agentType?: string;
-    dependsOn?: string[];
-    condition?: { type: string; value?: string };
-  }>;
-
-  // Create the workflow run record
   const [run] = await db
     .insert(workflowRuns)
     .values({
-      workflowTemplateId: templateId,
-      workspaceId: opts?.workspaceId,
-      createdBy: opts?.createdBy,
-      status: "running",
-      taskMapping: {},
+      workflowId: input.workflowId,
+      triggerId: input.triggerId,
+      params: input.params,
+      state: "queued",
     })
     .returning();
 
-  const taskMapping: Record<string, string> = {};
-
-  // Create tasks for each step
-  for (const step of steps) {
-    const repoUrl = opts?.repoUrlOverride ?? step.repoUrl;
-    if (!repoUrl) {
-      throw new Error(`Step "${step.id}" has no repoUrl and no override was provided`);
-    }
-    const task = await taskService.createTask({
-      title: step.title,
-      prompt: step.prompt,
-      repoUrl,
-      agentType: step.agentType ?? "claude-code", // workflow steps define their own agent; repo default not used here
-      workspaceId: opts?.workspaceId ?? null,
-      createdBy: opts?.createdBy,
-    });
-    taskMapping[step.id] = task.id;
-
-    // Store workflow run ID on the task
-    await db.update(tasks).set({ workflowRunId: run.id }).where(eq(tasks.id, task.id));
-  }
-
-  // Wire up dependencies between tasks based on step definitions
-  for (const step of steps) {
-    if (step.dependsOn && step.dependsOn.length > 0) {
-      const taskId = taskMapping[step.id];
-      const depTaskIds = step.dependsOn.map((depStepId) => {
-        const depTaskId = taskMapping[depStepId];
-        if (!depTaskId) throw new Error(`Missing task for step "${depStepId}"`);
-        return depTaskId;
-      });
-      await dependencyService.addDependencies(taskId, depTaskIds);
-    }
-  }
-
-  // Update run with task mapping
-  await db
-    .update(workflowRuns)
-    .set({ taskMapping, updatedAt: new Date() })
-    .where(eq(workflowRuns.id, run.id));
-
-  // Start tasks that have no dependencies (roots)
-  for (const step of steps) {
-    const taskId = taskMapping[step.id];
-    const hasDeps = step.dependsOn && step.dependsOn.length > 0;
-
-    if (hasDeps) {
-      // Task waits for dependencies
-      await taskService.transitionTask(taskId, TaskState.WAITING_ON_DEPS, "workflow_start");
-    } else {
-      // No dependencies — queue immediately
-      await taskService.transitionTask(taskId, TaskState.QUEUED, "workflow_start");
-      await taskQueue.add(
-        "process-task",
-        { taskId },
-        { jobId: `${taskId}-workflow-${Date.now()}`, priority: 100 },
-      );
-    }
-  }
-
-  logger.info(
-    { workflowRunId: run.id, templateId, taskCount: steps.length },
-    "Workflow run started",
-  );
-
-  return { ...run, taskMapping };
+  logger.info({ workflowRunId: run.id, workflowId: input.workflowId }, "Workflow run created");
+  return run;
 }
 
-/**
- * Check if a workflow run is complete (all tasks are terminal).
- * Called by the task worker after any task in a workflow finishes.
- */
-export async function checkWorkflowRunCompletion(workflowRunId: string): Promise<void> {
-  const run = await getWorkflowRun(workflowRunId);
-  if (!run || run.status !== "running") return;
+export async function transitionWorkflowRun(
+  id: string,
+  toState: WorkflowState,
+  updates?: {
+    output?: Record<string, unknown>;
+    costUsd?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    modelUsed?: string;
+    errorMessage?: string;
+    sessionId?: string;
+    podName?: string;
+  },
+): Promise<void> {
+  const run = await getWorkflowRun(id);
+  if (!run) throw new Error("Workflow run not found");
 
-  const mapping = (run.taskMapping ?? {}) as Record<string, string>;
-  const taskIds = Object.values(mapping);
-  if (taskIds.length === 0) return;
-
-  const allTasks = await Promise.all(taskIds.map((id) => taskService.getTask(id)));
-
-  const allCompleted = allTasks.every((t) => t?.state === TaskState.COMPLETED);
-  const anyFailed = allTasks.some(
-    (t) => t?.state === TaskState.FAILED || t?.state === TaskState.CANCELLED,
-  );
-  const allTerminal = allTasks.every(
-    (t) =>
-      t?.state === TaskState.COMPLETED ||
-      t?.state === TaskState.FAILED ||
-      t?.state === TaskState.CANCELLED,
-  );
-
-  if (allCompleted) {
-    await db
-      .update(workflowRuns)
-      .set({ status: "completed", completedAt: new Date(), updatedAt: new Date() })
-      .where(eq(workflowRuns.id, workflowRunId));
-    logger.info({ workflowRunId }, "Workflow run completed");
-  } else if (allTerminal && anyFailed) {
-    await db
-      .update(workflowRuns)
-      .set({ status: "failed", completedAt: new Date(), updatedAt: new Date() })
-      .where(eq(workflowRuns.id, workflowRunId));
-    logger.info({ workflowRunId }, "Workflow run failed");
+  const fromState = run.state as WorkflowState;
+  if (!canTransitionWorkflow(fromState, toState)) {
+    throw new InvalidWorkflowTransitionError(fromState, toState);
   }
+
+  const setValues: Record<string, unknown> = {
+    state: toState,
+    updatedAt: new Date(),
+  };
+  if (updates?.output !== undefined) setValues.output = updates.output;
+  if (updates?.costUsd !== undefined) setValues.costUsd = updates.costUsd;
+  if (updates?.inputTokens !== undefined) setValues.inputTokens = updates.inputTokens;
+  if (updates?.outputTokens !== undefined) setValues.outputTokens = updates.outputTokens;
+  if (updates?.modelUsed !== undefined) setValues.modelUsed = updates.modelUsed;
+  if (updates?.errorMessage !== undefined) setValues.errorMessage = updates.errorMessage;
+  if (updates?.sessionId !== undefined) setValues.sessionId = updates.sessionId;
+  if (updates?.podName !== undefined) setValues.podName = updates.podName;
+
+  // Increment retryCount when re-queuing from failed
+  if (fromState === WorkflowState.FAILED && toState === WorkflowState.QUEUED) {
+    setValues.retryCount = run.retryCount + 1;
+  }
+
+  await db.update(workflowRuns).set(setValues).where(eq(workflowRuns.id, id));
+
+  logger.info({ workflowRunId: id, from: fromState, to: toState }, "Workflow run transitioned");
+}
+
+// ── Workflow Pods ────────────────────────────────────────────────────────────
+
+export async function listWorkflowPods(workflowId: string) {
+  return db
+    .select()
+    .from(workflowPods)
+    .where(eq(workflowPods.workflowId, workflowId))
+    .orderBy(desc(workflowPods.createdAt));
+}
+
+export async function getWorkflowPod(id: string) {
+  const [pod] = await db.select().from(workflowPods).where(eq(workflowPods.id, id));
+  return pod ?? null;
+}
+
+export async function createWorkflowPod(input: { workflowId: string; podName?: string }) {
+  const [pod] = await db
+    .insert(workflowPods)
+    .values({
+      workflowId: input.workflowId,
+      podName: input.podName,
+      state: "provisioning",
+    })
+    .returning();
+  return pod;
+}
+
+export async function deleteWorkflowPod(id: string): Promise<boolean> {
+  const deleted = await db.delete(workflowPods).where(eq(workflowPods.id, id)).returning();
+  return deleted.length > 0;
 }

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -928,13 +928,6 @@ export function startTaskWorker() {
               .cascadeFailure(taskId)
               .catch((err) => log.warn({ err }, "Failed to cascade failure to dependents"));
           }
-          // Update workflow run status if part of a workflow
-          if (completedTask.workflowRunId) {
-            const { checkWorkflowRunCompletion } = await import("../services/workflow-service.js");
-            await checkWorkflowRunCompletion(completedTask.workflowRunId).catch((err) =>
-              log.warn({ err }, "Failed to update workflow run status"),
-            );
-          }
         }
       } catch (err) {
         // State race errors mean another worker claimed the task — not a real failure

--- a/apps/web/src/app/workflows/page.tsx
+++ b/apps/web/src/app/workflows/page.tsx
@@ -4,101 +4,69 @@ import { useState, useEffect } from "react";
 import { api } from "@/lib/api-client";
 import { Loader2, Plus, Trash2, GitBranch, Play, ChevronDown, ChevronRight, X } from "lucide-react";
 import { toast } from "sonner";
-import Link from "next/link";
-
-interface WorkflowStep {
-  id: string;
-  title: string;
-  prompt: string;
-  repoUrl?: string;
-  agentType?: string;
-  dependsOn?: string[];
-}
 
 export default function WorkflowsPage() {
-  const [templates, setTemplates] = useState<any[]>([]);
+  const [workflows, setWorkflows] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
-  const [repos, setRepos] = useState<any[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [runningId, setRunningId] = useState<string | null>(null);
 
   // Form state
   const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [steps, setSteps] = useState<WorkflowStep[]>([
-    { id: "step-1", title: "", prompt: "", dependsOn: [] },
-  ]);
+  const [promptTemplate, setPromptTemplate] = useState("");
+  const [agentRuntime, setAgentRuntime] = useState("claude-code");
+  const [model, setModel] = useState("");
+  const [maxTurns, setMaxTurns] = useState("");
+  const [maxConcurrent, setMaxConcurrent] = useState("1");
+  const [maxRetries, setMaxRetries] = useState("3");
+  const [enabled, setEnabled] = useState(true);
 
-  const loadTemplates = () => {
+  const loadWorkflows = () => {
     api
       .listWorkflows()
-      .then((res) => setTemplates(res.templates))
-      .catch(() => toast.error("Failed to load workflow templates"))
+      .then((res) => setWorkflows(res.workflows))
+      .catch(() => toast.error("Failed to load workflows"))
       .finally(() => setLoading(false));
   };
 
   useEffect(() => {
-    loadTemplates();
-    api
-      .listRepos()
-      .then((res) => setRepos(res.repos))
-      .catch(() => {});
+    loadWorkflows();
   }, []);
 
   const resetForm = () => {
     setName("");
-    setDescription("");
-    setSteps([{ id: "step-1", title: "", prompt: "", dependsOn: [] }]);
+    setPromptTemplate("");
+    setAgentRuntime("claude-code");
+    setModel("");
+    setMaxTurns("");
+    setMaxConcurrent("1");
+    setMaxRetries("3");
+    setEnabled(true);
     setShowForm(false);
-  };
-
-  const addStep = () => {
-    const nextId = `step-${steps.length + 1}`;
-    setSteps([...steps, { id: nextId, title: "", prompt: "", dependsOn: [] }]);
-  };
-
-  const removeStep = (idx: number) => {
-    const removedId = steps[idx].id;
-    const newSteps = steps.filter((_, i) => i !== idx);
-    // Remove references to the deleted step from dependsOn arrays
-    setSteps(
-      newSteps.map((s) => ({
-        ...s,
-        dependsOn: (s.dependsOn ?? []).filter((d) => d !== removedId),
-      })),
-    );
-  };
-
-  const updateStep = (idx: number, field: keyof WorkflowStep, value: any) => {
-    const newSteps = [...steps];
-    newSteps[idx] = { ...newSteps[idx], [field]: value };
-    setSteps(newSteps);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return toast.error("Name is required");
-    if (steps.some((s) => !s.title.trim() || !s.prompt.trim())) {
-      return toast.error("All steps must have a title and prompt");
-    }
+    if (!promptTemplate.trim()) return toast.error("Prompt template is required");
 
     setSubmitting(true);
     try {
       await api.createWorkflow({
         name,
-        description: description || undefined,
-        steps: steps.map((s) => ({
-          ...s,
-          repoUrl: s.repoUrl || undefined,
-          agentType: s.agentType || undefined,
-        })),
-        status: "active",
+        promptTemplate,
+        agentRuntime: agentRuntime || undefined,
+        model: model || undefined,
+        maxTurns: maxTurns ? parseInt(maxTurns, 10) : undefined,
+        maxConcurrent: maxConcurrent ? parseInt(maxConcurrent, 10) : undefined,
+        maxRetries: maxRetries ? parseInt(maxRetries, 10) : undefined,
+        enabled,
       });
-      toast.success("Workflow template created");
+      toast.success("Workflow created");
       resetForm();
-      loadTemplates();
+      loadWorkflows();
     } catch (err) {
       toast.error("Failed to create workflow", {
         description: err instanceof Error ? err.message : undefined,
@@ -109,11 +77,11 @@ export default function WorkflowsPage() {
   };
 
   const handleDelete = async (id: string) => {
-    if (!confirm("Delete this workflow template?")) return;
+    if (!confirm("Delete this workflow?")) return;
     try {
       await api.deleteWorkflow(id);
       toast.success("Workflow deleted");
-      loadTemplates();
+      loadWorkflows();
     } catch {
       toast.error("Failed to delete");
     }
@@ -122,10 +90,8 @@ export default function WorkflowsPage() {
   const handleRun = async (id: string) => {
     setRunningId(id);
     try {
-      const result = await api.runWorkflow(id);
-      toast.success("Workflow started", {
-        description: `Created ${Object.keys(result.workflowRun?.taskMapping ?? {}).length} tasks`,
-      });
+      await api.runWorkflow(id);
+      toast.success("Workflow run queued");
     } catch (err) {
       toast.error("Failed to run workflow", {
         description: err instanceof Error ? err.message : undefined,
@@ -149,7 +115,7 @@ export default function WorkflowsPage() {
         <div>
           <h1 className="text-xl font-semibold text-text">Workflows</h1>
           <p className="text-sm text-text-muted mt-1">
-            Define multi-step task pipelines with dependencies and conditions
+            Define reusable workflow definitions with prompt templates, parameters, and triggers
           </p>
         </div>
         <button
@@ -173,111 +139,89 @@ export default function WorkflowsPage() {
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="e.g., Refactor & Test Pipeline"
+                placeholder="e.g., Code Review Pipeline"
                 className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-bg text-text"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-text mb-1">Description</label>
+              <label className="block text-sm font-medium text-text mb-1">Agent Runtime</label>
+              <select
+                value={agentRuntime}
+                onChange={(e) => setAgentRuntime(e.target.value)}
+                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-bg text-text"
+              >
+                <option value="claude-code">Claude Code</option>
+                <option value="codex">Codex</option>
+                <option value="copilot">Copilot</option>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text mb-1">Prompt Template</label>
+            <textarea
+              value={promptTemplate}
+              onChange={(e) => setPromptTemplate(e.target.value)}
+              placeholder="Enter the prompt template for this workflow..."
+              rows={4}
+              className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-bg text-text"
+            />
+          </div>
+
+          <div className="grid grid-cols-4 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-text mb-1">Model</label>
               <input
                 type="text"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Optional description"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                placeholder="e.g., opus"
+                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-bg text-text"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-text mb-1">Max Turns</label>
+              <input
+                type="number"
+                value={maxTurns}
+                onChange={(e) => setMaxTurns(e.target.value)}
+                placeholder="250"
+                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-bg text-text"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-text mb-1">Max Concurrent</label>
+              <input
+                type="number"
+                value={maxConcurrent}
+                onChange={(e) => setMaxConcurrent(e.target.value)}
+                placeholder="1"
+                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-bg text-text"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-text mb-1">Max Retries</label>
+              <input
+                type="number"
+                value={maxRetries}
+                onChange={(e) => setMaxRetries(e.target.value)}
+                placeholder="3"
                 className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-bg text-text"
               />
             </div>
           </div>
 
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <label className="text-sm font-medium text-text">Steps</label>
-              <button
-                type="button"
-                onClick={addStep}
-                className="text-xs text-primary hover:underline"
-              >
-                + Add Step
-              </button>
-            </div>
-            <div className="space-y-3">
-              {steps.map((step, idx) => (
-                <div key={step.id} className="border border-border rounded-lg p-4 bg-bg">
-                  <div className="flex items-center justify-between mb-2">
-                    <span className="text-xs font-mono text-text-muted">{step.id}</span>
-                    {steps.length > 1 && (
-                      <button
-                        type="button"
-                        onClick={() => removeStep(idx)}
-                        className="text-text-muted hover:text-red-400"
-                      >
-                        <X className="w-3.5 h-3.5" />
-                      </button>
-                    )}
-                  </div>
-                  <div className="grid grid-cols-2 gap-3 mb-2">
-                    <input
-                      type="text"
-                      value={step.title}
-                      onChange={(e) => updateStep(idx, "title", e.target.value)}
-                      placeholder="Step title"
-                      className="border border-border rounded-lg px-3 py-1.5 text-sm bg-bg text-text"
-                    />
-                    <select
-                      value={step.repoUrl ?? ""}
-                      onChange={(e) => updateStep(idx, "repoUrl", e.target.value || undefined)}
-                      className="border border-border rounded-lg px-3 py-1.5 text-sm bg-bg text-text"
-                    >
-                      <option value="">Select repo (optional)</option>
-                      {repos.map((r) => (
-                        <option key={r.id} value={r.repoUrl}>
-                          {r.fullName}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <textarea
-                    value={step.prompt}
-                    onChange={(e) => updateStep(idx, "prompt", e.target.value)}
-                    placeholder="Task prompt for this step..."
-                    rows={2}
-                    className="w-full border border-border rounded-lg px-3 py-1.5 text-sm bg-bg text-text mb-2"
-                  />
-                  {idx > 0 && (
-                    <div>
-                      <label className="text-xs text-text-muted mb-1 block">
-                        Depends on (runs after these complete):
-                      </label>
-                      <div className="flex flex-wrap gap-2">
-                        {steps.slice(0, idx).map((prev) => (
-                          <label
-                            key={prev.id}
-                            className="flex items-center gap-1.5 text-xs text-text"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={(step.dependsOn ?? []).includes(prev.id)}
-                              onChange={(e) => {
-                                const deps = step.dependsOn ?? [];
-                                updateStep(
-                                  idx,
-                                  "dependsOn",
-                                  e.target.checked
-                                    ? [...deps, prev.id]
-                                    : deps.filter((d) => d !== prev.id),
-                                );
-                              }}
-                              className="rounded"
-                            />
-                            {prev.title || prev.id}
-                          </label>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+              id="workflow-enabled"
+              className="rounded"
+            />
+            <label htmlFor="workflow-enabled" className="text-sm text-text">
+              Enabled
+            </label>
           </div>
 
           <div className="flex gap-2 pt-2">
@@ -299,25 +243,24 @@ export default function WorkflowsPage() {
         </form>
       )}
 
-      {templates.length === 0 ? (
+      {workflows.length === 0 ? (
         <div className="text-center py-12 text-text-muted">
           <GitBranch className="w-10 h-10 mx-auto mb-3 opacity-40" />
-          <p>No workflow templates yet</p>
+          <p>No workflows yet</p>
           <p className="text-sm mt-1">
-            Create a workflow to chain multiple tasks with dependencies
+            Create a workflow to define reusable agent execution patterns
           </p>
         </div>
       ) : (
         <div className="space-y-3">
-          {templates.map((t) => {
-            const stepCount = Array.isArray(t.steps) ? t.steps.length : 0;
-            const isExpanded = expandedId === t.id;
+          {workflows.map((w) => {
+            const isExpanded = expandedId === w.id;
             return (
-              <div key={t.id} className="bg-bg-card border border-border rounded-xl">
+              <div key={w.id} className="bg-bg-card border border-border rounded-xl">
                 <div className="flex items-center justify-between p-4">
                   <button
                     className="flex items-center gap-3 text-left flex-1"
-                    onClick={() => setExpandedId(isExpanded ? null : t.id)}
+                    onClick={() => setExpandedId(isExpanded ? null : w.id)}
                   >
                     {isExpanded ? (
                       <ChevronDown className="w-4 h-4 text-text-muted" />
@@ -325,30 +268,22 @@ export default function WorkflowsPage() {
                       <ChevronRight className="w-4 h-4 text-text-muted" />
                     )}
                     <div>
-                      <div className="font-medium text-sm text-text">{t.name}</div>
+                      <div className="font-medium text-sm text-text">{w.name}</div>
                       <div className="text-xs text-text-muted">
-                        {stepCount} step{stepCount !== 1 ? "s" : ""} &middot;{" "}
-                        <span
-                          className={
-                            t.status === "active"
-                              ? "text-green-400"
-                              : t.status === "archived"
-                                ? "text-text-muted"
-                                : "text-yellow-400"
-                          }
-                        >
-                          {t.status}
+                        {w.agentRuntime} &middot;{" "}
+                        <span className={w.enabled ? "text-green-400" : "text-text-muted"}>
+                          {w.enabled ? "enabled" : "disabled"}
                         </span>
                       </div>
                     </div>
                   </button>
                   <div className="flex items-center gap-2">
                     <button
-                      onClick={() => handleRun(t.id)}
-                      disabled={runningId === t.id}
+                      onClick={() => handleRun(w.id)}
+                      disabled={runningId === w.id || !w.enabled}
                       className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs bg-green-500/10 text-green-400 hover:bg-green-500/20 disabled:opacity-50"
                     >
-                      {runningId === t.id ? (
+                      {runningId === w.id ? (
                         <Loader2 className="w-3.5 h-3.5 animate-spin" />
                       ) : (
                         <Play className="w-3.5 h-3.5" />
@@ -356,7 +291,7 @@ export default function WorkflowsPage() {
                       Run
                     </button>
                     <button
-                      onClick={() => handleDelete(t.id)}
+                      onClick={() => handleDelete(w.id)}
                       className="p-1.5 rounded-lg text-text-muted hover:bg-red-500/10 hover:text-red-400"
                     >
                       <Trash2 className="w-4 h-4" />
@@ -364,38 +299,26 @@ export default function WorkflowsPage() {
                   </div>
                 </div>
                 {isExpanded && (
-                  <div className="border-t border-border p-4">
-                    {t.description && (
-                      <p className="text-sm text-text-muted mb-3">{t.description}</p>
-                    )}
-                    <div className="space-y-2">
-                      {(t.steps as WorkflowStep[]).map((step, i) => (
-                        <div
-                          key={step.id}
-                          className="flex items-start gap-3 p-3 bg-bg rounded-lg border border-border/50"
-                        >
-                          <div className="w-6 h-6 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-medium shrink-0">
-                            {i + 1}
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <div className="text-sm font-medium text-text">{step.title}</div>
-                            <div className="text-xs text-text-muted mt-0.5 truncate">
-                              {step.prompt}
-                            </div>
-                            {step.dependsOn && step.dependsOn.length > 0 && (
-                              <div className="text-xs text-text-muted mt-1">
-                                Depends on:{" "}
-                                {step.dependsOn
-                                  .map((d) => {
-                                    const dep = (t.steps as WorkflowStep[]).find((s) => s.id === d);
-                                    return dep?.title ?? d;
-                                  })
-                                  .join(", ")}
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      ))}
+                  <div className="border-t border-border p-4 space-y-2">
+                    <div className="text-sm text-text-muted">
+                      <strong>Prompt Template:</strong>
+                      <pre className="mt-1 text-xs bg-bg rounded-lg p-3 whitespace-pre-wrap">
+                        {w.promptTemplate}
+                      </pre>
+                    </div>
+                    <div className="grid grid-cols-4 gap-4 text-xs text-text-muted">
+                      <div>
+                        <strong>Model:</strong> {w.model ?? "default"}
+                      </div>
+                      <div>
+                        <strong>Max Turns:</strong> {w.maxTurns ?? "default"}
+                      </div>
+                      <div>
+                        <strong>Max Concurrent:</strong> {w.maxConcurrent}
+                      </div>
+                      <div>
+                        <strong>Max Retries:</strong> {w.maxRetries}
+                      </div>
                     </div>
                   </div>
                 )}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -882,48 +882,51 @@ export const api = {
   removeTaskDependency: (taskId: string, depTaskId: string) =>
     request<void>(`/api/tasks/${taskId}/dependencies/${depTaskId}`, { method: "DELETE" }),
 
-  // Workflow Templates
-  listWorkflows: () => request<{ templates: any[] }>("/api/workflow-templates"),
+  // Workflows
+  listWorkflows: () => request<{ workflows: any[] }>("/api/workflows"),
 
-  getWorkflow: (id: string) => request<{ template: any }>(`/api/workflow-templates/${id}`),
+  getWorkflow: (id: string) => request<{ workflow: any }>(`/api/workflows/${id}`),
 
   createWorkflow: (data: {
     name: string;
-    description?: string;
-    steps: Array<{
-      id: string;
-      title: string;
-      prompt: string;
-      repoUrl?: string;
-      agentType?: string;
-      dependsOn?: string[];
-    }>;
-    status?: string;
+    promptTemplate: string;
+    agentRuntime?: string;
+    model?: string;
+    maxTurns?: number;
+    budgetUsd?: string;
+    maxConcurrent?: number;
+    maxRetries?: number;
+    warmPoolSize?: number;
+    enabled?: boolean;
+    environmentSpec?: Record<string, unknown>;
+    paramsSchema?: Record<string, unknown>;
   }) =>
-    request<{ template: any }>("/api/workflow-templates", {
+    request<{ workflow: any }>("/api/workflows", {
       method: "POST",
       body: JSON.stringify(data),
     }),
 
   updateWorkflow: (id: string, data: Record<string, unknown>) =>
-    request<{ template: any }>(`/api/workflow-templates/${id}`, {
+    request<{ workflow: any }>(`/api/workflows/${id}`, {
       method: "PATCH",
       body: JSON.stringify(data),
     }),
 
-  deleteWorkflow: (id: string) =>
-    request<void>(`/api/workflow-templates/${id}`, { method: "DELETE" }),
+  deleteWorkflow: (id: string) => request<void>(`/api/workflows/${id}`, { method: "DELETE" }),
 
-  runWorkflow: (templateId: string, data?: { repoUrlOverride?: string }) =>
-    request<{ workflowRun: any }>(`/api/workflow-templates/${templateId}/run`, {
+  runWorkflow: (
+    workflowId: string,
+    data?: { triggerId?: string; params?: Record<string, unknown> },
+  ) =>
+    request<{ run: any }>(`/api/workflows/${workflowId}/runs`, {
       method: "POST",
       body: JSON.stringify(data ?? {}),
     }),
 
-  getWorkflowRuns: (templateId: string) =>
-    request<{ runs: any[] }>(`/api/workflow-templates/${templateId}/runs`),
+  getWorkflowRuns: (workflowId: string) =>
+    request<{ runs: any[] }>(`/api/workflows/${workflowId}/runs`),
 
-  getWorkflowRun: (id: string) => request<{ workflowRun: any }>(`/api/workflow-runs/${id}`),
+  getWorkflowRun: (id: string) => request<{ run: any }>(`/api/workflow-runs/${id}`),
 
   // MCP Servers
   listMcpServers: (scope?: string) => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export * from "./types/ticket.js";
 export * from "./types/events.js";
 export * from "./types/agent-events.js";
 export * from "./utils/state-machine.js";
+export * from "./utils/workflow-state-machine.js";
 export * from "./utils/normalize-repo-url.js";
 export * from "./utils/dag.js";
 export * from "./utils/k8s-resources.js";

--- a/packages/shared/src/types/task.ts
+++ b/packages/shared/src/types/task.ts
@@ -131,39 +131,62 @@ export interface ReviewDraft {
   updatedAt: string;
 }
 
-export interface WorkflowStep {
-  id: string;
-  title: string;
-  prompt: string;
-  repoUrl?: string;
-  agentType?: string;
-  dependsOn?: string[];
-  condition?: {
-    type: "always" | "if_pr_opened" | "if_ci_passes" | "if_cost_under";
-    value?: string;
-  };
+// ── Workflow types (new data model) ──────────────────────────────────────────
+
+export enum WorkflowState {
+  QUEUED = "queued",
+  RUNNING = "running",
+  COMPLETED = "completed",
+  FAILED = "failed",
 }
 
-export interface WorkflowTemplate {
+export type WorkflowTriggerType = "manual" | "schedule" | "webhook";
+
+export interface Workflow {
   id: string;
   name: string;
-  description?: string;
   workspaceId?: string;
-  steps: WorkflowStep[];
-  status: "draft" | "active" | "archived";
-  createdBy?: string;
+  environmentSpec?: Record<string, unknown>;
+  promptTemplate: string;
+  paramsSchema?: Record<string, unknown>;
+  agentRuntime: string;
+  model?: string;
+  maxTurns?: number;
+  budgetUsd?: string;
+  maxConcurrent: number;
+  maxRetries: number;
+  warmPoolSize: number;
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface WorkflowTrigger {
+  id: string;
+  workflowId: string;
+  type: WorkflowTriggerType;
+  config?: Record<string, unknown>;
+  paramMapping?: Record<string, unknown>;
+  enabled: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
 
 export interface WorkflowRun {
   id: string;
-  workflowTemplateId: string;
-  workspaceId?: string;
-  status: "running" | "paused" | "completed" | "failed" | "cancelled";
-  taskMapping?: Record<string, string>;
-  createdBy?: string;
+  workflowId: string;
+  triggerId?: string;
+  params?: Record<string, unknown>;
+  state: WorkflowState;
+  output?: Record<string, unknown>;
+  costUsd?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  modelUsed?: string;
+  errorMessage?: string;
+  sessionId?: string;
+  podName?: string;
+  retryCount: number;
   createdAt: Date;
   updatedAt: Date;
-  completedAt?: Date;
 }

--- a/packages/shared/src/utils/workflow-state-machine.test.ts
+++ b/packages/shared/src/utils/workflow-state-machine.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  canTransitionWorkflow,
+  transitionWorkflow,
+  isWorkflowTerminal,
+  getValidWorkflowTransitions,
+  InvalidWorkflowTransitionError,
+} from "./workflow-state-machine.js";
+import { WorkflowState } from "../types/task.js";
+
+describe("workflow-state-machine", () => {
+  describe("canTransitionWorkflow", () => {
+    it("allows queued → running", () => {
+      expect(canTransitionWorkflow(WorkflowState.QUEUED, WorkflowState.RUNNING)).toBe(true);
+    });
+
+    it("allows queued → failed", () => {
+      expect(canTransitionWorkflow(WorkflowState.QUEUED, WorkflowState.FAILED)).toBe(true);
+    });
+
+    it("allows running → completed", () => {
+      expect(canTransitionWorkflow(WorkflowState.RUNNING, WorkflowState.COMPLETED)).toBe(true);
+    });
+
+    it("allows running → failed", () => {
+      expect(canTransitionWorkflow(WorkflowState.RUNNING, WorkflowState.FAILED)).toBe(true);
+    });
+
+    it("allows failed → queued (retry)", () => {
+      expect(canTransitionWorkflow(WorkflowState.FAILED, WorkflowState.QUEUED)).toBe(true);
+    });
+
+    it("disallows completed → any", () => {
+      expect(canTransitionWorkflow(WorkflowState.COMPLETED, WorkflowState.QUEUED)).toBe(false);
+      expect(canTransitionWorkflow(WorkflowState.COMPLETED, WorkflowState.RUNNING)).toBe(false);
+      expect(canTransitionWorkflow(WorkflowState.COMPLETED, WorkflowState.FAILED)).toBe(false);
+    });
+
+    it("disallows queued → completed (must go through running)", () => {
+      expect(canTransitionWorkflow(WorkflowState.QUEUED, WorkflowState.COMPLETED)).toBe(false);
+    });
+  });
+
+  describe("transitionWorkflow", () => {
+    it("returns the target state on valid transition", () => {
+      expect(transitionWorkflow(WorkflowState.QUEUED, WorkflowState.RUNNING)).toBe(
+        WorkflowState.RUNNING,
+      );
+    });
+
+    it("throws InvalidWorkflowTransitionError on invalid transition", () => {
+      expect(() => transitionWorkflow(WorkflowState.COMPLETED, WorkflowState.RUNNING)).toThrow(
+        InvalidWorkflowTransitionError,
+      );
+    });
+  });
+
+  describe("isWorkflowTerminal", () => {
+    it("completed is terminal", () => {
+      expect(isWorkflowTerminal(WorkflowState.COMPLETED)).toBe(true);
+    });
+
+    it("queued is not terminal", () => {
+      expect(isWorkflowTerminal(WorkflowState.QUEUED)).toBe(false);
+    });
+
+    it("running is not terminal", () => {
+      expect(isWorkflowTerminal(WorkflowState.RUNNING)).toBe(false);
+    });
+
+    it("failed is not terminal (can retry)", () => {
+      expect(isWorkflowTerminal(WorkflowState.FAILED)).toBe(false);
+    });
+  });
+
+  describe("getValidWorkflowTransitions", () => {
+    it("returns [running, failed] for queued", () => {
+      const transitions = getValidWorkflowTransitions(WorkflowState.QUEUED);
+      expect(transitions).toContain(WorkflowState.RUNNING);
+      expect(transitions).toContain(WorkflowState.FAILED);
+      expect(transitions).toHaveLength(2);
+    });
+
+    it("returns empty array for completed", () => {
+      expect(getValidWorkflowTransitions(WorkflowState.COMPLETED)).toEqual([]);
+    });
+  });
+});

--- a/packages/shared/src/utils/workflow-state-machine.ts
+++ b/packages/shared/src/utils/workflow-state-machine.ts
@@ -1,0 +1,37 @@
+import { WorkflowState } from "../types/task.js";
+
+const VALID_WORKFLOW_TRANSITIONS: Record<WorkflowState, WorkflowState[]> = {
+  [WorkflowState.QUEUED]: [WorkflowState.RUNNING, WorkflowState.FAILED],
+  [WorkflowState.RUNNING]: [WorkflowState.COMPLETED, WorkflowState.FAILED],
+  [WorkflowState.COMPLETED]: [],
+  [WorkflowState.FAILED]: [WorkflowState.QUEUED],
+};
+
+export class InvalidWorkflowTransitionError extends Error {
+  constructor(
+    public readonly from: WorkflowState,
+    public readonly to: WorkflowState,
+  ) {
+    super(`Invalid workflow state transition: ${from} -> ${to}`);
+    this.name = "InvalidWorkflowTransitionError";
+  }
+}
+
+export function canTransitionWorkflow(from: WorkflowState, to: WorkflowState): boolean {
+  return VALID_WORKFLOW_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function transitionWorkflow(from: WorkflowState, to: WorkflowState): WorkflowState {
+  if (!canTransitionWorkflow(from, to)) {
+    throw new InvalidWorkflowTransitionError(from, to);
+  }
+  return to;
+}
+
+export function isWorkflowTerminal(state: WorkflowState): boolean {
+  return VALID_WORKFLOW_TRANSITIONS[state]?.length === 0;
+}
+
+export function getValidWorkflowTransitions(state: WorkflowState): WorkflowState[] {
+  return VALID_WORKFLOW_TRANSITIONS[state] ?? [];
+}


### PR DESCRIPTION
Closes #370

## What changed

Replaced the old `workflow_templates` and `workflow_runs` tables with a new, more flexible Workflows data model consisting of four tables:

- **`workflows`** — reusable workflow definitions with prompt templates, params schemas, agent runtime config, concurrency/retry/warm-pool settings
- **`workflow_triggers`** — trigger configurations (manual, schedule, webhook) with param mapping
- **`workflow_runs`** — individual run instances with state tracking, cost/token metrics, session/pod info
- **`workflow_pods`** — dedicated pod management per workflow

Key changes across the stack:
- **Schema** (`apps/api/src/db/schema.ts`): Removed `workflowTemplates`/`workflowRuns` (old), removed `workflowRunId` from tasks table. Added `workflows`, `workflowTriggers`, `workflowRuns` (new), `workflowPods` with three new enums
- **Shared types** (`packages/shared/src/types/task.ts`): Replaced `WorkflowStep`/`WorkflowTemplate` with `Workflow`, `WorkflowTrigger`, `WorkflowRun` interfaces; added `WorkflowState` enum and `WorkflowTriggerType`
- **State machine** (`packages/shared/src/utils/workflow-state-machine.ts`): New workflow run state machine (queued → running → completed/failed, with failed → queued retry path)
- **Service** (`apps/api/src/services/workflow-service.ts`): Complete rewrite with CRUD for all four tables, state transition validation, run creation with workflow validation
- **Routes** (`apps/api/src/routes/workflows.ts`): New REST API at `/api/workflows` (was `/api/workflow-templates`) with nested triggers and runs endpoints
- **Task integration**: Removed `workflowRunId` column and `checkWorkflowRunCompletion` calls from `task-service.ts` and `task-worker.ts`
- **Web UI**: Updated api-client methods and workflows page for the new data model
- **Migration**: `1775791878_replace_workflow_tables.sql` drops old tables and creates new ones with proper enums, indexes, and FK constraints

## How to test

1. `pnpm turbo typecheck` — all 12 packages pass
2. `pnpm turbo test` — all 1515 tests pass across 97 test files
3. `cd apps/web && npx next build` — production build succeeds
4. Review the migration SQL to verify it correctly drops old tables and creates new ones
5. Verify the new `/api/workflows` endpoints match the route definitions