### PR TITLE
Feat/add nodeselectors

### DIFF
--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -360,6 +360,12 @@ spec:
             tmpfsMounts: [{ mountPath: "/var/lib/docker", sizeLimit: "10Gi" }],
           }
         : {}),
+      ...(process.env.OPTIO_AGENT_NODE_SELECTOR
+        ? { nodeSelector: JSON.parse(process.env.OPTIO_AGENT_NODE_SELECTOR) }
+        : {}),
+      ...(process.env.OPTIO_AGENT_TOLERATIONS
+        ? { tolerations: JSON.parse(process.env.OPTIO_AGENT_TOLERATIONS) }
+        : {}),
     };
 
     // Add Envoy sidecar containers and volumes when secret proxy is enabled

--- a/helm/optio/templates/api-deployment.yaml
+++ b/helm/optio/templates/api-deployment.yaml
@@ -40,6 +40,10 @@ spec:
                     app: optio-api
                 topologyKey: kubernetes.io/hostname
       {{- end }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/helm/optio/templates/optio-deployment.yaml
+++ b/helm/optio/templates/optio-deployment.yaml
@@ -25,6 +25,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.optio.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/helm/optio/templates/postgres.yaml
+++ b/helm/optio/templates/postgres.yaml
@@ -41,6 +41,10 @@ spec:
       labels:
         app: postgres
     spec:
+      {{- with .Values.postgresql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/helm/optio/templates/redis.yaml
+++ b/helm/optio/templates/redis.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: redis
     spec:
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/helm/optio/templates/secrets.yaml
+++ b/helm/optio/templates/secrets.yaml
@@ -64,6 +64,13 @@ stringData:
   # Agent PVC configuration (read by API server at runtime)
   OPTIO_AGENT_PVC_STORAGE_CLASS: {{ .Values.agent.pvc.storageClass | quote }}
   OPTIO_AGENT_PVC_SIZE: {{ .Values.agent.pvc.size | quote }}
+  # Agent pod scheduling
+  {{- if .Values.agent.nodeSelector }}
+  OPTIO_AGENT_NODE_SELECTOR: {{ .Values.agent.nodeSelector | toJson | quote }}
+  {{- end }}
+  {{- if .Values.agent.tolerations }}
+  OPTIO_AGENT_TOLERATIONS: {{ .Values.agent.tolerations | toJson | quote }}
+  {{- end }}
   # Cache directory PVC configuration
   OPTIO_CACHE_ENABLED: {{ .Values.agent.cache.enabled | quote }}
   OPTIO_CACHE_STORAGE_CLASS: {{ .Values.agent.cache.storageClass | quote }}

--- a/helm/optio/templates/web-deployment.yaml
+++ b/helm/optio/templates/web-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                     app: optio-web
                 topologyKey: kubernetes.io/hostname
       {{- end }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -37,6 +37,8 @@ api:
   # "hard" = requiredDuringSchedulingIgnoredDuringExecution
   # ""     = disabled
   antiAffinity: soft
+  # Kubernetes nodeSelector for API pods (opt-in).
+  nodeSelector: {}
   # Pod disruption budget. Enable when running multiple replicas to ensure
   # availability during voluntary disruptions (rolling updates, node drains).
   pdb:
@@ -80,6 +82,8 @@ web:
       memory: 512Mi
   # Pod anti-affinity (same options as api.antiAffinity)
   antiAffinity: soft
+  # Kubernetes nodeSelector for web pods (opt-in).
+  nodeSelector: {}
   # Pod disruption budget (same options as api.pdb)
   pdb:
     enabled: false
@@ -104,6 +108,8 @@ optio:
     repository: ghcr.io/jonwiggins/optio-optio
     tag: latest
     pullPolicy: IfNotPresent
+  # Kubernetes nodeSelector for the optio assistant pod (opt-in).
+  nodeSelector: {}
   resources:
     requests:
       cpu: 100m
@@ -188,6 +194,8 @@ postgresql:
     limits:
       cpu: 500m
       memory: 512Mi
+  # Kubernetes nodeSelector for PostgreSQL pods (opt-in).
+  nodeSelector: {}
   storage:
     size: 5Gi
   auth:
@@ -210,6 +218,8 @@ redis:
   image:
     repository: redis
     tag: 7-alpine
+  # Kubernetes nodeSelector for Redis pods (opt-in).
+  nodeSelector: {}
   resources:
     requests:
       cpu: 50m

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -143,6 +143,16 @@ agent:
     size: 10Gi
     accessModes:
       - ReadWriteOnce
+  # Kubernetes scheduling constraints for agent pods.
+  # nodeSelector pins pods to nodes with matching labels (e.g. a dedicated node pool).
+  # tolerations allow pods to schedule on tainted nodes.
+  nodeSelector: {}
+  #  cloud.google.com/gke-nodepool: agents
+  tolerations: []
+  #  - key: optio.dev/agents
+  #    operator: Equal
+  #    value: "true"
+  #    effect: NoSchedule
   # Shared cache directory PVCs (opt-in per repo).
   # Controls storage class and size limits for cache directories.
   cache:

--- a/packages/container-runtime/src/kubernetes.ts
+++ b/packages/container-runtime/src/kubernetes.ts
@@ -235,6 +235,14 @@ export class KubernetesContainerRuntime implements ContainerRuntime {
       podSpec.hostUsers = false;
     }
 
+    // Node scheduling constraints (e.g. pin agent pods to a dedicated node pool)
+    if (spec.nodeSelector && Object.keys(spec.nodeSelector).length > 0) {
+      podSpec.nodeSelector = spec.nodeSelector;
+    }
+    if (spec.tolerations && spec.tolerations.length > 0) {
+      podSpec.tolerations = spec.tolerations as V1PodSpec["tolerations"];
+    }
+
     const metadata = new V1ObjectMeta();
     metadata.name = podName;
     metadata.namespace = this.namespace;

--- a/packages/shared/src/types/container.ts
+++ b/packages/shared/src/types/container.ts
@@ -27,6 +27,10 @@ export interface ContainerSpec {
   extraVolumes?: ExtraVolume[];
   /** Optional extra volume mounts for the main container. */
   extraVolumeMounts?: ExtraVolumeMount[];
+  /** Kubernetes nodeSelector for pod scheduling (e.g. pin to a node pool). */
+  nodeSelector?: Record<string, string>;
+  /** Kubernetes tolerations for pod scheduling (raw V1Toleration objects). */
+  tolerations?: unknown[];
 }
 
 export interface VolumeMount {


### PR DESCRIPTION
## Summary

This PR allows configuring nodeSelectors in order to ensure that optio infra and _escpeially_ optio agents can be scheduled on specific nodes.

We run optio alongside our ci/cd runners inside kubernetes.
The optio infra we want on cheap low powered nodes.
The agents should run on fast high powered nodes (more expensive).

## Changes

For agents:
- add nodeSelector and tolerations inside `apps/api/src/services/repo-pool-service.ts` (read from ENV)
- pass these values through to the container definition in `packages/container-runtime/src/kubernetes.ts`
- add option/example to `helm/optio/templates/secrets.yaml` to pass on these values

## Testing

- [x] Tests pass (`pnpm turbo test`)
- [x] Typechecks pass (`pnpm turbo typecheck`)

We are running this in our branch (and kubernetes cluster) so that we can schedule optio pods on "low end" nodes, but agent pods get very performant disk i/o and cpu nodes. 
