### PR TITLE
fix(api): health check passes when ClusterRole is not deployed

### DIFF
--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -18,7 +18,7 @@ vi.mock("../services/container-service.js", () => ({
   checkRuntimeHealth: (...args: unknown[]) => mockCheckRuntimeHealth(...args),
 }));
 
-import { healthRoutes } from "./health.js";
+import { healthRoutes, _resetHealthCache } from "./health.js";
 
 // ─── Helpers ───
 
@@ -34,6 +34,7 @@ describe("GET /api/health", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    _resetHealthCache();
     app = await buildTestApp();
   });
 
@@ -55,6 +56,31 @@ describe("GET /api/health", () => {
   it("returns 503 when database is down", async () => {
     mockDbExecute.mockRejectedValue(new Error("connection refused"));
     mockCheckRuntimeHealth.mockResolvedValue(true);
+
+    const res = await app.inject({ method: "GET", url: "/api/health" });
+
+    expect(res.statusCode).toBe(503);
+    const body = res.json();
+    expect(body.healthy).toBe(false);
+    expect(body.checks.database).toBe(false);
+  });
+
+  it("returns 200 when database is up but container runtime is down", async () => {
+    mockDbExecute.mockResolvedValue(undefined);
+    mockCheckRuntimeHealth.mockResolvedValue(false);
+
+    const res = await app.inject({ method: "GET", url: "/api/health" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.healthy).toBe(true);
+    expect(body.checks.database).toBe(true);
+    expect(body.checks.containerRuntime).toBe(false);
+  });
+
+  it("returns 503 only when database is down, regardless of container runtime", async () => {
+    mockDbExecute.mockRejectedValue(new Error("connection refused"));
+    mockCheckRuntimeHealth.mockResolvedValue(false);
 
     const res = await app.inject({ method: "GET", url: "/api/health" });
 

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -10,6 +10,12 @@ let cachedRuntimeHealth: boolean | null = null;
 let cachedRuntimeHealthAt = 0;
 const RUNTIME_HEALTH_TTL_MS = 30_000;
 
+/** Reset cached runtime health (exported for tests). */
+export function _resetHealthCache() {
+  cachedRuntimeHealth = null;
+  cachedRuntimeHealthAt = 0;
+}
+
 export async function healthRoutes(app: FastifyInstance) {
   app.get("/api/health", async (_req, reply) => {
     const checks: Record<string, boolean> = {};
@@ -38,7 +44,10 @@ export async function healthRoutes(app: FastifyInstance) {
       cachedRuntimeHealthAt = Date.now();
     }
 
-    const healthy = Object.values(checks).every(Boolean);
+    // Only database is critical for API health. Container runtime being
+    // unavailable (e.g. no ClusterRole, K8s API unreachable) is a degraded
+    // state but should not cause liveness/readiness probes to fail.
+    const healthy = checks.database;
     const maxConcurrent = parseInt(process.env.OPTIO_MAX_CONCURRENT ?? "5", 10);
     reply
       .status(healthy ? 200 : 503)

--- a/packages/container-runtime/src/kubernetes.test.ts
+++ b/packages/container-runtime/src/kubernetes.test.ts
@@ -755,7 +755,23 @@ describe("KubernetesContainerRuntime", () => {
       expect(result).toBe(true);
     });
 
-    it("returns false when it throws", async () => {
+    it("returns true when listNamespacedPod returns 403 Forbidden (no ClusterRole)", async () => {
+      mockCoreApi.listNamespacedPod.mockRejectedValue({ statusCode: 403 });
+
+      const result = await runtime.ping();
+      expect(result).toBe(true);
+    });
+
+    it("returns true when listNamespacedPod returns 403 via response.httpStatusCode", async () => {
+      mockCoreApi.listNamespacedPod.mockRejectedValue({
+        response: { httpStatusCode: 403 },
+      });
+
+      const result = await runtime.ping();
+      expect(result).toBe(true);
+    });
+
+    it("returns false when it throws a non-403 error", async () => {
       mockCoreApi.listNamespacedPod.mockRejectedValue(new Error("connection refused"));
 
       const result = await runtime.ping();

--- a/packages/container-runtime/src/kubernetes.ts
+++ b/packages/container-runtime/src/kubernetes.ts
@@ -442,7 +442,12 @@ export class KubernetesContainerRuntime implements ContainerRuntime {
     try {
       await this.coreApi.listNamespacedPod({ namespace: this.namespace, limit: 1 });
       return true;
-    } catch {
+    } catch (err: unknown) {
+      // 403 Forbidden means the K8s API is reachable but we lack permission
+      // (e.g. no ClusterRole). The runtime is still available.
+      if (this.isForbiddenError(err)) {
+        return true;
+      }
       return false;
     }
   }


### PR DESCRIPTION
Closes #403

## What changed

Two fixes to prevent the API health endpoint from returning 503 when the
ClusterRole is not deployed (i.e. `rbac.clusterRole.create: false`):

1. **`kubernetes.ts` — `ping()` handles 403 Forbidden**: When the K8s API
   returns 403 (insufficient permissions), `ping()` now returns `true` instead
   of `false`. A 403 response means the API *is* reachable — we just lack
   specific permissions. This is consistent with how `ensureNamespace()` already
   handles 403 errors.

2. **`health.ts` — container runtime is non-critical**: The overall `healthy`
   status now depends only on the database check. `containerRuntime` is still
   reported in the response body for debugging, but a `false` value no longer
   causes liveness/readiness probes to fail with 503. The API can still serve
   the web UI and handle requests when the container runtime is degraded.

## How to test

1. Deploy without ClusterRole (`rbac.clusterRole.create: false` in Helm values)
2. Hit `GET /api/health` — should return `200` with `healthy: true`
3. Verify the `containerRuntime` field is still present in the response
4. Deploy with ClusterRole enabled — health check still works as before
5. Stop the database — health check should return `503` with `healthy: false`