### PR TITLE
feat(workflows): workflow pod management

### DIFF
--- a/apps/api/src/db/migrations/1775792368_workflow_pods.sql
+++ b/apps/api/src/db/migrations/1775792368_workflow_pods.sql
@@ -1,0 +1,26 @@
+-- Create the workflow_pod_state enum type
+DO $$ BEGIN
+  CREATE TYPE "workflow_pod_state" AS ENUM ('provisioning', 'ready', 'error', 'terminating');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Drop the old workflow_pods table (created in 1775791846 with different schema)
+DROP TABLE IF EXISTS "workflow_pods" CASCADE;
+
+-- Recreate workflow_pods with workflow_run_id FK, enum state, and additional columns
+CREATE TABLE "workflow_pods" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "workflow_run_id" uuid NOT NULL REFERENCES "workflow_runs"("id") ON DELETE CASCADE,
+  "workspace_id" uuid,
+  "pod_name" text,
+  "pod_id" text,
+  "state" "workflow_pod_state" DEFAULT 'provisioning' NOT NULL,
+  "active_run_count" integer DEFAULT 0 NOT NULL,
+  "last_run_at" timestamp with time zone,
+  "error_message" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "workflow_pods_run_id_idx" ON "workflow_pods" ("workflow_run_id");
+CREATE INDEX IF NOT EXISTS "workflow_pods_workspace_id_idx" ON "workflow_pods" ("workspace_id");

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1775791846000,
       "tag": "1775791846_replace_workflow_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1775792368000,
+      "tag": "1775792368_workflow_pods",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -621,22 +621,6 @@ export const workflowRuns = pgTable(
   ],
 );
 
-export const workflowPods = pgTable(
-  "workflow_pods",
-  {
-    id: uuid("id").primaryKey().defaultRandom(),
-    workflowId: uuid("workflow_id")
-      .notNull()
-      .references(() => workflows.id, { onDelete: "cascade" }),
-    podName: text("pod_name").notNull(),
-    state: text("state").notNull().default("creating"), // "creating" | "ready" | "busy" | "failed"
-    activeRunCount: integer("active_run_count").notNull().default(0),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (table) => [index("workflow_pods_workflow_id_idx").on(table.workflowId)],
-);
-
 // ── MCP Servers ──────────────────────────────────────────────────────────────
 
 export const mcpServers = pgTable(

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -871,3 +871,35 @@ export const repoSharedDirectories = pgTable(
     index("repo_shared_dirs_workspace_idx").on(table.workspaceId),
   ],
 );
+
+// ── Workflow Pods ──────────────────────────────────────────────────────────────
+
+export const workflowPodStateEnum = pgEnum("workflow_pod_state", [
+  "provisioning",
+  "ready",
+  "error",
+  "terminating",
+]);
+
+export const workflowPods = pgTable(
+  "workflow_pods",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    workflowRunId: uuid("workflow_run_id")
+      .notNull()
+      .references(() => workflowRuns.id, { onDelete: "cascade" }),
+    workspaceId: uuid("workspace_id"),
+    podName: text("pod_name"),
+    podId: text("pod_id"),
+    state: workflowPodStateEnum("state").notNull().default("provisioning"),
+    activeRunCount: integer("active_run_count").notNull().default(0),
+    lastRunAt: timestamp("last_run_at", { withTimezone: true }),
+    errorMessage: text("error_message"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("workflow_pods_run_id_idx").on(table.workflowRunId),
+    index("workflow_pods_workspace_id_idx").on(table.workspaceId),
+  ],
+);

--- a/apps/api/src/services/workflow-pool-service.test.ts
+++ b/apps/api/src/services/workflow-pool-service.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ───────────────────────────────────────────────────────────
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  workflowPods: {
+    id: "id",
+    workflowRunId: "workflowRunId",
+    workspaceId: "workspaceId",
+    state: "state",
+    activeRunCount: "activeRunCount",
+    updatedAt: "updatedAt",
+    podName: "podName",
+    podId: "podId",
+    lastRunAt: "lastRunAt",
+    errorMessage: "errorMessage",
+  },
+}));
+
+const mockRuntimeCreate = vi.fn();
+const mockRuntimeExec = vi.fn();
+const mockRuntimeStatus = vi.fn();
+const mockRuntimeDestroy = vi.fn();
+
+vi.mock("./container-service.js", () => ({
+  getRuntime: () => ({
+    create: mockRuntimeCreate,
+    exec: mockRuntimeExec,
+    status: mockRuntimeStatus,
+    destroy: mockRuntimeDestroy,
+  }),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  lt: vi.fn(),
+  sql: vi.fn(),
+  asc: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { db } from "../db/client.js";
+import {
+  getOrCreateWorkflowPod,
+  createWorkflowPod,
+  execRunInPod,
+  releaseRun,
+  cleanupIdleWorkflowPods,
+  listWorkflowPods,
+} from "./workflow-pool-service.js";
+
+// ── releaseRun ──────────────────────────────────────────────────────
+
+describe("releaseRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("decrements the active run count via DB update", async () => {
+    vi.mocked(db.update(undefined as any).set(undefined as any).where as any).mockResolvedValueOnce(
+      [],
+    );
+
+    await releaseRun("pod-1");
+
+    expect(db.update).toHaveBeenCalled();
+    expect(db.update(undefined as any).set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updatedAt: expect.any(Date),
+      }),
+    );
+  });
+});
+
+// ── cleanupIdleWorkflowPods ─────────────────────────────────────────
+
+describe("cleanupIdleWorkflowPods", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 0 when no idle pods exist", async () => {
+    vi.mocked(db.select().from(undefined as any).where as any).mockResolvedValueOnce([]);
+
+    const cleaned = await cleanupIdleWorkflowPods();
+    expect(cleaned).toBe(0);
+  });
+
+  it("destroys idle pods and removes their records", async () => {
+    const idlePod = {
+      id: "pod-1",
+      workflowRunId: "wf-run-1",
+      podName: "optio-wf-abc123-def4",
+      podId: "k8s-pod-id-1",
+      state: "ready",
+      activeRunCount: 0,
+    };
+
+    vi.mocked(db.select().from(undefined as any).where as any).mockResolvedValueOnce([idlePod]);
+
+    mockRuntimeDestroy.mockResolvedValueOnce(undefined);
+    vi.mocked(db.delete(undefined as any).where as any).mockResolvedValueOnce(undefined);
+
+    const cleaned = await cleanupIdleWorkflowPods();
+    expect(cleaned).toBe(1);
+    expect(mockRuntimeDestroy).toHaveBeenCalledWith({
+      id: idlePod.podId,
+      name: idlePod.podName,
+    });
+  });
+
+  it("continues cleanup even if one pod fails to destroy", async () => {
+    const pods = [
+      {
+        id: "pod-1",
+        workflowRunId: "wf-run-1",
+        podName: "pod-a",
+        podId: "id-a",
+        state: "ready",
+        activeRunCount: 0,
+      },
+      {
+        id: "pod-2",
+        workflowRunId: "wf-run-2",
+        podName: "pod-b",
+        podId: "id-b",
+        state: "ready",
+        activeRunCount: 0,
+      },
+    ];
+
+    vi.mocked(db.select().from(undefined as any).where as any).mockResolvedValueOnce(pods);
+
+    mockRuntimeDestroy
+      .mockRejectedValueOnce(new Error("Failed to destroy"))
+      .mockResolvedValueOnce(undefined);
+
+    vi.mocked(db.delete(undefined as any).where as any).mockResolvedValue(undefined);
+
+    const cleaned = await cleanupIdleWorkflowPods();
+    // First pod fails, second succeeds
+    expect(cleaned).toBe(1);
+  });
+
+  it("skips destroy if pod has no podName", async () => {
+    const pod = {
+      id: "pod-1",
+      workflowRunId: "wf-run-1",
+      podName: null,
+      podId: null,
+      state: "ready",
+      activeRunCount: 0,
+    };
+
+    vi.mocked(db.select().from(undefined as any).where as any).mockResolvedValueOnce([pod]);
+    vi.mocked(db.delete(undefined as any).where as any).mockResolvedValue(undefined);
+
+    const cleaned = await cleanupIdleWorkflowPods();
+    expect(cleaned).toBe(1);
+    expect(mockRuntimeDestroy).not.toHaveBeenCalled();
+  });
+});
+
+// ── listWorkflowPods ────────────────────────────────────────────────
+
+describe("listWorkflowPods", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns all workflow pods from the database", async () => {
+    const mockPods = [
+      { id: "pod-1", workflowRunId: "wf-1", podName: "p1", state: "ready" },
+      { id: "pod-2", workflowRunId: "wf-2", podName: "p2", state: "provisioning" },
+    ];
+
+    vi.mocked(db.select().from as any).mockResolvedValueOnce(mockPods);
+
+    const result = await listWorkflowPods();
+    expect(result).toEqual(mockPods);
+  });
+});
+
+// ── getOrCreateWorkflowPod ──────────────────────────────────────────
+
+describe("getOrCreateWorkflowPod", () => {
+  function mockGetOrCreateFlow(opts: { existingPods?: any[]; insertedPod?: any }) {
+    const dbMock = db as any;
+
+    let whereCallCount = 0;
+    dbMock.where.mockImplementation(() => {
+      whereCallCount++;
+      if (whereCallCount === 1) {
+        // existing pods query
+        return Promise.resolve(opts.existingPods ?? []);
+      }
+      // Remaining calls: update queries
+      return Promise.resolve([]);
+    });
+
+    if (opts.insertedPod) {
+      dbMock.returning.mockResolvedValueOnce([opts.insertedPod]);
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (db as any).where.mockReset().mockReturnThis();
+  });
+
+  it("returns existing ready pod when available", async () => {
+    const existingPod = {
+      id: "pod-1",
+      workflowRunId: "wf-run-1",
+      podName: "optio-wf-abc-1234",
+      podId: "k8s-id",
+      state: "ready",
+      activeRunCount: 0,
+    };
+
+    mockGetOrCreateFlow({ existingPods: [existingPod] });
+    mockRuntimeStatus.mockResolvedValueOnce({ state: "running" });
+
+    const pod = await getOrCreateWorkflowPod("wf-run-1", {});
+    expect(pod.id).toBe("pod-1");
+    expect(pod.state).toBe("ready");
+  });
+
+  it("creates a new pod when none exists", async () => {
+    const insertedPod = {
+      id: "pod-new",
+      workflowRunId: "wf-run-1",
+      state: "provisioning",
+    };
+
+    mockGetOrCreateFlow({
+      existingPods: [],
+      insertedPod,
+    });
+
+    mockRuntimeCreate.mockResolvedValueOnce({ id: "k8s-id", name: "optio-wf-abc-def4" });
+
+    const pod = await getOrCreateWorkflowPod("wf-run-1", {});
+    expect(pod.state).toBe("ready");
+    expect(mockRuntimeCreate).toHaveBeenCalled();
+  });
+
+  it("cleans up error pods and creates a new one", async () => {
+    const errorPod = {
+      id: "pod-err",
+      workflowRunId: "wf-run-1",
+      podName: "optio-wf-err",
+      podId: "k8s-err",
+      state: "error",
+      activeRunCount: 0,
+    };
+    const insertedPod = {
+      id: "pod-new",
+      workflowRunId: "wf-run-1",
+      state: "provisioning",
+    };
+
+    mockGetOrCreateFlow({
+      existingPods: [errorPod],
+      insertedPod,
+    });
+
+    mockRuntimeCreate.mockResolvedValueOnce({ id: "k8s-id", name: "optio-wf-new-abc1" });
+
+    const pod = await getOrCreateWorkflowPod("wf-run-1", {});
+    expect(pod.state).toBe("ready");
+    expect(db.delete).toHaveBeenCalled(); // error pod record deleted
+  });
+});
+
+// ── execRunInPod ────────────────────────────────────────────────────
+
+describe("execRunInPod", () => {
+  function makeExecSession(output: string) {
+    return {
+      stdout: {
+        [Symbol.asyncIterator]: async function* () {
+          if (output) yield Buffer.from(output);
+        },
+      },
+      stdin: { write: vi.fn(), end: vi.fn() },
+      stderr: {
+        [Symbol.asyncIterator]: async function* () {},
+      },
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("increments active run count and returns exec session", async () => {
+    const pod = {
+      id: "pod-1",
+      workflowRunId: "wf-run-1",
+      podName: "optio-wf-abc-def4",
+      podId: "k8s-id",
+      state: "ready",
+      activeRunCount: 0,
+    };
+
+    const mockSession = makeExecSession("output");
+    mockRuntimeExec.mockResolvedValueOnce(mockSession);
+    vi.mocked(db.update(undefined as any).set(undefined as any).where as any).mockResolvedValue([]);
+
+    const session = await execRunInPod(pod, "step-1", ["echo", "hello"], { KEY: "val" });
+    expect(session).toBeDefined();
+    expect(db.update).toHaveBeenCalled();
+    expect(mockRuntimeExec).toHaveBeenCalled();
+  });
+
+  it("passes env vars in the exec script", async () => {
+    const pod = {
+      id: "pod-1",
+      workflowRunId: "wf-run-1",
+      podName: "optio-wf-abc-def4",
+      podId: "k8s-id",
+      state: "ready",
+      activeRunCount: 0,
+    };
+
+    const mockSession = makeExecSession("");
+    mockRuntimeExec.mockResolvedValueOnce(mockSession);
+    vi.mocked(db.update(undefined as any).set(undefined as any).where as any).mockResolvedValue([]);
+
+    await execRunInPod(pod, "step-1", ["echo", "test"], { MY_VAR: "hello" });
+
+    // Verify exec was called with bash -c and the script includes env setup
+    const execCall = mockRuntimeExec.mock.calls[0];
+    expect(execCall[1][0]).toBe("bash");
+    expect(execCall[1][1]).toBe("-c");
+    // The script should contain the base64-encoded env
+    expect(execCall[1][2]).toContain("base64");
+  });
+});

--- a/apps/api/src/services/workflow-pool-service.ts
+++ b/apps/api/src/services/workflow-pool-service.ts
@@ -1,0 +1,314 @@
+import { eq, and, lt, sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { workflowPods } from "../db/schema.js";
+import { getRuntime } from "./container-service.js";
+import type { ContainerHandle, ContainerSpec, ExecSession } from "@optio/shared";
+import { DEFAULT_AGENT_IMAGE, generateWorkflowPodName } from "@optio/shared";
+import { logger } from "../logger.js";
+import { resolveImage } from "./repo-pool-service.js";
+import type { RepoImageConfig } from "@optio/shared";
+
+const IDLE_TIMEOUT_MS = parseInt(process.env.OPTIO_WORKFLOW_POD_IDLE_MS ?? "600000", 10); // 10 min default
+
+export interface WorkflowPod {
+  id: string;
+  workflowRunId: string;
+  podName: string | null;
+  podId: string | null;
+  state: string;
+  activeRunCount: number;
+}
+
+/**
+ * Select (or create) a workflow pod for the given workflow run.
+ *
+ * Workflow pods differ from repo pods: they don't clone a git repo.
+ * The pod runs a setup script and then sleeps, waiting for exec commands.
+ */
+export async function getOrCreateWorkflowPod(
+  workflowRunId: string,
+  env: Record<string, string>,
+  opts?: {
+    imageConfig?: RepoImageConfig;
+    workspaceId?: string | null;
+    cpuRequest?: string | null;
+    cpuLimit?: string | null;
+    memoryRequest?: string | null;
+    memoryLimit?: string | null;
+  },
+): Promise<WorkflowPod> {
+  // Check for existing pods for this workflow run
+  const existingPods = await db
+    .select()
+    .from(workflowPods)
+    .where(eq(workflowPods.workflowRunId, workflowRunId));
+
+  const rt = getRuntime();
+  for (const pod of existingPods) {
+    if (pod.state === "ready" && pod.podName) {
+      try {
+        const status = await rt.status({
+          id: pod.podId ?? pod.podName,
+          name: pod.podName,
+        });
+        if (status.state === "running") {
+          return pod as WorkflowPod;
+        }
+      } catch {
+        // Pod is gone, clean up record
+      }
+      await db.delete(workflowPods).where(eq(workflowPods.id, pod.id));
+    } else if (pod.state === "provisioning") {
+      return waitForPodReady(pod.id);
+    } else if (pod.state === "error") {
+      await db.delete(workflowPods).where(eq(workflowPods.id, pod.id));
+    }
+  }
+
+  // Create new pod
+  try {
+    return await createWorkflowPod(workflowRunId, env, opts);
+  } catch (err: any) {
+    if (err?.message?.includes("unique") || err?.code === "23505") {
+      logger.info({ workflowRunId }, "Concurrent pod creation detected, retrying lookup");
+      return getOrCreateWorkflowPod(workflowRunId, env, opts);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Create a new workflow pod.
+ *
+ * Unlike repo pods, workflow pods don't clone a git repo. They run a setup
+ * script that touches a ready marker and then sleeps, waiting for exec commands.
+ */
+export async function createWorkflowPod(
+  workflowRunId: string,
+  env: Record<string, string>,
+  opts?: {
+    imageConfig?: RepoImageConfig;
+    workspaceId?: string | null;
+    cpuRequest?: string | null;
+    cpuLimit?: string | null;
+    memoryRequest?: string | null;
+    memoryLimit?: string | null;
+  },
+): Promise<WorkflowPod> {
+  const [record] = await db
+    .insert(workflowPods)
+    .values({
+      workflowRunId,
+      workspaceId: opts?.workspaceId ?? undefined,
+      state: "provisioning",
+    })
+    .returning();
+
+  const rt = getRuntime();
+  const image = resolveImage(opts?.imageConfig);
+  const podName = generateWorkflowPodName(workflowRunId);
+
+  let podNameForCleanup: string | undefined;
+  try {
+    podNameForCleanup = podName;
+
+    // Workflow pods use a simple init script: create workspace, mark ready, sleep.
+    // No git clone needed — workflow steps exec into the pod directly.
+    const initScript = [
+      "set -e",
+      "mkdir -p /workspace/runs",
+      "touch /workspace/.ready",
+      "echo '[optio] Workflow pod ready'",
+      "exec sleep infinity",
+    ].join("\n");
+
+    const spec: ContainerSpec = {
+      name: podName,
+      image,
+      command: ["bash", "-c", initScript],
+      env: {
+        ...env,
+        OPTIO_WORKFLOW_RUN_ID: workflowRunId,
+      },
+      workDir: "/workspace",
+      imagePullPolicy: (process.env.OPTIO_IMAGE_PULL_POLICY as any) ?? "Never",
+      cpuRequest: opts?.cpuRequest ?? undefined,
+      cpuLimit: opts?.cpuLimit ?? undefined,
+      memoryRequest: opts?.memoryRequest ?? undefined,
+      memoryLimit: opts?.memoryLimit ?? undefined,
+      labels: {
+        "optio.workflow-run-id": workflowRunId.slice(0, 63),
+        "optio.type": "workflow-pod",
+        "managed-by": "optio",
+      },
+    };
+
+    const handle = await rt.create(spec);
+
+    await db
+      .update(workflowPods)
+      .set({
+        podName: handle.name,
+        podId: handle.id,
+        state: "ready",
+        updatedAt: new Date(),
+      })
+      .where(eq(workflowPods.id, record.id));
+
+    logger.info({ workflowRunId, podName: handle.name }, "Workflow pod created");
+
+    return {
+      ...record,
+      podName: handle.name,
+      podId: handle.id,
+      state: "ready",
+    };
+  } catch (err) {
+    await db
+      .update(workflowPods)
+      .set({
+        state: "error",
+        errorMessage: String(err),
+        updatedAt: new Date(),
+      })
+      .where(eq(workflowPods.id, record.id));
+
+    // Clean up the K8s pod if it was created
+    if (podNameForCleanup) {
+      try {
+        const rtForCleanup = getRuntime();
+        await rtForCleanup.destroy({ id: podNameForCleanup, name: podNameForCleanup });
+        logger.info({ podName: podNameForCleanup }, "Cleaned up failed workflow pod");
+      } catch (cleanupErr) {
+        logger.warn(
+          { err: cleanupErr, podName: podNameForCleanup },
+          "Failed to cleanup errored workflow pod",
+        );
+      }
+    }
+
+    throw err;
+  }
+}
+
+async function waitForPodReady(podId: string, timeoutMs = 120_000): Promise<WorkflowPod> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const [pod] = await db.select().from(workflowPods).where(eq(workflowPods.id, podId));
+    if (!pod) throw new Error(`Workflow pod record ${podId} disappeared`);
+    if (pod.state === "ready") return pod as WorkflowPod;
+    if (pod.state === "error") throw new Error(`Workflow pod failed: ${pod.errorMessage}`);
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error(`Timed out waiting for workflow pod ${podId}`);
+}
+
+/**
+ * Execute a workflow step/run inside a workflow pod.
+ * Returns an ExecSession for streaming output.
+ */
+export async function execRunInPod(
+  pod: WorkflowPod,
+  stepId: string,
+  agentCommand: string[],
+  env: Record<string, string>,
+): Promise<ExecSession> {
+  const rt = getRuntime();
+  const handle: ContainerHandle = { id: pod.podId ?? pod.podName!, name: pod.podName! };
+
+  // Increment active run count
+  await db
+    .update(workflowPods)
+    .set({
+      activeRunCount: sql`${workflowPods.activeRunCount} + 1`,
+      lastRunAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(workflowPods.id, pod.id));
+
+  // Build the exec command — simpler than repo pods (no git worktree setup)
+  const envJson = JSON.stringify({ ...env, OPTIO_STEP_ID: stepId });
+  const envB64 = Buffer.from(envJson).toString("base64");
+
+  const script = [
+    "set -e",
+    `eval $(echo '${envB64}' | base64 -d | python3 -c "`,
+    `import json, sys, shlex`,
+    `env = json.load(sys.stdin)`,
+    `for k, v in env.items():`,
+    `    print(f'export {k}={shlex.quote(v)}')`,
+    `")`,
+    `echo "[optio] Waiting for workflow pod to be ready..."`,
+    `for i in $(seq 1 120); do [ -f /workspace/.ready ] && break; sleep 1; done`,
+    `[ -f /workspace/.ready ] || { echo "[optio] ERROR: workflow pod not ready after 120s"; exit 1; }`,
+    `echo "[optio] Workflow pod ready"`,
+    `mkdir -p /workspace/runs/${stepId}`,
+    `cd /workspace/runs/${stepId}`,
+    `export OPTIO_STEP_ID="${stepId}"`,
+    `set +e`,
+    ...agentCommand,
+    `AGENT_EXIT=$?`,
+    `exit $AGENT_EXIT`,
+  ].join("\n");
+
+  return rt.exec(handle, ["bash", "-c", script], { tty: false });
+}
+
+/**
+ * Decrement the active run count for a workflow pod.
+ */
+export async function releaseRun(podId: string): Promise<void> {
+  await db
+    .update(workflowPods)
+    .set({
+      activeRunCount: sql`GREATEST(${workflowPods.activeRunCount} - 1, 0)`,
+      updatedAt: new Date(),
+    })
+    .where(eq(workflowPods.id, podId));
+}
+
+/**
+ * Clean up idle workflow pods that have no active runs.
+ */
+export async function cleanupIdleWorkflowPods(): Promise<number> {
+  const cutoff = new Date(Date.now() - IDLE_TIMEOUT_MS);
+
+  const idlePods = await db
+    .select()
+    .from(workflowPods)
+    .where(
+      and(
+        eq(workflowPods.activeRunCount, 0),
+        eq(workflowPods.state, "ready"),
+        lt(workflowPods.updatedAt, cutoff),
+      ),
+    );
+
+  const rt = getRuntime();
+  let cleaned = 0;
+
+  for (const pod of idlePods) {
+    try {
+      if (pod.podName) {
+        await rt.destroy({ id: pod.podId ?? pod.podName, name: pod.podName });
+      }
+      await db.delete(workflowPods).where(eq(workflowPods.id, pod.id));
+      logger.info(
+        { workflowRunId: pod.workflowRunId, podName: pod.podName },
+        "Cleaned up idle workflow pod",
+      );
+      cleaned++;
+    } catch (err) {
+      logger.warn({ err, podId: pod.id }, "Failed to cleanup workflow pod");
+    }
+  }
+
+  return cleaned;
+}
+
+/**
+ * List all workflow pods.
+ */
+export async function listWorkflowPods(): Promise<WorkflowPod[]> {
+  return db.select().from(workflowPods) as Promise<WorkflowPod[]>;
+}

--- a/apps/api/src/workers/repo-cleanup-worker.ts
+++ b/apps/api/src/workers/repo-cleanup-worker.ts
@@ -9,6 +9,7 @@ import {
   deleteNetworkPolicy,
   killOrphanedAgentInPod,
 } from "../services/repo-pool-service.js";
+import { cleanupIdleWorkflowPods } from "../services/workflow-pool-service.js";
 import { getRuntime } from "../services/container-service.js";
 import { TaskState, DEFAULT_STALL_THRESHOLD_MS } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
@@ -463,6 +464,16 @@ export function startRepoCleanupWorker() {
       const cleaned = await cleanupIdleRepoPods();
       if (cleaned > 0) {
         logger.info({ cleaned }, "Cleaned up idle repo pods");
+      }
+
+      // Clean up idle workflow pods
+      try {
+        const workflowCleaned = await cleanupIdleWorkflowPods();
+        if (workflowCleaned > 0) {
+          logger.info({ workflowCleaned }, "Cleaned up idle workflow pods");
+        }
+      } catch (err) {
+        logger.warn({ err }, "Failed to clean up idle workflow pods");
       }
 
       // Clean up expired auth sessions

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,29 @@ const K8S_NAME_MAX = 63;
  * for uniqueness. Names are valid K8s resource names (lowercase, alphanumeric +
  * hyphens, max 63 chars). Long owner/repo names are truncated gracefully.
  */
+/**
+ * Generate a human-readable pod name for a workflow run.
+ *
+ * Format: `optio-wf-<runId-prefix>-<hash>` where hash is a 4-char hex suffix
+ * for uniqueness. Names are valid K8s resource names.
+ */
+export function generateWorkflowPodName(workflowRunId: string): string {
+  const prefix = "optio-wf-";
+  const suffixLen = 5; // 4-char hash + 1 hyphen
+  const maxBodyLen = K8S_NAME_MAX - prefix.length - suffixLen;
+
+  // Use first portion of the run ID (already a UUID), sanitized
+  const sanitized = workflowRunId
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, maxBodyLen);
+
+  const hash = Math.random().toString(16).slice(2, 6);
+  return `${prefix}${sanitized}-${hash}`;
+}
+
 export function generateRepoPodName(repoUrl: string): string {
   // Extract owner/repo from URL patterns like:
   //   https://github.com/owner/repo.git

--- a/packages/shared/src/types/workflow.test.ts
+++ b/packages/shared/src/types/workflow.test.ts
@@ -27,10 +27,10 @@ describe("WorkflowTriggerType enum", () => {
 
 describe("WorkflowPodState enum", () => {
   it("has the expected values", () => {
-    expect(WorkflowPodState.CREATING).toBe("creating");
+    expect(WorkflowPodState.PROVISIONING).toBe("provisioning");
     expect(WorkflowPodState.READY).toBe("ready");
-    expect(WorkflowPodState.BUSY).toBe("busy");
-    expect(WorkflowPodState.FAILED).toBe("failed");
+    expect(WorkflowPodState.ERROR).toBe("error");
+    expect(WorkflowPodState.TERMINATING).toBe("terminating");
   });
 });
 

--- a/packages/shared/src/types/workflow.ts
+++ b/packages/shared/src/types/workflow.ts
@@ -67,18 +67,22 @@ export interface WorkflowRun {
 }
 
 export enum WorkflowPodState {
-  CREATING = "creating",
+  PROVISIONING = "provisioning",
   READY = "ready",
-  BUSY = "busy",
-  FAILED = "failed",
+  ERROR = "error",
+  TERMINATING = "terminating",
 }
 
 export interface WorkflowPod {
   id: string;
-  workflowId: string;
-  podName: string;
+  workflowRunId: string;
+  workspaceId?: string | null;
+  podName: string | null;
+  podId: string | null;
   state: WorkflowPodState;
   activeRunCount: number;
+  lastRunAt?: Date | null;
+  errorMessage?: string | null;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
Closes #374

## What changed

Added `workflow-pool-service.ts` for managing workflow environment pods. Unlike repo pods, workflow pods don't clone a git repository — they initialize with a setup script and sleep, waiting for exec commands from workflow steps.

### New components:
- **`workflow_pods` DB table** — tracks pod state, active run counts, and lifecycle for workflow runs (with migration)
- **`workflow-pool-service.ts`** — core service with:
  - `getOrCreateWorkflowPod()` — finds existing ready pod or creates a new one
  - `createWorkflowPod()` — provisions a K8s pod with setup script + sleep entrypoint
  - `execRunInPod()` — executes a workflow step inside the pod with env vars
  - `releaseRun()` — decrements active run count after step completion
  - `cleanupIdleWorkflowPods()` — removes pods idle beyond timeout (10min default)
  - `listWorkflowPods()` — lists all workflow pods
- **`generateWorkflowPodName()`** — K8s-safe pod name generator in shared constants
- **Cleanup worker integration** — idle workflow pods are cleaned up alongside repo pods

### Design decisions:
- Modeled after `repo-pool-service.ts` but simplified (no git worktrees, no PVC, no network policies)
- Each workflow run gets its own pod; steps exec into it via `/workspace/runs/<stepId>`
- Reuses `resolveImage()` from repo-pool-service for image resolution
- Workflow pods cascade-delete when their workflow run is deleted

## How to test

1. Run the test suite: `cd apps/api && npx vitest run src/services/workflow-pool-service.test.ts` (11 tests)
2. Run full typecheck: `npx turbo typecheck` — passes cleanly
3. Run full test suite: `npx turbo test` — all 1525 tests pass
4. Verify migration: check `apps/api/src/db/migrations/1775792368_workflow_pods.sql` creates the table correctly