### PR TITLE
fix(api): add error handling for JSON.parse of agent scheduling env vars

### DIFF
--- a/apps/api/src/services/repo-pool-service.test.ts
+++ b/apps/api/src/services/repo-pool-service.test.ts
@@ -96,6 +96,7 @@ import {
   reconcileActiveTaskCounts,
   deleteNetworkPolicy,
   killOrphanedAgentInPod,
+  parseJsonEnv,
 } from "./repo-pool-service.js";
 
 // ── resolveImage ────────────────────────────────────────────────────
@@ -766,5 +767,181 @@ describe("killOrphanedAgentInPod", () => {
     expect(result).toBe(false);
     // Should still attempt worktree cleanup
     expect(mockRuntimeExec).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── parseJsonEnv ─────────────────────────────────────────────────────
+
+describe("parseJsonEnv", () => {
+  it("returns undefined when value is undefined", () => {
+    expect(parseJsonEnv("TEST_VAR", undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when value is empty string", () => {
+    expect(parseJsonEnv("TEST_VAR", "")).toBeUndefined();
+  });
+
+  it("parses valid JSON object", () => {
+    const result = parseJsonEnv("TEST_VAR", '{"disktype":"ssd"}');
+    expect(result).toEqual({ disktype: "ssd" });
+  });
+
+  it("parses valid JSON array", () => {
+    const result = parseJsonEnv(
+      "TEST_VAR",
+      '[{"key":"gpu","operator":"Exists","effect":"NoSchedule"}]',
+    );
+    expect(result).toEqual([{ key: "gpu", operator: "Exists", effect: "NoSchedule" }]);
+  });
+
+  it("throws a descriptive error for malformed JSON", () => {
+    expect(() => parseJsonEnv("OPTIO_AGENT_NODE_SELECTOR", "{bad json}")).toThrow(
+      /Invalid JSON in OPTIO_AGENT_NODE_SELECTOR/,
+    );
+  });
+
+  it("includes the original value in the error message", () => {
+    expect(() => parseJsonEnv("OPTIO_AGENT_TOLERATIONS", "not-json")).toThrow(/not-json/);
+  });
+});
+
+// ── nodeSelector / tolerations env var integration ────────────────────
+
+describe("getOrCreateRepoPod — nodeSelector and tolerations env vars", () => {
+  function mockGetOrCreateFlow(opts: {
+    existingPods?: any[];
+    podCount?: number;
+    insertedPod?: any;
+  }) {
+    const dbMock = db as any;
+
+    const orderByResult = opts.existingPods ?? [];
+    const chainableWithOrderBy = {
+      orderBy: vi.fn().mockResolvedValue(orderByResult),
+    };
+
+    let whereCallCount = 0;
+    dbMock.where.mockImplementation(() => {
+      whereCallCount++;
+      if (whereCallCount === 1) return chainableWithOrderBy;
+      if (whereCallCount === 2) return Promise.resolve([{ count: opts.podCount ?? 0 }]);
+      return Promise.resolve([]);
+    });
+
+    if (opts.insertedPod) {
+      dbMock.returning.mockResolvedValueOnce([opts.insertedPod]);
+    }
+  }
+
+  const origNodeSelector = process.env.OPTIO_AGENT_NODE_SELECTOR;
+  const origTolerations = process.env.OPTIO_AGENT_TOLERATIONS;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    (db as any).where.mockReset().mockReturnThis();
+    if (origNodeSelector !== undefined) {
+      process.env.OPTIO_AGENT_NODE_SELECTOR = origNodeSelector;
+    } else {
+      delete process.env.OPTIO_AGENT_NODE_SELECTOR;
+    }
+    if (origTolerations !== undefined) {
+      process.env.OPTIO_AGENT_TOLERATIONS = origTolerations;
+    } else {
+      delete process.env.OPTIO_AGENT_TOLERATIONS;
+    }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (db as any).where.mockReset().mockReturnThis();
+  });
+
+  it("passes parsed nodeSelector to the container spec", async () => {
+    process.env.OPTIO_AGENT_NODE_SELECTOR = '{"disktype":"ssd"}';
+    delete process.env.OPTIO_AGENT_TOLERATIONS;
+
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    mockRuntimeCreate.mockResolvedValueOnce({ id: "k8s-id", name: "optio-repo-abc" });
+
+    await getOrCreateRepoPod("https://github.com/org/repo", "main", {});
+    const spec = mockRuntimeCreate.mock.calls[0][0];
+    expect(spec.nodeSelector).toEqual({ disktype: "ssd" });
+  });
+
+  it("passes parsed tolerations to the container spec", async () => {
+    delete process.env.OPTIO_AGENT_NODE_SELECTOR;
+    process.env.OPTIO_AGENT_TOLERATIONS =
+      '[{"key":"gpu","operator":"Exists","effect":"NoSchedule"}]';
+
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    mockRuntimeCreate.mockResolvedValueOnce({ id: "k8s-id", name: "optio-repo-abc" });
+
+    await getOrCreateRepoPod("https://github.com/org/repo", "main", {});
+    const spec = mockRuntimeCreate.mock.calls[0][0];
+    expect(spec.tolerations).toEqual([{ key: "gpu", operator: "Exists", effect: "NoSchedule" }]);
+  });
+
+  it("throws a descriptive error when OPTIO_AGENT_NODE_SELECTOR contains malformed JSON", async () => {
+    process.env.OPTIO_AGENT_NODE_SELECTOR = "{bad json}";
+    delete process.env.OPTIO_AGENT_TOLERATIONS;
+
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    await expect(getOrCreateRepoPod("https://github.com/org/repo", "main", {})).rejects.toThrow(
+      /Invalid JSON in OPTIO_AGENT_NODE_SELECTOR/,
+    );
+  });
+
+  it("throws a descriptive error when OPTIO_AGENT_TOLERATIONS contains malformed JSON", async () => {
+    delete process.env.OPTIO_AGENT_NODE_SELECTOR;
+    process.env.OPTIO_AGENT_TOLERATIONS = "not valid json";
+
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    await expect(getOrCreateRepoPod("https://github.com/org/repo", "main", {})).rejects.toThrow(
+      /Invalid JSON in OPTIO_AGENT_TOLERATIONS/,
+    );
   });
 });

--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -24,6 +24,22 @@ import {
 
 const IDLE_TIMEOUT_MS = parseInt(process.env.OPTIO_REPO_POD_IDLE_MS ?? "600000", 10); // 10 min default
 
+/**
+ * Parse a JSON-encoded environment variable, returning `undefined` when unset/empty.
+ * Throws a descriptive error (including the variable name and raw value) on malformed JSON
+ * so operators can quickly identify typos in values.yaml or Helm overrides.
+ */
+export function parseJsonEnv(name: string, value: string | undefined): unknown {
+  if (!value) return undefined;
+  try {
+    return JSON.parse(value);
+  } catch (err) {
+    throw new Error(
+      `Invalid JSON in ${name}: ${err instanceof Error ? err.message : err} (raw value: ${value})`,
+    );
+  }
+}
+
 export interface RepoPod {
   id: string;
   repoUrl: string;
@@ -361,10 +377,20 @@ spec:
           }
         : {}),
       ...(process.env.OPTIO_AGENT_NODE_SELECTOR
-        ? { nodeSelector: JSON.parse(process.env.OPTIO_AGENT_NODE_SELECTOR) }
+        ? {
+            nodeSelector: parseJsonEnv(
+              "OPTIO_AGENT_NODE_SELECTOR",
+              process.env.OPTIO_AGENT_NODE_SELECTOR,
+            ) as Record<string, string>,
+          }
         : {}),
       ...(process.env.OPTIO_AGENT_TOLERATIONS
-        ? { tolerations: JSON.parse(process.env.OPTIO_AGENT_TOLERATIONS) }
+        ? {
+            tolerations: parseJsonEnv(
+              "OPTIO_AGENT_TOLERATIONS",
+              process.env.OPTIO_AGENT_TOLERATIONS,
+            ) as unknown[],
+          }
         : {}),
     };
 


### PR DESCRIPTION
Closes #405

## What changed

Added a `parseJsonEnv()` helper function in `repo-pool-service.ts` that wraps `JSON.parse` with try/catch and produces a descriptive error message including the environment variable name and raw value. This replaces the two bare `JSON.parse` calls for `OPTIO_AGENT_NODE_SELECTOR` and `OPTIO_AGENT_TOLERATIONS` introduced in #404.

Previously, malformed JSON in these env vars (e.g. a typo in `values.yaml`) would throw a cryptic `SyntaxError` during pod creation. Now it throws a clear message like:

```
Invalid JSON in OPTIO_AGENT_NODE_SELECTOR: Expected property name ... (raw value: {bad json})
```

## How to test

1. **Unit tests**: 8 new tests cover `parseJsonEnv` directly (valid JSON, empty/undefined, malformed JSON error messages) and integration with `getOrCreateRepoPod` (valid nodeSelector/tolerations passed through, malformed values produce descriptive errors).

2. **Manual verification**: Set `OPTIO_AGENT_NODE_SELECTOR` to invalid JSON (e.g. `{bad}`) in Helm values, start the API, and trigger pod creation — confirm the error message names the variable and includes the raw value.