### PR TITLE
feat(agent-adapters): add OpenClaw agent runtime support

### DIFF
--- a/apps/api/src/db/migrations/1775855324_openclaw_repo_columns.sql
+++ b/apps/api/src/db/migrations/1775855324_openclaw_repo_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "repos" ADD COLUMN IF NOT EXISTS "openclaw_model" text;--> statement-breakpoint
+ALTER TABLE "repos" ADD COLUMN IF NOT EXISTS "openclaw_agent" text;

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1775809203000,
       "tag": "1775809203_planning_mode_enabled",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1775855324000,
+      "tag": "1775855324_openclaw_repo_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -251,6 +251,8 @@ export const repos = pgTable(
     opencodeProvider: text("opencode_provider"), // "anthropic" | "openai" | ... for default provider inference
     geminiModel: text("gemini_model").default("gemini-2.5-pro"),
     geminiApprovalMode: text("gemini_approval_mode").default("yolo"), // "default" | "auto_edit" | "yolo"
+    openclawModel: text("openclaw_model"), // model selection, null = OpenClaw default
+    openclawAgent: text("openclaw_agent"), // named agent/preset, null = default
     maxTurnsCoding: integer("max_turns_coding"), // null = use global default (250)
     maxTurnsReview: integer("max_turns_review"), // null = use global default (10)
     autoResume: boolean("auto_resume").notNull().default(false),

--- a/apps/api/src/services/__fixtures__/openclaw.ndjson
+++ b/apps/api/src/services/__fixtures__/openclaw.ndjson
@@ -1,0 +1,14 @@
+{"type":"system","subtype":"init","session_id":"oc-sess-claw001","model":"anthropic/claude-sonnet-4","version":"1.2.0"}
+{"type":"message","role":"assistant","content":"I'll start by reading the task file to understand what needs to be done.","session_id":"oc-sess-claw001","model":"anthropic/claude-sonnet-4"}
+{"type":"tool_call","name":"read_file","call_id":"tc-001","arguments":"{\"path\":\".optio/task.md\"}","session_id":"oc-sess-claw001"}
+{"type":"tool_result","call_id":"tc-001","output":"# Fix login validation\n\nThe login form does not validate email format...","session_id":"oc-sess-claw001"}
+{"type":"message","role":"assistant","content":"I can see the issue. Let me fix the email validation in the login form.","session_id":"oc-sess-claw001"}
+{"type":"tool_call","name":"edit_file","call_id":"tc-002","arguments":"{\"path\":\"src/auth/login.ts\",\"old_string\":\"const isValid = email.length > 0\",\"new_string\":\"const isValid = /^[^@]+@[^@]+\\\\.[^@]+$/.test(email)\"}","session_id":"oc-sess-claw001"}
+{"type":"tool_result","call_id":"tc-002","output":"File edited successfully","session_id":"oc-sess-claw001"}
+{"type":"tool_call","name":"shell","call_id":"tc-003","arguments":"{\"command\":\"npm test -- --grep email\"}","session_id":"oc-sess-claw001"}
+{"type":"tool_result","call_id":"tc-003","output":"PASS src/auth/__tests__/login.test.ts\n  ✓ validates email format (12ms)\n\nTests: 1 passed, 1 total","session_id":"oc-sess-claw001"}
+{"type":"message","role":"assistant","content":"Tests pass. Now I'll create the PR.","session_id":"oc-sess-claw001","usage":{"input_tokens":3200,"output_tokens":850}}
+{"type":"tool_call","name":"shell","call_id":"tc-004","arguments":"{\"command\":\"git add -A && git commit -m 'fix: add email validation to login form' && gh pr create --title 'fix: add email validation to login form' --body 'Fixes email validation'\"}","session_id":"oc-sess-claw001"}
+{"type":"tool_result","call_id":"tc-004","output":"https://github.com/org/repo/pull/42\nPR created successfully","session_id":"oc-sess-claw001"}
+{"type":"message","role":"assistant","content":"Done! I've fixed the email validation and opened PR #42.","session_id":"oc-sess-claw001","usage":{"input_tokens":450,"output_tokens":120},"total_cost_usd":0.0198}
+{"type":"result","result":"Fixed email validation in login form and opened PR https://github.com/org/repo/pull/42","session_id":"oc-sess-claw001","total_cost_usd":0.0198}

--- a/apps/api/src/services/openclaw-event-parser.test.ts
+++ b/apps/api/src/services/openclaw-event-parser.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { parseOpenClawEvent } from "./openclaw-event-parser.js";
+
+const TASK_ID = "test-task-claw-123";
+
+// Load the NDJSON fixture
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(__dirname, "__fixtures__", "openclaw.ndjson");
+const fixtureLines = readFileSync(fixturePath, "utf-8").split("\n").filter(Boolean);
+
+describe("parseOpenClawEvent", () => {
+  it("parses system init event with model and version", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "init",
+      session_id: "claw-sess-abc",
+      model: "anthropic/claude-sonnet-4",
+      version: "1.2.0",
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("system");
+    expect(result.entries[0].content).toContain("anthropic/claude-sonnet-4");
+    expect(result.entries[0].content).toContain("OpenClaw v1.2.0");
+    expect(result.sessionId).toBe("claw-sess-abc");
+  });
+
+  it("parses system message", () => {
+    const line = JSON.stringify({
+      type: "message",
+      role: "system",
+      content: "You are a coding assistant.",
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("system");
+    expect(result.entries[0].content).toBe("You are a coding assistant.");
+  });
+
+  it("parses assistant text message", () => {
+    const line = JSON.stringify({
+      type: "message",
+      role: "assistant",
+      content: "I will fix this bug.",
+      session_id: "claw-sess-1",
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("text");
+    expect(result.entries[0].content).toBe("I will fix this bug.");
+    expect(result.sessionId).toBe("claw-sess-1");
+  });
+
+  it("parses assistant message with array content", () => {
+    const line = JSON.stringify({
+      type: "message",
+      role: "assistant",
+      content: [
+        { type: "text", text: "Part 1" },
+        { type: "output_text", text: "Part 2" },
+      ],
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("text");
+    expect(result.entries[0].content).toBe("Part 1\nPart 2");
+  });
+
+  it("parses tool_call event (shell)", () => {
+    const line = JSON.stringify({
+      type: "tool_call",
+      name: "shell",
+      call_id: "tc-001",
+      arguments: JSON.stringify({ command: "git status" }),
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("tool_use");
+    expect(result.entries[0].content).toBe("$ git status");
+    expect(result.entries[0].metadata?.toolName).toBe("shell");
+    expect(result.entries[0].metadata?.toolUseId).toBe("tc-001");
+  });
+
+  it("parses function_call event (read_file)", () => {
+    const line = JSON.stringify({
+      type: "function_call",
+      name: "read_file",
+      arguments: { path: "/src/main.ts" },
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries[0].content).toBe("Read /src/main.ts");
+  });
+
+  it("parses tool_call event (edit_file)", () => {
+    const line = JSON.stringify({
+      type: "tool_call",
+      name: "edit_file",
+      call_id: "tc-002",
+      arguments: JSON.stringify({ path: "src/auth/login.ts" }),
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries[0].content).toBe("Edit src/auth/login.ts");
+  });
+
+  it("parses tool_result event", () => {
+    const line = JSON.stringify({
+      type: "tool_result",
+      call_id: "tc-001",
+      output: "On branch main\nnothing to commit",
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("tool_result");
+    expect(result.entries[0].content).toContain("On branch main");
+  });
+
+  it("parses function_call_output event", () => {
+    const line = JSON.stringify({
+      type: "function_call_output",
+      call_id: "tc-002",
+      output: "File edited successfully",
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("tool_result");
+  });
+
+  it("truncates long tool result output", () => {
+    const longOutput = "x".repeat(500);
+    const line = JSON.stringify({
+      type: "tool_result",
+      call_id: "tc-001",
+      output: longOutput,
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries[0].content.length).toBeLessThan(400);
+    expect(result.entries[0].content).toContain("\u2026");
+  });
+
+  it("parses error event", () => {
+    const line = JSON.stringify({
+      type: "error",
+      message: "API key is invalid",
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("error");
+    expect(result.entries[0].content).toBe("API key is invalid");
+  });
+
+  it("parses result event", () => {
+    const line = JSON.stringify({
+      type: "result",
+      result: "Task completed successfully",
+      total_cost_usd: 0.0198,
+      session_id: "claw-sess-abc",
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries.length).toBeGreaterThanOrEqual(1);
+    const textEntry = result.entries.find((e) => e.type === "text");
+    expect(textEntry?.content).toBe("Task completed successfully");
+    const costEntry = result.entries.find((e) => e.type === "info");
+    expect(costEntry?.content).toContain("$0.0198");
+    expect(result.sessionId).toBe("claw-sess-abc");
+  });
+
+  it("parses reasoning event as thinking", () => {
+    const line = JSON.stringify({
+      type: "reasoning",
+      content: "Let me analyze this code...",
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("thinking");
+    expect(result.entries[0].content).toBe("Let me analyze this code...");
+  });
+
+  it("extracts session_id from events", () => {
+    const line = JSON.stringify({
+      type: "message",
+      role: "assistant",
+      content: "Hello",
+      session_id: "claw-sess-xyz",
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.sessionId).toBe("claw-sess-xyz");
+  });
+
+  it("handles non-JSON lines as raw text", () => {
+    const result = parseOpenClawEvent("[optio] Running OpenClaw...", TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("text");
+    expect(result.entries[0].content).toBe("[optio] Running OpenClaw...");
+  });
+
+  it("strips terminal control sequences", () => {
+    const result = parseOpenClawEvent("\x1b[32mgreen text\x1b[0m\r", TASK_ID);
+    expect(result.entries[0].content).toBe("green text");
+  });
+
+  it("skips empty lines", () => {
+    expect(parseOpenClawEvent("", TASK_ID).entries).toHaveLength(0);
+    expect(parseOpenClawEvent("   ", TASK_ID).entries).toHaveLength(0);
+  });
+
+  it("parses usage data in message event", () => {
+    const line = JSON.stringify({
+      type: "message",
+      role: "assistant",
+      content: "Done",
+      usage: { input_tokens: 1000, output_tokens: 500 },
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries.length).toBeGreaterThanOrEqual(2);
+    const infoEntry = result.entries.find((e) => e.type === "info");
+    expect(infoEntry).toBeDefined();
+    expect(infoEntry?.content).toContain("1000 input tokens");
+    expect(infoEntry?.metadata?.inputTokens).toBe(1000);
+  });
+
+  it("parses standalone usage event", () => {
+    const line = JSON.stringify({
+      usage: { prompt_tokens: 2000, completion_tokens: 1000 },
+      total_cost_usd: 0.05,
+    });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("info");
+    expect(result.entries[0].content).toContain("$0.0500");
+  });
+
+  it("skips unknown JSON events", () => {
+    const line = JSON.stringify({ type: "stream_delta", data: "partial" });
+    const result = parseOpenClawEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(0);
+  });
+
+  describe("NDJSON fixture", () => {
+    it("parses all fixture lines without throwing", () => {
+      for (const line of fixtureLines) {
+        expect(() => parseOpenClawEvent(line, TASK_ID)).not.toThrow();
+      }
+    });
+
+    it("extracts session ID from fixture", () => {
+      const allSessionIds = fixtureLines
+        .map((line) => parseOpenClawEvent(line, TASK_ID).sessionId)
+        .filter(Boolean);
+      expect(allSessionIds.length).toBeGreaterThan(0);
+      expect(allSessionIds[0]).toBe("oc-sess-claw001");
+    });
+
+    it("extracts system init from fixture", () => {
+      const initResult = parseOpenClawEvent(fixtureLines[0], TASK_ID);
+      expect(initResult.entries[0].type).toBe("system");
+      expect(initResult.entries[0].content).toContain("anthropic/claude-sonnet-4");
+    });
+
+    it("extracts tool calls from fixture", () => {
+      const toolCallLines = fixtureLines
+        .map((line) => parseOpenClawEvent(line, TASK_ID))
+        .filter((r) => r.entries.some((e) => e.type === "tool_use"));
+      expect(toolCallLines.length).toBeGreaterThan(0);
+    });
+
+    it("extracts result with cost from fixture", () => {
+      const lastLine = fixtureLines[fixtureLines.length - 1];
+      const result = parseOpenClawEvent(lastLine, TASK_ID);
+      const costEntry = result.entries.find((e) => e.type === "info" && e.metadata?.cost);
+      expect(costEntry).toBeDefined();
+      expect(costEntry?.metadata?.cost).toBe(0.0198);
+    });
+  });
+});

--- a/apps/api/src/services/openclaw-event-parser.ts
+++ b/apps/api/src/services/openclaw-event-parser.ts
@@ -1,0 +1,242 @@
+import type { AgentLogEntry } from "@optio/shared";
+
+/**
+ * Parse a single NDJSON line from OpenClaw's `agent --output-format stream-json` output.
+ *
+ * OpenClaw outputs events as one JSON object per line, similar to Claude Code's
+ * NDJSON format. This parser is designed to be tolerant of unknown event types.
+ *
+ * Known shapes:
+ * - { type: "system", subtype: "init", session_id, model, version }
+ * - { type: "message", role: "assistant"|"system", content: "...", session_id }
+ * - { type: "tool_call", name: "...", call_id: "...", arguments: "..." }
+ * - { type: "tool_result", call_id: "...", output: "..." }
+ * - { type: "error", message: "..." }
+ * - { type: "result", result: "...", total_cost_usd, session_id }
+ * - Events with usage data (input_tokens, output_tokens)
+ */
+export function parseOpenClawEvent(
+  line: string,
+  taskId: string,
+): { entries: AgentLogEntry[]; sessionId?: string; isTerminal?: boolean } {
+  let event: any;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    // Not JSON — raw text from shell/git
+    if (!line.trim()) return { entries: [] };
+    const clean = line.replace(/\x1b\[[0-9;]*[a-zA-Z]|\r/g, "").trim();
+    if (!clean || clean.length < 2) return { entries: [] };
+    return {
+      entries: [{ taskId, timestamp: new Date().toISOString(), type: "text", content: clean }],
+    };
+  }
+
+  const timestamp = new Date().toISOString();
+  const entries: AgentLogEntry[] = [];
+
+  // Extract session/conversation ID if present
+  const sessionId = (event.session_id ?? event.id ?? event.conversation_id) as string | undefined;
+
+  // System message or init
+  if (event.type === "message" && event.role === "system") {
+    const content =
+      typeof event.content === "string" ? event.content : JSON.stringify(event.content);
+    if (content?.trim()) {
+      entries.push({ taskId, timestamp, sessionId, type: "system", content });
+    }
+    return { entries, sessionId };
+  }
+
+  // System init event (model info)
+  if (event.type === "system" && event.subtype === "init") {
+    const parts: string[] = [];
+    if (event.model) parts.push(`Model: ${event.model}`);
+    if (event.version) parts.push(`OpenClaw v${event.version}`);
+    if (parts.length) {
+      entries.push({ taskId, timestamp, sessionId, type: "system", content: parts.join(" · ") });
+    }
+    return { entries, sessionId };
+  }
+
+  // Assistant message
+  if (event.type === "message" && event.role === "assistant") {
+    const content =
+      typeof event.content === "string"
+        ? event.content
+        : Array.isArray(event.content)
+          ? event.content
+              .map((block: any) => {
+                if (typeof block === "string") return block;
+                if (block.type === "text") return block.text;
+                if (block.type === "output_text") return block.text;
+                return "";
+              })
+              .filter(Boolean)
+              .join("\n")
+          : "";
+    if (content?.trim()) {
+      entries.push({ taskId, timestamp, sessionId, type: "text", content });
+    }
+
+    // Check for usage data in the message event
+    const usage = event.usage ?? event.response?.usage;
+    if (usage) {
+      const meta: string[] = [];
+      const inputTokens = usage.input_tokens ?? usage.prompt_tokens ?? 0;
+      const outputTokens = usage.output_tokens ?? usage.completion_tokens ?? 0;
+      if (inputTokens) meta.push(`${inputTokens} input tokens`);
+      if (outputTokens) meta.push(`${outputTokens} output tokens`);
+      if (event.total_cost_usd) meta.push(`$${event.total_cost_usd.toFixed(4)}`);
+      if (meta.length) {
+        entries.push({
+          taskId,
+          timestamp,
+          sessionId,
+          type: "info",
+          content: `Usage: ${meta.join(" · ")}`,
+          metadata: { inputTokens, outputTokens, cost: event.total_cost_usd },
+        });
+      }
+    }
+    return { entries, sessionId };
+  }
+
+  // Tool call (tool use) — OpenClaw may use "tool_call" or "function_call"
+  if (event.type === "tool_call" || event.type === "function_call") {
+    const args = parseArgs(event.arguments);
+    const formatted = formatToolUse(event.name, args);
+    entries.push({
+      taskId,
+      timestamp,
+      sessionId,
+      type: "tool_use",
+      content: formatted,
+      metadata: { toolName: event.name, toolInput: args, toolUseId: event.call_id },
+    });
+    return { entries, sessionId };
+  }
+
+  // Tool result — OpenClaw may use "tool_result" or "function_call_output"
+  if (event.type === "tool_result" || event.type === "function_call_output") {
+    const output = typeof event.output === "string" ? event.output : JSON.stringify(event.output);
+    const trimmed = output.length > 300 ? output.slice(0, 300) + "\u2026" : output;
+    if (trimmed.trim()) {
+      entries.push({
+        taskId,
+        timestamp,
+        sessionId,
+        type: "tool_result",
+        content: trimmed,
+        metadata: { toolUseId: event.call_id },
+      });
+    }
+    return { entries, sessionId };
+  }
+
+  // Error event
+  if (event.type === "error") {
+    const msg = event.message ?? event.error ?? JSON.stringify(event);
+    entries.push({ taskId, timestamp, sessionId, type: "error", content: msg });
+    return { entries, sessionId };
+  }
+
+  // Result/summary event
+  if (event.type === "result") {
+    const result = typeof event.result === "string" ? event.result : JSON.stringify(event.result);
+    if (result.trim()) {
+      entries.push({ taskId, timestamp, sessionId, type: "text", content: result });
+    }
+    if (event.total_cost_usd != null) {
+      entries.push({
+        taskId,
+        timestamp,
+        sessionId,
+        type: "info",
+        content: `Total cost: $${event.total_cost_usd.toFixed(4)}`,
+        metadata: { cost: event.total_cost_usd },
+      });
+    }
+    return { entries, sessionId };
+  }
+
+  // Reasoning/thinking event
+  if (event.type === "reasoning") {
+    const content = typeof event.content === "string" ? event.content : "";
+    if (content.trim()) {
+      entries.push({ taskId, timestamp, sessionId, type: "thinking", content });
+    }
+    return { entries, sessionId };
+  }
+
+  // Generic event with usage data
+  if (event.usage || event.response?.usage) {
+    const usage = event.usage ?? event.response.usage;
+    const inputTokens = usage.input_tokens ?? usage.prompt_tokens ?? 0;
+    const outputTokens = usage.output_tokens ?? usage.completion_tokens ?? 0;
+    const meta: string[] = [];
+    if (inputTokens) meta.push(`${inputTokens} input tokens`);
+    if (outputTokens) meta.push(`${outputTokens} output tokens`);
+    if (event.total_cost_usd) meta.push(`$${event.total_cost_usd.toFixed(4)}`);
+    if (meta.length) {
+      entries.push({
+        taskId,
+        timestamp,
+        sessionId,
+        type: "info",
+        content: `Usage: ${meta.join(" · ")}`,
+        metadata: { inputTokens, outputTokens, cost: event.total_cost_usd },
+      });
+    }
+    return { entries, sessionId };
+  }
+
+  // Unknown JSON event — skip silently
+  return { entries: [], sessionId };
+}
+
+function parseArgs(args: unknown): Record<string, unknown> | undefined {
+  if (!args) return undefined;
+  if (typeof args === "object") return args as Record<string, unknown>;
+  if (typeof args === "string") {
+    try {
+      return JSON.parse(args);
+    } catch {
+      return { raw: args };
+    }
+  }
+  return undefined;
+}
+
+function formatToolUse(name: string, args: Record<string, unknown> | undefined): string {
+  if (!name) return "unknown tool";
+  if (!args) return name;
+
+  switch (name) {
+    case "shell":
+    case "bash":
+    case "terminal":
+      return `$ ${String(args.command ?? args.cmd ?? "")
+        .split("\n")[0]
+        .slice(0, 120)}`;
+    case "read_file":
+    case "readFile":
+      return `Read ${args.path ?? args.file_path ?? ""}`;
+    case "write_file":
+    case "writeFile":
+    case "create_file":
+      return `Write ${args.path ?? args.file_path ?? ""}`;
+    case "edit_file":
+    case "editFile":
+    case "apply_diff":
+      return `Edit ${args.path ?? args.file_path ?? ""}`;
+    case "search":
+    case "grep":
+      return `Search: ${args.query ?? args.pattern ?? ""}`;
+    case "list_dir":
+    case "listDir":
+      return `List ${args.path ?? args.dir ?? "."}`;
+    default:
+      return name;
+  }
+}

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -19,6 +19,7 @@ import { parseCodexEvent } from "../services/codex-event-parser.js";
 import { parseCopilotEvent } from "../services/copilot-event-parser.js";
 import { parseOpenCodeEvent } from "../services/opencode-event-parser.js";
 import { parseGeminiEvent } from "../services/gemini-event-parser.js";
+import { parseOpenClawEvent } from "../services/openclaw-event-parser.js";
 import { checkExistingPr } from "../services/pr-detection-service.js";
 import { db } from "../db/client.js";
 import { tasks } from "../db/schema.js";
@@ -670,7 +671,9 @@ export function startTaskWorker() {
                     ? parseOpenCodeEvent(line, taskId)
                     : task.agentType === "gemini"
                       ? parseGeminiEvent(line, taskId)
-                      : parseClaudeEvent(line, taskId);
+                      : task.agentType === "openclaw"
+                        ? parseOpenClawEvent(line, taskId)
+                        : parseClaudeEvent(line, taskId);
             if (parsed.sessionId && !sessionId) {
               sessionId = parsed.sessionId;
               await taskService.updateTaskSession(taskId, sessionId);
@@ -770,7 +773,9 @@ export function startTaskWorker() {
                   ? parseOpenCodeEvent(lineBuf, taskId)
                   : task.agentType === "gemini"
                     ? parseGeminiEvent(lineBuf, taskId)
-                    : parseClaudeEvent(lineBuf, taskId);
+                    : task.agentType === "openclaw"
+                      ? parseOpenClawEvent(lineBuf, taskId)
+                      : parseClaudeEvent(lineBuf, taskId);
           for (const entry of parsed.entries) {
             await taskService.appendTaskLog(
               taskId,
@@ -1365,6 +1370,18 @@ export function buildAgentCommand(
         `  --approval-mode yolo${geminiModelFlag}`,
       ];
     }
+    case "openclaw": {
+      const openclawModelFlag = env.OPTIO_OPENCLAW_MODEL
+        ? ` --model ${JSON.stringify(env.OPTIO_OPENCLAW_MODEL)}`
+        : "";
+      const openclawAgentFlag = env.OPTIO_OPENCLAW_AGENT
+        ? ` --agent ${JSON.stringify(env.OPTIO_OPENCLAW_AGENT)}`
+        : "";
+      return [
+        `echo "[optio] Running OpenClaw (experimental)..."`,
+        `openclaw agent --output-format stream-json${openclawModelFlag}${openclawAgentFlag} "$OPTIO_PROMPT"`,
+      ];
+    }
     default:
       return [`echo "Unknown agent type: ${agentType}" && exit 1`];
   }
@@ -1424,6 +1441,21 @@ export function inferExitCode(agentType: string, logs: string): number {
       const hasModelError = /model.*not found|model_not_found|does not exist.*model/i.test(logs);
       const hasTurnLimit = /turn.?limit|exit code 53/i.test(logs);
       return hasErrorEvent || hasAuthError || hasQuotaError || hasModelError || hasTurnLimit
+        ? 1
+        : 0;
+    }
+    case "openclaw": {
+      // OpenClaw: similar to OpenCode — look for error events and provider-specific failures
+      const hasErrorEvent = logs.includes('"type":"error"') || logs.includes('"type": "error"');
+      const hasApiErrorEnvelope = /"error"\s*:\s*\{\s*"message"/.test(logs);
+      const hasAuthError =
+        /ANTHROPIC_API_KEY|OPENAI_API_KEY|OPENCLAW_API_KEY|invalid.*api.?key|unauthorized|authentication.*failed/i.test(
+          logs,
+        );
+      const hasModelError = /model_not_found|model.*not found|does not exist.*model/i.test(logs);
+      const hasFatalError =
+        logs.includes("fatal:") || logs.includes("Error: authentication_failed");
+      return hasErrorEvent || hasApiErrorEnvelope || hasAuthError || hasModelError || hasFatalError
         ? 1
         : 0;
     }

--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -58,6 +58,7 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
   const [copilotEffort, setCopilotEffort] = useState("");
   const [geminiModel, setGeminiModel] = useState("gemini-2.5-pro");
   const [geminiApprovalMode, setGeminiApprovalMode] = useState("yolo");
+  const [openclawModel, setOpenclawModel] = useState("");
   const [maxTurnsCoding, setMaxTurnsCoding] = useState(250);
   const [maxTurnsReview, setMaxTurnsReview] = useState(30);
   const [autoResume, setAutoResume] = useState(false);
@@ -135,6 +136,7 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
         setCopilotEffort(r.copilotEffort ?? "");
         setGeminiModel(r.geminiModel ?? "gemini-2.5-pro");
         setGeminiApprovalMode(r.geminiApprovalMode ?? "yolo");
+        setOpenclawModel(r.openclawModel ?? "");
         setMaxTurnsCoding(r.maxTurnsCoding ?? 250);
         setMaxTurnsReview(r.maxTurnsReview ?? 30);
         setReviewEnabled(r.reviewEnabled ?? false);
@@ -207,6 +209,7 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
         copilotEffort: copilotEffort || undefined,
         geminiModel: geminiModel || undefined,
         geminiApprovalMode: geminiApprovalMode || undefined,
+        openclawModel: openclawModel || undefined,
         maxTurnsCoding,
         maxTurnsReview,
         reviewEnabled,
@@ -879,6 +882,7 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
           <option value="copilot">GitHub Copilot</option>
           <option value="opencode">OpenCode (Experimental)</option>
           <option value="gemini">Google Gemini</option>
+          <option value="openclaw">OpenClaw (Experimental)</option>
         </select>
       </section>
 
@@ -1021,6 +1025,23 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
               <option value="default">Default</option>
             </select>
           </div>
+        </div>
+      </section>
+
+      {/* OpenClaw Settings */}
+      <section className="p-5 rounded-xl border border-border/50 bg-bg-card space-y-3">
+        <h2 className="text-sm font-medium">OpenClaw Settings</h2>
+        <p className="text-xs text-text-muted">
+          Configure OpenClaw model when using the OpenClaw agent for this repo.
+        </p>
+        <div>
+          <label className="block text-xs text-text-muted mb-1">Model</label>
+          <input
+            value={openclawModel}
+            onChange={(e) => setOpenclawModel(e.target.value)}
+            placeholder="Default (auto-detect)"
+            className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+          />
         </div>
       </section>
 

--- a/apps/web/src/app/schedules/page.tsx
+++ b/apps/web/src/app/schedules/page.tsx
@@ -432,6 +432,8 @@ export default function SchedulesPage() {
                   <option value="codex">Codex</option>
                   <option value="copilot">Copilot</option>
                   <option value="opencode">OpenCode (Experimental)</option>
+                  <option value="gemini">Google Gemini</option>
+                  <option value="openclaw">OpenClaw (Experimental)</option>
                 </select>
               </div>
               <div>

--- a/apps/web/src/app/tasks/new/page.tsx
+++ b/apps/web/src/app/tasks/new/page.tsx
@@ -250,6 +250,7 @@ export default function NewTaskPage() {
               <option value="copilot">GitHub Copilot</option>
               <option value="opencode">OpenCode (Experimental)</option>
               <option value="gemini">Google Gemini</option>
+              <option value="openclaw">OpenClaw (Experimental)</option>
             </select>
           </div>
         </div>

--- a/apps/web/src/app/templates/page.tsx
+++ b/apps/web/src/app/templates/page.tsx
@@ -173,6 +173,8 @@ export default function TemplatesPage() {
                 <option value="codex">OpenAI Codex</option>
                 <option value="copilot">GitHub Copilot</option>
                 <option value="opencode">OpenCode (Experimental)</option>
+                <option value="gemini">Google Gemini</option>
+                <option value="openclaw">OpenClaw (Experimental)</option>
               </select>
             </div>
             <div>

--- a/apps/web/src/app/workflows/workflow-form.tsx
+++ b/apps/web/src/app/workflows/workflow-form.tsx
@@ -65,6 +65,7 @@ const AGENT_RUNTIMES = [
   { value: "copilot", label: "GitHub Copilot" },
   { value: "opencode", label: "OpenCode (Experimental)" },
   { value: "gemini", label: "Google Gemini" },
+  { value: "openclaw", label: "OpenClaw (Experimental)" },
 ];
 
 const TRIGGER_TYPES = [

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -50,6 +50,9 @@ RUN curl -fsSL https://opencode.ai/install | bash \
 # Google Gemini CLI
 RUN npm install -g @google/gemini-cli
 
+# OpenClaw CLI (experimental)
+RUN npm install -g openclaw || echo "WARN: openclaw install failed; openclaw agent will not be available in this image"
+
 # Python 3 (minimal — needed for setup file injection)
 RUN apt-get update && apt-get install -y python3 \
     && rm -rf /var/lib/apt/lists/*

--- a/packages/agent-adapters/src/index.ts
+++ b/packages/agent-adapters/src/index.ts
@@ -4,6 +4,7 @@ export { CodexAdapter } from "./codex.js";
 export { CopilotAdapter } from "./copilot.js";
 export { OpenCodeAdapter } from "./opencode.js";
 export { GeminiAdapter } from "./gemini.js";
+export { OpenClawAdapter } from "./openclaw.js";
 
 import type { AgentAdapter } from "./types.js";
 import { ClaudeCodeAdapter } from "./claude-code.js";
@@ -11,6 +12,7 @@ import { CodexAdapter } from "./codex.js";
 import { CopilotAdapter } from "./copilot.js";
 import { OpenCodeAdapter } from "./opencode.js";
 import { GeminiAdapter } from "./gemini.js";
+import { OpenClawAdapter } from "./openclaw.js";
 
 const adapters: Record<string, AgentAdapter> = {
   "claude-code": new ClaudeCodeAdapter(),
@@ -24,12 +26,22 @@ if (process.env.OPTIO_OPENCODE_ENABLED === "true") {
   adapters.opencode = new OpenCodeAdapter();
 }
 
+// OpenClaw is experimental — only register when explicitly enabled
+if (process.env.OPTIO_OPENCLAW_ENABLED === "true") {
+  adapters.openclaw = new OpenClawAdapter();
+}
+
 export function getAdapter(type: string): AgentAdapter {
   const adapter = adapters[type];
   if (!adapter) {
     if (type === "opencode" && process.env.OPTIO_OPENCODE_ENABLED !== "true") {
       throw new Error(
         "OpenCode adapter is disabled. Set OPTIO_OPENCODE_ENABLED=true to enable it.",
+      );
+    }
+    if (type === "openclaw" && process.env.OPTIO_OPENCLAW_ENABLED !== "true") {
+      throw new Error(
+        "OpenClaw adapter is disabled. Set OPTIO_OPENCLAW_ENABLED=true to enable it.",
       );
     }
     throw new Error(`Unknown agent type: ${type}. Available: ${Object.keys(adapters).join(", ")}`);

--- a/packages/agent-adapters/src/openclaw.test.ts
+++ b/packages/agent-adapters/src/openclaw.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from "vitest";
+import { OpenClawAdapter } from "./openclaw.js";
+
+const adapter = new OpenClawAdapter();
+
+describe("OpenClawAdapter", () => {
+  describe("type and displayName", () => {
+    it("has correct type", () => {
+      expect(adapter.type).toBe("openclaw");
+    });
+
+    it("has correct displayName", () => {
+      expect(adapter.displayName).toBe("OpenClaw");
+    });
+  });
+
+  describe("validateSecrets", () => {
+    it("returns valid when ANTHROPIC_API_KEY is present", () => {
+      const result = adapter.validateSecrets(["ANTHROPIC_API_KEY"]);
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+
+    it("returns valid when OPENAI_API_KEY is present", () => {
+      const result = adapter.validateSecrets(["OPENAI_API_KEY"]);
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+
+    it("returns valid when OPENCLAW_API_KEY is present", () => {
+      const result = adapter.validateSecrets(["OPENCLAW_API_KEY"]);
+      expect(result.valid).toBe(true);
+      expect(result.missing).toEqual([]);
+    });
+
+    it("reports missing when no provider keys are present", () => {
+      const result = adapter.validateSecrets([]);
+      expect(result.valid).toBe(false);
+      expect(result.missing).toEqual(["ANTHROPIC_API_KEY or OPENAI_API_KEY or OPENCLAW_API_KEY"]);
+    });
+
+    it("reports missing when only unrelated secrets are present", () => {
+      const result = adapter.validateSecrets(["GITHUB_TOKEN", "COPILOT_GITHUB_TOKEN"]);
+      expect(result.valid).toBe(false);
+      expect(result.missing).toEqual(["ANTHROPIC_API_KEY or OPENAI_API_KEY or OPENCLAW_API_KEY"]);
+    });
+  });
+
+  describe("buildContainerConfig", () => {
+    const baseInput = {
+      taskId: "test-123",
+      prompt: "Fix the bug",
+      repoUrl: "https://github.com/org/repo",
+      repoBranch: "main",
+    };
+
+    it("uses rendered prompt when available", () => {
+      const config = adapter.buildContainerConfig({
+        ...baseInput,
+        renderedPrompt: "Rendered: Fix the bug",
+      });
+      expect(config.env.OPTIO_PROMPT).toBe("Rendered: Fix the bug");
+    });
+
+    it("falls back to raw prompt when no rendered prompt", () => {
+      const config = adapter.buildContainerConfig(baseInput);
+      expect(config.env.OPTIO_PROMPT).toBe("Fix the bug");
+    });
+
+    it("sets correct env vars", () => {
+      const config = adapter.buildContainerConfig(baseInput);
+      expect(config.env.OPTIO_TASK_ID).toBe("test-123");
+      expect(config.env.OPTIO_AGENT_TYPE).toBe("openclaw");
+      expect(config.env.OPTIO_BRANCH_NAME).toBe("optio/task-test-123");
+      expect(config.env.OPTIO_REPO_URL).toBe("https://github.com/org/repo");
+      expect(config.env.OPTIO_REPO_BRANCH).toBe("main");
+    });
+
+    it("requires provider API key secrets", () => {
+      const config = adapter.buildContainerConfig(baseInput);
+      expect(config.requiredSecrets).toContain("ANTHROPIC_API_KEY");
+      expect(config.requiredSecrets).toContain("OPENAI_API_KEY");
+      expect(config.requiredSecrets).toContain("OPENCLAW_API_KEY");
+    });
+
+    it("sets OPTIO_OPENCLAW_MODEL when openclawModel is provided", () => {
+      const config = adapter.buildContainerConfig({
+        ...baseInput,
+        openclawModel: "anthropic/claude-sonnet-4",
+      });
+      expect(config.env.OPTIO_OPENCLAW_MODEL).toBe("anthropic/claude-sonnet-4");
+    });
+
+    it("sets OPTIO_OPENCLAW_AGENT when openclawAgent is provided", () => {
+      const config = adapter.buildContainerConfig({
+        ...baseInput,
+        openclawAgent: "build",
+      });
+      expect(config.env.OPTIO_OPENCLAW_AGENT).toBe("build");
+    });
+
+    it("does not set OPTIO_OPENCLAW_MODEL or OPTIO_OPENCLAW_AGENT when not provided", () => {
+      const config = adapter.buildContainerConfig(baseInput);
+      expect(config.env.OPTIO_OPENCLAW_MODEL).toBeUndefined();
+      expect(config.env.OPTIO_OPENCLAW_AGENT).toBeUndefined();
+    });
+
+    it("includes openclaw config as setup file", () => {
+      const config = adapter.buildContainerConfig(baseInput);
+      const configFile = config.setupFiles?.find((f) => f.path.includes(".openclaw/config.json"));
+      expect(configFile).toBeDefined();
+      expect(JSON.parse(configFile!.content)).toEqual({
+        $schema: "https://openclaw.dev/config.json",
+      });
+    });
+
+    it("includes task file in setup files when provided", () => {
+      const config = adapter.buildContainerConfig({
+        ...baseInput,
+        taskFileContent: "# Task\nDo something",
+        taskFilePath: ".optio/task.md",
+      });
+      const taskFile = config.setupFiles?.find((f) => f.path === ".optio/task.md");
+      expect(taskFile).toBeDefined();
+      expect(taskFile!.content).toBe("# Task\nDo something");
+    });
+
+    it("returns only openclaw config in setupFiles when no task file", () => {
+      const config = adapter.buildContainerConfig(baseInput);
+      expect(config.setupFiles).toHaveLength(1);
+      expect(config.setupFiles![0].path).toContain("config.json");
+    });
+
+    it("uses entrypoint.sh as command", () => {
+      const config = adapter.buildContainerConfig(baseInput);
+      expect(config.command).toEqual(["/opt/optio/entrypoint.sh"]);
+    });
+  });
+
+  describe("parseResult", () => {
+    it("returns success for exit code 0 with no errors", () => {
+      const result = adapter.parseResult(0, "some output\nmore output");
+      expect(result.success).toBe(true);
+      expect(result.summary).toBe("Agent completed successfully");
+      expect(result.error).toBeUndefined();
+    });
+
+    it("returns failure for non-zero exit code", () => {
+      const result = adapter.parseResult(1, "some output");
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Exit code: 1");
+    });
+
+    it("extracts GitHub PR URL from logs", () => {
+      const logs = `Working on task...\nhttps://github.com/org/repo/pull/42\nDone!`;
+      const result = adapter.parseResult(0, logs);
+      expect(result.prUrl).toBe("https://github.com/org/repo/pull/42");
+    });
+
+    it("extracts GitLab MR URL from logs", () => {
+      const logs = `Working on task...\nhttps://gitlab.com/org/repo/-/merge_requests/7\nDone!`;
+      const result = adapter.parseResult(0, logs);
+      expect(result.prUrl).toBe("https://gitlab.com/org/repo/-/merge_requests/7");
+    });
+
+    it("extracts summary from last assistant message", () => {
+      const logs = [
+        '{"type":"message","role":"assistant","content":"Starting work"}',
+        '{"type":"message","role":"assistant","content":"All done, PR created"}',
+      ].join("\n");
+      const result = adapter.parseResult(0, logs);
+      expect(result.summary).toBe("All done, PR created");
+    });
+
+    it("extracts summary from result event", () => {
+      const logs = '{"type":"result","result":"Task completed successfully"}';
+      const result = adapter.parseResult(0, logs);
+      expect(result.summary).toBe("Task completed successfully");
+    });
+
+    it("truncates long summaries", () => {
+      const longMsg = "x".repeat(300);
+      const logs = `{"type":"message","role":"assistant","content":"${longMsg}"}`;
+      const result = adapter.parseResult(0, logs);
+      expect(result.summary!.length).toBeLessThanOrEqual(201); // 200 + ellipsis
+    });
+
+    it("uses total_cost_usd when provided directly", () => {
+      const logs = '{"type":"result","total_cost_usd":0.0534}';
+      const result = adapter.parseResult(0, logs);
+      expect(result.costUsd).toBe(0.0534);
+    });
+
+    it("leaves cost undefined when not provided", () => {
+      const logs = '{"type":"message","role":"assistant","content":"Done"}';
+      const result = adapter.parseResult(0, logs);
+      expect(result.costUsd).toBeUndefined();
+    });
+
+    it("detects error events in JSON output", () => {
+      const logs = '{"type":"error","message":"Provider API key is invalid"}';
+      const result = adapter.parseResult(0, logs);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Provider API key is invalid");
+    });
+
+    it("detects error envelope in JSON output", () => {
+      const logs =
+        '{"error":{"message":"Invalid API key","type":"auth_error","code":"invalid_key"}}';
+      const result = adapter.parseResult(0, logs);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Invalid API key");
+    });
+
+    it("detects is_error result events", () => {
+      const logs = '{"is_error":true,"result":"Authentication failed"}';
+      const result = adapter.parseResult(0, logs);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Authentication failed");
+    });
+
+    it("extracts token usage from events", () => {
+      const logs = [
+        '{"type":"message","role":"assistant","content":"Done","usage":{"input_tokens":1000,"output_tokens":500}}',
+      ].join("\n");
+      const result = adapter.parseResult(0, logs);
+      expect(result.inputTokens).toBe(1000);
+      expect(result.outputTokens).toBe(500);
+    });
+
+    it("extracts token usage from OpenAI-style naming", () => {
+      const logs =
+        '{"type":"message","role":"assistant","content":"Done","usage":{"prompt_tokens":2000,"completion_tokens":1000}}';
+      const result = adapter.parseResult(0, logs);
+      expect(result.inputTokens).toBe(2000);
+      expect(result.outputTokens).toBe(1000);
+    });
+
+    it("extracts model from events", () => {
+      const logs =
+        '{"model":"anthropic/claude-sonnet-4","type":"message","role":"assistant","content":"Hi"}';
+      const result = adapter.parseResult(0, logs);
+      expect(result.model).toBe("anthropic/claude-sonnet-4");
+    });
+
+    it("detects auth errors in raw text", () => {
+      const logs = "Error: OPENCLAW_API_KEY authentication failed";
+      const result = adapter.parseResult(1, logs);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("OPENCLAW_API_KEY");
+    });
+
+    it("detects model not found errors in raw text", () => {
+      const logs = "Error: model_not_found - The model does not exist";
+      const result = adapter.parseResult(1, logs);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("model_not_found");
+    });
+
+    it("detects server errors in raw text", () => {
+      const logs = "Error: 503 service unavailable";
+      const result = adapter.parseResult(1, logs);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("503");
+    });
+
+    it("handles empty logs gracefully", () => {
+      const result = adapter.parseResult(0, "");
+      expect(result.success).toBe(true);
+      expect(result.costUsd).toBeUndefined();
+      expect(result.inputTokens).toBeUndefined();
+      expect(result.outputTokens).toBeUndefined();
+      expect(result.model).toBeUndefined();
+    });
+
+    it("does not compute cost from tokens (provider-agnostic)", () => {
+      const logs =
+        '{"type":"message","role":"assistant","content":"Done","usage":{"input_tokens":1000,"output_tokens":500}}';
+      const result = adapter.parseResult(0, logs);
+      // OpenClaw is provider-agnostic — no per-token cost calculation
+      expect(result.costUsd).toBeUndefined();
+    });
+  });
+});

--- a/packages/agent-adapters/src/openclaw.ts
+++ b/packages/agent-adapters/src/openclaw.ts
@@ -1,0 +1,240 @@
+import type { AgentTaskInput, AgentContainerConfig, AgentResult } from "@optio/shared";
+import { TASK_BRANCH_PREFIX } from "@optio/shared";
+import type { AgentAdapter } from "./types.js";
+
+/**
+ * OpenClaw CLI (openclaw agent --output-format stream-json) outputs NDJSON events.
+ * Each line is a JSON object. The format is similar to Claude Code's NDJSON:
+ *
+ * - { type: "message", role: "assistant"|"system", content: "..." }
+ * - { type: "tool_call", name: "...", call_id: "...", arguments: "..." }
+ * - { type: "tool_result", call_id: "...", output: "..." }
+ * - { type: "error", message: "..." }
+ * - { type: "result", result: "...", total_cost_usd, session_id }
+ * - Events with usage data (input_tokens, output_tokens)
+ *
+ * The parser is conservative — unrecognized events are skipped.
+ */
+
+export class OpenClawAdapter implements AgentAdapter {
+  readonly type = "openclaw";
+  readonly displayName = "OpenClaw";
+
+  validateSecrets(availableSecrets: string[]): { valid: boolean; missing: string[] } {
+    // OpenClaw is provider-agnostic — it needs at least one provider API key
+    const acceptedKeys = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENCLAW_API_KEY"];
+    const hasAny = acceptedKeys.some((k) => availableSecrets.includes(k));
+    return {
+      valid: hasAny,
+      missing: hasAny ? [] : ["ANTHROPIC_API_KEY or OPENAI_API_KEY or OPENCLAW_API_KEY"],
+    };
+  }
+
+  buildContainerConfig(input: AgentTaskInput): AgentContainerConfig {
+    const prompt = input.renderedPrompt ?? input.prompt;
+
+    const env: Record<string, string> = {
+      OPTIO_TASK_ID: input.taskId,
+      OPTIO_REPO_URL: input.repoUrl,
+      OPTIO_REPO_BRANCH: input.repoBranch,
+      OPTIO_PROMPT: prompt,
+      OPTIO_AGENT_TYPE: "openclaw",
+      OPTIO_BRANCH_NAME: `${TASK_BRANCH_PREFIX}${input.taskId}`,
+    };
+
+    // OpenClaw reads provider-specific env vars directly (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
+    // These are injected via requiredSecrets
+    const requiredSecrets: string[] = [];
+
+    // Determine which provider keys to request based on what's configured
+    // The task worker resolves these against available secrets
+    requiredSecrets.push("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENCLAW_API_KEY");
+
+    const setupFiles: AgentContainerConfig["setupFiles"] = [];
+
+    // Set model if configured
+    if (input.openclawModel) {
+      env.OPTIO_OPENCLAW_MODEL = input.openclawModel;
+    }
+    // Set named agent if configured
+    if (input.openclawAgent) {
+      env.OPTIO_OPENCLAW_AGENT = input.openclawAgent;
+    }
+
+    // Pre-seed a minimal openclaw config so the CLI doesn't hit first-run setup
+    setupFiles.push({
+      path: "/home/agent/.openclaw/config.json",
+      content: JSON.stringify({ $schema: "https://openclaw.dev/config.json" }),
+    });
+
+    // Write the task file into the worktree
+    if (input.taskFileContent && input.taskFilePath) {
+      setupFiles.push({
+        path: input.taskFilePath,
+        content: input.taskFileContent,
+      });
+    }
+
+    return {
+      command: ["/opt/optio/entrypoint.sh"],
+      env,
+      requiredSecrets,
+      setupFiles,
+    };
+  }
+
+  parseResult(exitCode: number, logs: string): AgentResult {
+    const prMatch = logs.match(
+      /https:\/\/(?![\w.-]+\/api\/)[^\s"]+\/(?:pull\/\d+|-\/merge_requests\/\d+)/,
+    );
+    const { costUsd, errorMessage, hasError, summary, inputTokens, outputTokens, model } =
+      this.parseLogs(logs);
+
+    const success = exitCode === 0 && !hasError;
+
+    return {
+      success,
+      prUrl: prMatch?.[0],
+      costUsd,
+      inputTokens,
+      outputTokens,
+      model,
+      summary:
+        summary ??
+        (success ? "Agent completed successfully" : `Agent exited with code ${exitCode}`),
+      error: !success ? (errorMessage ?? `Exit code: ${exitCode}`) : undefined,
+    };
+  }
+
+  private parseLogs(logs: string): {
+    costUsd?: number;
+    errorMessage?: string;
+    hasError: boolean;
+    summary?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    model?: string;
+  } {
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let directCost: number | undefined;
+    let model: string | undefined;
+    let errorMessage: string | undefined;
+    let hasError = false;
+    let lastAssistantMessage: string | undefined;
+
+    for (const line of logs.split("\n")) {
+      if (!line.trim()) continue;
+
+      let event: any;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        if (!errorMessage && isRawTextError(line)) {
+          errorMessage = line.trim();
+          hasError = true;
+        }
+        continue;
+      }
+
+      // Extract model name
+      if (event.model && !model) {
+        model = event.model;
+      }
+
+      // Error envelope: { error: { message, type, code } }
+      if (event.error && typeof event.error === "object" && event.error.message) {
+        errorMessage = event.error.message;
+        hasError = true;
+        continue;
+      }
+
+      // Error events: { type: "error", message: "..." }
+      if (event.type === "error") {
+        errorMessage = event.message ?? event.error ?? JSON.stringify(event);
+        hasError = true;
+        continue;
+      }
+
+      // Result with is_error flag
+      if (event.is_error === true && event.result) {
+        errorMessage =
+          typeof event.result === "string" ? event.result : JSON.stringify(event.result);
+        hasError = true;
+        continue;
+      }
+
+      // Track assistant messages for summary
+      if (event.type === "message" && event.role === "assistant" && event.content) {
+        if (typeof event.content === "string") {
+          lastAssistantMessage = event.content;
+        }
+      }
+
+      // Result event with summary
+      if (event.type === "result" && event.result && !event.is_error) {
+        if (typeof event.result === "string") {
+          lastAssistantMessage = event.result;
+        }
+      }
+
+      // Extract usage data
+      const usage = event.usage ?? event.response?.usage;
+      if (usage) {
+        if (usage.input_tokens) totalInputTokens += usage.input_tokens;
+        if (usage.output_tokens) totalOutputTokens += usage.output_tokens;
+        if (usage.prompt_tokens) totalInputTokens += usage.prompt_tokens;
+        if (usage.completion_tokens) totalOutputTokens += usage.completion_tokens;
+      }
+
+      if (event.total_cost_usd != null) {
+        directCost = event.total_cost_usd;
+      }
+    }
+
+    // OpenClaw is provider-agnostic — cost may not be available.
+    // Use direct cost if reported, otherwise leave undefined.
+    const costUsd = directCost;
+
+    return {
+      costUsd,
+      errorMessage,
+      hasError,
+      summary: lastAssistantMessage ? truncate(lastAssistantMessage, 200) : undefined,
+      inputTokens: totalInputTokens > 0 ? totalInputTokens : undefined,
+      outputTokens: totalOutputTokens > 0 ? totalOutputTokens : undefined,
+      model,
+    };
+  }
+}
+
+function truncate(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen) + "\u2026";
+}
+
+/** Detect common OpenClaw error patterns in non-JSON output lines */
+function isRawTextError(line: string): boolean {
+  // Auth / API key errors
+  if (
+    /error|failed|fatal/i.test(line) &&
+    /ANTHROPIC_API_KEY|OPENAI_API_KEY|OPENCLAW_API_KEY|api.?key|authentication|unauthorized|forbidden/i.test(
+      line,
+    )
+  ) {
+    return true;
+  }
+  // Provider errors
+  if (/invalid.*key|key.*invalid|api.*error/i.test(line)) {
+    return true;
+  }
+  // Model not found
+  if (/model.*not found|model_not_found|does not exist|invalid.*model/i.test(line)) {
+    return true;
+  }
+  // Server errors
+  if (/server.?error|internal.?error|service.?unavailable|503|502/i.test(line)) {
+    return true;
+  }
+  return false;
+}

--- a/packages/shared/src/error-classifier.ts
+++ b/packages/shared/src/error-classifier.ts
@@ -92,6 +92,17 @@ const ERROR_PATTERNS: Array<{
     }),
   },
   {
+    pattern: /OPENCLAW_API_KEY/i,
+    classify: () => ({
+      category: "auth",
+      title: "OpenClaw API key missing",
+      description: "No OpenClaw API key is configured and the OpenClaw agent cannot authenticate.",
+      remedy:
+        "Go to Secrets and add OPENCLAW_API_KEY, or provide an ANTHROPIC_API_KEY or OPENAI_API_KEY instead.",
+      retryable: true,
+    }),
+  },
+  {
     pattern: /COPILOT_GITHUB_TOKEN|copilot.*auth|copilot.*unauthorized|subscription.*required/i,
     classify: () => ({
       category: "auth",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -2,6 +2,7 @@ export type ClaudeAuthMode = "api-key" | "max-subscription";
 export type CodexAuthMode = "api-key" | "app-server";
 export type CopilotAuthMode = "github-token";
 export type GeminiAuthMode = "api-key" | "vertex-ai";
+export type OpenClawAuthMode = "api-key";
 
 export interface AgentTaskInput {
   taskId: string;
@@ -29,6 +30,8 @@ export interface AgentTaskInput {
   copilotEffort?: string;
   opencodeModel?: string;
   opencodeAgent?: string;
+  openclawModel?: string;
+  openclawAgent?: string;
   geminiAuthMode?: GeminiAuthMode;
   geminiModel?: string;
   geminiApprovalMode?: "default" | "auto_edit" | "yolo";


### PR DESCRIPTION
Closes #409

## What changed

Added **OpenClaw** as the 6th supported agent runtime in Optio, expanding coverage alongside Claude Code, Codex, Copilot, OpenCode, and Gemini. This is a full-stack implementation following the established adapter plugin pattern.

### New files
- **Adapter** (`packages/agent-adapters/src/openclaw.ts`): Implements `AgentAdapter` interface with `validateSecrets()`, `buildContainerConfig()`, and `parseResult()`. Provider-agnostic — accepts `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `OPENCLAW_API_KEY`.
- **Event parser** (`apps/api/src/services/openclaw-event-parser.ts`): Parses NDJSON from `openclaw agent --output-format stream-json`. Handles init, message, tool_call, tool_result, error, result, reasoning events.
- **Test suites**: Full coverage for both adapter (26 tests) and event parser (25+ tests) with NDJSON fixture.
- **DB migration**: Adds `openclaw_model` and `openclaw_agent` columns to the `repos` table.

### Modified files
- **Shared types** (`agent.ts`): Added `OpenClawAuthMode`, `openclawModel`, `openclawAgent` fields to `AgentTaskInput`.
- **Adapter registry** (`index.ts`): Registered OpenClaw adapter, feature-gated behind `OPTIO_OPENCLAW_ENABLED=true`.
- **Task worker**: Added OpenClaw to event parser routing, `buildAgentCommand()`, and `inferExitCode()`.
- **Error classifier**: Added `OPENCLAW_API_KEY` auth error pattern.
- **Web UI**: Added OpenClaw option to all 5 agent selectors (tasks/new, repos settings, templates, schedules, workflows) and added OpenClaw model settings section in repo settings page.
- **Docker base image**: Added `openclaw` CLI installation.

### Design decisions
- **Feature-gated**: Like OpenCode, OpenClaw is disabled by default. Enable with `OPTIO_OPENCLAW_ENABLED=true`.
- **Provider-agnostic**: Similar to OpenCode, accepts multiple provider API keys rather than requiring a specific one.
- **NDJSON format**: Uses `--output-format stream-json` similar to Claude Code/Gemini, so event parser follows the same patterns.

## How to test

1. **Unit tests**: `pnpm turbo test` — all tests pass including 26 new adapter tests and 25+ new event parser tests.
2. **Typecheck**: `pnpm turbo typecheck` — passes across all 8 packages.
3. **Format**: `pnpm format:check` — clean.
4. **Manual verification**: Set `OPTIO_OPENCLAW_ENABLED=true`, add an API key secret, select "OpenClaw (Experimental)" when creating a task or in repo settings.