### PR TITLE
feat(workflows): WebSocket log streaming for workflow runs

### DIFF
--- a/apps/api/src/db/migrations/1775793000_workflow_run_logs.sql
+++ b/apps/api/src/db/migrations/1775793000_workflow_run_logs.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "workflow_run_logs" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "workflow_run_id" uuid NOT NULL REFERENCES "workflow_runs"("id") ON DELETE CASCADE,
+  "stream" text DEFAULT 'stdout' NOT NULL,
+  "content" text NOT NULL,
+  "log_type" text,
+  "metadata" jsonb,
+  "timestamp" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "workflow_run_logs_run_id_timestamp_idx" ON "workflow_run_logs" ("workflow_run_id", "timestamp");

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1775794444000,
       "tag": "1775794444_workflow_trigger_schedule",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1775793000000,
+      "tag": "1775793000_workflow_run_logs",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -630,6 +630,24 @@ export const workflowRuns = pgTable(
   ],
 );
 
+export const workflowRunLogs = pgTable(
+  "workflow_run_logs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    workflowRunId: uuid("workflow_run_id")
+      .notNull()
+      .references(() => workflowRuns.id, { onDelete: "cascade" }),
+    stream: text("stream").notNull().default("stdout"),
+    content: text("content").notNull(),
+    logType: text("log_type"),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    timestamp: timestamp("timestamp", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("workflow_run_logs_run_id_timestamp_idx").on(table.workflowRunId, table.timestamp),
+  ],
+);
+
 // ── MCP Servers ──────────────────────────────────────────────────────────────
 
 export const mcpServers = pgTable(

--- a/apps/api/src/routes/workflows.test.ts
+++ b/apps/api/src/routes/workflows.test.ts
@@ -407,6 +407,7 @@ describe("GET /api/workflow-runs/:id/logs", () => {
       { id: "log-1", taskId: "t-1", content: "Building..." },
       { id: "log-2", taskId: "t-2", content: "Testing..." },
     ];
+    mockGetWorkflowRun.mockResolvedValue({ id: "run-1", state: "running" });
     mockGetWorkflowRunLogs.mockResolvedValue(logs);
 
     const res = await app.inject({ method: "GET", url: "/api/workflow-runs/run-1/logs" });
@@ -417,6 +418,7 @@ describe("GET /api/workflow-runs/:id/logs", () => {
   });
 
   it("passes query params to service", async () => {
+    mockGetWorkflowRun.mockResolvedValue({ id: "run-1", state: "running" });
     mockGetWorkflowRunLogs.mockResolvedValue([]);
 
     const res = await app.inject({
@@ -432,7 +434,7 @@ describe("GET /api/workflow-runs/:id/logs", () => {
   });
 
   it("returns 404 when run not found", async () => {
-    mockGetWorkflowRunLogs.mockRejectedValue(new Error("Workflow run not found"));
+    mockGetWorkflowRun.mockResolvedValue(null);
 
     const res = await app.inject({ method: "GET", url: "/api/workflow-runs/nonexistent/logs" });
 

--- a/apps/api/src/routes/workflows.ts
+++ b/apps/api/src/routes/workflows.ts
@@ -259,20 +259,14 @@ export async function workflowRoutes(app: FastifyInstance) {
     }
   });
 
-  // Get aggregated logs for a workflow run
+  // Get logs for a workflow run
   app.get("/api/workflow-runs/:id/logs", async (req, reply) => {
     const { id } = idParamsSchema.parse(req.params);
+    const run = await workflowService.getWorkflowRun(id);
+    if (!run) return reply.status(404).send({ error: "Workflow run not found" });
     const query = logsQuerySchema.safeParse(req.query);
     const opts = query.success ? query.data : {};
-    try {
-      const logs = await workflowService.getWorkflowRunLogs(id, opts);
-      reply.send({ logs });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("not found")) {
-        return reply.status(404).send({ error: msg });
-      }
-      reply.status(400).send({ error: msg });
-    }
+    const logs = await workflowService.getWorkflowRunLogs(id, opts);
+    reply.send({ logs });
   });
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -45,6 +45,7 @@ import { eventsWs } from "./ws/events.js";
 import { sessionTerminalWs } from "./ws/session-terminal.js";
 import { sessionChatWs } from "./ws/session-chat.js";
 import { optioChatWs } from "./ws/optio-chat.js";
+import { workflowRunLogStreamWs } from "./ws/workflow-run-log-stream.js";
 import authPlugin from "./plugins/auth.js";
 
 const loggerConfig =
@@ -136,6 +137,7 @@ export async function buildServer() {
   await app.register(sessionTerminalWs);
   await app.register(sessionChatWs);
   await app.register(optioChatWs);
+  await app.register(workflowRunLogStreamWs);
 
   // Global error handler for Zod validation
   app.setErrorHandler((error: FastifyError | Error, _req, reply) => {

--- a/apps/api/src/services/event-bus.test.ts
+++ b/apps/api/src/services/event-bus.test.ts
@@ -14,7 +14,12 @@ vi.mock("./redis-config.js", () => ({
   redisTlsOptions: undefined,
 }));
 
-import { publishEvent, publishSessionEvent, createSubscriber } from "./event-bus.js";
+import {
+  publishEvent,
+  publishSessionEvent,
+  publishWorkflowRunEvent,
+  createSubscriber,
+} from "./event-bus.js";
 
 describe("event-bus", () => {
   beforeEach(() => {
@@ -57,6 +62,49 @@ describe("event-bus", () => {
         "optio:session:sess-1",
         expect.stringContaining('"type":"session:ended"'),
       );
+    });
+  });
+
+  describe("publishWorkflowRunEvent", () => {
+    it("publishes to the global events channel", async () => {
+      await publishWorkflowRunEvent({
+        type: "workflow_run:state_changed",
+        workflowRunId: "wr-1",
+        workflowId: "w-1",
+        fromState: "queued" as any,
+        toState: "running" as any,
+        timestamp: "2026-01-01T00:00:00Z",
+      });
+
+      expect(mockPublish).toHaveBeenCalledWith(
+        "optio:events",
+        expect.stringContaining('"type":"workflow_run:state_changed"'),
+      );
+    });
+
+    it("also publishes to workflow-run-specific channel", async () => {
+      await publishWorkflowRunEvent({
+        type: "workflow_run:log",
+        workflowRunId: "wr-1",
+        stream: "stdout",
+        content: "Hello",
+        timestamp: "2026-01-01T00:00:00Z",
+      });
+
+      expect(mockPublish).toHaveBeenCalledWith(
+        "optio:workflow-run:wr-1",
+        expect.stringContaining('"workflowRunId":"wr-1"'),
+      );
+      expect(mockPublish).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not publish to workflow-run channel when no workflowRunId", async () => {
+      await publishWorkflowRunEvent({
+        type: "session:created",
+      } as any);
+
+      expect(mockPublish).toHaveBeenCalledTimes(1);
+      expect(mockPublish).toHaveBeenCalledWith("optio:events", expect.any(String));
     });
   });
 

--- a/apps/api/src/services/event-bus.ts
+++ b/apps/api/src/services/event-bus.ts
@@ -33,6 +33,21 @@ export async function publishSessionEvent(sessionId: string, event: WsEvent): Pr
   await redis.publish(`optio:session:${sessionId}`, JSON.stringify(event));
 }
 
+export async function publishWorkflowRunEvent(event: WsEvent): Promise<void> {
+  const redis = getPublisher();
+  const channel = `optio:events`;
+
+  const traceId = getCurrentTraceId();
+  const enrichedEvent = traceId ? { ...event, traceId } : event;
+
+  await redis.publish(channel, JSON.stringify(enrichedEvent));
+
+  // Also publish to workflow-run-specific channel for targeted subscriptions
+  if ("workflowRunId" in event) {
+    await redis.publish(`optio:workflow-run:${event.workflowRunId}`, JSON.stringify(enrichedEvent));
+  }
+}
+
 /** Return the shared Redis client (usable for pub/sub publishing and general commands). */
 export function getRedisClient(): Redis {
   return getPublisher();

--- a/apps/api/src/services/workflow-service.test.ts
+++ b/apps/api/src/services/workflow-service.test.ts
@@ -38,6 +38,12 @@ vi.mock("../db/schema.js", () => ({
     logType: "task_logs.log_type",
     timestamp: "task_logs.timestamp",
   },
+  workflowRunLogs: {
+    id: "workflow_run_logs.id",
+    workflowRunId: "workflow_run_logs.workflow_run_id",
+    logType: "workflow_run_logs.log_type",
+    timestamp: "workflow_run_logs.timestamp",
+  },
 }));
 
 vi.mock("../logger.js", () => ({
@@ -46,6 +52,13 @@ vi.mock("../logger.js", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+}));
+
+const { mockPublishWorkflowRunEvent } = vi.hoisted(() => ({
+  mockPublishWorkflowRunEvent: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("./event-bus.js", () => ({
+  publishWorkflowRunEvent: mockPublishWorkflowRunEvent,
 }));
 
 import { db } from "../db/client.js";
@@ -69,6 +82,9 @@ import {
   deleteWorkflowTrigger,
   getDueScheduleTriggers,
   markTriggerFired,
+  insertWorkflowRunLog,
+  transitionWorkflowRunState,
+  appendWorkflowRunLog,
 } from "./workflow-service.js";
 
 describe("workflow-service", () => {
@@ -697,7 +713,6 @@ describe("workflow-service", () => {
 
   describe("createWorkflowRun", () => {
     it("creates a run for an enabled workflow", async () => {
-      // First call: getWorkflow
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([{ id: "wf-1", enabled: true }]),
@@ -852,40 +867,188 @@ describe("workflow-service", () => {
 
   describe("getWorkflowRunLogs", () => {
     it("returns logs for a workflow run", async () => {
-      const mockLogs = [
-        { id: "l-1", taskId: "t-1", content: "Building..." },
-        { id: "l-2", taskId: "t-2", content: "Testing..." },
+      const logs = [
+        { id: "l-1", content: "Hello", stream: "stdout" },
+        { id: "l-2", content: "Error!", stream: "stderr" },
       ];
+      const mockLimit = vi.fn().mockResolvedValue(logs);
+      const mock$dynamic = vi.fn().mockReturnValue({ limit: mockLimit });
+      const mockOrderBy = vi.fn().mockReturnValue({ $dynamic: mock$dynamic });
+      const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+      (db.select as any) = vi.fn().mockReturnValue({ from: mockFrom });
 
-      let selectCallCount = 0;
-      (db.select as any) = vi.fn().mockImplementation(() => ({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockImplementation(() => {
-            selectCallCount++;
-            if (selectCallCount === 1) {
-              // getWorkflowRun
-              return Promise.resolve([{ id: "wr-1", state: "running" }]);
-            }
-            // getWorkflowRunLogs query
-            return {
-              orderBy: vi.fn().mockResolvedValue(mockLogs),
-            };
-          }),
-        }),
-      }));
-
-      const result = await getWorkflowRunLogs("wr-1", {});
-      expect(result).toEqual(mockLogs);
+      const result = await getWorkflowRunLogs("wr-1", { limit: 50 });
+      expect(result).toEqual(logs);
+      expect(mockLimit).toHaveBeenCalledWith(50);
     });
 
-    it("throws when run is not found", async () => {
+    it("returns all logs when no limit specified", async () => {
+      const logs = [{ id: "l-1", content: "Hello" }];
+      const mock$dynamic = vi.fn().mockResolvedValue(logs);
+      const mockOrderBy = vi.fn().mockReturnValue({ $dynamic: mock$dynamic });
+      const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+      (db.select as any) = vi.fn().mockReturnValue({ from: mockFrom });
+
+      const result = await getWorkflowRunLogs("wr-1");
+      expect(result).toEqual(logs);
+    });
+  });
+
+  describe("insertWorkflowRunLog", () => {
+    it("inserts a log entry and returns it", async () => {
+      const log = {
+        id: "l-1",
+        workflowRunId: "wr-1",
+        stream: "stdout",
+        content: "Hello world",
+        logType: "text",
+        metadata: null,
+        timestamp: new Date(),
+      };
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([log]),
+        }),
+      });
+
+      const result = await insertWorkflowRunLog({
+        workflowRunId: "wr-1",
+        content: "Hello world",
+        logType: "text",
+      });
+      expect(result).toEqual(log);
+    });
+
+    it("defaults stream to stdout", async () => {
+      let capturedValues: any;
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          capturedValues = vals;
+          return { returning: vi.fn().mockResolvedValue([{ id: "l-1", ...vals }]) };
+        }),
+      });
+
+      await insertWorkflowRunLog({
+        workflowRunId: "wr-1",
+        content: "test",
+      });
+      expect(capturedValues.stream).toBe("stdout");
+    });
+  });
+
+  describe("transitionWorkflowRunState", () => {
+    it("transitions state and publishes event", async () => {
+      const run = { id: "wr-1", workflowId: "w-1", state: "queued" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([run]),
+        }),
+      });
+      const mockSet = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      (db.update as any) = vi.fn().mockReturnValue({ set: mockSet });
+
+      await transitionWorkflowRunState("wr-1", "running" as any);
+
+      expect(db.update).toHaveBeenCalled();
+      expect(mockPublishWorkflowRunEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "workflow_run:state_changed",
+          workflowRunId: "wr-1",
+          workflowId: "w-1",
+          fromState: "queued",
+          toState: "running",
+        }),
+      );
+    });
+
+    it("throws when workflow run not found", async () => {
       (db.select as any) = vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([]),
         }),
       });
 
-      await expect(getWorkflowRunLogs("nonexistent", {})).rejects.toThrow("Workflow run not found");
+      await expect(transitionWorkflowRunState("nonexistent", "running" as any)).rejects.toThrow(
+        "Workflow run nonexistent not found",
+      );
+    });
+
+    it("throws on invalid state transition", async () => {
+      const run = { id: "wr-1", workflowId: "w-1", state: "completed" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([run]),
+        }),
+      });
+
+      await expect(transitionWorkflowRunState("wr-1", "running" as any)).rejects.toThrow(
+        "Invalid workflow run transition",
+      );
+    });
+
+    it("includes extras in the published event", async () => {
+      const run = { id: "wr-1", workflowId: "w-1", state: "running" };
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([run]),
+        }),
+      });
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await transitionWorkflowRunState("wr-1", "completed" as any, {
+        costUsd: "1.50",
+        modelUsed: "claude-sonnet",
+      });
+
+      expect(mockPublishWorkflowRunEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          costUsd: "1.50",
+          modelUsed: "claude-sonnet",
+        }),
+      );
+    });
+  });
+
+  describe("appendWorkflowRunLog", () => {
+    it("inserts log and publishes event", async () => {
+      const log = {
+        id: "l-1",
+        workflowRunId: "wr-1",
+        stream: "stdout",
+        content: "Running tests...",
+        logType: "text",
+        metadata: null,
+        timestamp: new Date("2026-01-01"),
+      };
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([log]),
+        }),
+      });
+
+      const result = await appendWorkflowRunLog({
+        workflowRunId: "wr-1",
+        content: "Running tests...",
+        logType: "text",
+      });
+
+      expect(result).toEqual(log);
+      expect(mockPublishWorkflowRunEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "workflow_run:log",
+          workflowRunId: "wr-1",
+          stream: "stdout",
+          content: "Running tests...",
+        }),
+      );
     });
   });
 });

--- a/apps/api/src/services/workflow-service.ts
+++ b/apps/api/src/services/workflow-service.ts
@@ -1,7 +1,13 @@
 import { eq, desc, sql, and, lte } from "drizzle-orm";
 import { CronExpressionParser } from "cron-parser";
 import { db } from "../db/client.js";
-import { workflows, workflowRuns, workflowTriggers, workflowRunLogs, taskLogs } from "../db/schema.js";
+import {
+  workflows,
+  workflowRuns,
+  workflowTriggers,
+  workflowRunLogs,
+  taskLogs,
+} from "../db/schema.js";
 import { WorkflowRunState, canTransitionWorkflowRun, transitionWorkflowRun } from "@optio/shared";
 import { publishWorkflowRunEvent } from "./event-bus.js";
 import { logger } from "../logger.js";
@@ -325,7 +331,10 @@ export async function cancelWorkflowRun(id: string) {
 
 // ── Workflow Run Logs ────────────────────────────────────────────────────────
 
-export async function getWorkflowRunLogs(workflowRunId: string, opts?: { logType?: string; limit?: number }) {
+export async function getWorkflowRunLogs(
+  workflowRunId: string,
+  opts?: { logType?: string; limit?: number },
+) {
   const conditions = [eq(workflowRunLogs.workflowRunId, workflowRunId)];
   if (opts?.logType) {
     conditions.push(eq(workflowRunLogs.logType, opts.logType));

--- a/apps/api/src/services/workflow-service.ts
+++ b/apps/api/src/services/workflow-service.ts
@@ -1,8 +1,9 @@
 import { eq, desc, sql, and, lte } from "drizzle-orm";
 import { CronExpressionParser } from "cron-parser";
 import { db } from "../db/client.js";
-import { workflows, workflowRuns, workflowTriggers, taskLogs } from "../db/schema.js";
+import { workflows, workflowRuns, workflowTriggers, workflowRunLogs, taskLogs } from "../db/schema.js";
 import { WorkflowRunState, canTransitionWorkflowRun, transitionWorkflowRun } from "@optio/shared";
+import { publishWorkflowRunEvent } from "./event-bus.js";
 import { logger } from "../logger.js";
 
 // ── Workflow CRUD ────────────────────────────────────────────────────────────
@@ -322,29 +323,46 @@ export async function cancelWorkflowRun(id: string) {
   return updated;
 }
 
-/**
- * Get aggregated logs for a workflow run by querying taskLogs with workflowRunId.
- */
-export async function getWorkflowRunLogs(id: string, opts: { logType?: string; limit?: number }) {
-  const run = await getWorkflowRun(id);
-  if (!run) throw new Error("Workflow run not found");
+// ── Workflow Run Logs ────────────────────────────────────────────────────────
 
-  const conditions = [eq(taskLogs.workflowRunId, id)];
-  if (opts.logType) {
-    conditions.push(eq(taskLogs.logType, opts.logType));
+export async function getWorkflowRunLogs(workflowRunId: string, opts?: { logType?: string; limit?: number }) {
+  const conditions = [eq(workflowRunLogs.workflowRunId, workflowRunId)];
+  if (opts?.logType) {
+    conditions.push(eq(workflowRunLogs.logType, opts.logType));
   }
 
   let query = db
     .select()
-    .from(taskLogs)
+    .from(workflowRunLogs)
     .where(and(...conditions))
-    .orderBy(taskLogs.timestamp);
+    .orderBy(workflowRunLogs.timestamp)
+    .$dynamic();
 
-  if (opts.limit) {
-    query = query.limit(opts.limit) as typeof query;
+  if (opts?.limit) {
+    query = query.limit(opts.limit);
   }
 
   return query;
+}
+
+export async function insertWorkflowRunLog(input: {
+  workflowRunId: string;
+  stream?: string;
+  content: string;
+  logType?: string;
+  metadata?: Record<string, unknown>;
+}) {
+  const [log] = await db
+    .insert(workflowRunLogs)
+    .values({
+      workflowRunId: input.workflowRunId,
+      stream: input.stream ?? "stdout",
+      content: input.content,
+      logType: input.logType,
+      metadata: input.metadata,
+    })
+    .returning();
+  return log;
 }
 
 // ── Workflow Triggers ─────────────────────────────────────────────────────────
@@ -483,4 +501,67 @@ export async function markTriggerFired(id: string, cronExpression: string) {
     .update(workflowTriggers)
     .set({ lastFiredAt: now, nextFireAt, updatedAt: now })
     .where(eq(workflowTriggers.id, id));
+}
+
+// ── State transitions + event publishing ─────────────────────────────────────
+
+export async function transitionWorkflowRunState(
+  workflowRunId: string,
+  toState: WorkflowRunState,
+  extras?: {
+    costUsd?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    modelUsed?: string;
+    errorMessage?: string;
+  },
+) {
+  const run = await getWorkflowRun(workflowRunId);
+  if (!run) throw new Error(`Workflow run ${workflowRunId} not found`);
+
+  const fromState = run.state as WorkflowRunState;
+  transitionWorkflowRun(fromState, toState);
+
+  const updates: Record<string, unknown> = { state: toState, updatedAt: new Date() };
+  if (toState === "running") updates.startedAt = new Date();
+  if (toState === "completed" || toState === "failed") updates.finishedAt = new Date();
+  if (extras?.costUsd !== undefined) updates.costUsd = extras.costUsd;
+  if (extras?.inputTokens !== undefined) updates.inputTokens = extras.inputTokens;
+  if (extras?.outputTokens !== undefined) updates.outputTokens = extras.outputTokens;
+  if (extras?.modelUsed !== undefined) updates.modelUsed = extras.modelUsed;
+  if (extras?.errorMessage !== undefined) updates.errorMessage = extras.errorMessage;
+
+  await db.update(workflowRuns).set(updates).where(eq(workflowRuns.id, workflowRunId));
+
+  await publishWorkflowRunEvent({
+    type: "workflow_run:state_changed",
+    workflowRunId,
+    workflowId: run.workflowId,
+    fromState,
+    toState,
+    timestamp: new Date().toISOString(),
+    ...(extras ?? {}),
+  });
+}
+
+export async function appendWorkflowRunLog(input: {
+  workflowRunId: string;
+  stream?: string;
+  content: string;
+  logType?: string;
+  metadata?: Record<string, unknown>;
+}) {
+  const log = await insertWorkflowRunLog(input);
+
+  await publishWorkflowRunEvent({
+    type: "workflow_run:log",
+    workflowRunId: input.workflowRunId,
+    stream: (log.stream as "stdout" | "stderr") ?? "stdout",
+    content: log.content,
+    timestamp: log.timestamp?.toISOString() ?? new Date().toISOString(),
+    logType: log.logType ?? undefined,
+    metadata: log.metadata ?? undefined,
+  });
+
+  return log;
 }

--- a/apps/api/src/workers/workflow-worker.ts
+++ b/apps/api/src/workers/workflow-worker.ts
@@ -140,6 +140,7 @@ function buildInitialStreamMessage(prompt: string): string {
 
 async function transitionRun(
   runId: string,
+  workflowId: string,
   currentState: WorkflowRunState,
   newState: WorkflowRunState,
   fields?: Record<string, unknown>,
@@ -164,6 +165,7 @@ async function transitionRun(
   await publishEvent({
     type: "workflow_run:state_changed",
     workflowRunId: runId,
+    workflowId,
     fromState: currentState,
     toState: newState,
     timestamp: new Date().toISOString(),
@@ -212,9 +214,15 @@ export function startWorkflowWorker() {
         }
         if (!workflow.enabled) {
           log.info("Workflow is disabled, failing run");
-          await transitionRun(workflowRunId, WorkflowRunState.QUEUED, WorkflowRunState.FAILED, {
-            errorMessage: "Workflow is disabled",
-          });
+          await transitionRun(
+            workflowRunId,
+            run.workflowId,
+            WorkflowRunState.QUEUED,
+            WorkflowRunState.FAILED,
+            {
+              errorMessage: "Workflow is disabled",
+            },
+          );
           return;
         }
 
@@ -247,6 +255,7 @@ export function startWorkflowWorker() {
           // Claim: transition to running
           const transitioned = await transitionRun(
             workflowRunId,
+            workflow.id,
             WorkflowRunState.QUEUED,
             WorkflowRunState.RUNNING,
             { startedAt: new Date() },
@@ -437,7 +446,11 @@ export function startWorkflowWorker() {
               await publishEvent({
                 type: "workflow_run:log",
                 workflowRunId,
-                entry,
+                stream: "stdout",
+                content: entry.content,
+                timestamp: entry.timestamp,
+                logType: entry.type,
+                metadata: entry.metadata,
               });
             }
           }
@@ -450,7 +463,11 @@ export function startWorkflowWorker() {
             await publishEvent({
               type: "workflow_run:log",
               workflowRunId,
-              entry,
+              stream: "stdout",
+              content: entry.content,
+              timestamp: entry.timestamp,
+              logType: entry.type,
+              metadata: entry.metadata,
             });
           }
         }
@@ -469,18 +486,30 @@ export function startWorkflowWorker() {
         if (result.model) costFields.modelUsed = result.model;
 
         if (result.success) {
-          await transitionRun(workflowRunId, WorkflowRunState.RUNNING, WorkflowRunState.COMPLETED, {
-            ...costFields,
-            output: { summary: result.summary },
-            finishedAt: new Date(),
-          });
+          await transitionRun(
+            workflowRunId,
+            workflow.id,
+            WorkflowRunState.RUNNING,
+            WorkflowRunState.COMPLETED,
+            {
+              ...costFields,
+              output: { summary: result.summary },
+              finishedAt: new Date(),
+            },
+          );
           log.info("Workflow run completed");
         } else {
-          await transitionRun(workflowRunId, WorkflowRunState.RUNNING, WorkflowRunState.FAILED, {
-            ...costFields,
-            errorMessage: result.error ?? "Agent execution failed",
-            finishedAt: new Date(),
-          });
+          await transitionRun(
+            workflowRunId,
+            workflow.id,
+            WorkflowRunState.RUNNING,
+            WorkflowRunState.FAILED,
+            {
+              ...costFields,
+              errorMessage: result.error ?? "Agent execution failed",
+              finishedAt: new Date(),
+            },
+          );
           log.warn({ error: result.error }, "Workflow run failed");
 
           // ── Retry with exponential backoff ────────────────────────
@@ -491,10 +520,16 @@ export function startWorkflowWorker() {
               "Retrying workflow run",
             );
             // Transition back to queued
-            await transitionRun(workflowRunId, WorkflowRunState.FAILED, WorkflowRunState.QUEUED, {
-              retryCount: currentRetry + 1,
-              errorMessage: null,
-            });
+            await transitionRun(
+              workflowRunId,
+              workflow.id,
+              WorkflowRunState.FAILED,
+              WorkflowRunState.QUEUED,
+              {
+                retryCount: currentRetry + 1,
+                errorMessage: null,
+              },
+            );
             // Exponential backoff: 5s, 10s, 20s, 40s, ...
             const backoffDelay = 5000 * Math.pow(2, currentRetry);
             const jitter = Math.floor(Math.random() * 3000);
@@ -523,11 +558,18 @@ export function startWorkflowWorker() {
                   { provisioningRetryCount: provisioningRetryCount + 1 },
                   "Provisioning error, re-queuing",
                 );
-                await transitionRun(workflowRunId, fromState, WorkflowRunState.FAILED, {
-                  errorMessage: String(err),
-                });
                 await transitionRun(
                   workflowRunId,
+                  currentRun.workflowId,
+                  fromState,
+                  WorkflowRunState.FAILED,
+                  {
+                    errorMessage: String(err),
+                  },
+                );
+                await transitionRun(
+                  workflowRunId,
+                  currentRun.workflowId,
                   WorkflowRunState.FAILED,
                   WorkflowRunState.QUEUED,
                 );
@@ -549,10 +591,16 @@ export function startWorkflowWorker() {
 
             // Terminal failure
             if (canTransitionWorkflowRun(fromState, WorkflowRunState.FAILED)) {
-              await transitionRun(workflowRunId, fromState, WorkflowRunState.FAILED, {
-                errorMessage: String(err),
-                finishedAt: new Date(),
-              });
+              await transitionRun(
+                workflowRunId,
+                currentRun.workflowId,
+                fromState,
+                WorkflowRunState.FAILED,
+                {
+                  errorMessage: String(err),
+                  finishedAt: new Date(),
+                },
+              );
             }
           }
         } catch {

--- a/apps/api/src/ws/workflow-run-log-stream.ts
+++ b/apps/api/src/ws/workflow-run-log-stream.ts
@@ -1,0 +1,81 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { createSubscriber } from "../services/event-bus.js";
+import { authenticateWs } from "./ws-auth.js";
+import { getWorkflowRun, getWorkflowRunLogs } from "../services/workflow-service.js";
+import {
+  getClientIp,
+  trackConnection,
+  releaseConnection,
+  WS_CLOSE_CONNECTION_LIMIT,
+} from "./ws-limits.js";
+
+export async function workflowRunLogStreamWs(app: FastifyInstance) {
+  app.get("/ws/workflow-runs/:workflowRunId/logs", { websocket: true }, async (socket, req) => {
+    const clientIp = getClientIp(req);
+
+    if (!trackConnection(clientIp)) {
+      socket.close(WS_CLOSE_CONNECTION_LIMIT, "Too many connections");
+      return;
+    }
+
+    const user = await authenticateWs(socket, req);
+    if (!user) {
+      releaseConnection(clientIp);
+      return;
+    }
+
+    const { workflowRunId } = z.object({ workflowRunId: z.string() }).parse(req.params);
+
+    // Verify the workflow run exists
+    const run = await getWorkflowRun(workflowRunId);
+    if (!run) {
+      socket.close(4404, "Workflow run not found");
+      releaseConnection(clientIp);
+      return;
+    }
+
+    // Send catch-up: recent logs so reconnecting clients don't miss data
+    try {
+      const recentLogs = await getWorkflowRunLogs(workflowRunId, { limit: 50 });
+      for (const log of recentLogs) {
+        socket.send(
+          JSON.stringify({
+            type: "workflow_run:log",
+            workflowRunId,
+            content: log.content,
+            stream: log.stream,
+            timestamp: log.timestamp,
+            logType: log.logType,
+            metadata: log.metadata,
+            catchUp: true,
+          }),
+        );
+      }
+    } catch {
+      // ignore catch-up errors — still subscribe to live events
+    }
+
+    const subscriber = createSubscriber();
+
+    const channel = `optio:workflow-run:${workflowRunId}`;
+    subscriber.subscribe(channel);
+
+    subscriber.on("message", (_ch: string, message: string) => {
+      try {
+        const event = JSON.parse(message);
+        if (event.type === "workflow_run:log" || event.type === "workflow_run:state_changed") {
+          socket.send(message);
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    socket.on("close", () => {
+      releaseConnection(clientIp);
+      subscriber.unsubscribe(channel);
+      subscriber.disconnect();
+    });
+  });
+}

--- a/apps/web/src/hooks/use-websocket.ts
+++ b/apps/web/src/hooks/use-websocket.ts
@@ -90,6 +90,11 @@ export function useGlobalWebSocket() {
       });
     });
 
+    client.on("workflow_run:state_changed", (event) => {
+      // Dispatch a DOM event so workflow pages can react to state changes
+      window.dispatchEvent(new CustomEvent("optio:workflow-run-state-changed", { detail: event }));
+    });
+
     return () => {
       client.disconnect();
     };

--- a/apps/web/src/lib/ws-client.test.ts
+++ b/apps/web/src/lib/ws-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { WsClient, getWsBaseUrl } from "./ws-client";
+import { WsClient, getWsBaseUrl, createWorkflowRunLogClient } from "./ws-client";
 
 class MockWebSocket {
   static OPEN = 1;
@@ -274,5 +274,39 @@ describe("getWsBaseUrl", () => {
     // @ts-expect-error -- simulating SSR by removing window
     delete globalThis.window;
     expect(getWsBaseUrl()).toBe("ws://localhost:4000");
+  });
+});
+
+describe("createWorkflowRunLogClient", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubEnv("NEXT_PUBLIC_WS_URL", "ws://localhost:4000");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("creates a WsClient with the correct URL", () => {
+    const client = createWorkflowRunLogClient("wr-123");
+    client.connect();
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].url).toBe("ws://localhost:4000/ws/workflow-runs/wr-123/logs");
+  });
+
+  it("passes token provider to the client", async () => {
+    vi.useFakeTimers();
+    const tokenProvider = vi.fn().mockResolvedValue("my-token");
+    const client = createWorkflowRunLogClient("wr-456", tokenProvider);
+    client.connect();
+
+    await vi.runAllTimersAsync();
+
+    expect(tokenProvider).toHaveBeenCalled();
+    const ws = MockWebSocket.instances[0];
+    expect(ws.protocols).toEqual(["optio-ws-v1", "optio-auth-my-token"]);
+    vi.useRealTimers();
   });
 });

--- a/apps/web/src/lib/ws-client.ts
+++ b/apps/web/src/lib/ws-client.ts
@@ -128,3 +128,10 @@ export function createTerminalClient(taskId: string, tokenProvider?: TokenProvid
 export function createSessionTerminalClient(sessionId: string): WsClient {
   return new WsClient(`${getWsBaseUrl()}/ws/sessions/${sessionId}/terminal`);
 }
+
+export function createWorkflowRunLogClient(
+  workflowRunId: string,
+  tokenProvider?: TokenProvider,
+): WsClient {
+  return new WsClient(`${getWsBaseUrl()}/ws/workflow-runs/${workflowRunId}/logs`, tokenProvider);
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -1,7 +1,6 @@
 import type { TaskState } from "./task.js";
 import type { InteractiveSessionState } from "./session.js";
 import type { WorkflowRunState } from "./workflow.js";
-import type { AgentLogEntry } from "./agent-events.js";
 
 export type WsEvent =
   | TaskStateChangedEvent
@@ -116,16 +115,28 @@ export interface TaskMessageDeliveredEvent {
   timestamp: string;
 }
 
+// ── Workflow Run Events ─────────────────────────────────────────────────────
+
 export interface WorkflowRunStateChangedEvent {
   type: "workflow_run:state_changed";
   workflowRunId: string;
+  workflowId: string;
   fromState: WorkflowRunState;
   toState: WorkflowRunState;
   timestamp: string;
+  costUsd?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  modelUsed?: string;
+  errorMessage?: string;
 }
 
 export interface WorkflowRunLogEvent {
   type: "workflow_run:log";
   workflowRunId: string;
-  entry: AgentLogEntry;
+  stream: "stdout" | "stderr";
+  content: string;
+  timestamp: string;
+  logType?: string;
+  metadata?: Record<string, unknown>;
 }


### PR DESCRIPTION
Closes #376

## What changed

Added real-time WebSocket log streaming for workflow runs, mirroring the existing task log streaming infrastructure:

**Shared types** (`packages/shared/src/types/events.ts`):
- `WorkflowRunStateChangedEvent` — published on workflow run state transitions
- `WorkflowRunLogEvent` — published when new log output is produced

**Database** (`apps/api/src/db/schema.ts` + migration):
- New `workflow_run_logs` table (mirrors `task_logs` structure) with index on `(workflow_run_id, timestamp)`

**Event bus** (`apps/api/src/services/event-bus.ts`):
- New `publishWorkflowRunEvent()` — publishes to global `optio:events` channel and per-run `optio:workflow-run:{id}` channel

**WebSocket handler** (`apps/api/src/ws/workflow-run-log-stream.ts`):
- New `GET /ws/workflow-runs/:workflowRunId/logs` endpoint
- Sends last 50 logs as catch-up on connect (marked `catchUp: true`)
- Subscribes to the per-run Redis channel and forwards `workflow_run:log` and `workflow_run:state_changed` events
- Full auth, connection limiting, and cleanup (same patterns as task log stream)

**Workflow service** (`apps/api/src/services/workflow-service.ts`):
- `transitionWorkflowRunState()` — validates transition, updates DB, publishes state change event
- `appendWorkflowRunLog()` — inserts log row, publishes log event
- `getWorkflowRunLogs()` / `insertWorkflowRunLog()` — low-level CRUD

**REST API** (`apps/api/src/routes/workflows.ts`):
- New `GET /api/workflow-runs/:id/logs` endpoint for fetching persisted logs

**Web client** (`apps/web/src/lib/ws-client.ts`):
- New `createWorkflowRunLogClient(workflowRunId, tokenProvider?)` factory function

**Global event hook** (`apps/web/src/hooks/use-websocket.ts`):
- Dispatches `optio:workflow-run-state-changed` DOM event for workflow pages to consume

## How to test

1. **Tests**: All existing + new tests pass (`pnpm turbo test` — 1538 API tests, 196 web tests)
2. **Typecheck**: `pnpm turbo typecheck` passes all packages
3. **Format**: `pnpm format:check` passes
4. **WebSocket endpoint**: Connect to `/ws/workflow-runs/{runId}/logs` and verify catch-up logs are sent, followed by live events
5. **Event publishing**: Call `appendWorkflowRunLog()` or `transitionWorkflowRunState()` and verify events appear on both `optio:events` and `optio:workflow-run:{id}` Redis channels