### PR TITLE
feat(workflows): webhook trigger ingress

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -58,7 +58,7 @@ const PUBLIC_ROUTES = new Set([
  * route handler itself (see hmac-auth-service.ts). The Helm ingress also
  * blocks /api/internal/* from public traffic as defense in depth.
  */
-const PUBLIC_PREFIXES = ["/api/webhooks/", "/ws/", "/api/internal/git-credentials"];
+const PUBLIC_PREFIXES = ["/api/webhooks/", "/api/hooks/", "/ws/", "/api/internal/git-credentials"];
 
 /**
  * Auth routes that are public (OAuth login/callback flows only).

--- a/apps/api/src/routes/hooks.test.ts
+++ b/apps/api/src/routes/hooks.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHmac } from "node:crypto";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+
+// ─── Mocks ───
+
+const mockGetWebhookTriggerByPath = vi.fn();
+const mockGetWorkflow = vi.fn();
+const mockCreateWorkflowRun = vi.fn();
+
+vi.mock("../services/workflow-service.js", () => ({
+  getWebhookTriggerByPath: (...args: unknown[]) => mockGetWebhookTriggerByPath(...args),
+  getWorkflow: (...args: unknown[]) => mockGetWorkflow(...args),
+  createWorkflowRun: (...args: unknown[]) => mockCreateWorkflowRun(...args),
+}));
+
+import { hookRoutes } from "./hooks.js";
+
+// ─── Helpers ───
+
+function hmacSign(payload: string, secret: string): string {
+  return createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await hookRoutes(app);
+  await app.ready();
+  return app;
+}
+
+const TRIGGER = {
+  id: "trig-1",
+  workflowId: "wf-1",
+  type: "webhook",
+  config: { webhookPath: "my-hook", secret: "test-secret" },
+  paramMapping: null,
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const WORKFLOW = {
+  id: "wf-1",
+  name: "Deploy",
+  enabled: true,
+  promptTemplate: "Do the thing",
+};
+
+describe("POST /api/hooks/:webhookPath", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns 202 with runId on valid webhook", async () => {
+    mockGetWebhookTriggerByPath.mockResolvedValue(TRIGGER);
+    mockGetWorkflow.mockResolvedValue(WORKFLOW);
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-1", state: "queued" });
+
+    const body = JSON.stringify({ ref: "main" });
+    const sig = hmacSign(body, "test-secret");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/my-hook",
+      headers: {
+        "content-type": "application/json",
+        "x-optio-signature": sig,
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(202);
+    const json = res.json();
+    expect(json.runId).toBe("run-1");
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith("wf-1", {
+      triggerId: "trig-1",
+      params: expect.any(Object),
+    });
+  });
+
+  it("returns 404 when trigger not found", async () => {
+    mockGetWebhookTriggerByPath.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/nonexistent",
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toContain("not found");
+  });
+
+  it("returns 404 when trigger is disabled", async () => {
+    mockGetWebhookTriggerByPath.mockResolvedValue({ ...TRIGGER, enabled: false });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/disabled-hook",
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toContain("not found");
+  });
+
+  it("returns 404 when workflow not found", async () => {
+    mockGetWebhookTriggerByPath.mockResolvedValue(TRIGGER);
+    mockGetWorkflow.mockResolvedValue(null);
+
+    const body = JSON.stringify({});
+    const sig = hmacSign(body, "test-secret");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/my-hook",
+      headers: { "x-optio-signature": sig, "content-type": "application/json" },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toContain("Workflow not found");
+  });
+
+  it("returns 404 when workflow is disabled", async () => {
+    mockGetWebhookTriggerByPath.mockResolvedValue(TRIGGER);
+    mockGetWorkflow.mockResolvedValue({ ...WORKFLOW, enabled: false });
+
+    const body = JSON.stringify({});
+    const sig = hmacSign(body, "test-secret");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/my-hook",
+      headers: { "x-optio-signature": sig, "content-type": "application/json" },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toContain("disabled");
+  });
+
+  it("returns 401 when HMAC signature is missing and secret is configured", async () => {
+    mockGetWebhookTriggerByPath.mockResolvedValue(TRIGGER);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/my-hook",
+      payload: { ref: "main" },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toContain("signature");
+  });
+
+  it("returns 401 when HMAC signature is invalid", async () => {
+    mockGetWebhookTriggerByPath.mockResolvedValue(TRIGGER);
+
+    const body = JSON.stringify({ ref: "main" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/my-hook",
+      headers: {
+        "content-type": "application/json",
+        "x-optio-signature": "deadbeef",
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error).toContain("Invalid signature");
+  });
+
+  it("skips HMAC verification when no secret is configured", async () => {
+    const triggerNoSecret = {
+      ...TRIGGER,
+      config: { webhookPath: "open-hook" },
+    };
+    mockGetWebhookTriggerByPath.mockResolvedValue(triggerNoSecret);
+    mockGetWorkflow.mockResolvedValue(WORKFLOW);
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-2", state: "queued" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/open-hook",
+      payload: { ref: "main" },
+    });
+
+    expect(res.statusCode).toBe(202);
+    expect(res.json().runId).toBe("run-2");
+  });
+
+  it("applies param mapping from JSON path expressions", async () => {
+    const triggerWithMapping = {
+      ...TRIGGER,
+      config: { webhookPath: "mapped-hook", secret: "test-secret" },
+      paramMapping: {
+        branch: "$.ref",
+        repo: "$.repository.full_name",
+        action: "$.action",
+      },
+    };
+    mockGetWebhookTriggerByPath.mockResolvedValue(triggerWithMapping);
+    mockGetWorkflow.mockResolvedValue(WORKFLOW);
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-3", state: "queued" });
+
+    const payload = {
+      ref: "refs/heads/main",
+      repository: { full_name: "org/repo" },
+      action: "push",
+    };
+    const body = JSON.stringify(payload);
+    const sig = hmacSign(body, "test-secret");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/mapped-hook",
+      headers: {
+        "content-type": "application/json",
+        "x-optio-signature": sig,
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(202);
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith("wf-1", {
+      triggerId: "trig-1",
+      params: {
+        branch: "refs/heads/main",
+        repo: "org/repo",
+        action: "push",
+      },
+    });
+  });
+
+  it("passes raw body as params when no param mapping is configured", async () => {
+    const triggerNoMapping = {
+      ...TRIGGER,
+      paramMapping: null,
+    };
+    mockGetWebhookTriggerByPath.mockResolvedValue(triggerNoMapping);
+    mockGetWorkflow.mockResolvedValue(WORKFLOW);
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-4", state: "queued" });
+
+    const payload = { ref: "main", action: "push" };
+    const body = JSON.stringify(payload);
+    const sig = hmacSign(body, "test-secret");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/my-hook",
+      headers: {
+        "content-type": "application/json",
+        "x-optio-signature": sig,
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(202);
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith("wf-1", {
+      triggerId: "trig-1",
+      params: payload,
+    });
+  });
+
+  it("handles nested JSON path expressions gracefully when path does not exist", async () => {
+    const triggerWithMapping = {
+      ...TRIGGER,
+      config: { webhookPath: "mapped-hook", secret: "test-secret" },
+      paramMapping: {
+        branch: "$.ref",
+        missing: "$.does.not.exist",
+      },
+    };
+    mockGetWebhookTriggerByPath.mockResolvedValue(triggerWithMapping);
+    mockGetWorkflow.mockResolvedValue(WORKFLOW);
+    mockCreateWorkflowRun.mockResolvedValue({ id: "run-5", state: "queued" });
+
+    const payload = { ref: "main" };
+    const body = JSON.stringify(payload);
+    const sig = hmacSign(body, "test-secret");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/hooks/mapped-hook",
+      headers: {
+        "content-type": "application/json",
+        "x-optio-signature": sig,
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(202);
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith("wf-1", {
+      triggerId: "trig-1",
+      params: {
+        branch: "main",
+        missing: undefined,
+      },
+    });
+  });
+});

--- a/apps/api/src/routes/hooks.ts
+++ b/apps/api/src/routes/hooks.ts
@@ -1,0 +1,122 @@
+import type { FastifyInstance } from "fastify";
+import { timingSafeEqual, createHmac } from "node:crypto";
+import { z } from "zod";
+import * as workflowService from "../services/workflow-service.js";
+import { logger } from "../logger.js";
+
+const webhookPathSchema = z.object({ webhookPath: z.string().min(1) });
+const webhookBodySchema = z.record(z.unknown()).default({});
+
+/**
+ * Resolve a simple JSON-path expression (e.g. "$.foo.bar") against an object.
+ * Supports dotted property access only — no arrays, filters, or wildcards.
+ */
+function resolveJsonPath(obj: unknown, path: string): unknown {
+  // Strip leading "$." prefix if present
+  const normalized = path.startsWith("$.") ? path.slice(2) : path;
+  const segments = normalized.split(".");
+
+  let current: unknown = obj;
+  for (const seg of segments) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[seg];
+  }
+  return current;
+}
+
+/**
+ * Apply param mapping: for each key in the mapping, resolve the JSON-path
+ * expression against the incoming body and build a params object.
+ */
+function applyParamMapping(
+  body: Record<string, unknown>,
+  mapping: Record<string, unknown>,
+): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+  for (const [key, pathExpr] of Object.entries(mapping)) {
+    if (typeof pathExpr === "string") {
+      params[key] = resolveJsonPath(body, pathExpr);
+    }
+  }
+  return params;
+}
+
+/**
+ * Verify HMAC-SHA256 signature using timing-safe comparison.
+ */
+function verifyHmac(payload: string, secret: string, signature: string): boolean {
+  const expected = createHmac("sha256", secret).update(payload).digest("hex");
+  if (expected.length !== signature.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+}
+
+export async function hookRoutes(app: FastifyInstance) {
+  // Webhook trigger ingress — exempt from session auth, custom rate limit
+  app.post(
+    "/api/hooks/:webhookPath",
+    {
+      config: {
+        rateLimit: {
+          max: 60,
+          timeWindow: "1 minute",
+        },
+      },
+    },
+    async (req, reply) => {
+      const { webhookPath } = webhookPathSchema.parse(req.params);
+
+      // 1. Look up the webhook trigger
+      const trigger = await workflowService.getWebhookTriggerByPath(webhookPath);
+      if (!trigger || !trigger.enabled) {
+        return reply.status(404).send({ error: "Webhook trigger not found" });
+      }
+
+      const config = trigger.config as Record<string, unknown> | null;
+      const secret = config?.secret as string | undefined;
+
+      // 2. HMAC verification (if secret is configured)
+      if (secret) {
+        const rawBody = typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+        const signature = req.headers["x-optio-signature"] as string | undefined;
+
+        if (!signature) {
+          return reply
+            .status(401)
+            .send({ error: "Missing X-Optio-Signature header — signature required" });
+        }
+
+        if (!verifyHmac(rawBody, secret, signature)) {
+          return reply.status(401).send({ error: "Invalid signature" });
+        }
+      }
+
+      // 3. Look up the workflow
+      const workflow = await workflowService.getWorkflow(trigger.workflowId);
+      if (!workflow) {
+        return reply.status(404).send({ error: "Workflow not found" });
+      }
+      if (!workflow.enabled) {
+        return reply.status(404).send({ error: "Workflow is disabled" });
+      }
+
+      // 4. Apply param mapping
+      const body = webhookBodySchema.parse(req.body);
+      const paramMapping = trigger.paramMapping as Record<string, unknown> | null;
+
+      const params = paramMapping ? applyParamMapping(body, paramMapping) : body;
+
+      // 5. Create workflow run
+      const run = await workflowService.createWorkflowRun(trigger.workflowId, {
+        triggerId: trigger.id,
+        params,
+      });
+
+      logger.info(
+        { runId: run.id, workflowId: trigger.workflowId, triggerId: trigger.id },
+        "Webhook trigger created workflow run",
+      );
+
+      return reply.status(202).send({ runId: run.id });
+    },
+  );
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -39,6 +39,7 @@ import { optioRoutes } from "./routes/optio.js";
 import { optioSettingsRoutes } from "./routes/optio-settings.js";
 import githubAppRoutes from "./routes/github-app.js";
 import { githubTokenRoutes } from "./routes/github-token.js";
+import { hookRoutes } from "./routes/hooks.js";
 import { logStreamWs } from "./ws/log-stream.js";
 import { eventsWs } from "./ws/events.js";
 import { sessionTerminalWs } from "./ws/session-terminal.js";
@@ -127,6 +128,7 @@ export async function buildServer() {
   await app.register(optioSettingsRoutes);
   await app.register(githubAppRoutes);
   await app.register(githubTokenRoutes);
+  await app.register(hookRoutes);
 
   // WebSocket routes
   await app.register(logStreamWs);

--- a/apps/api/src/services/workflow-service.ts
+++ b/apps/api/src/services/workflow-service.ts
@@ -354,3 +354,21 @@ export async function listWorkflowTriggers(workflowId: string) {
     .where(eq(workflowTriggers.workflowId, workflowId))
     .orderBy(desc(workflowTriggers.createdAt));
 }
+
+/**
+ * Look up an enabled webhook trigger by its `config.webhookPath` value.
+ * Returns null if no matching trigger exists.
+ */
+export async function getWebhookTriggerByPath(webhookPath: string) {
+  const allWebhookTriggers = await db
+    .select()
+    .from(workflowTriggers)
+    .where(eq(workflowTriggers.type, "webhook"));
+
+  const trigger = allWebhookTriggers.find((t) => {
+    const config = t.config as Record<string, unknown> | null;
+    return config?.webhookPath === webhookPath;
+  });
+
+  return trigger ?? null;
+}


### PR DESCRIPTION
Closes #379

## What changed

Added `POST /api/hooks/:webhookPath` — an incoming webhook endpoint that allows external services (GitHub, Linear, etc.) to trigger workflow runs.

Key implementation details:
- **Auth-exempt**: Added `/api/hooks/` to `PUBLIC_PREFIXES` in the auth plugin so external callers don't need session tokens
- **HMAC-SHA256 verification**: When a trigger has a `secret` in its config, the endpoint verifies the `X-Optio-Signature` header using timing-safe comparison
- **JSON-path param mapping**: Trigger's `paramMapping` config maps incoming JSON fields to workflow params (e.g. `{"branch": "$.ref", "repo": "$.repository.full_name"}`)
- **Rate limiting**: 60 requests/minute per IP via `@fastify/rate-limit` route config
- **202 Accepted**: Returns `{ runId }` immediately after creating a queued workflow run

Files changed:
- `apps/api/src/routes/hooks.ts` — New route handler
- `apps/api/src/routes/hooks.test.ts` — 11 tests covering happy path, auth failures, disabled triggers/workflows, param mapping, and missing paths
- `apps/api/src/services/workflow-service.ts` — Added `getWebhookTriggerByPath()` and `createWorkflowRun()` service functions
- `apps/api/src/plugins/auth.ts` — Added `/api/hooks/` to public prefixes
- `apps/api/src/server.ts` — Registered hook routes

## How to test

1. Create a workflow with a webhook trigger that has `config: { webhookPath: "my-hook", secret: "s3cret" }`
2. Send a POST request:
   ```bash
   BODY='{"ref":"main","action":"push"}'
   SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "s3cret" | awk '{print $2}')
   curl -X POST http://localhost:30400/api/hooks/my-hook \
     -H "Content-Type: application/json" \
     -H "X-Optio-Signature: $SIG" \
     -d "$BODY"
   ```
3. Expect 202 response with `{ "runId": "<uuid>" }`
4. Verify a workflow run was created in `queued` state