### PR TITLE
feat: expanded dashboard analytics — performance, agents, and failure insights

### DIFF
--- a/apps/api/src/routes/analytics.test.ts
+++ b/apps/api/src/routes/analytics.test.ts
@@ -12,6 +12,18 @@ vi.mock("../db/client.js", () => ({
   },
 }));
 
+const mockGetPerformance = vi.fn();
+const mockGetAgents = vi.fn();
+const mockGetFailures = vi.fn();
+const mockGetPrs = vi.fn();
+
+vi.mock("../services/analytics-service.js", () => ({
+  getPerformanceAnalytics: (...args: unknown[]) => mockGetPerformance(...args),
+  getAgentAnalytics: (...args: unknown[]) => mockGetAgents(...args),
+  getFailureAnalytics: (...args: unknown[]) => mockGetFailures(...args),
+  getPrAnalytics: (...args: unknown[]) => mockGetPrs(...args),
+}));
+
 import { analyticsRoutes } from "./analytics.js";
 
 // ─── Helpers ───
@@ -194,5 +206,176 @@ describe("GET /api/analytics/costs", () => {
     expect(res.statusCode).toBe(200);
     // Verify that db.execute was called (the repoUrl filter is embedded in SQL)
     expect(mockExecute).toHaveBeenCalledTimes(10);
+  });
+});
+
+describe("GET /api/analytics/performance", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns performance analytics with default params", async () => {
+    mockGetPerformance.mockResolvedValueOnce({
+      durations: {
+        avgWallClock: 3600,
+        p50WallClock: 3000,
+        p95WallClock: 7200,
+        avgExecution: 3000,
+        p50Execution: 2500,
+        p95Execution: 6000,
+        avgQueueWait: 600,
+        taskCount: 10,
+      },
+      successRate: 80,
+      successRateTrend: 5,
+      tasksPerDay: [{ date: "2026-04-10", total: 5, succeeded: 4, failed: 1 }],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/analytics/performance",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.durations.avgWallClock).toBe(3600);
+    expect(body.successRate).toBe(80);
+    expect(body.tasksPerDay).toHaveLength(1);
+  });
+
+  it("passes filters to service", async () => {
+    mockGetPerformance.mockResolvedValueOnce({
+      durations: {
+        avgWallClock: 0,
+        p50WallClock: 0,
+        p95WallClock: 0,
+        avgExecution: 0,
+        p50Execution: 0,
+        p95Execution: 0,
+        avgQueueWait: 0,
+        taskCount: 0,
+      },
+      successRate: 0,
+      successRateTrend: 0,
+      tasksPerDay: [],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/analytics/performance?days=7&agentType=claude&repoUrl=https://github.com/org/repo",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockGetPerformance).toHaveBeenCalledWith({
+      days: 7,
+      agentType: "claude",
+      repoUrl: "https://github.com/org/repo",
+      workspaceId: "ws-1",
+    });
+  });
+});
+
+describe("GET /api/analytics/agents", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns agent comparison analytics", async () => {
+    mockGetAgents.mockResolvedValueOnce({
+      agents: [
+        {
+          agentType: "claude",
+          taskCount: 15,
+          successRate: 80,
+          avgDuration: 1800,
+          avgCost: "1.5000",
+          avgRetries: 0.5,
+          models: [{ model: "claude-sonnet-4-6", taskCount: 10, avgCost: "1.2000" }],
+        },
+      ],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/analytics/agents",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0].agentType).toBe("claude");
+  });
+});
+
+describe("GET /api/analytics/failures", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns failure analytics", async () => {
+    mockGetFailures.mockResolvedValueOnce({
+      errorMessages: [{ message: "ImagePullBackOff", count: 5 }],
+      failureByRepo: [],
+      failureByAgent: [],
+      failureByModel: [],
+      retrySuccessRate: 67,
+      retriedCount: 6,
+      retrySucceededCount: 4,
+      stallCount: 3,
+      stallRecoveryRate: 67,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/analytics/failures?days=7",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.errorMessages).toHaveLength(1);
+    expect(body.retrySuccessRate).toBe(67);
+  });
+});
+
+describe("GET /api/analytics/prs", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns PR lifecycle metrics", async () => {
+    mockGetPrs.mockResolvedValueOnce({
+      totalPrs: 20,
+      merged: 15,
+      closed: 2,
+      open: 3,
+      ciPassRate: 90,
+      reviewApprovalRate: 80,
+      autoMergeRate: 75,
+      avgMergeTime: 7200,
+      mergeCount: 15,
+      funnel: { prOpened: 20, ciPassed: 18, reviewApproved: 16, merged: 15 },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/analytics/prs",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.totalPrs).toBe(20);
+    expect(body.funnel.merged).toBe(15);
   });
 });

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -5,7 +5,19 @@ import { z } from "zod";
 import { db } from "../db/client.js";
 import { requireRole } from "../plugins/auth.js";
 import { ErrorResponseSchema } from "../schemas/common.js";
-import { CostAnalyticsSchema } from "../schemas/workspace.js";
+import {
+  CostAnalyticsSchema,
+  PerformanceAnalyticsSchema,
+  AgentAnalyticsSchema,
+  FailureAnalyticsSchema,
+  PrAnalyticsSchema,
+} from "../schemas/workspace.js";
+import {
+  getPerformanceAnalytics,
+  getAgentAnalytics,
+  getFailureAnalytics,
+  getPrAnalytics,
+} from "../services/analytics-service.js";
 
 const costsQuerySchema = z
   .object({
@@ -20,6 +32,37 @@ const costsQuerySchema = z
     repoUrl: z.string().optional().describe("Optional repo URL filter"),
   })
   .describe("Query parameters for cost analytics");
+
+const performanceQuerySchema = z
+  .object({
+    days: z.coerce.number().int().min(1).max(365).optional().default(30),
+    repoUrl: z.string().optional(),
+    agentType: z.string().optional(),
+  })
+  .describe("Query parameters for performance analytics");
+
+const agentQuerySchema = z
+  .object({
+    days: z.coerce.number().int().min(1).max(365).optional().default(30),
+    repoUrl: z.string().optional(),
+  })
+  .describe("Query parameters for agent analytics");
+
+const failureQuerySchema = z
+  .object({
+    days: z.coerce.number().int().min(1).max(365).optional().default(30),
+    repoUrl: z.string().optional(),
+    agentType: z.string().optional(),
+  })
+  .describe("Query parameters for failure analytics");
+
+const prQuerySchema = z
+  .object({
+    days: z.coerce.number().int().min(1).max(365).optional().default(30),
+    repoUrl: z.string().optional(),
+    agentType: z.string().optional(),
+  })
+  .describe("Query parameters for PR analytics");
 
 export async function analyticsRoutes(rawApp: FastifyInstance) {
   const app = rawApp.withTypeProvider<ZodTypeProvider>();
@@ -395,6 +438,129 @@ export async function analyticsRoutes(rawApp: FastifyInstance) {
           createdAt: r.created_at,
         })),
       });
+    },
+  );
+
+  // ── Performance Analytics ────────────────────────────────────────────────
+
+  app.get(
+    "/api/analytics/performance",
+    {
+      preHandler: [requireRole("member")],
+      schema: {
+        operationId: "getPerformanceAnalytics",
+        summary: "Get task performance analytics",
+        description:
+          "Return task duration metrics (avg/p50/p95), success rate with trend, " +
+          "and tasks-per-day time series. Filterable by days, repoUrl, agentType.",
+        tags: ["Analytics"],
+        querystring: performanceQuerySchema,
+        response: {
+          200: PerformanceAnalyticsSchema,
+          400: ErrorResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const result = await getPerformanceAnalytics({
+        days: req.query.days,
+        repoUrl: req.query.repoUrl || null,
+        agentType: req.query.agentType || null,
+        workspaceId: req.user?.workspaceId || null,
+      });
+      reply.send(result);
+    },
+  );
+
+  // ── Agent Comparison Analytics ───────────────────────────────────────────
+
+  app.get(
+    "/api/analytics/agents",
+    {
+      preHandler: [requireRole("member")],
+      schema: {
+        operationId: "getAgentAnalytics",
+        summary: "Get per-agent-type comparison analytics",
+        description:
+          "Return task count, success rate, avg duration, avg cost, avg retries, " +
+          "and model breakdown for each agent type.",
+        tags: ["Analytics"],
+        querystring: agentQuerySchema,
+        response: {
+          200: AgentAnalyticsSchema,
+          400: ErrorResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const result = await getAgentAnalytics({
+        days: req.query.days,
+        repoUrl: req.query.repoUrl || null,
+        workspaceId: req.user?.workspaceId || null,
+      });
+      reply.send(result);
+    },
+  );
+
+  // ── Failure Analytics ────────────────────────────────────────────────────
+
+  app.get(
+    "/api/analytics/failures",
+    {
+      preHandler: [requireRole("member")],
+      schema: {
+        operationId: "getFailureAnalytics",
+        summary: "Get failure pattern analysis",
+        description:
+          "Return top error messages, failure rates by repo/agent/model, " +
+          "retry success rate, and stall frequency.",
+        tags: ["Analytics"],
+        querystring: failureQuerySchema,
+        response: {
+          200: FailureAnalyticsSchema,
+          400: ErrorResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const result = await getFailureAnalytics({
+        days: req.query.days,
+        repoUrl: req.query.repoUrl || null,
+        agentType: req.query.agentType || null,
+        workspaceId: req.user?.workspaceId || null,
+      });
+      reply.send(result);
+    },
+  );
+
+  // ── PR Lifecycle Analytics ───────────────────────────────────────────────
+
+  app.get(
+    "/api/analytics/prs",
+    {
+      preHandler: [requireRole("member")],
+      schema: {
+        operationId: "getPrAnalytics",
+        summary: "Get PR lifecycle metrics",
+        description:
+          "Return PR open→merge time, CI pass rate, review approval rate, " +
+          "auto-merge success rate, and PR lifecycle funnel.",
+        tags: ["Analytics"],
+        querystring: prQuerySchema,
+        response: {
+          200: PrAnalyticsSchema,
+          400: ErrorResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const result = await getPrAnalytics({
+        days: req.query.days,
+        repoUrl: req.query.repoUrl || null,
+        agentType: req.query.agentType || null,
+        workspaceId: req.user?.workspaceId || null,
+      });
+      reply.send(result);
     },
   );
 }

--- a/apps/api/src/schemas/workspace.ts
+++ b/apps/api/src/schemas/workspace.ts
@@ -29,3 +29,31 @@ export const CostAnalyticsSchema = z
       "costByRepo, costByType, costByModel, anomalies, modelSuggestions, " +
       "topTasks.",
   );
+
+export const PerformanceAnalyticsSchema = z
+  .unknown()
+  .describe(
+    "Task performance analytics: duration metrics (avg/p50/p95 wall clock and execution), " +
+      "success rate with trend, and tasks-per-day time series.",
+  );
+
+export const AgentAnalyticsSchema = z
+  .unknown()
+  .describe(
+    "Per-agent-type comparison: task count, success rate, avg duration, " +
+      "avg cost, avg retries, and model breakdown for each agent type.",
+  );
+
+export const FailureAnalyticsSchema = z
+  .unknown()
+  .describe(
+    "Failure pattern analysis: top error messages, failure rate by repo/agent/model, " +
+      "retry success rate, and stall frequency.",
+  );
+
+export const PrAnalyticsSchema = z
+  .unknown()
+  .describe(
+    "PR lifecycle metrics: open→merge time, CI pass rate, review approval rate, " +
+      "auto-merge rate, and lifecycle funnel data.",
+  );

--- a/apps/api/src/services/analytics-service.test.ts
+++ b/apps/api/src/services/analytics-service.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockExecute = vi.fn();
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    execute: (...args: unknown[]) => mockExecute(...args),
+  },
+}));
+
+import {
+  getPerformanceAnalytics,
+  getAgentAnalytics,
+  getFailureAnalytics,
+  getPrAnalytics,
+} from "./analytics-service.js";
+
+describe("analytics-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getPerformanceAnalytics", () => {
+    it("returns duration metrics, success rate, and tasks per day", async () => {
+      mockExecute
+        // durations
+        .mockResolvedValueOnce([
+          {
+            avg_wall_clock: "3600",
+            p50_wall_clock: "3000",
+            p95_wall_clock: "7200",
+            avg_execution: "3000",
+            p50_execution: "2500",
+            p95_execution: "6000",
+            avg_queue_wait: "600",
+            task_count: "10",
+          },
+        ])
+        // success rates
+        .mockResolvedValueOnce([{ total: "20", succeeded: "16" }])
+        // prev period rates
+        .mockResolvedValueOnce([{ total: "15", succeeded: "10" }])
+        // tasks per day
+        .mockResolvedValueOnce([
+          { date: "2026-04-10", total: "5", succeeded: "4", failed: "1" },
+          { date: "2026-04-11", total: "7", succeeded: "6", failed: "0" },
+        ]);
+
+      const result = await getPerformanceAnalytics({
+        days: 30,
+        workspaceId: "ws-1",
+      });
+
+      expect(result.durations.avgWallClock).toBe(3600);
+      expect(result.durations.p50WallClock).toBe(3000);
+      expect(result.durations.p95WallClock).toBe(7200);
+      expect(result.durations.avgExecution).toBe(3000);
+      expect(result.durations.avgQueueWait).toBe(600);
+      expect(result.durations.taskCount).toBe(10);
+      expect(result.successRate).toBe(80);
+      // prev was 67%, current is 80%, trend = 80-67 = 13
+      expect(result.successRateTrend).toBe(13);
+      expect(result.tasksPerDay).toHaveLength(2);
+      expect(result.tasksPerDay[0].total).toBe(5);
+    });
+
+    it("handles zero tasks gracefully", async () => {
+      mockExecute
+        .mockResolvedValueOnce([
+          {
+            avg_wall_clock: "0",
+            p50_wall_clock: "0",
+            p95_wall_clock: "0",
+            avg_execution: "0",
+            p50_execution: "0",
+            p95_execution: "0",
+            avg_queue_wait: "0",
+            task_count: "0",
+          },
+        ])
+        .mockResolvedValueOnce([{ total: "0", succeeded: "0" }])
+        .mockResolvedValueOnce([{ total: "0", succeeded: "0" }])
+        .mockResolvedValueOnce([]);
+
+      const result = await getPerformanceAnalytics({ days: 7 });
+
+      expect(result.successRate).toBe(0);
+      expect(result.successRateTrend).toBe(0);
+      expect(result.tasksPerDay).toEqual([]);
+    });
+  });
+
+  describe("getAgentAnalytics", () => {
+    it("returns per-agent-type comparison with model breakdown", async () => {
+      mockExecute
+        // agents
+        .mockResolvedValueOnce([
+          {
+            agent_type: "claude",
+            task_count: "15",
+            succeeded: "12",
+            avg_duration: "1800",
+            avg_cost: "1.5000",
+            avg_retries: "0.50",
+          },
+          {
+            agent_type: "codex",
+            task_count: "5",
+            succeeded: "3",
+            avg_duration: "2400",
+            avg_cost: "0.8000",
+            avg_retries: "1.00",
+          },
+        ])
+        // model breakdown
+        .mockResolvedValueOnce([
+          {
+            agent_type: "claude",
+            model: "claude-sonnet-4-6",
+            task_count: "10",
+            avg_cost: "1.2000",
+          },
+          { agent_type: "claude", model: "claude-opus-4-6", task_count: "5", avg_cost: "2.5000" },
+          { agent_type: "codex", model: "gpt-4o", task_count: "5", avg_cost: "0.8000" },
+        ]);
+
+      const result = await getAgentAnalytics({ days: 30, workspaceId: "ws-1" });
+
+      expect(result.agents).toHaveLength(2);
+      expect(result.agents[0].agentType).toBe("claude");
+      expect(result.agents[0].taskCount).toBe(15);
+      expect(result.agents[0].successRate).toBe(80);
+      expect(result.agents[0].avgDuration).toBe(1800);
+      expect(result.agents[0].avgCost).toBe("1.5000");
+      expect(result.agents[0].models).toHaveLength(2);
+      expect(result.agents[1].agentType).toBe("codex");
+      expect(result.agents[1].successRate).toBe(60);
+    });
+  });
+
+  describe("getFailureAnalytics", () => {
+    it("returns failure patterns with retry and stall stats", async () => {
+      mockExecute
+        // error messages
+        .mockResolvedValueOnce([
+          { error_message: "ImagePullBackOff", count: "5" },
+          { error_message: "OAuth token expired", count: "3" },
+        ])
+        // failure by repo
+        .mockResolvedValueOnce([
+          { repo_url: "https://github.com/org/repo1", total: "10", failed: "3" },
+        ])
+        // failure by agent
+        .mockResolvedValueOnce([{ agent_type: "claude", total: "20", failed: "4" }])
+        // failure by model
+        .mockResolvedValueOnce([{ model: "claude-sonnet-4-6", total: "15", failed: "2" }])
+        // retry stats
+        .mockResolvedValueOnce([{ retried: "6", retry_succeeded: "4" }])
+        // stall stats
+        .mockResolvedValueOnce([{ stalled: "3", recovered: "2" }]);
+
+      const result = await getFailureAnalytics({ days: 7, workspaceId: "ws-1" });
+
+      expect(result.errorMessages).toHaveLength(2);
+      expect(result.errorMessages[0].message).toBe("ImagePullBackOff");
+      expect(result.errorMessages[0].count).toBe(5);
+      expect(result.failureByRepo).toHaveLength(1);
+      expect(result.failureByRepo[0].failureRate).toBe(30);
+      expect(result.failureByAgent[0].failureRate).toBe(20);
+      expect(result.failureByModel[0].failureRate).toBe(13);
+      expect(result.retrySuccessRate).toBe(67);
+      expect(result.retriedCount).toBe(6);
+      expect(result.stallCount).toBe(3);
+      expect(result.stallRecoveryRate).toBe(67);
+    });
+
+    it("handles zero retries and stalls", async () => {
+      mockExecute
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ retried: "0", retry_succeeded: "0" }])
+        .mockResolvedValueOnce([{ stalled: "0", recovered: "0" }]);
+
+      const result = await getFailureAnalytics({ days: 7 });
+
+      expect(result.retrySuccessRate).toBe(0);
+      expect(result.stallRecoveryRate).toBe(0);
+    });
+  });
+
+  describe("getPrAnalytics", () => {
+    it("returns PR lifecycle metrics and funnel", async () => {
+      mockExecute
+        // pr stats
+        .mockResolvedValueOnce([
+          {
+            total_prs: "20",
+            merged: "15",
+            closed: "2",
+            open: "3",
+            checks_passing: "18",
+            checks_failing: "2",
+            review_approved: "16",
+            review_changes_requested: "4",
+          },
+        ])
+        // merge time
+        .mockResolvedValueOnce([{ avg_merge_time: "7200", merge_count: "15" }]);
+
+      const result = await getPrAnalytics({ days: 30, workspaceId: "ws-1" });
+
+      expect(result.totalPrs).toBe(20);
+      expect(result.merged).toBe(15);
+      expect(result.closed).toBe(2);
+      expect(result.open).toBe(3);
+      expect(result.ciPassRate).toBe(90);
+      expect(result.reviewApprovalRate).toBe(80);
+      expect(result.autoMergeRate).toBe(75);
+      expect(result.avgMergeTime).toBe(7200);
+      expect(result.funnel.prOpened).toBe(20);
+      expect(result.funnel.ciPassed).toBe(18);
+      expect(result.funnel.reviewApproved).toBe(16);
+      expect(result.funnel.merged).toBe(15);
+    });
+
+    it("handles zero PRs gracefully", async () => {
+      mockExecute
+        .mockResolvedValueOnce([
+          {
+            total_prs: "0",
+            merged: "0",
+            closed: "0",
+            open: "0",
+            checks_passing: "0",
+            checks_failing: "0",
+            review_approved: "0",
+            review_changes_requested: "0",
+          },
+        ])
+        .mockResolvedValueOnce([{ avg_merge_time: "0", merge_count: "0" }]);
+
+      const result = await getPrAnalytics({ days: 7 });
+
+      expect(result.ciPassRate).toBe(0);
+      expect(result.reviewApprovalRate).toBe(0);
+      expect(result.autoMergeRate).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/services/analytics-service.ts
+++ b/apps/api/src/services/analytics-service.ts
@@ -1,0 +1,466 @@
+import { sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+
+export interface AnalyticsFilters {
+  days: number;
+  repoUrl?: string | null;
+  agentType?: string | null;
+  workspaceId?: string | null;
+}
+
+function buildFilters(filters: AnalyticsFilters) {
+  const dateFilter = sql`AND created_at >= NOW() - INTERVAL '1 day' * ${filters.days}`;
+  const repoFilter = filters.repoUrl ? sql`AND repo_url = ${filters.repoUrl}` : sql``;
+  const agentFilter = filters.agentType ? sql`AND agent_type = ${filters.agentType}` : sql``;
+  const wsFilter = filters.workspaceId ? sql`AND workspace_id = ${filters.workspaceId}` : sql``;
+  return { dateFilter, repoFilter, agentFilter, wsFilter };
+}
+
+function prevDateFilter(days: number) {
+  return sql`AND created_at >= NOW() - INTERVAL '1 day' * ${days * 2}
+             AND created_at < NOW() - INTERVAL '1 day' * ${days}`;
+}
+
+// ── Performance Analytics ────────────────────────────────────────────────────
+
+export async function getPerformanceAnalytics(filters: AnalyticsFilters) {
+  const { dateFilter, repoFilter, agentFilter, wsFilter } = buildFilters(filters);
+
+  // Duration metrics (only completed tasks with both timestamps)
+  const [durations] = await db.execute<{
+    avg_wall_clock: string;
+    p50_wall_clock: string;
+    p95_wall_clock: string;
+    avg_execution: string;
+    p50_execution: string;
+    p95_execution: string;
+    avg_queue_wait: string;
+    task_count: string;
+  }>(sql`
+    SELECT
+      COALESCE(AVG(EXTRACT(EPOCH FROM (completed_at - created_at))), 0) AS avg_wall_clock,
+      COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (completed_at - created_at))), 0) AS p50_wall_clock,
+      COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (completed_at - created_at))), 0) AS p95_wall_clock,
+      COALESCE(AVG(EXTRACT(EPOCH FROM (completed_at - started_at))), 0) AS avg_execution,
+      COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (completed_at - started_at))), 0) AS p50_execution,
+      COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (completed_at - started_at))), 0) AS p95_execution,
+      COALESCE(AVG(EXTRACT(EPOCH FROM (started_at - created_at))), 0) AS avg_queue_wait,
+      COUNT(*) AS task_count
+    FROM tasks
+    WHERE state IN ('completed', 'pr_opened')
+      AND completed_at IS NOT NULL
+      AND started_at IS NOT NULL
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+  `);
+
+  // Success rate
+  const [rates] = await db.execute<{
+    total: string;
+    succeeded: string;
+  }>(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE state NOT IN ('cancelled')) AS total,
+      COUNT(*) FILTER (WHERE state IN ('completed', 'pr_opened')) AS succeeded
+    FROM tasks
+    WHERE 1=1
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+  `);
+
+  // Previous period success rate for trend
+  const prevFilter = prevDateFilter(filters.days);
+  const [prevRates] = await db.execute<{
+    total: string;
+    succeeded: string;
+  }>(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE state NOT IN ('cancelled')) AS total,
+      COUNT(*) FILTER (WHERE state IN ('completed', 'pr_opened')) AS succeeded
+    FROM tasks
+    WHERE 1=1
+      ${prevFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+  `);
+
+  // Tasks per day
+  const tasksPerDay = await db.execute<{
+    date: string;
+    total: string;
+    succeeded: string;
+    failed: string;
+  }>(sql`
+    SELECT
+      DATE(created_at) AS date,
+      COUNT(*) AS total,
+      COUNT(*) FILTER (WHERE state IN ('completed', 'pr_opened')) AS succeeded,
+      COUNT(*) FILTER (WHERE state = 'failed') AS failed
+    FROM tasks
+    WHERE 1=1
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+    GROUP BY DATE(created_at)
+    ORDER BY date ASC
+  `);
+
+  const total = parseInt(rates.total) || 0;
+  const succeeded = parseInt(rates.succeeded) || 0;
+  const successRate = total > 0 ? Math.round((succeeded / total) * 100) : 0;
+
+  const prevTotal = parseInt(prevRates.total) || 0;
+  const prevSucceeded = parseInt(prevRates.succeeded) || 0;
+  const prevSuccessRate = prevTotal > 0 ? Math.round((prevSucceeded / prevTotal) * 100) : 0;
+  const successRateTrend = prevSuccessRate > 0 ? successRate - prevSuccessRate : 0;
+
+  return {
+    durations: {
+      avgWallClock: Math.round(parseFloat(durations.avg_wall_clock) || 0),
+      p50WallClock: Math.round(parseFloat(durations.p50_wall_clock) || 0),
+      p95WallClock: Math.round(parseFloat(durations.p95_wall_clock) || 0),
+      avgExecution: Math.round(parseFloat(durations.avg_execution) || 0),
+      p50Execution: Math.round(parseFloat(durations.p50_execution) || 0),
+      p95Execution: Math.round(parseFloat(durations.p95_execution) || 0),
+      avgQueueWait: Math.round(parseFloat(durations.avg_queue_wait) || 0),
+      taskCount: parseInt(durations.task_count) || 0,
+    },
+    successRate,
+    successRateTrend,
+    tasksPerDay: tasksPerDay.map((r) => ({
+      date: r.date,
+      total: parseInt(r.total) || 0,
+      succeeded: parseInt(r.succeeded) || 0,
+      failed: parseInt(r.failed) || 0,
+    })),
+  };
+}
+
+// ── Agent Comparison Analytics ───────────────────────────────────────────────
+
+export async function getAgentAnalytics(filters: Omit<AnalyticsFilters, "agentType">) {
+  const { dateFilter, repoFilter, wsFilter } = buildFilters({ ...filters, agentType: null });
+
+  const agents = await db.execute<{
+    agent_type: string;
+    task_count: string;
+    succeeded: string;
+    avg_duration: string;
+    avg_cost: string;
+    avg_retries: string;
+  }>(sql`
+    SELECT
+      agent_type,
+      COUNT(*) AS task_count,
+      COUNT(*) FILTER (WHERE state IN ('completed', 'pr_opened')) AS succeeded,
+      COALESCE(AVG(EXTRACT(EPOCH FROM (completed_at - started_at))) FILTER (WHERE completed_at IS NOT NULL AND started_at IS NOT NULL), 0) AS avg_duration,
+      COALESCE(AVG(CAST(cost_usd AS NUMERIC)) FILTER (WHERE cost_usd IS NOT NULL), 0) AS avg_cost,
+      COALESCE(AVG(retry_count), 0) AS avg_retries
+    FROM tasks
+    WHERE 1=1
+      ${dateFilter}
+      ${repoFilter}
+      ${wsFilter}
+    GROUP BY agent_type
+    ORDER BY task_count DESC
+  `);
+
+  // Model breakdown per agent type
+  const modelBreakdown = await db.execute<{
+    agent_type: string;
+    model: string;
+    task_count: string;
+    avg_cost: string;
+  }>(sql`
+    SELECT
+      agent_type,
+      COALESCE(model_used, 'unknown') AS model,
+      COUNT(*) AS task_count,
+      COALESCE(AVG(CAST(cost_usd AS NUMERIC)) FILTER (WHERE cost_usd IS NOT NULL), 0) AS avg_cost
+    FROM tasks
+    WHERE 1=1
+      ${dateFilter}
+      ${repoFilter}
+      ${wsFilter}
+    GROUP BY agent_type, COALESCE(model_used, 'unknown')
+    ORDER BY agent_type, task_count DESC
+  `);
+
+  // Group model breakdown by agent type
+  const modelsByAgent = new Map<
+    string,
+    Array<{ model: string; taskCount: number; avgCost: string }>
+  >();
+  for (const row of modelBreakdown) {
+    const list = modelsByAgent.get(row.agent_type) ?? [];
+    list.push({
+      model: row.model,
+      taskCount: parseInt(row.task_count) || 0,
+      avgCost: (parseFloat(row.avg_cost) || 0).toFixed(4),
+    });
+    modelsByAgent.set(row.agent_type, list);
+  }
+
+  return {
+    agents: agents.map((r) => {
+      const count = parseInt(r.task_count) || 0;
+      const succeeded = parseInt(r.succeeded) || 0;
+      return {
+        agentType: r.agent_type,
+        taskCount: count,
+        successRate: count > 0 ? Math.round((succeeded / count) * 100) : 0,
+        avgDuration: Math.round(parseFloat(r.avg_duration) || 0),
+        avgCost: (parseFloat(r.avg_cost) || 0).toFixed(4),
+        avgRetries: parseFloat(parseFloat(r.avg_retries).toFixed(2)),
+        models: modelsByAgent.get(r.agent_type) ?? [],
+      };
+    }),
+  };
+}
+
+// ── Failure Analytics ────────────────────────────────────────────────────────
+
+export async function getFailureAnalytics(filters: AnalyticsFilters) {
+  const { dateFilter, repoFilter, agentFilter, wsFilter } = buildFilters(filters);
+
+  // Top error categories (using error_message patterns)
+  const errorMessages = await db.execute<{
+    error_message: string;
+    count: string;
+  }>(sql`
+    SELECT
+      COALESCE(error_message, 'Unknown error') AS error_message,
+      COUNT(*) AS count
+    FROM tasks
+    WHERE state = 'failed'
+      AND error_message IS NOT NULL
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+    GROUP BY error_message
+    ORDER BY count DESC
+    LIMIT 50
+  `);
+
+  // Failure rate by repo
+  const failureByRepo = await db.execute<{
+    repo_url: string;
+    total: string;
+    failed: string;
+  }>(sql`
+    SELECT
+      repo_url,
+      COUNT(*) AS total,
+      COUNT(*) FILTER (WHERE state = 'failed') AS failed
+    FROM tasks
+    WHERE state NOT IN ('cancelled')
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+    GROUP BY repo_url
+    HAVING COUNT(*) >= 2
+    ORDER BY COUNT(*) FILTER (WHERE state = 'failed') DESC
+    LIMIT 20
+  `);
+
+  // Failure rate by agent type
+  const failureByAgent = await db.execute<{
+    agent_type: string;
+    total: string;
+    failed: string;
+  }>(sql`
+    SELECT
+      agent_type,
+      COUNT(*) AS total,
+      COUNT(*) FILTER (WHERE state = 'failed') AS failed
+    FROM tasks
+    WHERE state NOT IN ('cancelled')
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+    GROUP BY agent_type
+    ORDER BY COUNT(*) FILTER (WHERE state = 'failed') DESC
+  `);
+
+  // Failure rate by model
+  const failureByModel = await db.execute<{
+    model: string;
+    total: string;
+    failed: string;
+  }>(sql`
+    SELECT
+      COALESCE(model_used, 'unknown') AS model,
+      COUNT(*) AS total,
+      COUNT(*) FILTER (WHERE state = 'failed') AS failed
+    FROM tasks
+    WHERE state NOT IN ('cancelled')
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+    GROUP BY COALESCE(model_used, 'unknown')
+    ORDER BY COUNT(*) FILTER (WHERE state = 'failed') DESC
+  `);
+
+  // Retry success rate
+  const [retryStats] = await db.execute<{
+    retried: string;
+    retry_succeeded: string;
+  }>(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE retry_count > 0) AS retried,
+      COUNT(*) FILTER (WHERE retry_count > 0 AND state IN ('completed', 'pr_opened')) AS retry_succeeded
+    FROM tasks
+    WHERE 1=1
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+  `);
+
+  // Stall stats
+  const [stallStats] = await db.execute<{
+    stalled: string;
+    recovered: string;
+  }>(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE activity_substate = 'stalled') AS stalled,
+      COUNT(*) FILTER (WHERE activity_substate = 'recovered') AS recovered
+    FROM tasks
+    WHERE 1=1
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+  `);
+
+  const retried = parseInt(retryStats.retried) || 0;
+  const retrySucceeded = parseInt(retryStats.retry_succeeded) || 0;
+  const stalled = parseInt(stallStats.stalled) || 0;
+  const recovered = parseInt(stallStats.recovered) || 0;
+
+  return {
+    errorMessages: errorMessages.map((r) => ({
+      message: r.error_message,
+      count: parseInt(r.count) || 0,
+    })),
+    failureByRepo: failureByRepo.map((r) => {
+      const total = parseInt(r.total) || 0;
+      const failed = parseInt(r.failed) || 0;
+      return {
+        repoUrl: r.repo_url,
+        total,
+        failed,
+        failureRate: total > 0 ? Math.round((failed / total) * 100) : 0,
+      };
+    }),
+    failureByAgent: failureByAgent.map((r) => {
+      const total = parseInt(r.total) || 0;
+      const failed = parseInt(r.failed) || 0;
+      return {
+        agentType: r.agent_type,
+        total,
+        failed,
+        failureRate: total > 0 ? Math.round((failed / total) * 100) : 0,
+      };
+    }),
+    failureByModel: failureByModel.map((r) => {
+      const total = parseInt(r.total) || 0;
+      const failed = parseInt(r.failed) || 0;
+      return {
+        model: r.model,
+        total,
+        failed,
+        failureRate: total > 0 ? Math.round((failed / total) * 100) : 0,
+      };
+    }),
+    retrySuccessRate: retried > 0 ? Math.round((retrySucceeded / retried) * 100) : 0,
+    retriedCount: retried,
+    retrySucceededCount: retrySucceeded,
+    stallCount: stalled,
+    stallRecoveryRate: stalled > 0 ? Math.round((recovered / stalled) * 100) : 0,
+  };
+}
+
+// ── PR Lifecycle Analytics ───────────────────────────────────────────────────
+
+export async function getPrAnalytics(filters: AnalyticsFilters) {
+  const { dateFilter, repoFilter, agentFilter, wsFilter } = buildFilters(filters);
+
+  // PR lifecycle stats
+  const [prStats] = await db.execute<{
+    total_prs: string;
+    merged: string;
+    closed: string;
+    open: string;
+    checks_passing: string;
+    checks_failing: string;
+    review_approved: string;
+    review_changes_requested: string;
+  }>(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE pr_url IS NOT NULL) AS total_prs,
+      COUNT(*) FILTER (WHERE pr_state = 'merged') AS merged,
+      COUNT(*) FILTER (WHERE pr_state = 'closed') AS closed,
+      COUNT(*) FILTER (WHERE pr_state = 'open') AS open,
+      COUNT(*) FILTER (WHERE pr_checks_status = 'passing') AS checks_passing,
+      COUNT(*) FILTER (WHERE pr_checks_status = 'failing') AS checks_failing,
+      COUNT(*) FILTER (WHERE pr_review_status = 'approved') AS review_approved,
+      COUNT(*) FILTER (WHERE pr_review_status = 'changes_requested') AS review_changes_requested
+    FROM tasks
+    WHERE 1=1
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+  `);
+
+  // Average PR open → merge time
+  const [mergeTime] = await db.execute<{
+    avg_merge_time: string;
+    merge_count: string;
+  }>(sql`
+    SELECT
+      COALESCE(AVG(EXTRACT(EPOCH FROM (completed_at - created_at))), 0) AS avg_merge_time,
+      COUNT(*) AS merge_count
+    FROM tasks
+    WHERE pr_state = 'merged'
+      AND completed_at IS NOT NULL
+      ${dateFilter}
+      ${repoFilter}
+      ${agentFilter}
+      ${wsFilter}
+  `);
+
+  const totalPrs = parseInt(prStats.total_prs) || 0;
+  const merged = parseInt(prStats.merged) || 0;
+  const checksPassing = parseInt(prStats.checks_passing) || 0;
+  const reviewApproved = parseInt(prStats.review_approved) || 0;
+
+  return {
+    totalPrs,
+    merged,
+    closed: parseInt(prStats.closed) || 0,
+    open: parseInt(prStats.open) || 0,
+    ciPassRate: totalPrs > 0 ? Math.round((checksPassing / totalPrs) * 100) : 0,
+    reviewApprovalRate: totalPrs > 0 ? Math.round((reviewApproved / totalPrs) * 100) : 0,
+    autoMergeRate: totalPrs > 0 ? Math.round((merged / totalPrs) * 100) : 0,
+    avgMergeTime: Math.round(parseFloat(mergeTime.avg_merge_time) || 0),
+    mergeCount: parseInt(mergeTime.merge_count) || 0,
+    funnel: {
+      prOpened: totalPrs,
+      ciPassed: checksPassing,
+      reviewApproved,
+      merged,
+    },
+  };
+}

--- a/apps/web/src/app/analytics/page.tsx
+++ b/apps/web/src/app/analytics/page.tsx
@@ -1,0 +1,613 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
+import { api } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
+import { classifyError } from "@optio/shared";
+import Link from "next/link";
+import {
+  BarChart3,
+  Loader2,
+  Clock,
+  CheckCircle2,
+  AlertTriangle,
+  GitPullRequest,
+  RefreshCw,
+  Users,
+  Zap,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+} from "lucide-react";
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  Legend,
+} from "recharts";
+
+type PerformanceData = Awaited<ReturnType<typeof api.getPerformanceAnalytics>>;
+type AgentData = Awaited<ReturnType<typeof api.getAgentAnalytics>>;
+type FailureData = Awaited<ReturnType<typeof api.getFailureAnalytics>>;
+type PrData = Awaited<ReturnType<typeof api.getPrAnalytics>>;
+
+const PERIOD_OPTIONS = [
+  { label: "7d", days: 7 },
+  { label: "14d", days: 14 },
+  { label: "30d", days: 30 },
+  { label: "90d", days: 90 },
+];
+
+const CATEGORY_COLORS: Record<string, string> = {
+  image: "#f06060",
+  auth: "#f0a040",
+  network: "#60a5fa",
+  timeout: "#c084fc",
+  agent: "#fb923c",
+  state: "#38bdf8",
+  resource: "#f06060",
+  unknown: "#807c88",
+};
+
+function formatDuration(seconds: number): string {
+  if (seconds === 0) return "\u2014";
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.round((seconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+function formatCost(value: string | number): string {
+  const n = typeof value === "string" ? parseFloat(value) : value;
+  if (isNaN(n) || n === 0) return "$0.00";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+function repoShortName(repoUrl: string): string {
+  const match = repoUrl.match(/([^/]+\/[^/]+?)(?:\.git)?$/);
+  return match ? match[1] : repoUrl;
+}
+
+function ChartTooltipContent({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ color: string; name: string; value: number }>;
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="glass-tooltip px-3 py-2">
+      <p className="text-xs text-text-muted mb-1">{label}</p>
+      {payload.map((p, i) => (
+        <p key={i} className="text-sm font-medium" style={{ color: p.color }}>
+          {p.name}: {p.value}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+  icon: Icon,
+  color,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  icon: React.ComponentType<{ className?: string }>;
+  color?: string;
+}) {
+  return (
+    <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5 card-hover">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[10px] text-text-muted font-semibold uppercase tracking-widest">
+          {label}
+        </span>
+        <Icon className={cn("w-4 h-4", color ?? "text-text-muted/50")} />
+      </div>
+      <div className="text-2xl font-bold tracking-tight text-text">{value}</div>
+      {sub && <div className="mt-1.5 text-xs text-text-muted">{sub}</div>}
+    </div>
+  );
+}
+
+export default function AnalyticsPage() {
+  usePageTitle("Analytics");
+  const [days, setDays] = useState(30);
+  const [loading, setLoading] = useState(true);
+  const [performance, setPerformance] = useState<PerformanceData | null>(null);
+  const [agents, setAgents] = useState<AgentData | null>(null);
+  const [failures, setFailures] = useState<FailureData | null>(null);
+  const [prs, setPrs] = useState<PrData | null>(null);
+
+  const fetchAll = useCallback(async (d: number) => {
+    setLoading(true);
+    try {
+      const [perf, ag, fail, pr] = await Promise.all([
+        api.getPerformanceAnalytics({ days: d }),
+        api.getAgentAnalytics({ days: d }),
+        api.getFailureAnalytics({ days: d }),
+        api.getPrAnalytics({ days: d }),
+      ]);
+      setPerformance(perf);
+      setAgents(ag);
+      setFailures(fail);
+      setPrs(pr);
+    } catch {
+      // fail silently — sections show empty state
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll(days);
+  }, [days, fetchAll]);
+
+  // Classify failure messages into categories
+  const failureCategories = failures
+    ? (() => {
+        const map = new Map<string, { category: string; title: string; count: number }>();
+        for (const err of failures.errorMessages) {
+          const classified = classifyError(err.message);
+          const existing = map.get(classified.category);
+          if (existing) {
+            existing.count += err.count;
+          } else {
+            map.set(classified.category, {
+              category: classified.category,
+              title: classified.title,
+              count: err.count,
+            });
+          }
+        }
+        return [...map.values()].sort((a, b) => b.count - a.count);
+      })()
+    : [];
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto space-y-6 stagger">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-gradient">Analytics</h1>
+          <p className="text-sm text-text-muted mt-0.5">
+            Performance, agent comparison, and failure insights
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {PERIOD_OPTIONS.map((opt) => (
+            <button
+              key={opt.days}
+              onClick={() => setDays(opt.days)}
+              className={cn(
+                "px-3 py-1.5 text-xs font-medium rounded-lg transition-colors",
+                days === opt.days
+                  ? "bg-primary text-white"
+                  : "bg-bg-card text-text-muted hover:bg-bg-hover border border-border/50",
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="w-6 h-6 text-primary animate-spin" />
+        </div>
+      ) : (
+        <>
+          {/* Performance Summary Cards */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <StatCard
+              label="Success Rate"
+              value={`${performance?.successRate ?? 0}%`}
+              sub={
+                performance?.successRateTrend
+                  ? `${performance.successRateTrend > 0 ? "+" : ""}${performance.successRateTrend}pp vs prev`
+                  : undefined
+              }
+              icon={CheckCircle2}
+              color="text-success"
+            />
+            <StatCard
+              label="Avg Duration"
+              value={formatDuration(performance?.durations.avgExecution ?? 0)}
+              sub={`p95: ${formatDuration(performance?.durations.p95Execution ?? 0)}`}
+              icon={Clock}
+              color="text-info"
+            />
+            <StatCard
+              label="Queue Wait"
+              value={formatDuration(performance?.durations.avgQueueWait ?? 0)}
+              sub={`${performance?.durations.taskCount ?? 0} completed tasks`}
+              icon={Clock}
+            />
+            <StatCard
+              label="PR Merge Rate"
+              value={`${prs?.autoMergeRate ?? 0}%`}
+              sub={`${prs?.merged ?? 0} of ${prs?.totalPrs ?? 0} PRs merged`}
+              icon={GitPullRequest}
+              color="text-primary"
+            />
+          </div>
+
+          {/* Performance Over Time */}
+          {performance && performance.tasksPerDay.length > 0 && (
+            <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5">
+              <h3 className="text-xs font-semibold uppercase tracking-widest text-text-muted mb-4">
+                Tasks Over Time
+              </h3>
+              <ResponsiveContainer width="100%" height={280}>
+                <AreaChart data={performance.tasksPerDay}>
+                  <defs>
+                    <linearGradient id="successGrad" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#34d399" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="#34d399" stopOpacity={0} />
+                    </linearGradient>
+                    <linearGradient id="failGrad" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#f06060" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="#f06060" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fill: "#6b7280", fontSize: 11 }}
+                    tickFormatter={(v) => {
+                      const d = new Date(v);
+                      return `${d.getMonth() + 1}/${d.getDate()}`;
+                    }}
+                  />
+                  <YAxis tick={{ fill: "#6b7280", fontSize: 11 }} allowDecimals={false} />
+                  <Tooltip content={<ChartTooltipContent />} />
+                  <Legend />
+                  <Area
+                    type="monotone"
+                    dataKey="succeeded"
+                    name="Succeeded"
+                    stroke="#34d399"
+                    fill="url(#successGrad)"
+                    stackId="1"
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="failed"
+                    name="Failed"
+                    stroke="#f06060"
+                    fill="url(#failGrad)"
+                    stackId="1"
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {/* Agent Comparison Table */}
+          {agents && agents.agents.length > 0 && (
+            <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  Agent Comparison
+                </h3>
+                <Users className="w-4 h-4 text-text-muted/50" />
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border/50">
+                      <th className="text-left py-2 px-3 text-xs text-text-muted font-medium uppercase tracking-wider">
+                        Agent
+                      </th>
+                      <th className="text-right py-2 px-3 text-xs text-text-muted font-medium uppercase tracking-wider">
+                        Tasks
+                      </th>
+                      <th className="text-right py-2 px-3 text-xs text-text-muted font-medium uppercase tracking-wider">
+                        Success
+                      </th>
+                      <th className="text-right py-2 px-3 text-xs text-text-muted font-medium uppercase tracking-wider">
+                        Avg Duration
+                      </th>
+                      <th className="text-right py-2 px-3 text-xs text-text-muted font-medium uppercase tracking-wider">
+                        Avg Cost
+                      </th>
+                      <th className="text-right py-2 px-3 text-xs text-text-muted font-medium uppercase tracking-wider">
+                        Retries
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {agents.agents.map((agent) => (
+                      <tr
+                        key={agent.agentType}
+                        className="border-b border-border/30 hover:bg-bg-hover/40 transition-colors"
+                      >
+                        <td className="py-2.5 px-3 font-medium text-text capitalize">
+                          {agent.agentType}
+                          {agent.models.length > 0 && (
+                            <span className="block text-xs text-text-muted mt-0.5">
+                              {agent.models
+                                .map((m) => m.model.split("-").slice(-2, -1)[0] || m.model)
+                                .join(", ")}
+                            </span>
+                          )}
+                        </td>
+                        <td className="py-2.5 px-3 text-right tabular-nums text-text">
+                          {agent.taskCount}
+                        </td>
+                        <td className="py-2.5 px-3 text-right">
+                          <span
+                            className={cn(
+                              "tabular-nums font-medium",
+                              agent.successRate >= 80
+                                ? "text-success"
+                                : agent.successRate >= 50
+                                  ? "text-warning"
+                                  : "text-error",
+                            )}
+                          >
+                            {agent.successRate}%
+                          </span>
+                        </td>
+                        <td className="py-2.5 px-3 text-right tabular-nums text-text-muted">
+                          {formatDuration(agent.avgDuration)}
+                        </td>
+                        <td className="py-2.5 px-3 text-right tabular-nums text-text-muted">
+                          {formatCost(agent.avgCost)}
+                        </td>
+                        <td className="py-2.5 px-3 text-right tabular-nums text-text-muted">
+                          {agent.avgRetries.toFixed(1)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Failure Breakdown */}
+          {failureCategories.length > 0 && (
+            <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  Failure Breakdown
+                </h3>
+                <AlertTriangle className="w-4 h-4 text-text-muted/50" />
+              </div>
+              <ResponsiveContainer
+                width="100%"
+                height={Math.max(200, failureCategories.length * 40)}
+              >
+                <BarChart data={failureCategories} layout="vertical">
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" />
+                  <XAxis
+                    type="number"
+                    tick={{ fill: "#6b7280", fontSize: 11 }}
+                    allowDecimals={false}
+                  />
+                  <YAxis
+                    type="category"
+                    dataKey="title"
+                    tick={{ fill: "#6b7280", fontSize: 11 }}
+                    width={180}
+                  />
+                  <Tooltip
+                    content={({ active, payload }) =>
+                      active && payload?.[0] ? (
+                        <div className="glass-tooltip px-3 py-2">
+                          <p className="text-sm font-medium text-text">
+                            {(payload[0].payload as { title: string }).title}: {payload[0].value}
+                          </p>
+                        </div>
+                      ) : null
+                    }
+                  />
+                  <Bar dataKey="count" radius={[0, 4, 4, 0]} fill="#f06060">
+                    {failureCategories.map((entry, i) => (
+                      <rect
+                        key={i}
+                        fill={CATEGORY_COLORS[entry.category] ?? CATEGORY_COLORS.unknown}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+              {/* Retry & Stall Stats */}
+              {failures && (
+                <div className="mt-4 flex items-center gap-6 text-sm text-text-muted border-t border-border/30 pt-4">
+                  <span className="flex items-center gap-1.5">
+                    <RefreshCw className="w-3.5 h-3.5" />
+                    Retry success rate:{" "}
+                    <strong className="text-text">{failures.retrySuccessRate}%</strong>
+                    <span className="text-text-muted/60">
+                      ({failures.retrySucceededCount}/{failures.retriedCount})
+                    </span>
+                  </span>
+                  {failures.stallCount > 0 && (
+                    <span className="flex items-center gap-1.5">
+                      <Zap className="w-3.5 h-3.5" />
+                      Stalls: <strong className="text-text">{failures.stallCount}</strong>
+                      <span className="text-text-muted/60">
+                        ({failures.stallRecoveryRate}% recovered)
+                      </span>
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Failure by Repo */}
+          {failures && failures.failureByRepo.length > 0 && (
+            <div className="grid md:grid-cols-2 gap-4">
+              <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5">
+                <h3 className="text-xs font-semibold uppercase tracking-widest text-text-muted mb-4">
+                  Failure Rate by Repo
+                </h3>
+                <div className="space-y-3">
+                  {failures.failureByRepo.slice(0, 8).map((r) => (
+                    <div key={r.repoUrl} className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="text-text truncate max-w-[200px]">
+                          {repoShortName(r.repoUrl)}
+                        </span>
+                        <span
+                          className={cn(
+                            "text-xs font-medium tabular-nums",
+                            r.failureRate >= 30
+                              ? "text-error"
+                              : r.failureRate >= 15
+                                ? "text-warning"
+                                : "text-text-muted",
+                          )}
+                        >
+                          {r.failureRate}% ({r.failed}/{r.total})
+                        </span>
+                      </div>
+                      <div className="h-1.5 bg-bg-hover rounded-full overflow-hidden">
+                        <div
+                          className={cn(
+                            "h-full rounded-full",
+                            r.failureRate >= 30
+                              ? "bg-error"
+                              : r.failureRate >= 15
+                                ? "bg-warning"
+                                : "bg-text-muted/30",
+                          )}
+                          style={{ width: `${r.failureRate}%` }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Failure by Model */}
+              {failures.failureByModel.length > 0 && (
+                <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5">
+                  <h3 className="text-xs font-semibold uppercase tracking-widest text-text-muted mb-4">
+                    Failure Rate by Model
+                  </h3>
+                  <div className="space-y-3">
+                    {failures.failureByModel.map((m) => (
+                      <div key={m.model} className="space-y-1">
+                        <div className="flex items-center justify-between text-sm">
+                          <span className="text-text">{m.model}</span>
+                          <span
+                            className={cn(
+                              "text-xs font-medium tabular-nums",
+                              m.failureRate >= 30
+                                ? "text-error"
+                                : m.failureRate >= 15
+                                  ? "text-warning"
+                                  : "text-text-muted",
+                            )}
+                          >
+                            {m.failureRate}% ({m.failed}/{m.total})
+                          </span>
+                        </div>
+                        <div className="h-1.5 bg-bg-hover rounded-full overflow-hidden">
+                          <div
+                            className={cn(
+                              "h-full rounded-full",
+                              m.failureRate >= 30
+                                ? "bg-error"
+                                : m.failureRate >= 15
+                                  ? "bg-warning"
+                                  : "bg-text-muted/30",
+                            )}
+                            style={{ width: `${m.failureRate}%` }}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* PR Lifecycle Funnel */}
+          {prs && prs.totalPrs > 0 && (
+            <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-xs font-semibold uppercase tracking-widest text-text-muted">
+                  PR Lifecycle Funnel
+                </h3>
+                <GitPullRequest className="w-4 h-4 text-text-muted/50" />
+              </div>
+              <div className="grid grid-cols-4 gap-3">
+                {[
+                  { label: "PR Opened", value: prs.funnel.prOpened, color: "bg-info" },
+                  { label: "CI Passed", value: prs.funnel.ciPassed, color: "bg-warning" },
+                  {
+                    label: "Review Approved",
+                    value: prs.funnel.reviewApproved,
+                    color: "bg-primary",
+                  },
+                  { label: "Merged", value: prs.funnel.merged, color: "bg-success" },
+                ].map((step, i) => {
+                  const pct =
+                    prs.funnel.prOpened > 0 ? (step.value / prs.funnel.prOpened) * 100 : 0;
+                  return (
+                    <div key={step.label} className="text-center">
+                      <div className="relative mx-auto mb-2 w-full max-w-[100px]">
+                        <div className="h-2 bg-bg-hover rounded-full overflow-hidden">
+                          <div
+                            className={cn("h-full rounded-full transition-all", step.color)}
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                      </div>
+                      <div className="text-lg font-bold tabular-nums text-text">{step.value}</div>
+                      <div className="text-[10px] text-text-muted uppercase tracking-wider">
+                        {step.label}
+                      </div>
+                      {i > 0 && prs.funnel.prOpened > 0 && (
+                        <div className="text-[10px] text-text-muted/60 mt-0.5">
+                          {Math.round(pct)}%
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="mt-4 flex items-center gap-6 text-sm text-text-muted border-t border-border/30 pt-4">
+                <span>
+                  CI pass rate: <strong className="text-text">{prs.ciPassRate}%</strong>
+                </span>
+                <span>
+                  Review approval: <strong className="text-text">{prs.reviewApprovalRate}%</strong>
+                </span>
+                <span>
+                  Avg merge time:{" "}
+                  <strong className="text-text">{formatDuration(prs.avgMergeTime)}</strong>
+                </span>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -11,6 +11,9 @@ import {
   RecentTasks,
   PodsList,
   WelcomeHero,
+  PerformanceSummary,
+  AgentComparison,
+  FailureInsights,
 } from "@/components/dashboard";
 import { useOptioChatStore } from "@/hooks/use-optio-chat";
 import { UpdateBanner } from "@/components/update-banner";
@@ -133,6 +136,13 @@ export default function OverviewPage() {
           </div>
         </button>
       )}
+
+      <PerformanceSummary />
+
+      <div className="grid md:grid-cols-2 gap-4">
+        <AgentComparison />
+        <FailureInsights />
+      </div>
 
       <UsagePanel usage={usage} onRefresh={refreshUsage} />
 

--- a/apps/web/src/components/dashboard/agent-comparison.tsx
+++ b/apps/web/src/components/dashboard/agent-comparison.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
+import { Users } from "lucide-react";
+
+type AgentData = Awaited<ReturnType<typeof api.getAgentAnalytics>>;
+
+function formatCost(value: string | number): string {
+  const n = typeof value === "string" ? parseFloat(value) : value;
+  if (isNaN(n) || n === 0) return "$0.00";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+export function AgentComparison() {
+  const [data, setData] = useState<AgentData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .getAgentAnalytics({ days: 7 })
+      .then(setData)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5">
+        <div className="h-4 w-32 skeleton-shimmer mb-4" />
+        <div className="space-y-3">
+          {[...Array(2)].map((_, i) => (
+            <div key={i} className="h-12 skeleton-shimmer" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Only show if there are multiple agent types
+  if (!data || data.agents.length < 2) return null;
+
+  const maxTasks = Math.max(...data.agents.map((a) => a.taskCount));
+
+  return (
+    <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5 card-hover">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-xs font-semibold uppercase tracking-widest text-text-muted">
+          Agent Comparison (7d)
+        </h3>
+        <Users className="w-4 h-4 text-text-muted/50" />
+      </div>
+      <div className="space-y-3">
+        {data.agents.map((agent) => (
+          <div key={agent.agentType} className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-text capitalize">{agent.agentType}</span>
+              <div className="flex items-center gap-3 text-xs text-text-muted">
+                <span>{agent.taskCount} tasks</span>
+                <span
+                  className={cn(
+                    "font-medium",
+                    agent.successRate >= 80
+                      ? "text-success"
+                      : agent.successRate >= 50
+                        ? "text-warning"
+                        : "text-error",
+                  )}
+                >
+                  {agent.successRate}%
+                </span>
+                <span className="tabular-nums">{formatCost(agent.avgCost)}</span>
+              </div>
+            </div>
+            <div className="h-1.5 bg-bg-hover rounded-full overflow-hidden">
+              <div
+                className="h-full bg-primary rounded-full transition-all"
+                style={{ width: `${(agent.taskCount / maxTasks) * 100}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/failure-insights.tsx
+++ b/apps/web/src/components/dashboard/failure-insights.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api-client";
+import { classifyError } from "@optio/shared";
+import { AlertTriangle, RefreshCw, Zap } from "lucide-react";
+import Link from "next/link";
+
+type FailureData = Awaited<ReturnType<typeof api.getFailureAnalytics>>;
+
+export function FailureInsights() {
+  const [data, setData] = useState<FailureData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .getFailureAnalytics({ days: 7 })
+      .then(setData)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5">
+        <div className="h-4 w-32 skeleton-shimmer mb-4" />
+        <div className="space-y-2">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-10 skeleton-shimmer" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.errorMessages.length === 0) return null;
+
+  // Group by error category using the classifier
+  const categoryMap = new Map<string, { title: string; count: number }>();
+  for (const err of data.errorMessages) {
+    const classified = classifyError(err.message);
+    const existing = categoryMap.get(classified.category);
+    if (existing) {
+      existing.count += err.count;
+    } else {
+      categoryMap.set(classified.category, {
+        title: classified.title,
+        count: err.count,
+      });
+    }
+  }
+  const topCategories = [...categoryMap.values()].sort((a, b) => b.count - a.count).slice(0, 3);
+
+  return (
+    <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5 card-hover">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-xs font-semibold uppercase tracking-widest text-text-muted">
+          Top Failures (7d)
+        </h3>
+        <AlertTriangle className="w-4 h-4 text-text-muted/50" />
+      </div>
+      <div className="space-y-2.5">
+        {topCategories.map((cat, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 p-2.5 rounded-lg bg-bg-hover/40 border border-border/30"
+          >
+            <div className="w-7 h-7 rounded-md bg-error/10 flex items-center justify-center shrink-0">
+              <AlertTriangle className="w-3.5 h-3.5 text-error" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-text truncate">{cat.title}</p>
+            </div>
+            <span className="text-sm font-semibold tabular-nums text-text-muted">{cat.count}</span>
+          </div>
+        ))}
+      </div>
+      {data.retriedCount > 0 && (
+        <div className="mt-3 flex items-center gap-4 text-xs text-text-muted">
+          <span className="flex items-center gap-1">
+            <RefreshCw className="w-3 h-3" />
+            Retry success: {data.retrySuccessRate}%
+          </span>
+          {data.stallCount > 0 && (
+            <span className="flex items-center gap-1">
+              <Zap className="w-3 h-3" />
+              Stalls: {data.stallCount} ({data.stallRecoveryRate}% recovered)
+            </span>
+          )}
+        </div>
+      )}
+      <Link
+        href="/analytics"
+        className="mt-3 block text-xs text-primary hover:text-primary-hover transition-colors"
+      >
+        View all failure insights →
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -6,4 +6,7 @@ export { RecentTasks } from "./recent-tasks.js";
 export { PodsList } from "./pods-list.js";
 export { WelcomeHero } from "./welcome-hero.js";
 export { EmptyState } from "./empty-state.js";
+export { PerformanceSummary } from "./performance-summary.js";
+export { AgentComparison } from "./agent-comparison.js";
+export { FailureInsights } from "./failure-insights.js";
 export type { TaskStats, UsageData, MetricsHistoryPoint } from "./types.js";

--- a/apps/web/src/components/dashboard/performance-summary.tsx
+++ b/apps/web/src/components/dashboard/performance-summary.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
+import { TrendingUp, TrendingDown, Minus, Clock, CheckCircle2, Activity } from "lucide-react";
+import { AreaChart, Area, ResponsiveContainer, Tooltip } from "recharts";
+
+type PerformanceData = Awaited<ReturnType<typeof api.getPerformanceAnalytics>>;
+
+function formatDuration(seconds: number): string {
+  if (seconds === 0) return "—";
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.round((seconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+export function PerformanceSummary() {
+  const [data, setData] = useState<PerformanceData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .getPerformanceAnalytics({ days: 7 })
+      .then(setData)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5">
+        <div className="h-4 w-32 skeleton-shimmer mb-4" />
+        <div className="grid grid-cols-3 gap-4">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-16 skeleton-shimmer" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.durations.taskCount === 0) return null;
+
+  const sparkData = data.tasksPerDay.map((d) => ({
+    date: d.date,
+    tasks: d.total,
+  }));
+
+  return (
+    <div className="bg-gradient-to-br from-bg-card to-bg-card/80 border border-border/50 rounded-xl p-5 card-hover">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-xs font-semibold uppercase tracking-widest text-text-muted">
+          Performance (7d)
+        </h3>
+        <Activity className="w-4 h-4 text-text-muted/50" />
+      </div>
+      <div className="grid grid-cols-3 gap-4">
+        {/* Success Rate */}
+        <div>
+          <div className="flex items-center gap-1.5 mb-1">
+            <CheckCircle2 className="w-3.5 h-3.5 text-success" />
+            <span className="text-[10px] text-text-muted uppercase tracking-wider">
+              Success Rate
+            </span>
+          </div>
+          <div className="text-xl font-bold text-text">{data.successRate}%</div>
+          {data.successRateTrend !== 0 && (
+            <div
+              className={cn(
+                "flex items-center gap-0.5 text-xs mt-0.5",
+                data.successRateTrend > 0 ? "text-success" : "text-error",
+              )}
+            >
+              {data.successRateTrend > 0 ? (
+                <TrendingUp className="w-3 h-3" />
+              ) : (
+                <TrendingDown className="w-3 h-3" />
+              )}
+              {data.successRateTrend > 0 ? "+" : ""}
+              {data.successRateTrend}pp
+            </div>
+          )}
+          {data.successRateTrend === 0 && (
+            <div className="flex items-center gap-0.5 text-xs mt-0.5 text-text-muted">
+              <Minus className="w-3 h-3" />
+              stable
+            </div>
+          )}
+        </div>
+        {/* Avg Duration */}
+        <div>
+          <div className="flex items-center gap-1.5 mb-1">
+            <Clock className="w-3.5 h-3.5 text-info" />
+            <span className="text-[10px] text-text-muted uppercase tracking-wider">
+              Avg Duration
+            </span>
+          </div>
+          <div className="text-xl font-bold text-text">
+            {formatDuration(data.durations.avgExecution)}
+          </div>
+          <div className="text-xs text-text-muted mt-0.5">
+            p95: {formatDuration(data.durations.p95Execution)}
+          </div>
+        </div>
+        {/* Tasks/Day Sparkline */}
+        <div>
+          <div className="flex items-center gap-1.5 mb-1">
+            <Activity className="w-3.5 h-3.5 text-primary" />
+            <span className="text-[10px] text-text-muted uppercase tracking-wider">Tasks/Day</span>
+          </div>
+          {sparkData.length > 1 ? (
+            <ResponsiveContainer width="100%" height={40}>
+              <AreaChart data={sparkData}>
+                <defs>
+                  <linearGradient id="sparkGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#7c3aed" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#7c3aed" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <Tooltip
+                  content={({ active, payload }) =>
+                    active && payload?.[0] ? (
+                      <div className="glass-tooltip px-2 py-1 text-xs">
+                        {payload[0].value} tasks
+                      </div>
+                    ) : null
+                  }
+                />
+                <Area
+                  type="monotone"
+                  dataKey="tasks"
+                  stroke="#7c3aed"
+                  strokeWidth={1.5}
+                  fill="url(#sparkGradient)"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="text-xl font-bold text-text">{sparkData[0]?.tasks ?? 0}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   GitBranch,
   Webhook,
   Plug,
+  BarChart3,
 } from "lucide-react";
 import { UserMenu } from "./user-menu";
 import { WorkspaceSwitcher } from "./workspace-switcher";
@@ -26,6 +27,7 @@ import { useOptioChatStore } from "@/hooks/use-optio-chat";
 const MAIN_NAV = [
   { href: "/", label: "Overview", icon: LayoutDashboard },
   { href: "/tasks", label: "Tasks", icon: ListTodo },
+  { href: "/analytics", label: "Analytics", icon: BarChart3 },
   { href: "/workflows", label: "Agent Workflows", icon: GitBranch },
   { href: "/sessions", label: "Sessions", icon: Terminal },
   { href: "/repos", label: "Repos", icon: FolderGit2 },

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -570,6 +570,115 @@ export const api = {
     }>(`/api/analytics/costs${query ? `?${query}` : ""}`);
   },
 
+  getPerformanceAnalytics: (params?: { days?: number; repoUrl?: string; agentType?: string }) => {
+    const qs = new URLSearchParams();
+    if (params?.days) qs.set("days", String(params.days));
+    if (params?.repoUrl) qs.set("repoUrl", params.repoUrl);
+    if (params?.agentType) qs.set("agentType", params.agentType);
+    const query = qs.toString();
+    return request<{
+      durations: {
+        avgWallClock: number;
+        p50WallClock: number;
+        p95WallClock: number;
+        avgExecution: number;
+        p50Execution: number;
+        p95Execution: number;
+        avgQueueWait: number;
+        taskCount: number;
+      };
+      successRate: number;
+      successRateTrend: number;
+      tasksPerDay: Array<{
+        date: string;
+        total: number;
+        succeeded: number;
+        failed: number;
+      }>;
+    }>(`/api/analytics/performance${query ? `?${query}` : ""}`);
+  },
+
+  getAgentAnalytics: (params?: { days?: number; repoUrl?: string }) => {
+    const qs = new URLSearchParams();
+    if (params?.days) qs.set("days", String(params.days));
+    if (params?.repoUrl) qs.set("repoUrl", params.repoUrl);
+    const query = qs.toString();
+    return request<{
+      agents: Array<{
+        agentType: string;
+        taskCount: number;
+        successRate: number;
+        avgDuration: number;
+        avgCost: string;
+        avgRetries: number;
+        models: Array<{
+          model: string;
+          taskCount: number;
+          avgCost: string;
+        }>;
+      }>;
+    }>(`/api/analytics/agents${query ? `?${query}` : ""}`);
+  },
+
+  getFailureAnalytics: (params?: { days?: number; repoUrl?: string; agentType?: string }) => {
+    const qs = new URLSearchParams();
+    if (params?.days) qs.set("days", String(params.days));
+    if (params?.repoUrl) qs.set("repoUrl", params.repoUrl);
+    if (params?.agentType) qs.set("agentType", params.agentType);
+    const query = qs.toString();
+    return request<{
+      errorMessages: Array<{ message: string; count: number }>;
+      failureByRepo: Array<{
+        repoUrl: string;
+        total: number;
+        failed: number;
+        failureRate: number;
+      }>;
+      failureByAgent: Array<{
+        agentType: string;
+        total: number;
+        failed: number;
+        failureRate: number;
+      }>;
+      failureByModel: Array<{
+        model: string;
+        total: number;
+        failed: number;
+        failureRate: number;
+      }>;
+      retrySuccessRate: number;
+      retriedCount: number;
+      retrySucceededCount: number;
+      stallCount: number;
+      stallRecoveryRate: number;
+    }>(`/api/analytics/failures${query ? `?${query}` : ""}`);
+  },
+
+  getPrAnalytics: (params?: { days?: number; repoUrl?: string; agentType?: string }) => {
+    const qs = new URLSearchParams();
+    if (params?.days) qs.set("days", String(params.days));
+    if (params?.repoUrl) qs.set("repoUrl", params.repoUrl);
+    if (params?.agentType) qs.set("agentType", params.agentType);
+    const query = qs.toString();
+    return request<{
+      totalPrs: number;
+      merged: number;
+      closed: number;
+      open: number;
+      ciPassRate: number;
+      reviewApprovalRate: number;
+      autoMergeRate: number;
+      avgMergeTime: number;
+      mergeCount: number;
+      funnel: {
+        prOpened: number;
+        ciPassed: number;
+        reviewApproved: number;
+        merged: number;
+      };
+    }>(`/api/analytics/prs${query ? `?${query}` : ""}`);
+  },
+
   assignIssue: (data: {
     issueNumber: number;
     repoId: string;


### PR DESCRIPTION
Closes #416

## What changed

Added four new analytics API endpoints and a complete analytics UI to surface task performance, agent comparison, and failure pattern insights using data already captured in the `tasks` table.

### Backend
- **`GET /api/analytics/performance`** — task duration metrics (avg/p50/p95 wall clock and execution time), success rate with trend vs previous period, tasks-per-day time series. Filterable by days, repoUrl, agentType.
- **`GET /api/analytics/agents`** — per-agent-type comparison: task count, success rate, avg duration, avg cost, avg retries, with model breakdown per agent type. Filterable by days, repoUrl.
- **`GET /api/analytics/failures`** — top error messages grouped by error-classifier categories, failure rates by repo/agent/model, retry success rate, stall frequency and recovery rate. Filterable by days, repoUrl, agentType.
- **`GET /api/analytics/prs`** — PR lifecycle metrics: avg merge time, CI pass rate, review approval rate, auto-merge rate, and lifecycle funnel (opened → CI passed → review approved → merged).
- **`analytics-service.ts`** — extracted analytics query logic into a proper service with workspace-scoped Drizzle SQL aggregations.
- Response schemas added to `workspace.ts`, all endpoints require `member` role.

### Frontend
- **Dashboard widgets** on the main `/` page:
  - `PerformanceSummary` — success rate gauge, avg duration, tasks/day sparkline
  - `AgentComparison` — bar chart comparing agent types (only shows with 2+ agent types)
  - `FailureInsights` — top 3 failure categories with counts, retry/stall stats, link to analytics page
- **Dedicated `/analytics` page** with full-page visualizations:
  - Period selector (7d/14d/30d/90d)
  - Summary stat cards (success rate, avg duration, queue wait, PR merge rate)
  - Tasks over time stacked area chart (succeeded vs failed)
  - Agent comparison table with sortable columns
  - Failure breakdown horizontal bar chart by error category
  - Failure rate by repo and model bar charts
  - PR lifecycle funnel visualization
  - Retry success rate and stall recovery stats
- **Navigation** — "Analytics" added to sidebar between Tasks and Agent Workflows (BarChart3 icon)

### Tests
- Unit tests for all four analytics service functions (performance, agents, failures, PRs)
- Route-level integration tests for all four new endpoints
- All 1892 existing tests continue to pass

## How to test
1. Run `pnpm turbo test` — all tests should pass
2. Run `pnpm turbo typecheck` — clean typecheck
3. Run `cd apps/web && npx next build` — web builds successfully
4. Deploy and navigate to `/analytics` — should show performance charts, agent comparison, failure breakdown, and PR funnel
5. Check main dashboard `/` — new widgets appear below pipeline stats (performance summary, agent comparison if multiple agents used, failure insights if failures exist)