### PR TITLE
feat(workflows): workflow run detail page

### DIFF
--- a/apps/web/src/app/workflows/[id]/page.tsx
+++ b/apps/web/src/app/workflows/[id]/page.tsx
@@ -396,7 +396,7 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ id: s
       </div>
 
       {/* Tab content */}
-      {activeTab === "runs" && <RunsTable runs={runs} />}
+      {activeTab === "runs" && <RunsTable runs={runs} workflowId={id} />}
       {activeTab === "triggers" && <TriggersList triggers={triggers} />}
       {activeTab === "config" && (
         <ConfigPanel workflow={workflow} showPrompt={showPrompt} setShowPrompt={setShowPrompt} />
@@ -407,7 +407,8 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ id: s
 
 // ── Runs table ─────────────────────────────────────────────────────────────────
 
-function RunsTable({ runs }: { runs: WorkflowRun[] }) {
+function RunsTable({ runs, workflowId }: { runs: WorkflowRun[]; workflowId: string }) {
+  const router = useRouter();
   if (runs.length === 0) {
     return (
       <div className="text-center py-8 text-text-muted border border-dashed border-border rounded-lg">
@@ -435,10 +436,13 @@ function RunsTable({ runs }: { runs: WorkflowRun[] }) {
           {runs.map((run) => (
             <tr
               key={run.id}
-              className="border-b border-border/30 last:border-0 hover:bg-bg-hover/40"
+              className="border-b border-border/30 last:border-0 hover:bg-bg-hover/40 cursor-pointer"
+              onClick={() => router.push(`/workflows/${workflowId}/runs/${run.id}`)}
             >
               <td className="px-4 py-2.5">
-                <RunStateBadge state={run.state} />
+                <Link href={`/workflows/${workflowId}/runs/${run.id}`}>
+                  <RunStateBadge state={run.state} />
+                </Link>
               </td>
               <td className="px-4 py-2.5 text-text-muted text-xs">
                 {run.startedAt

--- a/apps/web/src/app/workflows/[id]/runs/[runId]/page.tsx
+++ b/apps/web/src/app/workflows/[id]/runs/[runId]/page.tsx
@@ -1,0 +1,519 @@
+"use client";
+
+import Link from "next/link";
+import { use, useState, useEffect, useCallback } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
+import { useWorkflowRunLogs } from "@/hooks/use-workflow-run-logs";
+import { LogViewer } from "@/components/log-viewer";
+import { api } from "@/lib/api-client";
+import { classifyError } from "@optio/shared";
+import { cn, formatRelativeTime, formatDuration } from "@/lib/utils";
+import { toast } from "sonner";
+import {
+  Loader2,
+  ArrowLeft,
+  RefreshCw,
+  XCircle,
+  RotateCcw,
+  StopCircle,
+  Clock,
+  DollarSign,
+  Hash,
+  Bot,
+  Server,
+  ChevronDown,
+  ChevronRight,
+  AlertTriangle,
+  CheckCircle2,
+  Timer,
+  Braces,
+  FileText,
+  Activity,
+} from "lucide-react";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface WorkflowRun {
+  id: string;
+  workflowId: string;
+  triggerId: string | null;
+  params: Record<string, unknown> | null;
+  state: string;
+  output: Record<string, unknown> | null;
+  costUsd: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  modelUsed: string | null;
+  errorMessage: string | null;
+  sessionId: string | null;
+  podName: string | null;
+  retryCount: number;
+  startedAt: string | null;
+  finishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface WorkflowSummary {
+  id: string;
+  name: string;
+}
+
+// ── Run state badge ────────────────────────────────────────────────────────────
+
+const RUN_STATE_CONFIG: Record<
+  string,
+  { label: string; color: string; dotColor: string; glowClass: string; pulse?: boolean }
+> = {
+  queued: {
+    label: "Queued",
+    color: "text-info",
+    dotColor: "bg-info",
+    glowClass: "badge-glow-info",
+  },
+  running: {
+    label: "Running",
+    color: "text-primary",
+    dotColor: "bg-primary",
+    glowClass: "badge-glow-primary",
+    pulse: true,
+  },
+  completed: {
+    label: "Completed",
+    color: "text-success",
+    dotColor: "bg-success",
+    glowClass: "badge-glow-success",
+  },
+  failed: {
+    label: "Failed",
+    color: "text-error",
+    dotColor: "bg-error",
+    glowClass: "badge-glow-error",
+  },
+};
+
+function RunStateBadge({ state }: { state: string }) {
+  const config = RUN_STATE_CONFIG[state] ?? {
+    label: state,
+    color: "text-text-muted",
+    dotColor: "bg-text-muted",
+    glowClass: "badge-glow-muted",
+  };
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium tracking-wide uppercase transition-all duration-200",
+        config.color,
+        config.glowClass,
+      )}
+    >
+      <span
+        className={cn("w-1.5 h-1.5 rounded-full", config.dotColor, config.pulse && "glow-dot")}
+      />
+      {config.label}
+    </span>
+  );
+}
+
+// ── Main page ──────────────────────────────────────────────────────────────────
+
+export default function WorkflowRunDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string; runId: string }>;
+}) {
+  const { id: workflowId, runId } = use(params);
+
+  const [run, setRun] = useState<WorkflowRun | null>(null);
+  const [workflow, setWorkflow] = useState<WorkflowSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState<"logs" | "output" | "params">("logs");
+  const [showParams, setShowParams] = useState(true);
+
+  usePageTitle(run ? `Run ${run.id.slice(0, 8)}` : "Workflow Run");
+
+  const isActive = run?.state === "running" || run?.state === "queued";
+
+  const refresh = useCallback(async () => {
+    try {
+      const [runRes, wfRes] = await Promise.all([
+        api.getWorkflowRun(runId),
+        api.getWorkflow(workflowId),
+      ]);
+      setRun(runRes.run as WorkflowRun);
+      setWorkflow({ id: wfRes.workflow.id, name: wfRes.workflow.name });
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load workflow run");
+    } finally {
+      setLoading(false);
+    }
+  }, [runId, workflowId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Auto-refresh while active
+  useEffect(() => {
+    if (!isActive) return;
+    const interval = setInterval(refresh, 5000);
+    return () => clearInterval(interval);
+  }, [isActive, refresh]);
+
+  // Logs hook
+  const logData = useWorkflowRunLogs(runId, isActive ?? false);
+
+  const handleRetry = async () => {
+    setActionLoading(true);
+    try {
+      const res = await api.retryWorkflowRun(runId);
+      setRun(res.run as WorkflowRun);
+      toast.success("Run retried");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to retry run");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    setActionLoading(true);
+    try {
+      const res = await api.cancelWorkflowRun(runId);
+      setRun(res.run as WorkflowRun);
+      toast.success("Run cancelled");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to cancel run");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  // ── Loading / Error states ─────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20 text-text-muted">
+        <Loader2 className="w-5 h-5 animate-spin mr-2" />
+        Loading workflow run...
+      </div>
+    );
+  }
+
+  if (error || !run) {
+    return (
+      <div className="p-6 max-w-4xl mx-auto">
+        <Link
+          href={`/workflows/${workflowId}`}
+          className="inline-flex items-center gap-1.5 text-sm text-text-muted hover:text-text mb-4"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Workflow
+        </Link>
+        <div className="text-center py-12 text-text-muted border border-dashed border-border rounded-lg">
+          <XCircle className="w-8 h-8 mx-auto mb-2 opacity-50" />
+          <p>{error ?? "Workflow run not found"}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Computed values ─────────────────────────────────────────────────────────
+
+  const classifiedError = run.errorMessage ? classifyError(run.errorMessage) : null;
+  const duration = run.startedAt
+    ? formatDuration(run.startedAt, run.finishedAt ?? undefined)
+    : null;
+  const canRetry = run.state === "failed";
+  const canCancel = run.state === "running" || run.state === "queued";
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-1.5 text-sm text-text-muted mb-4">
+        <Link href="/workflows" className="hover:text-text transition-colors">
+          Workflows
+        </Link>
+        <span>/</span>
+        <Link href={`/workflows/${workflowId}`} className="hover:text-text transition-colors">
+          {workflow?.name ?? "Workflow"}
+        </Link>
+        <span>/</span>
+        <span className="text-text">Run {run.id.slice(0, 8)}</span>
+      </div>
+
+      {/* Header */}
+      <div className="flex flex-col gap-3 mb-6 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <RunStateBadge state={run.state} />
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight">Run {run.id.slice(0, 8)}</h1>
+            <p className="text-sm text-text-muted mt-0.5">
+              Created {formatRelativeTime(run.createdAt)}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => refresh()}
+            disabled={actionLoading}
+            className="p-2 rounded-md hover:bg-bg-hover text-text-muted hover:text-text transition-colors"
+            title="Refresh"
+          >
+            <RefreshCw className="w-4 h-4" />
+          </button>
+          {canRetry && (
+            <button
+              onClick={handleRetry}
+              disabled={actionLoading}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm hover:bg-primary/10 text-text-muted hover:text-primary transition-colors"
+            >
+              <RotateCcw className="w-4 h-4" />
+              Retry
+            </button>
+          )}
+          {canCancel && (
+            <button
+              onClick={handleCancel}
+              disabled={actionLoading}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm text-text-muted hover:text-error hover:bg-error/10 transition-colors"
+            >
+              <StopCircle className="w-4 h-4" />
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Active indicator */}
+      {isActive && (
+        <div className="mb-4 flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/5 border border-primary/20 text-sm text-primary">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          Run is {run.state} — auto-refreshing
+        </div>
+      )}
+
+      {/* Metadata bar */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+        <MetadataCard icon={Timer} label="Duration" value={duration ?? "\u2014"} />
+        <MetadataCard
+          icon={DollarSign}
+          label="Cost"
+          value={run.costUsd ? `$${parseFloat(run.costUsd).toFixed(2)}` : "\u2014"}
+        />
+        <MetadataCard icon={Bot} label="Model" value={run.modelUsed ?? "\u2014"} />
+        <MetadataCard
+          icon={Hash}
+          label="Tokens"
+          value={
+            run.inputTokens != null && run.outputTokens != null
+              ? `${(run.inputTokens / 1000).toFixed(1)}k / ${(run.outputTokens / 1000).toFixed(1)}k`
+              : "\u2014"
+          }
+        />
+      </div>
+
+      {/* Secondary metadata */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+        <MetadataCard icon={Server} label="Pod" value={run.podName ?? "\u2014"} />
+        <MetadataCard
+          icon={Activity}
+          label="Session"
+          value={run.sessionId?.slice(0, 8) ?? "\u2014"}
+        />
+        <MetadataCard icon={RotateCcw} label="Retry Count" value={String(run.retryCount)} />
+        <MetadataCard
+          icon={Clock}
+          label="Started"
+          value={run.startedAt ? formatRelativeTime(run.startedAt) : "\u2014"}
+        />
+      </div>
+
+      {/* Error panel */}
+      {classifiedError && (
+        <div className="mb-6 rounded-lg border border-error/30 bg-error/5 p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 text-error shrink-0 mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <h3 className="text-sm font-medium text-error">{classifiedError.title}</h3>
+              <p className="text-sm text-text-muted mt-1">{classifiedError.description}</p>
+              {classifiedError.remedy && (
+                <div className="mt-2 text-xs text-text-muted bg-bg rounded-md p-2 font-mono whitespace-pre-wrap border border-border/30">
+                  {classifiedError.remedy}
+                </div>
+              )}
+              <div className="flex items-center gap-3 mt-2 text-xs text-text-muted">
+                <span className="capitalize">{classifiedError.category}</span>
+                {classifiedError.retryable && (
+                  <span className="text-primary flex items-center gap-1">
+                    <CheckCircle2 className="w-3 h-3" /> Retryable
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+          {run.errorMessage && (
+            <details className="mt-3">
+              <summary className="text-xs text-text-muted cursor-pointer hover:text-text">
+                Raw error message
+              </summary>
+              <pre className="mt-2 text-xs text-error/80 bg-bg rounded-md p-2 overflow-x-auto whitespace-pre-wrap border border-border/30">
+                {run.errorMessage}
+              </pre>
+            </details>
+          )}
+        </div>
+      )}
+
+      {/* Tabs */}
+      <div className="flex gap-1 mb-4 border-b border-border">
+        {(
+          [
+            { key: "logs", label: "Logs", icon: FileText },
+            { key: "output", label: "Output", icon: Braces },
+            { key: "params", label: "Parameters", icon: Hash },
+          ] as const
+        ).map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            onClick={() => setActiveTab(key)}
+            className={cn(
+              "flex items-center gap-1.5 px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+              activeTab === key
+                ? "border-primary text-text"
+                : "border-transparent text-text-muted hover:text-text",
+            )}
+          >
+            <Icon className="w-3.5 h-3.5" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {activeTab === "logs" && (
+        <div className="rounded-lg border border-border/50 overflow-hidden">
+          <LogViewer
+            externalLogs={{
+              logs: logData.logs,
+              connected: logData.connected,
+              capped: logData.capped,
+              clear: logData.clear,
+            }}
+          />
+        </div>
+      )}
+
+      {activeTab === "output" && <OutputPanel output={run.output} />}
+
+      {activeTab === "params" && (
+        <ParamsPanel params={run.params} showParams={showParams} setShowParams={setShowParams} />
+      )}
+    </div>
+  );
+}
+
+// ── Metadata card ───────────────────────────────────────────────────────────
+
+function MetadataCard({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border/50 bg-bg-card p-3">
+      <div className="flex items-center gap-2 text-xs text-text-muted mb-1">
+        <Icon className="w-3.5 h-3.5" />
+        {label}
+      </div>
+      <div className="text-sm font-semibold truncate" title={value}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+// ── Output panel ────────────────────────────────────────────────────────────
+
+function OutputPanel({ output }: { output: Record<string, unknown> | null }) {
+  if (!output) {
+    return (
+      <div className="text-center py-8 text-text-muted border border-dashed border-border rounded-lg">
+        <Braces className="w-6 h-6 mx-auto mb-2 opacity-50" />
+        <p className="text-sm">No output data</p>
+        <p className="text-xs mt-1">Output will appear here when the run completes.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-bg-card p-4">
+      <h3 className="text-sm font-medium mb-3 flex items-center gap-2">
+        <Braces className="w-4 h-4 text-text-muted" />
+        Run Output
+      </h3>
+      <pre className="text-xs text-text-muted bg-bg rounded-md p-3 overflow-x-auto whitespace-pre-wrap border border-border/30 max-h-[500px] overflow-y-auto">
+        {JSON.stringify(output, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+// ── Params panel ────────────────────────────────────────────────────────────
+
+function ParamsPanel({
+  params,
+  showParams,
+  setShowParams,
+}: {
+  params: Record<string, unknown> | null;
+  showParams: boolean;
+  setShowParams: (v: boolean) => void;
+}) {
+  if (!params || Object.keys(params).length === 0) {
+    return (
+      <div className="text-center py-8 text-text-muted border border-dashed border-border rounded-lg">
+        <Hash className="w-6 h-6 mx-auto mb-2 opacity-50" />
+        <p className="text-sm">No parameters</p>
+        <p className="text-xs mt-1">This run was started without any parameters.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-bg-card p-4">
+      <button
+        onClick={() => setShowParams(!showParams)}
+        className="text-sm font-medium flex items-center gap-2 w-full text-left"
+      >
+        {showParams ? (
+          <ChevronDown className="w-4 h-4 text-text-muted" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-text-muted" />
+        )}
+        <span className="flex-1">Run Parameters</span>
+        <span className="text-xs text-text-muted">{Object.keys(params).length} params</span>
+      </button>
+      {showParams && (
+        <div className="mt-3 space-y-2">
+          {Object.entries(params).map(([key, value]) => (
+            <div key={key} className="flex items-start gap-3 text-sm">
+              <span className="text-text-muted font-mono text-xs shrink-0 pt-0.5">{key}</span>
+              <span className="text-text font-mono text-xs break-all">
+                {typeof value === "string" ? value : JSON.stringify(value)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/log-viewer.tsx
+++ b/apps/web/src/components/log-viewer.tsx
@@ -99,8 +99,19 @@ function HighlightedText({ text, search }: { text: string; search: string }) {
   );
 }
 
-export function LogViewer({ taskId }: { taskId: string }) {
-  const { logs, connected, capped, clear } = useLogs(taskId);
+interface LogViewerProps {
+  taskId?: string;
+  externalLogs?: {
+    logs: LogEntry[];
+    connected: boolean;
+    capped: boolean;
+    clear: () => void;
+  };
+}
+
+export function LogViewer({ taskId, externalLogs }: LogViewerProps) {
+  const internal = useLogs(taskId ?? "");
+  const { logs, connected, capped, clear } = externalLogs ?? internal;
   const containerRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
   const [showThinking, setShowThinking] = useState(false);
@@ -218,6 +229,7 @@ export function LogViewer({ taskId }: { taskId: string }) {
 
   const handleExport = useCallback(
     (format: string) => {
+      if (!taskId) return;
       const url = api.exportTaskLogs(taskId, { format });
       window.open(url, "_blank");
       setShowExportMenu(false);
@@ -408,41 +420,43 @@ export function LogViewer({ taskId }: { taskId: string }) {
           >
             <Search className="w-3.5 h-3.5" />
           </button>
-          {/* Export dropdown */}
-          <div className="relative">
-            <button
-              onClick={() => setShowExportMenu(!showExportMenu)}
-              className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted/50 hover:text-text-muted transition-colors"
-              title="Export logs"
-            >
-              <Download className="w-3.5 h-3.5" />
-            </button>
-            {showExportMenu && (
-              <>
-                <div className="fixed inset-0 z-10" onClick={() => setShowExportMenu(false)} />
-                <div className="absolute right-0 top-full mt-1 z-20 glass-tooltip rounded-lg py-1 min-w-[140px]">
-                  <button
-                    onClick={() => handleExport("json")}
-                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-bg-hover transition-colors"
-                  >
-                    Export as JSON
-                  </button>
-                  <button
-                    onClick={() => handleExport("plaintext")}
-                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-bg-hover transition-colors"
-                  >
-                    Export as Text
-                  </button>
-                  <button
-                    onClick={() => handleExport("markdown")}
-                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-bg-hover transition-colors"
-                  >
-                    Export as Markdown
-                  </button>
-                </div>
-              </>
-            )}
-          </div>
+          {/* Export dropdown (only available when taskId is set) */}
+          {taskId && (
+            <div className="relative">
+              <button
+                onClick={() => setShowExportMenu(!showExportMenu)}
+                className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted/50 hover:text-text-muted transition-colors"
+                title="Export logs"
+              >
+                <Download className="w-3.5 h-3.5" />
+              </button>
+              {showExportMenu && (
+                <>
+                  <div className="fixed inset-0 z-10" onClick={() => setShowExportMenu(false)} />
+                  <div className="absolute right-0 top-full mt-1 z-20 glass-tooltip rounded-lg py-1 min-w-[140px]">
+                    <button
+                      onClick={() => handleExport("json")}
+                      className="w-full px-3 py-1.5 text-left text-xs hover:bg-bg-hover transition-colors"
+                    >
+                      Export as JSON
+                    </button>
+                    <button
+                      onClick={() => handleExport("plaintext")}
+                      className="w-full px-3 py-1.5 text-left text-xs hover:bg-bg-hover transition-colors"
+                    >
+                      Export as Text
+                    </button>
+                    <button
+                      onClick={() => handleExport("markdown")}
+                      className="w-full px-3 py-1.5 text-left text-xs hover:bg-bg-hover transition-colors"
+                    >
+                      Export as Markdown
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
           <button
             onClick={clear}
             className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted/50 hover:text-text-muted transition-colors"

--- a/apps/web/src/hooks/use-logs.ts
+++ b/apps/web/src/hooks/use-logs.ts
@@ -24,6 +24,8 @@ export function useLogs(taskId: string) {
 
   // Load historical logs, then connect WebSocket for live streaming
   useEffect(() => {
+    if (!taskId) return;
+
     // Buffer live events until historical logs are merged into state.
     // `merged` flips to true only AFTER setLogs is called with historical data,
     // closing the race where live events bypass dedup.

--- a/apps/web/src/hooks/use-workflow-run-logs.test.ts
+++ b/apps/web/src/hooks/use-workflow-run-logs.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+const mockGetWorkflowRunLogs = vi.fn();
+vi.mock("@/lib/api-client", () => ({
+  api: {
+    getWorkflowRunLogs: (...args: any[]) => mockGetWorkflowRunLogs(...args),
+  },
+}));
+
+import { useWorkflowRunLogs } from "./use-workflow-run-logs";
+
+describe("useWorkflowRunLogs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetWorkflowRunLogs.mockResolvedValue({
+      logs: [
+        {
+          content: "Starting agent",
+          stream: "stdout",
+          timestamp: "2025-06-01T00:00:00Z",
+          logType: "system",
+          metadata: null,
+        },
+        {
+          content: "Running tool",
+          stream: "stdout",
+          timestamp: "2025-06-01T00:00:01Z",
+          logType: "tool_use",
+          metadata: { tool: "Bash" },
+        },
+      ],
+    });
+  });
+
+  it("fetches logs on mount", async () => {
+    vi.useRealTimers();
+    const { result } = renderHook(() => useWorkflowRunLogs("run-1", false));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetWorkflowRunLogs).toHaveBeenCalledWith("run-1", { limit: 10000 });
+    expect(result.current.logs).toHaveLength(2);
+    expect(result.current.logs[0].content).toBe("Starting agent");
+  });
+
+  it("starts with loading=true", () => {
+    const { result } = renderHook(() => useWorkflowRunLogs("run-1", false));
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("sets connected=true when isActive", async () => {
+    vi.useRealTimers();
+    const { result } = renderHook(() => useWorkflowRunLogs("run-1", true));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.connected).toBe(true);
+  });
+
+  it("sets connected=false when not active", async () => {
+    vi.useRealTimers();
+    const { result } = renderHook(() => useWorkflowRunLogs("run-1", false));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.connected).toBe(false);
+  });
+
+  it("polls when active", async () => {
+    const { result } = renderHook(() => useWorkflowRunLogs("run-1", true));
+
+    // Initial fetch
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockGetWorkflowRunLogs).toHaveBeenCalledTimes(1);
+
+    // Advance to trigger poll
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(mockGetWorkflowRunLogs).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not poll when inactive", async () => {
+    vi.useRealTimers();
+    const { result } = renderHook(() => useWorkflowRunLogs("run-1", false));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const callCount = mockGetWorkflowRunLogs.mock.calls.length;
+
+    // Wait well beyond the poll interval — no new calls should happen
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(mockGetWorkflowRunLogs).toHaveBeenCalledTimes(callCount);
+  });
+
+  it("clears logs when clear is called", async () => {
+    vi.useRealTimers();
+    const { result } = renderHook(() => useWorkflowRunLogs("run-1", false));
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(2);
+    });
+
+    act(() => {
+      result.current.clear();
+    });
+
+    expect(result.current.logs).toHaveLength(0);
+  });
+
+  it("sets capped when logs reach limit", async () => {
+    vi.useRealTimers();
+    const manyLogs = Array.from({ length: 10000 }, (_, i) => ({
+      content: `Log ${i}`,
+      stream: "stdout",
+      timestamp: `2025-06-01T00:00:${String(i).padStart(2, "0")}Z`,
+      logType: "text",
+      metadata: null,
+    }));
+    mockGetWorkflowRunLogs.mockResolvedValue({ logs: manyLogs });
+
+    const { result } = renderHook(() => useWorkflowRunLogs("run-1", false));
+
+    await waitFor(() => {
+      expect(result.current.capped).toBe(true);
+    });
+  });
+
+  it("handles fetch errors gracefully", async () => {
+    vi.useRealTimers();
+    mockGetWorkflowRunLogs.mockRejectedValue(new Error("Network error"));
+
+    const { result } = renderHook(() => useWorkflowRunLogs("run-1", false));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Should not crash, logs should be empty
+    expect(result.current.logs).toHaveLength(0);
+  });
+});

--- a/apps/web/src/hooks/use-workflow-run-logs.ts
+++ b/apps/web/src/hooks/use-workflow-run-logs.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { api } from "@/lib/api-client";
+import type { LogEntry } from "@/hooks/use-logs";
+
+const HISTORICAL_LIMIT = 10000;
+const POLL_INTERVAL = 3000;
+
+/**
+ * Hook to fetch and poll workflow run logs.
+ * Returns the same shape as useLogs so it can be used with LogViewer.
+ */
+export function useWorkflowRunLogs(runId: string, isActive: boolean) {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [capped, setCapped] = useState(false);
+  const lastCountRef = useRef(0);
+
+  const fetchLogs = useCallback(async () => {
+    try {
+      const res = await api.getWorkflowRunLogs(runId, { limit: HISTORICAL_LIMIT });
+      const entries: LogEntry[] = res.logs.map((l: any) => ({
+        content: l.content,
+        stream: l.stream,
+        timestamp: l.timestamp,
+        logType: l.logType ?? undefined,
+        metadata: l.metadata ?? undefined,
+      }));
+      lastCountRef.current = entries.length;
+      if (entries.length >= HISTORICAL_LIMIT) setCapped(true);
+      setLogs(entries);
+    } catch {
+      // Keep existing logs on error
+    } finally {
+      setLoading(false);
+    }
+  }, [runId]);
+
+  // Initial fetch
+  useEffect(() => {
+    setLoading(true);
+    fetchLogs();
+  }, [fetchLogs]);
+
+  // Poll while active
+  useEffect(() => {
+    if (!isActive) return;
+    const interval = setInterval(fetchLogs, POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [isActive, fetchLogs]);
+
+  const clear = useCallback(() => setLogs([]), []);
+
+  return { logs, connected: isActive, capped, clear, loading };
+}

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -214,4 +214,41 @@ describe("api-client", () => {
       expect(result).toEqual({ cancelled: 2, total: 4 });
     });
   });
+
+  describe("workflow run operations", () => {
+    it("retryWorkflowRun sends POST", async () => {
+      mockResponse({ run: { id: "run-1", state: "queued" } });
+      const result = await api.retryWorkflowRun("run-1");
+      expect(result).toEqual({ run: { id: "run-1", state: "queued" } });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/workflow-runs/run-1/retry",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("cancelWorkflowRun sends POST", async () => {
+      mockResponse({ run: { id: "run-1", state: "failed" } });
+      const result = await api.cancelWorkflowRun("run-1");
+      expect(result).toEqual({ run: { id: "run-1", state: "failed" } });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/workflow-runs/run-1/cancel",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("getWorkflowRunLogs fetches logs without params", async () => {
+      mockResponse({ logs: [{ content: "test" }] });
+      const result = await api.getWorkflowRunLogs("run-1");
+      expect(result).toEqual({ logs: [{ content: "test" }] });
+      expect(fetchMock).toHaveBeenCalledWith("/api/workflow-runs/run-1/logs", expect.any(Object));
+    });
+
+    it("getWorkflowRunLogs appends query params", async () => {
+      mockResponse({ logs: [] });
+      await api.getWorkflowRunLogs("run-1", { limit: 100, offset: 50 });
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toContain("limit=100");
+      expect(url).toContain("offset=50");
+    });
+  });
 });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1166,4 +1166,18 @@ export const api = {
     request<{ triggers: any[] }>(`/api/workflows/${workflowId}/triggers`),
 
   getWorkflowRun: (id: string) => request<{ run: any }>(`/api/workflow-runs/${id}`),
+
+  retryWorkflowRun: (id: string) =>
+    request<{ run: any }>(`/api/workflow-runs/${id}/retry`, { method: "POST" }),
+
+  cancelWorkflowRun: (id: string) =>
+    request<{ run: any }>(`/api/workflow-runs/${id}/cancel`, { method: "POST" }),
+
+  getWorkflowRunLogs: (id: string, opts?: { limit?: number; offset?: number }) => {
+    const params = new URLSearchParams();
+    if (opts?.limit != null) params.set("limit", String(opts.limit));
+    if (opts?.offset != null) params.set("offset", String(opts.offset));
+    const qs = params.toString();
+    return request<{ logs: any[] }>(`/api/workflow-runs/${id}/logs${qs ? `?${qs}` : ""}`);
+  },
 };


### PR DESCRIPTION
Closes #383

## What changed

Added the workflow run detail page at `/workflows/:id/runs/:runId` with:

- **Metadata bar**: Duration, cost, model, token usage, pod name, session ID, retry count, start time
- **Params panel**: Collapsible view of run parameters as key-value pairs
- **Live log streaming**: Reuses the existing `LogViewer` component with a new `useWorkflowRunLogs` hook that polls for updates while the run is active
- **Output JSON viewer**: Displays the run's output data in formatted JSON
- **Error panel with classifier**: Uses the shared `classifyError()` to show categorized error info with title, description, remedy, and retryable indicator
- **Retry/Cancel buttons**: Context-aware action buttons (retry for failed runs, cancel for running/queued runs)

Supporting changes:
- Extended `LogViewer` to accept external log data via `externalLogs` prop (preserves existing `taskId` behavior)
- Added `retryWorkflowRun`, `cancelWorkflowRun`, `getWorkflowRunLogs` to the API client
- Made run rows clickable in the workflow detail page (navigates to run detail)
- Added guard in `useLogs` for empty `taskId` to prevent unnecessary WebSocket connections

## How to test

1. Navigate to a workflow detail page at `/workflows/:id`
2. Click on any run row in the Runs table — it should navigate to `/workflows/:id/runs/:runId`
3. Verify the metadata bar shows run details (duration, cost, model, tokens, etc.)
4. Check the Logs tab displays agent logs (polls every 3s while active)
5. Check the Output tab shows JSON output (or empty state if no output)
6. Check the Parameters tab shows run params (or empty state)
7. For failed runs: verify the error panel shows classified error info and Retry button
8. For running/queued runs: verify the Cancel button and auto-refresh indicator
9. Verify breadcrumb navigation works (Workflows > Workflow Name > Run ID)