### PR TITLE
feat: planning mode + message bar improvements for agent interaction

### DIFF
--- a/apps/api/src/db/migrations/1775809203_planning_mode_enabled.sql
+++ b/apps/api/src/db/migrations/1775809203_planning_mode_enabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "repos" ADD COLUMN "planning_mode_enabled" boolean DEFAULT false NOT NULL;

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1775795000000,
       "tag": "1775795000_auth_events",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1775809203000,
+      "tag": "1775809203_planning_mode_enabled",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -254,6 +254,7 @@ export const repos = pgTable(
     maxTurnsCoding: integer("max_turns_coding"), // null = use global default (250)
     maxTurnsReview: integer("max_turns_review"), // null = use global default (10)
     autoResume: boolean("auto_resume").notNull().default(false),
+    planningModeEnabled: boolean("planning_mode_enabled").notNull().default(false),
     maxConcurrentTasks: integer("max_concurrent_tasks").notNull().default(2),
     maxPodInstances: integer("max_pod_instances").notNull().default(1),
     maxAgentsPerPod: integer("max_agents_per_pod").notNull().default(2),

--- a/apps/api/src/routes/repos.ts
+++ b/apps/api/src/routes/repos.ts
@@ -43,6 +43,7 @@ const updateRepoSchema = z.object({
   maxTurnsCoding: z.number().int().min(1).max(10000).optional(),
   maxTurnsReview: z.number().int().min(1).max(10000).optional(),
   autoResume: z.boolean().optional(),
+  planningModeEnabled: z.boolean().optional(),
   maxConcurrentTasks: z.number().int().min(1).max(50).optional(),
   maxPodInstances: z.number().int().min(1).max(20).optional(),
   maxAgentsPerPod: z.number().int().min(1).max(50).optional(),

--- a/apps/api/src/services/repo-service.ts
+++ b/apps/api/src/services/repo-service.ts
@@ -34,6 +34,7 @@ export interface RepoRecord {
   maxTurnsCoding: number | null;
   maxTurnsReview: number | null;
   autoResume: boolean;
+  planningModeEnabled: boolean;
   maxConcurrentTasks: number;
   maxPodInstances: number;
   maxAgentsPerPod: number;

--- a/apps/api/src/services/slack-service.test.ts
+++ b/apps/api/src/services/slack-service.test.ts
@@ -46,6 +46,7 @@ function makeRepoConfig(overrides: Partial<RepoRecord> = {}): RepoRecord {
     customDockerfile: null,
     autoMerge: false,
     cautiousMode: false,
+    planningModeEnabled: false,
     defaultAgentType: "claude-code",
     promptTemplateOverride: null,
     claudeModel: "opus",

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -272,6 +272,10 @@ export function startTaskWorker() {
         const branchName = `${TASK_BRANCH_PREFIX}${task.id}`;
         const taskFilePath = TASK_FILE_PATH;
 
+        // Enable planning mode for fresh runs (not resumed) when repo has it enabled
+        const isPlanningRun =
+          !!repoConfig?.planningModeEnabled && !resumeSessionId && !reviewOverride;
+
         const renderedPrompt = renderPromptTemplate(promptConfig.template, {
           TASK_FILE: taskFilePath,
           BRANCH_NAME: branchName,
@@ -282,6 +286,7 @@ export function startTaskWorker() {
           DRAFT_PR: String(promptConfig.cautiousMode),
           ISSUE_NUMBER: task.ticketExternalId ?? "",
           GIT_PLATFORM_GITLAB: isGitLab ? "true" : "",
+          PLANNING_MODE: isPlanningRun ? "true" : "",
         });
 
         const taskFileContent = renderTaskFile({
@@ -872,14 +877,26 @@ export function startTaskWorker() {
               log.warn({ err }, "Failed to parse pr_review output — draft may need manual editing");
             }
           }
-          await repoPool.updateWorktreeState(taskId, "removed");
-          await taskService.transitionTask(
-            taskId,
-            TaskState.COMPLETED,
-            "agent_success",
-            result.summary,
-          );
-          log.info("Task completed");
+          // Planning mode: agent finished planning — wait for human approval
+          if (isPlanningRun && !isReviewTask) {
+            await repoPool.updateWorktreeState(taskId, "preserved");
+            await taskService.transitionTask(
+              taskId,
+              TaskState.NEEDS_ATTENTION,
+              "plan_review",
+              "Agent has created an implementation plan and is waiting for approval",
+            );
+            log.info("Planning phase complete — awaiting human review");
+          } else {
+            await repoPool.updateWorktreeState(taskId, "removed");
+            await taskService.transitionTask(
+              taskId,
+              TaskState.COMPLETED,
+              "agent_success",
+              result.summary,
+            );
+            log.info("Task completed");
+          }
         } else {
           await repoPool.updateWorktreeState(taskId, "dirty");
           await taskService.transitionTask(taskId, TaskState.FAILED, "agent_failure", result.error);

--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -61,6 +61,7 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
   const [maxTurnsCoding, setMaxTurnsCoding] = useState(250);
   const [maxTurnsReview, setMaxTurnsReview] = useState(30);
   const [autoResume, setAutoResume] = useState(false);
+  const [planningModeEnabled, setPlanningModeEnabled] = useState(false);
   const [maxConcurrentTasks, setMaxConcurrentTasks] = useState(2);
   const [maxPodInstances, setMaxPodInstances] = useState(1);
   const [maxAgentsPerPod, setMaxAgentsPerPod] = useState(2);
@@ -113,6 +114,7 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
         setCautiousMode(r.cautiousMode ?? false);
         setDefaultAgentType(r.defaultAgentType ?? "claude-code");
         setAutoResume(r.autoResume ?? false);
+        setPlanningModeEnabled(r.planningModeEnabled ?? false);
         setMaxConcurrentTasks(r.maxConcurrentTasks ?? 2);
         setMaxPodInstances(r.maxPodInstances ?? 1);
         setMaxAgentsPerPod(r.maxAgentsPerPod ?? 2);
@@ -187,6 +189,7 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
         cautiousMode,
         defaultAgentType,
         autoResume,
+        planningModeEnabled,
         maxConcurrentTasks,
         maxPodInstances,
         maxAgentsPerPod,
@@ -625,6 +628,24 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
               <p className="text-xs text-text-muted">
                 Opens draft PRs and disables auto-merge. A human must mark PRs ready and merge them
                 manually.
+              </p>
+            </div>
+          </label>
+        </div>
+
+        {/* Planning Mode */}
+        <div className="flex items-center gap-3 p-3 rounded-lg border border-border/50 bg-bg mb-4">
+          <label className="flex items-center gap-2 cursor-pointer flex-1">
+            <input
+              type="checkbox"
+              checked={planningModeEnabled}
+              onChange={(e) => setPlanningModeEnabled(e.target.checked)}
+              className="w-4 h-4 rounded"
+            />
+            <div>
+              <span className="text-sm font-medium">Planning Mode</span>
+              <p className="text-xs text-text-muted">
+                Agent creates an implementation plan and waits for approval before coding
               </p>
             </div>
           </label>

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { use, useState, useEffect } from "react";
+import { use, useState, useEffect, useRef, useCallback } from "react";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { useTask } from "@/hooks/use-task";
 import { LogViewer } from "@/components/log-viewer";
@@ -35,7 +35,8 @@ import {
   X,
   Link2,
   MessageSquare,
-  Zap,
+  Square,
+  CheckCircle,
 } from "lucide-react";
 import { toast } from "sonner";
 import { useOptioChatStore } from "@/hooks/use-optio-chat";
@@ -127,15 +128,42 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
 
   const [messageInput, setMessageInput] = useState("");
   const [messageSending, setMessageSending] = useState(false);
+  const [userMessages, setUserMessages] = useState<
+    { text: string; timestamp: string; status: "sending" | "sent" | "failed" }[]
+  >([]);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const autoResizeTextarea = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+  }, []);
 
   const handleSendMessage = async (mode: "soft" | "interrupt" = "soft") => {
     if (!messageInput.trim()) return;
+    const text = messageInput;
     setMessageSending(true);
+    setUserMessages((prev) => [
+      ...prev,
+      { text, timestamp: new Date().toISOString(), status: "sending" },
+    ]);
     try {
-      await api.sendTaskMessage(id, messageInput, mode);
+      await api.sendTaskMessage(id, text, mode);
       setMessageInput("");
+      if (textareaRef.current) {
+        textareaRef.current.style.height = "auto";
+      }
+      setUserMessages((prev) =>
+        prev.map((m) => (m.text === text && m.status === "sending" ? { ...m, status: "sent" } : m)),
+      );
       toast.success(mode === "interrupt" ? "Interrupt sent" : "Message sent");
     } catch (err) {
+      setUserMessages((prev) =>
+        prev.map((m) =>
+          m.text === text && m.status === "sending" ? { ...m, status: "failed" } : m,
+        ),
+      );
       toast.error(err instanceof Error ? err.message : "Failed to send message");
     }
     setMessageSending(false);
@@ -149,6 +177,20 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
       setResumePrompt("");
       await refresh();
     } catch {}
+    setActionLoading(false);
+  };
+
+  const handleApprovePlan = async () => {
+    setActionLoading(true);
+    try {
+      await api.resumeTask(
+        id,
+        "Plan approved. Proceed with implementation following your plan above.",
+      );
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to approve plan");
+    }
     setActionLoading(false);
   };
 
@@ -212,6 +254,12 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   const canResume = ["needs_attention", "failed"].includes(task.state) && !!task.sessionId;
   const canMessage = task.state === "running" && task.agentType === "claude-code";
   const canForceRestart = ["needs_attention", "failed", "pr_opened"].includes(task.state);
+
+  // Detect plan review state: needs_attention with plan_review trigger
+  const isPlanReview =
+    task.state === "needs_attention" &&
+    events.length > 0 &&
+    events[events.length - 1]?.trigger === "plan_review";
 
   // (log filtering is handled by LogViewer component)
 
@@ -919,7 +967,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
           {/* Log content via LogViewer */}
           <div className="flex-1 overflow-hidden">
             <ErrorBoundary label="Log viewer">
-              <LogViewer taskId={id} />
+              <LogViewer taskId={id} userMessages={userMessages} />
             </ErrorBoundary>
           </div>
 
@@ -927,34 +975,87 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
           <div className="shrink-0 border-t border-border bg-bg-card px-4 py-2.5">
             {canMessage ? (
               /* Mid-task messaging bar (running claude-code tasks) */
-              <div className="flex gap-2 items-center">
-                <input
+              <div className="flex gap-2 items-end">
+                <textarea
+                  ref={textareaRef}
                   value={messageInput}
-                  onChange={(e) => setMessageInput(e.target.value)}
-                  onKeyDown={(e) => e.key === "Enter" && handleSendMessage("soft")}
+                  onChange={(e) => {
+                    setMessageInput(e.target.value);
+                    autoResizeTextarea();
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      handleSendMessage("soft");
+                    }
+                  }}
                   placeholder="Send a message to the running agent..."
-                  className="flex-1 px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+                  rows={1}
+                  className="flex-1 px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-none"
                 />
                 <button
                   onClick={() => handleSendMessage("soft")}
                   disabled={!messageInput.trim() || messageSending}
                   title="Send message (agent picks it up at next turn)"
-                  className="px-3 py-2 rounded-md text-sm font-medium transition-colors bg-primary text-white hover:bg-primary-hover disabled:opacity-30 disabled:cursor-not-allowed"
+                  className="px-3 py-2 rounded-md text-sm font-medium transition-colors bg-primary text-white hover:bg-primary-hover disabled:opacity-30 disabled:cursor-not-allowed flex items-center gap-1.5"
                 >
                   {messageSending ? (
                     <Loader2 className="w-4 h-4 animate-spin" />
                   ) : (
                     <Send className="w-4 h-4" />
                   )}
+                  <span className="hidden sm:inline">Send</span>
                 </button>
                 <button
                   onClick={() => handleSendMessage("interrupt")}
                   disabled={!messageInput.trim() || messageSending}
-                  title="Interrupt — urgent message with high priority"
-                  className="px-3 py-2 rounded-md text-sm font-medium transition-colors bg-warning text-white hover:bg-warning/90 disabled:opacity-30 disabled:cursor-not-allowed"
+                  title="Stop — interrupt with urgent message"
+                  className="px-3 py-2 rounded-md text-sm font-medium transition-colors bg-warning text-white hover:bg-warning/90 disabled:opacity-30 disabled:cursor-not-allowed flex items-center gap-1.5"
                 >
-                  <Zap className="w-4 h-4" />
+                  <Square className="w-4 h-4" />
+                  <span className="hidden sm:inline">Stop</span>
                 </button>
+              </div>
+            ) : isPlanReview && canResume ? (
+              /* Plan review bar */
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/5 border border-primary/20 text-sm">
+                  <Eye className="w-4 h-4 text-primary shrink-0" />
+                  <span className="text-primary font-medium">
+                    Plan ready for review — check the agent output above
+                  </span>
+                </div>
+                <div className="flex gap-2 items-center">
+                  <input
+                    value={resumePrompt}
+                    onChange={(e) => setResumePrompt(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleResume()}
+                    placeholder="Send feedback or modifications to the plan..."
+                    className="flex-1 px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+                  />
+                  <button
+                    onClick={handleResume}
+                    disabled={!resumePrompt.trim() || actionLoading}
+                    title="Send feedback to the agent"
+                    className="px-3 py-2 rounded-md text-sm font-medium transition-colors bg-bg-hover text-text hover:bg-bg-hover/80 disabled:opacity-30 disabled:cursor-not-allowed flex items-center gap-1.5"
+                  >
+                    <Send className="w-4 h-4" />
+                    <span className="hidden sm:inline">Send Feedback</span>
+                  </button>
+                  <button
+                    onClick={handleApprovePlan}
+                    disabled={actionLoading}
+                    title="Approve the plan and start implementation"
+                    className="px-3 py-2 rounded-md text-sm font-medium transition-colors bg-success text-white hover:bg-success/90 disabled:opacity-30 disabled:cursor-not-allowed flex items-center gap-1.5"
+                  >
+                    {actionLoading ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <CheckCircle className="w-4 h-4" />
+                    )}
+                    <span className="hidden sm:inline">Approve & Execute</span>
+                  </button>
+                </div>
               </div>
             ) : (
               /* Resume bar (for non-running or resumable tasks) */

--- a/apps/web/src/components/log-viewer.tsx
+++ b/apps/web/src/components/log-viewer.tsx
@@ -21,6 +21,9 @@ import {
   X,
   Download,
   Filter,
+  User,
+  Check,
+  Loader2,
 } from "lucide-react";
 
 const TOOL_ICONS: Record<string, any> = {
@@ -99,6 +102,12 @@ function HighlightedText({ text, search }: { text: string; search: string }) {
   );
 }
 
+export interface UserMessage {
+  text: string;
+  timestamp: string;
+  status: "sending" | "sent" | "failed";
+}
+
 interface LogViewerProps {
   taskId?: string;
   externalLogs?: {
@@ -107,9 +116,10 @@ interface LogViewerProps {
     capped: boolean;
     clear: () => void;
   };
+  userMessages?: UserMessage[];
 }
 
-export function LogViewer({ taskId, externalLogs }: LogViewerProps) {
+export function LogViewer({ taskId, externalLogs, userMessages }: LogViewerProps) {
   const internal = useLogs(taskId ?? "");
   const { logs, connected, capped, clear } = externalLogs ?? internal;
   const containerRef = useRef<HTMLDivElement>(null);
@@ -533,6 +543,33 @@ export function LogViewer({ taskId, externalLogs }: LogViewerProps) {
             );
           })
         )}
+        {/* Inline user message markers */}
+        {userMessages &&
+          userMessages.map((msg, i) => (
+            <div
+              key={`user-msg-${i}`}
+              className="flex gap-2.5 my-1 -mx-2 px-2 rounded bg-primary/5 border border-primary/10"
+            >
+              <span
+                className="text-[10px] leading-6 text-text-muted/25 tabular-nums shrink-0 select-none w-[54px] text-right"
+                title={new Date(msg.timestamp).toLocaleString()}
+              >
+                {formatTime(msg.timestamp)}
+              </span>
+              <div className="flex items-center gap-2 py-1 flex-1 min-w-0">
+                <User className="w-3 h-3 text-primary shrink-0" />
+                <span className="text-xs font-medium text-primary font-sans">You:</span>
+                <span className="text-xs text-text/80 truncate">{msg.text}</span>
+                <span className="ml-auto shrink-0">
+                  {msg.status === "sending" && (
+                    <Loader2 className="w-3 h-3 text-text-muted/40 animate-spin" />
+                  )}
+                  {msg.status === "sent" && <Check className="w-3 h-3 text-success/60" />}
+                  {msg.status === "failed" && <AlertCircle className="w-3 h-3 text-error/60" />}
+                </span>
+              </div>
+            </div>
+          ))}
       </div>
 
       {/* Scroll to bottom */}

--- a/packages/shared/src/prompt-template.test.ts
+++ b/packages/shared/src/prompt-template.test.ts
@@ -151,6 +151,52 @@ describe("DEFAULT_PROMPT_TEMPLATE", () => {
   });
 });
 
+describe("PLANNING_MODE in DEFAULT_PROMPT_TEMPLATE", () => {
+  it("includes planning mode instructions when PLANNING_MODE is truthy", () => {
+    const result = renderPromptTemplate(DEFAULT_PROMPT_TEMPLATE, {
+      TASK_FILE: ".optio/task.md",
+      BRANCH_NAME: "optio/task-abc",
+      TASK_ID: "abc-123",
+      TASK_TITLE: "Fix login bug",
+      REPO_NAME: "org/repo",
+      AUTO_MERGE: "false",
+      ISSUE_NUMBER: "",
+      PLANNING_MODE: "true",
+    });
+    expect(result).toContain("PLANNING MODE");
+    expect(result).toContain("DO NOT create/modify source files");
+    expect(result).toContain("implementation plan");
+  });
+
+  it("does not include planning mode instructions when PLANNING_MODE is empty", () => {
+    const result = renderPromptTemplate(DEFAULT_PROMPT_TEMPLATE, {
+      TASK_FILE: ".optio/task.md",
+      BRANCH_NAME: "optio/task-abc",
+      TASK_ID: "abc-123",
+      TASK_TITLE: "Fix login bug",
+      REPO_NAME: "org/repo",
+      AUTO_MERGE: "false",
+      ISSUE_NUMBER: "",
+      PLANNING_MODE: "",
+    });
+    expect(result).not.toContain("PLANNING MODE");
+    expect(result).not.toContain("DO NOT create/modify source files");
+  });
+
+  it("does not include planning mode instructions when PLANNING_MODE is not set", () => {
+    const result = renderPromptTemplate(DEFAULT_PROMPT_TEMPLATE, {
+      TASK_FILE: ".optio/task.md",
+      BRANCH_NAME: "optio/task-abc",
+      TASK_ID: "abc-123",
+      TASK_TITLE: "Fix login bug",
+      REPO_NAME: "org/repo",
+      AUTO_MERGE: "false",
+      ISSUE_NUMBER: "",
+    });
+    expect(result).not.toContain("PLANNING MODE");
+  });
+});
+
 describe("TASK_FILE_PATH", () => {
   it("is a relative path", () => {
     expect(TASK_FILE_PATH).not.toMatch(/^\//);

--- a/packages/shared/src/prompt-template.ts
+++ b/packages/shared/src/prompt-template.ts
@@ -1,4 +1,17 @@
-export const DEFAULT_PROMPT_TEMPLATE = `You are an autonomous coding agent. Your job is to WRITE CODE and open a pull request.
+export const DEFAULT_PROMPT_TEMPLATE = `{{#if PLANNING_MODE}}## PLANNING MODE
+
+You are in PLANNING MODE. Analyze the task and create a detailed implementation plan — DO NOT implement yet.
+
+1. Read and understand the relevant codebase
+2. Create a step-by-step implementation plan
+3. List files you'll modify or create
+4. Identify risks and edge cases
+5. Estimate complexity
+
+A human will review your plan and approve or request changes before you begin.
+
+DO NOT create/modify source files, open PRs, or make commits. Only plan.
+{{/if}}You are an autonomous coding agent. Your job is to WRITE CODE and open a pull request.
 
 ## Your Task
 


### PR DESCRIPTION
Closes #400

## What changed

### Planning Mode (new per-repo setting)
- **Schema**: Added `planning_mode_enabled` boolean column to `repos` table with migration
- **Prompt template**: Added `{{#if PLANNING_MODE}}` conditional block that instructs the agent to create an implementation plan without coding
- **Task worker**: When planning mode is enabled on a repo and the task is not a resume, injects `PLANNING_MODE: "true"` into template variables. After the agent completes the planning phase, transitions to `needs_attention` with trigger `plan_review` instead of `completed`
- **API route**: Added `planningModeEnabled` to the repo update schema
- **Repo settings UI**: New "Planning Mode" toggle in the PR Lifecycle section

### Message Bar UX Improvements
- **Auto-expanding textarea**: Replaced `<input>` with `<textarea>` that starts at 1 row and grows up to ~6 rows. Shift+Enter inserts newlines, Enter sends
- **Stop icon**: Replaced `Zap` (lightning bolt) with `Square` (stop) icon — universally understood stop metaphor
- **Text labels**: Added "Send" and "Stop" labels next to icons, visible on wider screens (`hidden sm:inline`)
- **Inline message echo**: User messages now appear in the log viewer as distinct entries with delivery status indicators (spinner while sending, checkmark on success, error icon on failure)

### Plan Review UI
- When a task is in `needs_attention` state with `plan_review` trigger, shows a dedicated UI:
  - Banner: "Plan ready for review — check the agent output above"
  - **Approve & Execute** button: resumes agent with approval message
  - **Send Feedback** input + button: lets user provide modifications before the agent proceeds

## How to test

1. **Planning Mode toggle**: Go to a repo's settings page → PR Lifecycle section → verify the "Planning Mode" toggle appears and persists on save
2. **Message bar**: Open a running task → verify textarea expands on multiline input, Shift+Enter adds newlines, Enter sends, Stop icon is a square
3. **Inline message echo**: Send a message to a running task → verify it appears in the log viewer with a delivery status indicator
4. **Plan review flow** (full integration): Enable planning mode on a repo, create a task, verify the agent plans without coding, then verify the plan review UI appears with Approve/Feedback buttons