### PR TITLE
fix(auth): clear stale auth-failure banner when token is updated

### DIFF
--- a/apps/api/src/db/migrations/1775795000_auth_events.sql
+++ b/apps/api/src/db/migrations/1775795000_auth_events.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS "auth_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "token_type" text NOT NULL,
+  "error_message" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "auth_events_token_type_created_idx" ON "auth_events" USING btree ("token_type","created_at");

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1775793000000,
       "tag": "1775793000_workflow_run_logs",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1775795000000,
+      "tag": "1775795000_auth_events",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -208,6 +208,20 @@ export const secrets = pgTable(
   ],
 );
 
+// ── Auth Events ─────────────────────────────────────────────────────────────
+// Lightweight table for recording auth failures from non-task contexts
+// (e.g. ticket-sync, pr-watcher) so the failure detector can surface them.
+export const authEvents = pgTable(
+  "auth_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    tokenType: text("token_type").notNull(), // "claude" | "github"
+    errorMessage: text("error_message").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("auth_events_token_type_created_idx").on(table.tokenType, table.createdAt)],
+);
+
 export const repos = pgTable(
   "repos",
   {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -5,7 +5,10 @@ import {
   getClaudeUsage,
   invalidateCredentialsCache,
 } from "../services/auth-service.js";
-import { hasRecentClaudeAuthFailure } from "../services/auth-failure-detector.js";
+import {
+  hasRecentClaudeAuthFailure,
+  getRecentAuthFailures,
+} from "../services/auth-failure-detector.js";
 import { getOAuthProvider, getEnabledProviders, isAuthDisabled } from "../services/oauth/index.js";
 import {
   createSession,
@@ -129,22 +132,29 @@ export async function authRoutes(app: FastifyInstance) {
   });
 
   app.get("/api/auth/usage", async (_req, reply) => {
-    const [usage, hasRecentAuthFailure] = await Promise.all([
+    const [usage, authFailures] = await Promise.all([
       getClaudeUsage(),
-      hasRecentClaudeAuthFailure().catch(() => false),
+      getRecentAuthFailures().catch(() => ({ claude: false, github: false })),
     ]);
-    reply.send({ usage: { ...usage, hasRecentAuthFailure } });
+    // hasRecentAuthFailure kept for backward compat (true if either token type has failures)
+    const hasRecentAuthFailure = authFailures.claude || authFailures.github;
+    reply.send({ usage: { ...usage, hasRecentAuthFailure, authFailures } });
   });
 
   app.post("/api/auth/refresh", async (_req, reply) => {
     invalidateCredentialsCache();
     const result = getClaudeAuthToken();
+    const authFailures = await getRecentAuthFailures().catch(() => ({
+      claude: false,
+      github: false,
+    }));
     reply.send({
       subscription: {
         available: result.available,
         expiresAt: result.expiresAt,
         error: result.error,
       },
+      authFailures,
     });
   });
 

--- a/apps/api/src/routes/secrets.ts
+++ b/apps/api/src/routes/secrets.ts
@@ -2,6 +2,8 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import * as secretService from "../services/secret-service.js";
 import { requireRole } from "../plugins/auth.js";
+import { invalidateCredentialsCache } from "../services/auth-service.js";
+import { publishEvent } from "../services/event-bus.js";
 
 const scopeQuerySchema = z.object({ scope: z.string().optional() });
 const nameParamsSchema = z.object({ name: z.string() });
@@ -11,6 +13,62 @@ const createSecretSchema = z.object({
   value: z.string().min(1),
   scope: z.string().optional(),
 });
+
+/** Secret names that are auth-related and should trigger validation + cache invalidation. */
+const AUTH_SECRET_NAMES = new Set(["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "GITHUB_TOKEN"]);
+
+/**
+ * Best-effort validation probe for auth tokens.
+ * Returns { valid, error? } — never throws.
+ */
+async function validateAuthToken(
+  name: string,
+  value: string,
+): Promise<{ valid: boolean; error?: string }> {
+  try {
+    if (name === "GITHUB_TOKEN") {
+      const res = await fetch("https://api.github.com/user", {
+        headers: {
+          Authorization: `token ${value}`,
+          Accept: "application/vnd.github+json",
+        },
+      });
+      if (res.ok) return { valid: true };
+      const body = await res.json().catch(() => ({}));
+      return { valid: false, error: body.message ?? `GitHub API returned ${res.status}` };
+    }
+
+    if (name === "CLAUDE_CODE_OAUTH_TOKEN") {
+      const res = await fetch("https://api.anthropic.com/api/oauth/usage", {
+        headers: {
+          Authorization: `Bearer ${value}`,
+          "anthropic-beta": "oauth-2025-04-20",
+        },
+      });
+      if (res.ok) return { valid: true };
+      if (res.status === 401) return { valid: false, error: "OAuth token is invalid or expired" };
+      // Non-auth errors (429, 500) — don't treat as invalid
+      return { valid: true };
+    }
+
+    if (name === "ANTHROPIC_API_KEY") {
+      const res = await fetch("https://api.anthropic.com/v1/models", {
+        headers: {
+          "x-api-key": value,
+          "anthropic-version": "2023-06-01",
+        },
+      });
+      if (res.ok) return { valid: true };
+      if (res.status === 401) return { valid: false, error: "API key is invalid" };
+      return { valid: true };
+    }
+  } catch {
+    // Network error — don't block, treat as valid (best-effort)
+    return { valid: true };
+  }
+
+  return { valid: true };
+}
 
 export async function secretRoutes(app: FastifyInstance) {
   // List secrets (names only) — any workspace member can view
@@ -26,7 +84,30 @@ export async function secretRoutes(app: FastifyInstance) {
     const input = createSecretSchema.parse(req.body);
     const workspaceId = req.user?.workspaceId ?? null;
     await secretService.storeSecret(input.name, input.value, input.scope, workspaceId);
-    reply.status(201).send({ name: input.name, scope: input.scope ?? "global" });
+
+    const isAuthSecret = AUTH_SECRET_NAMES.has(input.name);
+    let validation: { valid: boolean; error?: string } | undefined;
+
+    if (isAuthSecret) {
+      // Invalidate cached credentials so the next read picks up the new value
+      invalidateCredentialsCache();
+
+      // Run best-effort validation probe
+      validation = await validateAuthToken(input.name, input.value);
+
+      // Publish WebSocket event so the UI immediately re-fetches auth status.
+      // The watermark in the failure detector ensures old failures are ignored.
+      await publishEvent({
+        type: "auth:status_changed",
+        timestamp: new Date().toISOString(),
+      }).catch(() => {});
+    }
+
+    reply.status(201).send({
+      name: input.name,
+      scope: input.scope ?? "global",
+      ...(validation ? { validation } : {}),
+    });
   });
 
   // Delete secret — admin only

--- a/apps/api/src/services/auth-failure-detector.test.ts
+++ b/apps/api/src/services/auth-failure-detector.test.ts
@@ -8,7 +8,10 @@ const fromMock = vi.fn(() => ({ where: whereMock }));
 const selectMock = vi.fn(() => ({ from: fromMock }));
 
 vi.mock("../db/client.js", () => ({
-  db: { select: selectMock },
+  db: {
+    select: selectMock,
+    insert: vi.fn(() => ({ values: vi.fn() })),
+  },
 }));
 
 vi.mock("../db/schema.js", () => ({
@@ -16,13 +19,35 @@ vi.mock("../db/schema.js", () => ({
     content: "task_logs.content",
     timestamp: "task_logs.timestamp",
   },
+  secrets: {
+    name: "secrets.name",
+    updatedAt: "secrets.updated_at",
+  },
+  authEvents: {
+    tokenType: "auth_events.token_type",
+    createdAt: "auth_events.created_at",
+  },
 }));
 
 // Import after mocks are in place.
-const { hasRecentClaudeAuthFailure, AUTH_FAILURE_PATTERNS } =
-  await import("./auth-failure-detector.js");
+const {
+  hasRecentClaudeAuthFailure,
+  getRecentAuthFailures,
+  AUTH_FAILURE_PATTERNS,
+  GITHUB_FAILURE_PATTERNS,
+} = await import("./auth-failure-detector.js");
 
-describe("hasRecentClaudeAuthFailure", () => {
+// The execution order for getRecentAuthFailures is:
+// 1. Claude watermark  (Promise.all group 1)
+// 2. GitHub watermark  (Promise.all group 1)
+// 3. Claude task_logs  (Promise.all group 2)
+// 4. GitHub auth_events (Promise.all group 2)
+// 5. GitHub task_logs  (Promise.all group 2)
+//
+// For hasRecentClaudeAuthFailure (backward compat), it calls getRecentAuthFailures
+// which follows the same pattern but we only care about the claude result.
+
+describe("hasRecentClaudeAuthFailure (backward compat)", () => {
   beforeEach(() => {
     selectMock.mockClear();
     fromMock.mockClear();
@@ -31,25 +56,146 @@ describe("hasRecentClaudeAuthFailure", () => {
   });
 
   it("returns false when no recent auth-failure log lines are found", async () => {
+    // 1. Claude watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 2. GitHub watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 3. Claude task_logs
+    limitMock.mockResolvedValueOnce([]);
+    // 4. GitHub auth_events
+    limitMock.mockResolvedValueOnce([]);
+    // 5. GitHub task_logs
     limitMock.mockResolvedValueOnce([]);
     await expect(hasRecentClaudeAuthFailure()).resolves.toBe(false);
-    expect(selectMock).toHaveBeenCalledOnce();
   });
 
   it("returns true when at least one matching log row exists", async () => {
+    // 1. Claude watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 2. GitHub watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 3. Claude task_logs — match!
     limitMock.mockResolvedValueOnce([{ exists: 1 }]);
+    // 4. GitHub auth_events
+    limitMock.mockResolvedValueOnce([]);
+    // 5. GitHub task_logs
+    limitMock.mockResolvedValueOnce([]);
     await expect(hasRecentClaudeAuthFailure()).resolves.toBe(true);
   });
+});
 
-  it("passes a LIMIT 1 to the query (we only need to know existence)", async () => {
-    limitMock.mockResolvedValueOnce([]);
-    await hasRecentClaudeAuthFailure();
-    expect(limitMock).toHaveBeenCalledWith(1);
+describe("getRecentAuthFailures", () => {
+  beforeEach(() => {
+    selectMock.mockClear();
+    fromMock.mockClear();
+    whereMock.mockClear();
+    limitMock.mockClear();
   });
 
-  it("exposes the canonical set of auth-failure substrings", () => {
-    // These are the markers we want claude/Anthropic failures to match on.
-    // If the set changes, update the banner documentation too.
+  it("returns both false when no failures detected", async () => {
+    // 1. Claude watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 2. GitHub watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 3. Claude task_logs
+    limitMock.mockResolvedValueOnce([]);
+    // 4. GitHub auth_events
+    limitMock.mockResolvedValueOnce([]);
+    // 5. GitHub task_logs
+    limitMock.mockResolvedValueOnce([]);
+
+    const result = await getRecentAuthFailures();
+    expect(result).toEqual({ claude: false, github: false });
+  });
+
+  it("returns claude=true when Claude auth failures found in task logs", async () => {
+    // 1. Claude watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 2. GitHub watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 3. Claude task_logs — match!
+    limitMock.mockResolvedValueOnce([{ exists: 1 }]);
+    // 4. GitHub auth_events
+    limitMock.mockResolvedValueOnce([]);
+    // 5. GitHub task_logs
+    limitMock.mockResolvedValueOnce([]);
+
+    const result = await getRecentAuthFailures();
+    expect(result).toEqual({ claude: true, github: false });
+  });
+
+  it("returns github=true when GitHub auth failures found in auth_events", async () => {
+    // 1. Claude watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 2. GitHub watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 3. Claude task_logs
+    limitMock.mockResolvedValueOnce([]);
+    // 4. GitHub auth_events — match!
+    limitMock.mockResolvedValueOnce([{ exists: 1 }]);
+    // 5. GitHub task_logs
+    limitMock.mockResolvedValueOnce([]);
+
+    const result = await getRecentAuthFailures();
+    expect(result).toEqual({ claude: false, github: true });
+  });
+
+  it("returns both true when both token types have failures", async () => {
+    // 1. Claude watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 2. GitHub watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 3. Claude task_logs — match!
+    limitMock.mockResolvedValueOnce([{ exists: 1 }]);
+    // 4. GitHub auth_events — match!
+    limitMock.mockResolvedValueOnce([{ exists: 1 }]);
+    // 5. GitHub task_logs
+    limitMock.mockResolvedValueOnce([]);
+
+    const result = await getRecentAuthFailures();
+    expect(result).toEqual({ claude: true, github: true });
+  });
+
+  it("uses watermark from secrets.updatedAt when token was recently updated", async () => {
+    // 1. Claude watermark: token updated 2 minutes ago
+    const recentUpdate = new Date(Date.now() - 2 * 60 * 1000);
+    limitMock.mockResolvedValueOnce([{ updatedAt: recentUpdate }]);
+    // 2. GitHub watermark
+    limitMock.mockResolvedValueOnce([]);
+    // 3. Claude task_logs: no failures in the narrowed window
+    limitMock.mockResolvedValueOnce([]);
+    // 4. GitHub auth_events
+    limitMock.mockResolvedValueOnce([]);
+    // 5. GitHub task_logs
+    limitMock.mockResolvedValueOnce([]);
+
+    const result = await getRecentAuthFailures();
+    expect(result).toEqual({ claude: false, github: false });
+    // The watermark query was made
+    expect(selectMock).toHaveBeenCalled();
+  });
+
+  it("watermark narrows the window so old failures are ignored", async () => {
+    // 1. Claude watermark: token updated 1 minute ago
+    const recentUpdate = new Date(Date.now() - 60 * 1000);
+    limitMock.mockResolvedValueOnce([{ updatedAt: recentUpdate }]);
+    // 2. GitHub watermark: token updated 30 seconds ago
+    const githubUpdate = new Date(Date.now() - 30 * 1000);
+    limitMock.mockResolvedValueOnce([{ updatedAt: githubUpdate }]);
+    // 3. Claude task_logs: no failures in the 1-minute window
+    limitMock.mockResolvedValueOnce([]);
+    // 4. GitHub auth_events: no failures in the 30-second window
+    limitMock.mockResolvedValueOnce([]);
+    // 5. GitHub task_logs: no failures
+    limitMock.mockResolvedValueOnce([]);
+
+    const result = await getRecentAuthFailures();
+    expect(result).toEqual({ claude: false, github: false });
+  });
+});
+
+describe("failure pattern constants", () => {
+  it("exposes the canonical set of Claude auth-failure substrings", () => {
     expect(AUTH_FAILURE_PATTERNS).toEqual(
       expect.arrayContaining([
         "api error: 401",
@@ -59,6 +205,12 @@ describe("hasRecentClaudeAuthFailure", () => {
         "invalid api key",
         "oauth token has expired",
       ]),
+    );
+  });
+
+  it("exposes GitHub-specific auth-failure substrings", () => {
+    expect(GITHUB_FAILURE_PATTERNS).toEqual(
+      expect.arrayContaining(["Bad credentials", "bad credentials"]),
     );
   });
 });

--- a/apps/api/src/services/auth-failure-detector.ts
+++ b/apps/api/src/services/auth-failure-detector.ts
@@ -1,6 +1,6 @@
-import { and, gt, ilike, or, sql } from "drizzle-orm";
+import { and, gt, ilike, or, sql, inArray, eq } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { taskLogs } from "../db/schema.js";
+import { taskLogs, secrets, authEvents } from "../db/schema.js";
 
 /**
  * Substrings (case-insensitive) that indicate an authentication failure bubbling
@@ -22,8 +22,113 @@ export const AUTH_FAILURE_PATTERNS = [
   "oauth token has expired",
 ] as const;
 
+/** GitHub-specific failure patterns for detecting bad GITHUB_TOKEN. */
+export const GITHUB_FAILURE_PATTERNS = ["Bad credentials", "bad credentials"] as const;
+
 /** Default lookback window for the banner trigger. */
 export const RECENT_AUTH_FAILURE_WINDOW_MS = 15 * 60 * 1000;
+
+/** Secret names considered auth-related for each token type. */
+const CLAUDE_SECRET_NAMES = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"];
+const GITHUB_SECRET_NAMES = ["GITHUB_TOKEN"];
+
+export type AuthFailureStatus = {
+  claude: boolean;
+  github: boolean;
+};
+
+/**
+ * Get the most recent updatedAt from secrets matching the given names.
+ * Returns null if no matching secret exists.
+ */
+async function getSecretWatermark(secretNames: string[]): Promise<Date | null> {
+  const rows = await db
+    .select({ updatedAt: secrets.updatedAt })
+    .from(secrets)
+    .where(inArray(secrets.name, secretNames))
+    .limit(1);
+  // If multiple secrets match, use the most recent updatedAt
+  if (rows.length === 0) return null;
+  return rows[0].updatedAt;
+}
+
+/**
+ * Compute the effective cutoff: max(now - windowMs, lastTokenUpdate).
+ * If the token was recently updated, only consider failures after the update.
+ */
+function effectiveCutoff(windowMs: number, watermark: Date | null): Date {
+  const windowCutoff = new Date(Date.now() - windowMs);
+  if (!watermark) return windowCutoff;
+  return watermark > windowCutoff ? watermark : windowCutoff;
+}
+
+/**
+ * Check if any Claude auth failures exist in task_logs after the cutoff.
+ */
+async function hasClaudeFailuresInLogs(cutoff: Date): Promise<boolean> {
+  const patternClauses = AUTH_FAILURE_PATTERNS.map((p) => ilike(taskLogs.content, `%${p}%`));
+  const rows = await db
+    .select({ exists: sql<number>`1` })
+    .from(taskLogs)
+    .where(and(gt(taskLogs.timestamp, cutoff), or(...patternClauses)))
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * Check if any GitHub auth failures exist in the auth_events table after the cutoff.
+ */
+async function hasGithubFailuresInEvents(cutoff: Date): Promise<boolean> {
+  const rows = await db
+    .select({ exists: sql<number>`1` })
+    .from(authEvents)
+    .where(and(eq(authEvents.tokenType, "github"), gt(authEvents.createdAt, cutoff)))
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * Check if any GitHub auth failures exist in task_logs after the cutoff.
+ */
+async function hasGithubFailuresInLogs(cutoff: Date): Promise<boolean> {
+  const patternClauses = GITHUB_FAILURE_PATTERNS.map((p) => ilike(taskLogs.content, `%${p}%`));
+  const rows = await db
+    .select({ exists: sql<number>`1` })
+    .from(taskLogs)
+    .where(and(gt(taskLogs.timestamp, cutoff), or(...patternClauses)))
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * Returns per-token-type auth failure status. Uses watermarks from
+ * secrets.updatedAt to narrow the window: if a token was updated 2 minutes ago,
+ * only failures from those 2 minutes count.
+ */
+export async function getRecentAuthFailures(
+  windowMs: number = RECENT_AUTH_FAILURE_WINDOW_MS,
+): Promise<AuthFailureStatus> {
+  // Get watermarks in parallel
+  const [claudeWatermark, githubWatermark] = await Promise.all([
+    getSecretWatermark(CLAUDE_SECRET_NAMES),
+    getSecretWatermark(GITHUB_SECRET_NAMES),
+  ]);
+
+  const claudeCutoff = effectiveCutoff(windowMs, claudeWatermark);
+  const githubCutoff = effectiveCutoff(windowMs, githubWatermark);
+
+  // Check failures in parallel
+  const [claudeFailure, githubEventFailure, githubLogFailure] = await Promise.all([
+    hasClaudeFailuresInLogs(claudeCutoff),
+    hasGithubFailuresInEvents(githubCutoff),
+    hasGithubFailuresInLogs(githubCutoff),
+  ]);
+
+  return {
+    claude: claudeFailure,
+    github: githubEventFailure || githubLogFailure,
+  };
+}
 
 /**
  * Returns true if any task log line in the recent window contains an
@@ -31,18 +136,24 @@ export const RECENT_AUTH_FAILURE_WINDOW_MS = 15 * 60 * 1000;
  * whether to show the "OAuth token expired" banner — the usage endpoint alone
  * is unreliable because it can return 429 (rate limited) even when the
  * messages endpoint is returning 401.
+ *
+ * @deprecated Use getRecentAuthFailures() for per-token-type detection with watermarks.
  */
 export async function hasRecentClaudeAuthFailure(
   windowMs: number = RECENT_AUTH_FAILURE_WINDOW_MS,
 ): Promise<boolean> {
-  const cutoff = new Date(Date.now() - windowMs);
-  const patternClauses = AUTH_FAILURE_PATTERNS.map((p) => ilike(taskLogs.content, `%${p}%`));
+  const result = await getRecentAuthFailures(windowMs);
+  return result.claude;
+}
 
-  const rows = await db
-    .select({ exists: sql<number>`1` })
-    .from(taskLogs)
-    .where(and(gt(taskLogs.timestamp, cutoff), or(...patternClauses)))
-    .limit(1);
-
-  return rows.length > 0;
+/**
+ * Record a GitHub auth failure event so it can be surfaced in the dashboard banner.
+ * Call this from ticket-sync-worker, pr-watcher, or any non-task context that
+ * encounters a GitHub 401.
+ */
+export async function recordAuthEvent(
+  tokenType: "claude" | "github",
+  errorMessage: string,
+): Promise<void> {
+  await db.insert(authEvents).values({ tokenType, errorMessage });
 }

--- a/apps/web/src/components/dashboard/types.ts
+++ b/apps/web/src/components/dashboard/types.ts
@@ -20,6 +20,11 @@ export interface UsageData {
    * the usage response alone isn't a reliable signal.
    */
   hasRecentAuthFailure?: boolean;
+  /** Per-token-type auth failure status. */
+  authFailures?: {
+    claude: boolean;
+    github: boolean;
+  };
   fiveHour?: { utilization: number | null; resetsAt: string | null };
   sevenDay?: { utilization: number | null; resetsAt: string | null };
   sevenDaySonnet?: { utilization: number | null; resetsAt: string | null };

--- a/apps/web/src/components/dashboard/usage-panel.test.tsx
+++ b/apps/web/src/components/dashboard/usage-panel.test.tsx
@@ -69,3 +69,37 @@ describe("UsagePanel → TokenRefreshBanner trigger", () => {
     expect(screen.queryByText(/OAuth token expired/i)).not.toBeInTheDocument();
   });
 });
+
+describe("UsagePanel → per-token-type banners", () => {
+  afterEach(() => cleanup());
+
+  it("shows only the Claude banner when authFailures.claude is true", () => {
+    render(<UsagePanel usage={makeUsage({ authFailures: { claude: true, github: false } })} />);
+    expect(screen.getByText(/OAuth token expired/i)).toBeInTheDocument();
+    expect(screen.queryByText(/GitHub token invalid/i)).not.toBeInTheDocument();
+  });
+
+  it("shows only the GitHub banner when authFailures.github is true", () => {
+    render(<UsagePanel usage={makeUsage({ authFailures: { claude: false, github: true } })} />);
+    expect(screen.queryByText(/OAuth token expired/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/GitHub token invalid/i)).toBeInTheDocument();
+  });
+
+  it("shows both banners simultaneously when both tokens are bad", () => {
+    render(<UsagePanel usage={makeUsage({ authFailures: { claude: true, github: true } })} />);
+    expect(screen.getByText(/OAuth token expired/i)).toBeInTheDocument();
+    expect(screen.getByText(/GitHub token invalid/i)).toBeInTheDocument();
+  });
+
+  it("shows no banners when both tokens are valid", () => {
+    render(<UsagePanel usage={makeUsage({ authFailures: { claude: false, github: false } })} />);
+    expect(screen.queryByText(/OAuth token expired/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/GitHub token invalid/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Claude Max Usage/i)).toBeInTheDocument();
+  });
+
+  it("GitHub banner includes descriptive text about ticket sync and PR watching", () => {
+    render(<UsagePanel usage={makeUsage({ authFailures: { claude: false, github: true } })} />);
+    expect(screen.getByText(/ticket sync and PR watching are failing/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/usage-panel.tsx
+++ b/apps/web/src/components/dashboard/usage-panel.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import { Gauge, Clock, Moon } from "lucide-react";
 import { getOffPeakInfo } from "@optio/shared";
-import { TokenRefreshBanner } from "@/components/token-refresh-banner";
+import { TokenRefreshBanner, GitHubTokenBanner } from "@/components/token-refresh-banner";
 import type { UsageData } from "./types.js";
 
 function UsageMeter({
@@ -59,16 +59,21 @@ function UsageMeter({
 export function UsagePanel({ usage }: { usage: UsageData | null }) {
   if (!usage) return null;
 
-  // Show the refresh banner when:
-  //   (a) usage itself signals an auth error (401/expired), OR
-  //   (b) the API detected a recent task auth failure in task logs.
-  // Case (b) catches the split-endpoint scenario where /organizations/usage
-  // returns 429 but /v1/messages returns 401 — the usage panel alone can't
-  // tell that tasks are actively failing.
-  const usageAuthError =
-    !usage.available && (usage.error?.includes("401") || usage.error?.includes("expired"));
-  if (usageAuthError || usage.hasRecentAuthFailure) {
-    return <TokenRefreshBanner />;
+  // Determine which auth banners to show using per-token-type failure status.
+  // Falls back to the legacy hasRecentAuthFailure for backward compat.
+  const claudeFailure =
+    usage.authFailures?.claude ??
+    (usage.hasRecentAuthFailure ||
+      (!usage.available && (usage.error?.includes("401") || usage.error?.includes("expired"))));
+  const githubFailure = usage.authFailures?.github ?? false;
+
+  if (claudeFailure || githubFailure) {
+    return (
+      <div className="space-y-3">
+        {claudeFailure && <TokenRefreshBanner />}
+        {githubFailure && <GitHubTokenBanner />}
+      </div>
+    );
   }
 
   // Usage endpoint hit a non-auth issue (e.g. 429, network) and there's no

--- a/apps/web/src/components/token-refresh-banner.tsx
+++ b/apps/web/src/components/token-refresh-banner.tsx
@@ -15,8 +15,15 @@ export function TokenRefreshBanner() {
     if (!token.trim()) return;
     setSaving(true);
     try {
-      await api.createSecret({ name: "CLAUDE_CODE_OAUTH_TOKEN", value: token.trim() });
-      toast.success("Token updated — tasks will use it on next run");
+      const result = await api.createSecret({
+        name: "CLAUDE_CODE_OAUTH_TOKEN",
+        value: token.trim(),
+      });
+      if (result.validation && !result.validation.valid) {
+        toast.error(`Token saved but validation failed: ${result.validation.error}`);
+      } else {
+        toast.success("Token updated — tasks will use it on next run");
+      }
       setToken("");
     } catch {
       toast.error("Failed to save token");
@@ -59,6 +66,65 @@ export function TokenRefreshBanner() {
           value={token}
           onChange={(e) => setToken(e.target.value)}
           placeholder="Paste token here"
+          className="flex-1 px-3 py-1.5 rounded-md bg-bg border border-border text-sm focus:outline-none focus:border-primary font-mono"
+        />
+        <button
+          onClick={handleSave}
+          disabled={!token.trim() || saving}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-white text-xs font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+        >
+          {saving ? (
+            "Saving..."
+          ) : token.trim() ? (
+            <>
+              <Check className="w-3 h-3" />
+              Save Token
+            </>
+          ) : (
+            "Save Token"
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function GitHubTokenBanner() {
+  const [token, setToken] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    if (!token.trim()) return;
+    setSaving(true);
+    try {
+      const result = await api.createSecret({ name: "GITHUB_TOKEN", value: token.trim() });
+      const validation = (result as any).validation;
+      if (validation && !validation.valid) {
+        toast.error(`Token saved but validation failed: ${validation.error}`);
+      } else {
+        toast.success("GitHub token updated");
+      }
+      setToken("");
+    } catch {
+      toast.error("Failed to save token");
+    }
+    setSaving(false);
+  };
+
+  return (
+    <div className="rounded-xl border border-error/30 bg-error/5 p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="w-4 h-4 text-error shrink-0" />
+        <span className="text-sm font-medium text-text-heading">GitHub token invalid</span>
+        <span className="text-xs text-text-muted">— ticket sync and PR watching are failing</span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="password"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="Paste GitHub token here"
           className="flex-1 px-3 py-1.5 rounded-md bg-bg border border-border text-sm focus:outline-none focus:border-primary font-mono"
         />
         <button

--- a/apps/web/src/hooks/use-dashboard-data.ts
+++ b/apps/web/src/hooks/use-dashboard-data.ts
@@ -98,10 +98,18 @@ export function useDashboardData() {
     };
     window.addEventListener("optio:auth-failed", onAuthFailed);
 
+    // Listen for auth:status_changed (token updated via secrets page) to immediately
+    // re-fetch usage so the banner disappears as soon as the watermark moves forward
+    const onAuthStatusChanged = () => {
+      refreshUsage();
+    };
+    window.addEventListener("optio:auth-status-changed", onAuthStatusChanged);
+
     return () => {
       clearInterval(interval);
       clearInterval(usageInterval);
       window.removeEventListener("optio:auth-failed", onAuthFailed);
+      window.removeEventListener("optio:auth-status-changed", onAuthStatusChanged);
     };
   }, [refresh, refreshUsage]);
 

--- a/apps/web/src/hooks/use-websocket.ts
+++ b/apps/web/src/hooks/use-websocket.ts
@@ -57,6 +57,12 @@ export function useGlobalWebSocket() {
       window.dispatchEvent(new Event("optio:auth-failed"));
     });
 
+    // When an auth token is updated (via secrets page), immediately re-fetch
+    // auth status so the banner disappears without waiting for the poll interval.
+    client.on("auth:status_changed", () => {
+      window.dispatchEvent(new Event("optio:auth-status-changed"));
+    });
+
     client.on("task:pending_reason", (event) => {
       useStore
         .getState()

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -195,10 +195,13 @@ export const api = {
   },
 
   createSecret: (data: { name: string; value: string; scope?: string }) =>
-    request<{ name: string; scope: string }>("/api/secrets", {
-      method: "POST",
-      body: JSON.stringify(data),
-    }),
+    request<{ name: string; scope: string; validation?: { valid: boolean; error?: string } }>(
+      "/api/secrets",
+      {
+        method: "POST",
+        body: JSON.stringify(data),
+      },
+    ),
 
   deleteSecret: (name: string, scope?: string) => {
     const qs = scope ? `?scope=${scope}` : "";
@@ -429,6 +432,7 @@ export const api = {
       usage: {
         available: boolean;
         hasRecentAuthFailure?: boolean;
+        authFailures?: { claude: boolean; github: boolean };
         fiveHour?: { utilization: number | null; resetsAt: string | null };
         sevenDay?: { utilization: number | null; resetsAt: string | null };
         sevenDaySonnet?: { utilization: number | null; resetsAt: string | null };

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -10,6 +10,7 @@ export type WsEvent =
   | TaskStalledEvent
   | TaskRecoveredEvent
   | AuthFailedEvent
+  | AuthStatusChangedEvent
   | SessionCreatedEvent
   | SessionEndedEvent
   | TaskCommentEvent
@@ -57,6 +58,11 @@ export interface TaskPendingReasonEvent {
 export interface AuthFailedEvent {
   type: "auth:failed";
   message: string;
+  timestamp: string;
+}
+
+export interface AuthStatusChangedEvent {
+  type: "auth:status_changed";
   timestamp: string;
 }
 


### PR DESCRIPTION
Closes #399

## What changed

The auth failure banner ("OAuth token expired") persisted for up to 15 minutes after a user updated their token because the failure detector used a fixed lookback window with no awareness of when the token was changed. Additionally, GitHub token failures had no UI banner at all.

### Changes:

**Backend:**
- **Generalized auth failure detector** (`auth-failure-detector.ts`): New `getRecentAuthFailures()` returns per-token-type status (`{claude: boolean, github: boolean}`). Uses `secrets.updatedAt` as a watermark — if a token was updated 2 minutes ago, only failures from those 2 minutes count. Old failures from the expired token are ignored.
- **`auth_events` table**: New lightweight table for recording GitHub auth failures from non-task contexts (PR watcher, ticket sync workers). The detector queries this alongside `task_logs`.
- **Secrets route** (`secrets.ts`): When an auth-related secret is saved, validates the token (best-effort probe against GitHub/Anthropic APIs), invalidates the credential cache, and publishes an `auth:status_changed` WebSocket event.
- **Auth routes** (`auth.ts`): `/api/auth/usage` now returns `authFailures: {claude, github}` alongside the backward-compat `hasRecentAuthFailure` boolean. `/api/auth/refresh` returns fresh failure status.

**Frontend:**
- **GitHub token banner**: New `GitHubTokenBanner` component with "GitHub token invalid — ticket sync and PR watching are failing" message and token input.
- **Usage panel**: Shows Claude and/or GitHub banners based on `authFailures` field. Both can display simultaneously.
- **WebSocket handler**: Listens for `auth:status_changed` events and dispatches a DOM event to trigger immediate usage re-fetch.
- **Dashboard hook**: On `auth:status_changed`, re-fetches `/api/auth/usage` so the banner disappears immediately after token update.

**Shared:**
- Added `AuthStatusChangedEvent` to the WsEvent union type.

### Key behavior:
1. User updates token → secret saved → watermark moves → old failures ignored → banner clears immediately
2. If new token also fails → fresh failures logged after watermark → banner reappears
3. Token validation runs on save — result returned to UI (invalid tokens still saved, but UI shows warning)

## How to test

1. **Claude banner clears immediately**: Set an invalid `CLAUDE_CODE_OAUTH_TOKEN`, observe banner appears. Update with a valid token — banner should clear within seconds (no 15-minute wait).
2. **GitHub banner**: Set an invalid `GITHUB_TOKEN`. The GitHub token banner should appear. Update with a valid token — banner clears.
3. **Both banners**: Set both tokens to invalid values. Both banners should display simultaneously.
4. **Token validation**: Save an invalid token — the API response includes `validation: { valid: false, error: "..." }` and a toast warning appears.
5. **Tests**: `pnpm turbo test` — all 2304 tests pass across all packages.
6. **Typecheck**: `pnpm turbo typecheck` — clean across all 8 packages.