### PR TITLE
feat: workspace-level audit log and activity feed

### DIFF
--- a/apps/api/src/routes/activity.test.ts
+++ b/apps/api/src/routes/activity.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildRouteTestApp } from "../test-utils/build-route-test-app.js";
+
+const mockDbExecute = vi.fn();
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    execute: (...args: unknown[]) => mockDbExecute(...args),
+  },
+}));
+
+import { activityRoutes } from "./activity.js";
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  return buildRouteTestApp(activityRoutes);
+}
+
+describe("GET /api/activity", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns empty feed when no events exist", async () => {
+    mockDbExecute
+      .mockResolvedValueOnce([]) // items
+      .mockResolvedValueOnce([{ total: 0 }]) // count
+      .mockResolvedValueOnce([]); // stats
+
+    const res = await app.inject({ method: "GET", url: "/api/activity" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.items).toEqual([]);
+    expect(body.total).toBe(0);
+    expect(body.stats).toEqual({
+      actions: 0,
+      taskEvents: 0,
+      authEvents: 0,
+      infraEvents: 0,
+    });
+  });
+
+  it("returns activity items with correct shape", async () => {
+    const now = new Date().toISOString();
+    mockDbExecute
+      .mockResolvedValueOnce([
+        {
+          id: "a1",
+          type: "action",
+          timestamp: now,
+          user_id: "u1",
+          user_display_name: "Alice",
+          user_avatar_url: "https://example.com/alice.png",
+          action: "task.create",
+          resource_type: "task",
+          resource_id: "t1",
+          summary: "task.create succeeded",
+          details: { taskId: "t1" },
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([{ type: "action", cnt: 1 }]);
+
+    const res = await app.inject({ method: "GET", url: "/api/activity" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].type).toBe("action");
+    expect(body.items[0].actor).toEqual({
+      id: "u1",
+      displayName: "Alice",
+      avatarUrl: "https://example.com/alice.png",
+    });
+    expect(body.items[0].action).toBe("task.create");
+    expect(body.total).toBe(1);
+    expect(body.stats.actions).toBe(1);
+  });
+
+  it("supports type filter", async () => {
+    mockDbExecute
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ total: 0 }])
+      .mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/activity?type=task_event",
+    });
+
+    expect(res.statusCode).toBe(200);
+    // When filtering by task_event, the SQL queries should be issued (3 parallel queries)
+    expect(mockDbExecute).toHaveBeenCalledTimes(3);
+    const body = res.json();
+    expect(body.items).toEqual([]);
+  });
+
+  it("supports pagination via limit and offset", async () => {
+    mockDbExecute
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ total: 0 }])
+      .mockResolvedValueOnce([]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/activity?limit=10&offset=20",
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("handles system events without actors", async () => {
+    const now = new Date().toISOString();
+    mockDbExecute
+      .mockResolvedValueOnce([
+        {
+          id: "ae1",
+          type: "auth_event",
+          timestamp: now,
+          user_id: null,
+          user_display_name: null,
+          user_avatar_url: null,
+          action: "auth:github_failed",
+          resource_type: "auth",
+          resource_id: null,
+          summary: "github auth failed: token expired",
+          details: { tokenType: "github" },
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([{ type: "auth_event", cnt: 1 }]);
+
+    const res = await app.inject({ method: "GET", url: "/api/activity" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.items[0].actor).toBeNull();
+    expect(body.items[0].type).toBe("auth_event");
+    expect(body.stats.authEvents).toBe(1);
+  });
+
+  it("returns 500 on database error", async () => {
+    mockDbExecute.mockRejectedValue(new Error("connection refused"));
+
+    const res = await app.inject({ method: "GET", url: "/api/activity" });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json().error).toBe("Failed to fetch activity feed");
+  });
+});

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -1,0 +1,256 @@
+import type { FastifyInstance } from "fastify";
+import type { ZodTypeProvider } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+
+const activityQuerySchema = z
+  .object({
+    days: z.coerce.number().int().min(1).max(90).default(7).describe("Lookback window in days"),
+    type: z
+      .enum(["action", "task_event", "auth_event", "infra_event"])
+      .optional()
+      .describe("Filter by event type"),
+    userId: z.string().uuid().optional().describe("Filter by actor user ID"),
+    resourceType: z
+      .enum([
+        "task",
+        "repo",
+        "workflow",
+        "connection",
+        "secret",
+        "webhook",
+        "session",
+        "mcp_server",
+        "settings",
+      ])
+      .optional()
+      .describe("Filter by resource type"),
+    limit: z.coerce.number().int().min(1).max(200).default(50),
+    offset: z.coerce.number().int().min(0).default(0),
+  })
+  .describe("Query parameters for the unified activity feed");
+
+const ActivityItemSchema = z.object({
+  id: z.string(),
+  type: z.enum(["action", "task_event", "auth_event", "infra_event"]),
+  timestamp: z.string(),
+  actor: z
+    .object({
+      id: z.string(),
+      displayName: z.string(),
+      avatarUrl: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+  action: z.string(),
+  resourceType: z.string(),
+  resourceId: z.string().nullable().optional(),
+  summary: z.string(),
+  details: z.record(z.unknown()).nullable().optional(),
+});
+
+const ActivityResponseSchema = z
+  .object({
+    items: z.array(ActivityItemSchema),
+    total: z.number().int(),
+    stats: z.object({
+      actions: z.number().int(),
+      taskEvents: z.number().int(),
+      authEvents: z.number().int(),
+      infraEvents: z.number().int(),
+    }),
+  })
+  .describe("Unified activity feed response");
+
+export async function activityRoutes(rawApp: FastifyInstance) {
+  const app = rawApp.withTypeProvider<ZodTypeProvider>();
+
+  app.get(
+    "/api/activity",
+    {
+      schema: {
+        operationId: "getActivityFeed",
+        summary: "Get unified workspace activity feed",
+        description:
+          "Merges user actions, task state transitions, auth events, and " +
+          "infrastructure events into a single chronologically sorted feed. " +
+          "Supports filtering by type, user, and resource type.",
+        tags: ["System"],
+        querystring: activityQuerySchema,
+        response: {
+          200: ActivityResponseSchema,
+          500: z.object({ error: z.string() }),
+        },
+      },
+    },
+    async (req, reply) => {
+      const { days, type, userId, resourceType, limit, offset } = req.query;
+      const since = new Date(Date.now() - days * 86_400_000).toISOString();
+
+      try {
+        // Build individual CTEs for each event source, applying filters
+        const parts: string[] = [];
+        const typeFilters = type ? [type] : ["action", "task_event", "auth_event", "infra_event"];
+
+        if (typeFilters.includes("action")) {
+          const actionWhere = [`oa.created_at >= '${since}'`];
+          if (userId) actionWhere.push(`oa.user_id = '${userId}'`);
+          if (resourceType) actionWhere.push(`split_part(oa.action, '.', 1) = '${resourceType}'`);
+          parts.push(`
+            SELECT
+              oa.id::text,
+              'action' AS type,
+              oa.created_at AS timestamp,
+              oa.user_id,
+              u.display_name AS user_display_name,
+              u.avatar_url AS user_avatar_url,
+              oa.action,
+              split_part(oa.action, '.', 1) AS resource_type,
+              COALESCE((oa.params->>'id')::text, (oa.params->>'taskId')::text, (oa.params->>'repoId')::text) AS resource_id,
+              oa.action || ' ' || CASE WHEN oa.success THEN 'succeeded' ELSE 'failed' END AS summary,
+              oa.params AS details
+            FROM optio_actions oa
+            LEFT JOIN users u ON oa.user_id = u.id
+            WHERE ${actionWhere.join(" AND ")}
+          `);
+        }
+
+        if (typeFilters.includes("task_event")) {
+          const teWhere = [`te.created_at >= '${since}'`];
+          if (userId) teWhere.push(`te.user_id = '${userId}'`);
+          if (resourceType && resourceType !== "task") {
+            // task_events are always about tasks, skip if filtering for other types
+          } else {
+            parts.push(`
+              SELECT
+                te.id::text,
+                'task_event' AS type,
+                te.created_at AS timestamp,
+                te.user_id,
+                u.display_name AS user_display_name,
+                u.avatar_url AS user_avatar_url,
+                'task:' || COALESCE(te.from_state, 'new') || '→' || te.to_state AS action,
+                'task' AS resource_type,
+                te.task_id::text AS resource_id,
+                'Task transitioned to ' || te.to_state || ' via ' || te.trigger AS summary,
+                jsonb_build_object('fromState', te.from_state, 'toState', te.to_state, 'trigger', te.trigger) AS details
+              FROM task_events te
+              LEFT JOIN users u ON te.user_id = u.id
+              WHERE ${teWhere.join(" AND ")}
+            `);
+          }
+        }
+
+        if (typeFilters.includes("auth_event") && !resourceType) {
+          const aeWhere = [`ae.created_at >= '${since}'`];
+          // auth_events have no userId, skip if filtering by user
+          if (!userId) {
+            parts.push(`
+              SELECT
+                ae.id::text,
+                'auth_event' AS type,
+                ae.created_at AS timestamp,
+                NULL::uuid AS user_id,
+                NULL AS user_display_name,
+                NULL AS user_avatar_url,
+                'auth:' || ae.token_type || '_failed' AS action,
+                'auth' AS resource_type,
+                NULL AS resource_id,
+                ae.token_type || ' auth failed: ' || ae.error_message AS summary,
+                jsonb_build_object('tokenType', ae.token_type, 'error', ae.error_message) AS details
+              FROM auth_events ae
+              WHERE ${aeWhere.join(" AND ")}
+            `);
+          }
+        }
+
+        if (typeFilters.includes("infra_event") && !resourceType) {
+          const ieWhere = [`phe.created_at >= '${since}'`];
+          if (!userId) {
+            parts.push(`
+              SELECT
+                phe.id::text,
+                'infra_event' AS type,
+                phe.created_at AS timestamp,
+                NULL::uuid AS user_id,
+                NULL AS user_display_name,
+                NULL AS user_avatar_url,
+                'pod:' || phe.event_type AS action,
+                'pod' AS resource_type,
+                phe.repo_pod_id::text AS resource_id,
+                'Pod ' || COALESCE(phe.pod_name, 'unknown') || ' ' || phe.event_type AS summary,
+                jsonb_build_object('eventType', phe.event_type, 'podName', phe.pod_name, 'message', phe.message) AS details
+              FROM pod_health_events phe
+              WHERE ${ieWhere.join(" AND ")}
+            `);
+          }
+        }
+
+        if (parts.length === 0) {
+          return reply.send({
+            items: [],
+            total: 0,
+            stats: { actions: 0, taskEvents: 0, authEvents: 0, infraEvents: 0 },
+          });
+        }
+
+        const unionQuery = parts.join(" UNION ALL ");
+
+        // Get paginated results
+        const [rows, countRows, statsRows] = await Promise.all([
+          db.execute(
+            sql.raw(`
+            SELECT * FROM (${unionQuery}) AS activity
+            ORDER BY timestamp DESC
+            LIMIT ${limit} OFFSET ${offset}
+          `),
+          ),
+          db.execute(
+            sql.raw(`
+            SELECT count(*)::int AS total FROM (${unionQuery}) AS activity
+          `),
+          ),
+          db.execute(
+            sql.raw(`
+            SELECT type, count(*)::int AS cnt FROM (${unionQuery}) AS activity GROUP BY type
+          `),
+          ),
+        ]);
+
+        const total = (countRows[0] as any)?.total ?? 0;
+
+        const stats = { actions: 0, taskEvents: 0, authEvents: 0, infraEvents: 0 };
+        for (const row of statsRows as any[]) {
+          if (row.type === "action") stats.actions = row.cnt;
+          if (row.type === "task_event") stats.taskEvents = row.cnt;
+          if (row.type === "auth_event") stats.authEvents = row.cnt;
+          if (row.type === "infra_event") stats.infraEvents = row.cnt;
+        }
+
+        const items = (rows as any[]).map((row) => ({
+          id: row.id,
+          type: row.type as "action" | "task_event" | "auth_event" | "infra_event",
+          timestamp: new Date(row.timestamp).toISOString(),
+          actor: row.user_id
+            ? {
+                id: row.user_id,
+                displayName: row.user_display_name ?? "Unknown",
+                avatarUrl: row.user_avatar_url ?? null,
+              }
+            : null,
+          action: row.action,
+          resourceType: row.resource_type,
+          resourceId: row.resource_id ?? null,
+          summary: row.summary,
+          details: row.details ?? null,
+        }));
+
+        reply.send({ items, total, stats });
+      } catch (err) {
+        rawApp.log.error(err, "Failed to fetch activity feed");
+        return reply.status(500).send({ error: "Failed to fetch activity feed" });
+      }
+    },
+  );
+}

--- a/apps/api/src/routes/bulk.ts
+++ b/apps/api/src/routes/bulk.ts
@@ -8,6 +8,7 @@ import { TaskState } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
 import { taskQueue } from "../workers/task-worker.js";
 import { requireRole } from "../plugins/auth.js";
+import { logAction } from "../services/optio-action-service.js";
 
 const RetriedResponseSchema = z
   .object({
@@ -69,6 +70,13 @@ export async function bulkRoutes(rawApp: FastifyInstance) {
           // Skip tasks that can't transition
         }
       }
+      logAction({
+        userId: req.user?.id,
+        action: "task.bulk_retry",
+        params: {},
+        result: { retried, total: failedTasks.length },
+        success: true,
+      }).catch(() => {});
       reply.send({ retried, total: failedTasks.length });
     },
   );
@@ -117,6 +125,13 @@ export async function bulkRoutes(rawApp: FastifyInstance) {
           // Skip tasks that can't transition
         }
       }
+      logAction({
+        userId: req.user?.id,
+        action: "task.bulk_cancel",
+        params: {},
+        result: { cancelled, total: allActive.length },
+        success: true,
+      }).catch(() => {});
       reply.send({ cancelled, total: allActive.length });
     },
   );

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import * as connectionService from "../services/connection-service.js";
+import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import {
   ConnectionProviderSchema,
@@ -154,6 +155,13 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
     async (req, reply) => {
       const workspaceId = req.user?.workspaceId ?? null;
       const provider = await connectionService.createProvider(req.body, workspaceId);
+      logAction({
+        userId: req.user?.id,
+        action: "connection_provider.create",
+        params: { slug: req.body.slug, name: req.body.name },
+        result: { id: provider.id },
+        success: true,
+      }).catch(() => {});
       reply.status(201).send({ provider });
     },
   );
@@ -193,6 +201,13 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
     async (req, reply) => {
       const workspaceId = req.user?.workspaceId ?? null;
       const conn = await connectionService.createConnection(req.body, workspaceId);
+      logAction({
+        userId: req.user?.id,
+        action: "connection.create",
+        params: { name: req.body.name, providerSlug: req.body.providerSlug },
+        result: { id: conn.id },
+        success: true,
+      }).catch(() => {});
       reply.status(201).send({ connection: conn });
     },
   );
@@ -241,6 +256,13 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
         return reply.status(404).send({ error: "Connection not found" });
       }
       const conn = await connectionService.updateConnection(req.params.id, req.body);
+      logAction({
+        userId: req.user?.id,
+        action: "connection.update",
+        params: { connectionId: req.params.id, ...req.body },
+        result: { id: req.params.id },
+        success: true,
+      }).catch(() => {});
       reply.send({ connection: conn });
     },
   );
@@ -265,6 +287,13 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
         return reply.status(404).send({ error: "Connection not found" });
       }
       await connectionService.deleteConnection(req.params.id);
+      logAction({
+        userId: req.user?.id,
+        action: "connection.delete",
+        params: { connectionId: req.params.id },
+        result: { id: req.params.id },
+        success: true,
+      }).catch(() => {});
       reply.status(204).send(null);
     },
   );
@@ -333,6 +362,13 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
       const conn = await connectionService.getConnection(req.params.id);
       if (!conn) return reply.status(404).send({ error: "Connection not found" });
       const assignment = await connectionService.createAssignment(req.params.id, req.body);
+      logAction({
+        userId: req.user?.id,
+        action: "connection.assign",
+        params: { connectionId: req.params.id, ...req.body },
+        result: { id: assignment.id },
+        success: true,
+      }).catch(() => {});
       reply.status(201).send({ assignment });
     },
   );
@@ -352,6 +388,13 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
     },
     async (req, reply) => {
       const assignment = await connectionService.updateAssignment(req.params.id, req.body);
+      logAction({
+        userId: req.user?.id,
+        action: "connection_assignment.update",
+        params: { assignmentId: req.params.id, ...req.body },
+        result: { id: req.params.id },
+        success: true,
+      }).catch(() => {});
       reply.send({ assignment });
     },
   );
@@ -370,6 +413,13 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
     },
     async (req, reply) => {
       await connectionService.deleteAssignment(req.params.id);
+      logAction({
+        userId: req.user?.id,
+        action: "connection_assignment.delete",
+        params: { assignmentId: req.params.id },
+        result: { id: req.params.id },
+        success: true,
+      }).catch(() => {});
       reply.status(204).send(null);
     },
   );

--- a/apps/api/src/routes/mcp-servers.ts
+++ b/apps/api/src/routes/mcp-servers.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import * as mcpService from "../services/mcp-server-service.js";
+import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import { McpServerSchema } from "../schemas/integration.js";
 
@@ -100,6 +101,13 @@ export async function mcpServerRoutes(rawApp: FastifyInstance) {
     async (req, reply) => {
       const workspaceId = req.user?.workspaceId ?? null;
       const server = await mcpService.createMcpServer(req.body, workspaceId);
+      logAction({
+        userId: req.user?.id,
+        action: "mcp_server.create",
+        params: { name: req.body.name, command: req.body.command },
+        result: { id: server.id },
+        success: true,
+      }).catch(() => {});
       reply.status(201).send({ server });
     },
   );
@@ -126,6 +134,13 @@ export async function mcpServerRoutes(rawApp: FastifyInstance) {
         return reply.status(404).send({ error: "MCP server not found" });
       }
       const server = await mcpService.updateMcpServer(id, req.body);
+      logAction({
+        userId: req.user?.id,
+        action: "mcp_server.update",
+        params: { mcpServerId: id, ...req.body },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.send({ server });
     },
   );
@@ -151,6 +166,13 @@ export async function mcpServerRoutes(rawApp: FastifyInstance) {
         return reply.status(404).send({ error: "MCP server not found" });
       }
       await mcpService.deleteMcpServer(id);
+      logAction({
+        userId: req.user?.id,
+        action: "mcp_server.delete",
+        params: { mcpServerId: id },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.status(204).send(null);
     },
   );
@@ -203,6 +225,13 @@ export async function mcpServerRoutes(rawApp: FastifyInstance) {
         { ...req.body, repoUrl: repo.repoUrl },
         workspaceId,
       );
+      logAction({
+        userId: req.user?.id,
+        action: "mcp_server.create",
+        params: { name: req.body.name, repoId: id },
+        result: { id: server.id },
+        success: true,
+      }).catch(() => {});
       reply.status(201).send({ server });
     },
   );

--- a/apps/api/src/routes/optio-settings.ts
+++ b/apps/api/src/routes/optio-settings.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import * as optioSettingsService from "../services/optio-settings-service.js";
+import { logAction } from "../services/optio-action-service.js";
 
 const updateSettingsSchema = z
   .object({
@@ -60,6 +61,13 @@ export async function optioSettingsRoutes(rawApp: FastifyInstance) {
     async (req, reply) => {
       const workspaceId = req.user?.workspaceId ?? null;
       const settings = await optioSettingsService.upsertSettings(req.body, workspaceId);
+      logAction({
+        userId: req.user?.id,
+        action: "settings.update",
+        params: { ...req.body },
+        result: {},
+        success: true,
+      }).catch(() => {});
       reply.send({ settings });
     },
   );

--- a/apps/api/src/routes/pr-reviews.ts
+++ b/apps/api/src/routes/pr-reviews.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { requireRole } from "../plugins/auth.js";
 import * as prReviewService from "../services/pr-review-service.js";
 import { logger } from "../logger.js";
+import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import {
   ReviewDraftSchema,
@@ -128,6 +129,13 @@ export async function prReviewRoutes(rawApp: FastifyInstance) {
           workspaceId: req.user?.workspaceId ?? undefined,
           createdBy: req.user?.id,
         });
+        logAction({
+          userId: req.user?.id,
+          action: "review.launch",
+          params: { prUrl: req.body.prUrl },
+          result: result as Record<string, unknown>,
+          success: true,
+        }).catch(() => {});
         reply.status(201).send(result);
       } catch (err: unknown) {
         logger.warn({ err, prUrl: req.body.prUrl }, "Failed to launch PR review");

--- a/apps/api/src/routes/repos.ts
+++ b/apps/api/src/routes/repos.ts
@@ -12,6 +12,7 @@ import {
 import { requireRole } from "../plugins/auth.js";
 import { getGitHubToken } from "../services/github-token-service.js";
 import { isSsrfSafeUrl } from "../utils/ssrf.js";
+import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import { RepoSchema } from "../schemas/integration.js";
 
@@ -179,6 +180,13 @@ export async function repoRoutes(rawApp: FastifyInstance) {
         /* non-critical */
       }
 
+      logAction({
+        userId: req.user?.id,
+        action: "repo.create",
+        params: { repoUrl: body.repoUrl, fullName: body.fullName },
+        result: { id: repo.id },
+        success: true,
+      }).catch(() => {});
       reply.status(201).send({ repo });
     },
   );
@@ -252,6 +260,13 @@ export async function repoRoutes(rawApp: FastifyInstance) {
 
       const repo = await repoService.updateRepo(id, body);
       if (!repo) return reply.status(404).send({ error: "Repo not found" });
+      logAction({
+        userId: req.user?.id,
+        action: "repo.update",
+        params: { repoId: id, ...body },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.send({ repo });
     },
   );
@@ -280,6 +295,13 @@ export async function repoRoutes(rawApp: FastifyInstance) {
         return reply.status(404).send({ error: "Repo not found" });
       }
       await repoService.deleteRepo(id);
+      logAction({
+        userId: req.user?.id,
+        action: "repo.delete",
+        params: { repoId: id, repoUrl: existing.repoUrl },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.status(204).send(null);
     },
   );

--- a/apps/api/src/routes/secrets.ts
+++ b/apps/api/src/routes/secrets.ts
@@ -5,6 +5,7 @@ import * as secretService from "../services/secret-service.js";
 import { requireRole } from "../plugins/auth.js";
 import { invalidateCredentialsCache } from "../services/auth-service.js";
 import { publishEvent } from "../services/event-bus.js";
+import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema } from "../schemas/common.js";
 
 const scopeQuerySchema = z
@@ -147,6 +148,13 @@ export async function secretRoutes(rawApp: FastifyInstance) {
         }).catch(() => {});
       }
 
+      logAction({
+        userId: req.user?.id,
+        action: "secret.upsert",
+        params: { name: input.name, scope: input.scope ?? "global" },
+        result: { name: input.name },
+        success: true,
+      }).catch(() => {});
       reply.status(201).send({
         name: input.name,
         scope: input.scope ?? "global",
@@ -173,6 +181,13 @@ export async function secretRoutes(rawApp: FastifyInstance) {
       const { name } = req.params;
       const workspaceId = req.user?.workspaceId ?? null;
       await secretService.deleteSecret(name, req.query.scope, workspaceId);
+      logAction({
+        userId: req.user?.id,
+        action: "secret.delete",
+        params: { name },
+        result: { name },
+        success: true,
+      }).catch(() => {});
       reply.status(204).send(null);
     },
   );

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import * as sessionService from "../services/interactive-session-service.js";
 import { db } from "../db/client.js";
 import { repos } from "../db/schema.js";
+import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import {
   InteractiveSessionSchema,
@@ -209,6 +210,13 @@ export async function sessionRoutes(rawApp: FastifyInstance) {
         userId,
         workspaceId: req.user?.workspaceId ?? null,
       });
+      logAction({
+        userId: req.user?.id,
+        action: "session.create",
+        params: { repoUrl: input.repoUrl },
+        result: { id: session.id },
+        success: true,
+      }).catch(() => {});
       reply.status(201).send({ session });
     },
   );
@@ -242,6 +250,13 @@ export async function sessionRoutes(rawApp: FastifyInstance) {
 
       try {
         const updated = await sessionService.endSession(id);
+        logAction({
+          userId: req.user?.id,
+          action: "session.end",
+          params: { sessionId: id },
+          result: { id },
+          success: true,
+        }).catch(() => {});
         reply.send({ session: updated });
       } catch (err) {
         reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -9,6 +9,7 @@ import { taskQueue } from "../workers/task-worker.js";
 import { db } from "../db/client.js";
 import { tasks } from "../db/schema.js";
 import { requireRole } from "../plugins/auth.js";
+import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import {
   TaskSchema,
@@ -381,6 +382,13 @@ export async function taskRoutes(rawApp: FastifyInstance) {
         createdBy: req.user?.id,
         workspaceId: req.user?.workspaceId ?? null,
       });
+      logAction({
+        userId: req.user?.id,
+        action: "task.create",
+        params: { taskId: task.id, title: taskInput.title, repoUrl: taskInput.repoUrl },
+        result: { id: task.id },
+        success: true,
+      }).catch(() => {});
 
       const hasDeps = dependsOn && dependsOn.length > 0;
       if (hasDeps) {
@@ -458,6 +466,13 @@ export async function taskRoutes(rawApp: FastifyInstance) {
         undefined,
         req.user?.id,
       );
+      logAction({
+        userId: req.user?.id,
+        action: "task.cancel",
+        params: { taskId: id },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.send({ task });
     },
   );
@@ -505,6 +520,13 @@ export async function taskRoutes(rawApp: FastifyInstance) {
           attempts: 1,
         },
       );
+      logAction({
+        userId: req.user?.id,
+        action: "task.retry",
+        params: { taskId: id },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.send({ task });
     },
   );
@@ -554,6 +576,13 @@ export async function taskRoutes(rawApp: FastifyInstance) {
           attempts: 1,
         },
       );
+      logAction({
+        userId: req.user?.id,
+        action: "task.force_redo",
+        params: { taskId: id },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.send({ task });
     },
   );
@@ -798,6 +827,13 @@ export async function taskRoutes(rawApp: FastifyInstance) {
       try {
         const { launchReview } = await import("../services/review-service.js");
         const reviewTaskId = await launchReview(id);
+        logAction({
+          userId: req.user?.id,
+          action: "task.review",
+          params: { taskId: id },
+          result: { reviewTaskId },
+          success: true,
+        }).catch(() => {});
         reply.status(201).send({ reviewTaskId });
       } catch (err) {
         reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
@@ -859,6 +895,13 @@ export async function taskRoutes(rawApp: FastifyInstance) {
       );
 
       const task = await taskService.getTask(id);
+      logAction({
+        userId: req.user?.id,
+        action: "task.run_now",
+        params: { taskId: id },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.send({ task });
     },
   );
@@ -902,6 +945,13 @@ export async function taskRoutes(rawApp: FastifyInstance) {
           .set({ priority: i + 1, updatedAt: new Date() })
           .where(eq(tasks.id, body.taskIds[i]));
       }
+      logAction({
+        userId: req.user?.id,
+        action: "task.reorder",
+        params: { taskIds: body.taskIds },
+        result: { reordered: body.taskIds.length },
+        success: true,
+      }).catch(() => {});
       reply.send({ ok: true, reordered: body.taskIds.length });
     },
   );

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -3,6 +3,7 @@ import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { isSsrfSafeUrl } from "../utils/ssrf.js";
 import * as webhookService from "../services/webhook-service.js";
+import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import { WebhookSchema, WebhookDeliverySchema } from "../schemas/integration.js";
 
@@ -140,6 +141,13 @@ export async function webhookRoutes(rawApp: FastifyInstance) {
     async (req, reply) => {
       const workspaceId = req.user?.workspaceId ?? null;
       const webhook = await webhookService.createWebhook(req.body, req.user?.id, workspaceId);
+      logAction({
+        userId: req.user?.id,
+        action: "webhook.create",
+        params: { url: req.body.url, events: req.body.events },
+        result: { id: webhook.id },
+        success: true,
+      }).catch(() => {});
       reply.status(201).send({
         webhook: { ...webhook, secret: webhook.secret ? "••••••" : null },
       });
@@ -171,6 +179,13 @@ export async function webhookRoutes(rawApp: FastifyInstance) {
       }
       const updated = await webhookService.updateWebhook(id, req.body);
       if (!updated) return reply.status(404).send({ error: "Webhook not found" });
+      logAction({
+        userId: req.user?.id,
+        action: "webhook.update",
+        params: { webhookId: id, ...req.body },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.send({
         webhook: { ...updated, secret: updated.secret ? "••••••" : null },
       });
@@ -199,6 +214,13 @@ export async function webhookRoutes(rawApp: FastifyInstance) {
       }
       const deleted = await webhookService.deleteWebhook(id);
       if (!deleted) return reply.status(404).send({ error: "Webhook not found" });
+      logAction({
+        userId: req.user?.id,
+        action: "webhook.delete",
+        params: { webhookId: id },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.status(204).send(null);
     },
   );

--- a/apps/api/src/routes/workflow-triggers.ts
+++ b/apps/api/src/routes/workflow-triggers.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { workflows } from "../db/schema.js";
 import * as triggerService from "../services/workflow-trigger-service.js";
+import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema } from "../schemas/common.js";
 import { WorkflowTriggerSchema } from "../schemas/workflow.js";
 
@@ -156,6 +157,13 @@ export async function workflowTriggerRoutes(rawApp: FastifyInstance) {
           paramMapping: input.paramMapping,
           enabled: input.enabled,
         });
+        logAction({
+          userId: req.user?.id,
+          action: "workflow_trigger.create",
+          params: { workflowId: id, type: input.type },
+          result: { id: trigger.id },
+          success: true,
+        }).catch(() => {});
         reply.status(201).send({ trigger });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -218,6 +226,13 @@ export async function workflowTriggerRoutes(rawApp: FastifyInstance) {
       try {
         const trigger = await triggerService.updateTrigger(triggerId, input);
         if (!trigger) return reply.status(404).send({ error: "Trigger not found" });
+        logAction({
+          userId: req.user?.id,
+          action: "workflow_trigger.update",
+          params: { workflowId: id, triggerId },
+          result: { id: triggerId },
+          success: true,
+        }).catch(() => {});
         reply.send({ trigger });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -260,6 +275,13 @@ export async function workflowTriggerRoutes(rawApp: FastifyInstance) {
       }
 
       await triggerService.deleteTrigger(triggerId);
+      logAction({
+        userId: req.user?.id,
+        action: "workflow_trigger.delete",
+        params: { workflowId: id, triggerId },
+        result: { id: triggerId },
+        success: true,
+      }).catch(() => {});
       reply.status(204).send(null);
     },
   );

--- a/apps/api/src/routes/workflows.ts
+++ b/apps/api/src/routes/workflows.ts
@@ -3,6 +3,7 @@ import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import * as workflowService from "../services/workflow-service.js";
 import { workflowRunQueue } from "../workers/workflow-worker.js";
+import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import {
   WorkflowSchema,
@@ -164,6 +165,13 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
           workspaceId: req.user?.workspaceId ?? undefined,
           createdBy: req.user?.id,
         });
+        logAction({
+          userId: req.user?.id,
+          action: "workflow.create",
+          params: { name: input.name },
+          result: { id: workflow.id },
+          success: true,
+        }).catch(() => {});
         reply.status(201).send({ workflow });
       } catch (err) {
         reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
@@ -221,6 +229,18 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
       try {
         const workflow = await workflowService.updateWorkflow(id, input);
         if (!workflow) return reply.status(404).send({ error: "Workflow not found" });
+        logAction({
+          userId: req.user?.id,
+          action:
+            input.enabled !== undefined
+              ? input.enabled
+                ? "workflow.enable"
+                : "workflow.disable"
+              : "workflow.update",
+          params: { workflowId: id, ...input },
+          result: { id },
+          success: true,
+        }).catch(() => {});
         reply.send({ workflow });
       } catch (err) {
         reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
@@ -252,6 +272,13 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
         createdBy: req.user?.id,
       });
       if (!cloned) return reply.status(404).send({ error: "Workflow not found" });
+      logAction({
+        userId: req.user?.id,
+        action: "workflow.clone",
+        params: { sourceWorkflowId: id },
+        result: { id: cloned.id },
+        success: true,
+      }).catch(() => {});
       reply.status(201).send({ workflow: cloned });
     },
   );
@@ -275,6 +302,13 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
       const { id } = req.params;
       const deleted = await workflowService.deleteWorkflow(id);
       if (!deleted) return reply.status(404).send({ error: "Workflow not found" });
+      logAction({
+        userId: req.user?.id,
+        action: "workflow.delete",
+        params: { workflowId: id },
+        result: { id },
+        success: true,
+      }).catch(() => {});
       reply.status(204).send(null);
     },
   );
@@ -311,6 +345,13 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
           { jobId: run.id },
         );
 
+        logAction({
+          userId: req.user?.id,
+          action: "workflow_run.create",
+          params: { workflowId: id },
+          result: { id: run.id },
+          success: true,
+        }).catch(() => {});
         reply.status(201).send({ run });
       } catch (err) {
         reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
@@ -390,6 +431,13 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
       const { id } = req.params;
       try {
         const run = await workflowService.retryWorkflowRun(id);
+        logAction({
+          userId: req.user?.id,
+          action: "workflow_run.retry",
+          params: { workflowRunId: id },
+          result: { id },
+          success: true,
+        }).catch(() => {});
         reply.send({ run });
       } catch (err) {
         reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
@@ -416,6 +464,13 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
       const { id } = req.params;
       try {
         const run = await workflowService.cancelWorkflowRun(id);
+        logAction({
+          userId: req.user?.id,
+          action: "workflow_run.cancel",
+          params: { workflowRunId: id },
+          result: { id },
+          success: true,
+        }).catch(() => {});
         reply.send({ run });
       } catch (err) {
         reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -49,6 +49,7 @@ import { sharedDirectoryRoutes } from "./routes/shared-directories.js";
 import { notificationRoutes } from "./routes/notifications.js";
 import { optioRoutes } from "./routes/optio.js";
 import { optioSettingsRoutes } from "./routes/optio-settings.js";
+import { activityRoutes } from "./routes/activity.js";
 import githubAppRoutes from "./routes/github-app.js";
 import { githubTokenRoutes } from "./routes/github-token.js";
 import { hookRoutes } from "./routes/hooks.js";
@@ -278,6 +279,7 @@ export async function buildServer() {
   await app.register(notificationRoutes);
   await app.register(optioRoutes);
   await app.register(optioSettingsRoutes);
+  await app.register(activityRoutes);
   await app.register(githubAppRoutes);
   await app.register(githubTokenRoutes);
   await app.register(hookRoutes);

--- a/apps/api/src/services/optio-action-service.ts
+++ b/apps/api/src/services/optio-action-service.ts
@@ -2,6 +2,7 @@ import { eq, desc, and, gte, lte, sql, type SQL } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { optioActions, users } from "../db/schema.js";
 import type { OptioAction } from "@optio/shared";
+import { publishEvent } from "./event-bus.js";
 
 // ── Sensitive key patterns to strip from params ─────────────────────────────
 
@@ -50,6 +51,19 @@ export async function logAction(input: LogActionInput): Promise<OptioAction> {
       conversationSnippet: input.conversationSnippet ?? null,
     })
     .returning();
+
+  // Publish real-time activity event (non-blocking)
+  const [resourceType] = input.action.split(".");
+  publishEvent({
+    type: "activity:new",
+    action: input.action,
+    userId: input.userId,
+    resourceType,
+    resourceId: (input.params?.id ?? input.result?.id) as string | undefined,
+    summary: `${input.action} ${input.success ? "succeeded" : "failed"}`,
+    timestamp: new Date().toISOString(),
+  }).catch(() => {});
+
   return row as unknown as OptioAction;
 }
 

--- a/apps/web/src/app/activity/page.tsx
+++ b/apps/web/src/app/activity/page.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { usePageTitle } from "@/hooks/use-page-title";
+import { api } from "@/lib/api-client";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import Link from "next/link";
+import {
+  Activity,
+  RefreshCw,
+  User,
+  Zap,
+  AlertTriangle,
+  Server,
+  ChevronDown,
+  ChevronRight,
+  ListTodo,
+  FolderGit2,
+  GitBranch,
+  Plug,
+  KeyRound,
+  Webhook,
+  Terminal,
+  Settings,
+  Shield,
+  Loader2,
+} from "lucide-react";
+
+type ActivityItem = {
+  id: string;
+  type: "action" | "task_event" | "auth_event" | "infra_event";
+  timestamp: string;
+  actor?: { id: string; displayName: string; avatarUrl?: string | null } | null;
+  action: string;
+  resourceType: string;
+  resourceId?: string | null;
+  summary: string;
+  details?: Record<string, unknown> | null;
+};
+
+type ActivityStats = {
+  actions: number;
+  taskEvents: number;
+  authEvents: number;
+  infraEvents: number;
+};
+
+const TYPE_OPTIONS = [
+  { value: "", label: "All types" },
+  { value: "action", label: "User actions" },
+  { value: "task_event", label: "Task events" },
+  { value: "auth_event", label: "Auth events" },
+  { value: "infra_event", label: "Infra events" },
+];
+
+const RESOURCE_OPTIONS = [
+  { value: "", label: "All resources" },
+  { value: "task", label: "Tasks" },
+  { value: "repo", label: "Repos" },
+  { value: "workflow", label: "Workflows" },
+  { value: "connection", label: "Connections" },
+  { value: "secret", label: "Secrets" },
+  { value: "webhook", label: "Webhooks" },
+  { value: "session", label: "Sessions" },
+];
+
+const DAYS_OPTIONS = [
+  { value: 1, label: "Today" },
+  { value: 7, label: "7 days" },
+  { value: 14, label: "14 days" },
+  { value: 30, label: "30 days" },
+];
+
+const TYPE_COLORS: Record<string, string> = {
+  action: "text-primary",
+  task_event: "text-blue-400",
+  auth_event: "text-warning",
+  infra_event: "text-error",
+};
+
+const TYPE_BG: Record<string, string> = {
+  action: "bg-primary/10",
+  task_event: "bg-blue-400/10",
+  auth_event: "bg-warning/10",
+  infra_event: "bg-error/10",
+};
+
+function getResourceIcon(resourceType: string) {
+  switch (resourceType) {
+    case "task":
+      return ListTodo;
+    case "repo":
+      return FolderGit2;
+    case "workflow":
+    case "workflow_run":
+    case "workflow_trigger":
+      return GitBranch;
+    case "connection":
+    case "connection_provider":
+    case "connection_assignment":
+      return Plug;
+    case "secret":
+      return KeyRound;
+    case "webhook":
+      return Webhook;
+    case "session":
+      return Terminal;
+    case "settings":
+    case "mcp_server":
+      return Settings;
+    case "auth":
+      return Shield;
+    case "pod":
+      return Server;
+    case "review":
+      return Zap;
+    default:
+      return Activity;
+  }
+}
+
+function formatAction(action: string): string {
+  return action.replace(/[._]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function ActivityCard({ item }: { item: ActivityItem }) {
+  const [expanded, setExpanded] = useState(false);
+  const Icon = getResourceIcon(item.resourceType);
+  const typeColor = TYPE_COLORS[item.type] ?? "text-text-muted";
+  const typeBg = TYPE_BG[item.type] ?? "bg-bg-hover";
+
+  const resourceLink =
+    item.resourceType === "task" && item.resourceId
+      ? `/tasks/${item.resourceId}`
+      : item.resourceType === "workflow" && item.resourceId
+        ? `/workflows/${item.resourceId}`
+        : item.resourceType === "session" && item.resourceId
+          ? `/sessions/${item.resourceId}`
+          : null;
+
+  return (
+    <div className="flex gap-3 py-3 px-4 rounded-lg hover:bg-bg-hover/40 transition-colors group">
+      <div
+        className={cn(
+          "w-8 h-8 rounded-lg flex items-center justify-center shrink-0 mt-0.5",
+          typeBg,
+        )}
+      >
+        <Icon className={cn("w-4 h-4", typeColor)} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 text-sm">
+          {item.actor && <span className="font-medium text-text">{item.actor.displayName}</span>}
+          <span className="text-text-muted">{item.summary}</span>
+        </div>
+        <div className="flex items-center gap-2 mt-1 text-xs text-text-muted">
+          <span>{formatRelativeTime(item.timestamp)}</span>
+          <span className="opacity-40">·</span>
+          <span
+            className={cn(
+              "px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wider",
+              typeBg,
+              typeColor,
+            )}
+          >
+            {item.type.replace("_", " ")}
+          </span>
+          {resourceLink && (
+            <>
+              <span className="opacity-40">·</span>
+              <Link href={resourceLink} className="text-primary hover:underline">
+                View {item.resourceType}
+              </Link>
+            </>
+          )}
+        </div>
+        {item.details && Object.keys(item.details).length > 0 && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="flex items-center gap-1 mt-1.5 text-xs text-text-muted hover:text-text transition-colors"
+          >
+            {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+            Details
+          </button>
+        )}
+        {expanded && item.details && (
+          <pre className="mt-2 p-2 rounded bg-bg-hover/60 text-xs text-text-muted overflow-x-auto">
+            {JSON.stringify(item.details, null, 2)}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatsBar({ stats }: { stats: ActivityStats }) {
+  const total = stats.actions + stats.taskEvents + stats.authEvents + stats.infraEvents;
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <div className="p-3 rounded-lg bg-primary/5 border border-primary/10">
+        <div className="text-xs text-text-muted mb-1">User Actions</div>
+        <div className="text-lg font-semibold text-text">{stats.actions}</div>
+      </div>
+      <div className="p-3 rounded-lg bg-blue-400/5 border border-blue-400/10">
+        <div className="text-xs text-text-muted mb-1">Task Events</div>
+        <div className="text-lg font-semibold text-text">{stats.taskEvents}</div>
+      </div>
+      <div className="p-3 rounded-lg bg-warning/5 border border-warning/10">
+        <div className="text-xs text-text-muted mb-1">Auth Events</div>
+        <div className="text-lg font-semibold text-text">{stats.authEvents}</div>
+      </div>
+      <div className="p-3 rounded-lg bg-error/5 border border-error/10">
+        <div className="text-xs text-text-muted mb-1">Infra Events</div>
+        <div className="text-lg font-semibold text-text">{stats.infraEvents}</div>
+      </div>
+    </div>
+  );
+}
+
+export default function ActivityPage() {
+  usePageTitle("Activity");
+
+  const [items, setItems] = useState<ActivityItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [stats, setStats] = useState<ActivityStats>({
+    actions: 0,
+    taskEvents: 0,
+    authEvents: 0,
+    infraEvents: 0,
+  });
+  const [loading, setLoading] = useState(true);
+
+  const [typeFilter, setTypeFilter] = useState("");
+  const [resourceFilter, setResourceFilter] = useState("");
+  const [daysFilter, setDaysFilter] = useState(7);
+  const [offset, setOffset] = useState(0);
+  const limit = 50;
+
+  const fetchActivity = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await api.getActivityFeed({
+        days: daysFilter,
+        type: typeFilter || undefined,
+        resourceType: resourceFilter || undefined,
+        limit,
+        offset,
+      });
+      setItems(data.items);
+      setTotal(data.total);
+      setStats(data.stats);
+    } catch {
+      // handled silently
+    } finally {
+      setLoading(false);
+    }
+  }, [daysFilter, typeFilter, resourceFilter, offset]);
+
+  useEffect(() => {
+    fetchActivity();
+  }, [fetchActivity]);
+
+  // Listen for real-time activity events
+  useEffect(() => {
+    const handler = () => {
+      if (offset === 0) fetchActivity();
+    };
+    window.addEventListener("optio:activity-new", handler);
+    return () => window.removeEventListener("optio:activity-new", handler);
+  }, [fetchActivity, offset]);
+
+  // Group items by day
+  const groupedByDay = items.reduce<Record<string, ActivityItem[]>>((acc, item) => {
+    const day = new Date(item.timestamp).toLocaleDateString("en-US", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+    if (!acc[day]) acc[day] = [];
+    acc[day].push(item);
+    return acc;
+  }, {});
+
+  const hasPrev = offset > 0;
+  const hasNext = offset + limit < total;
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-6 stagger">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-gradient">Activity</h1>
+          <p className="text-sm text-text-muted mt-0.5">
+            {total} event{total !== 1 ? "s" : ""} in the last {daysFilter} day
+            {daysFilter !== 1 ? "s" : ""}
+          </p>
+        </div>
+        <button
+          onClick={fetchActivity}
+          className="p-2 rounded-lg hover:bg-bg-hover text-text-muted transition-all btn-press hover:text-text"
+        >
+          <RefreshCw className={cn("w-4 h-4", loading && "animate-spin")} />
+        </button>
+      </div>
+
+      <StatsBar stats={stats} />
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-2">
+        <select
+          value={typeFilter}
+          onChange={(e) => {
+            setTypeFilter(e.target.value);
+            setOffset(0);
+          }}
+          className="px-3 py-1.5 rounded-lg bg-bg-hover border border-border text-sm text-text"
+        >
+          {TYPE_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={resourceFilter}
+          onChange={(e) => {
+            setResourceFilter(e.target.value);
+            setOffset(0);
+          }}
+          className="px-3 py-1.5 rounded-lg bg-bg-hover border border-border text-sm text-text"
+        >
+          {RESOURCE_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={daysFilter}
+          onChange={(e) => {
+            setDaysFilter(Number(e.target.value));
+            setOffset(0);
+          }}
+          className="px-3 py-1.5 rounded-lg bg-bg-hover border border-border text-sm text-text"
+        >
+          {DAYS_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Timeline */}
+      {loading && items.length === 0 ? (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="w-6 h-6 animate-spin text-text-muted" />
+        </div>
+      ) : items.length === 0 ? (
+        <div className="text-center py-16">
+          <Activity className="w-10 h-10 text-text-muted/40 mx-auto mb-3" />
+          <p className="text-text-muted">No activity found for the selected filters</p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {Object.entries(groupedByDay).map(([day, dayItems]) => (
+            <div key={day}>
+              <div className="flex items-center gap-2 mb-2">
+                <div className="h-px flex-1 bg-border/50" />
+                <span className="text-xs font-medium text-text-muted px-2">{day}</span>
+                <div className="h-px flex-1 bg-border/50" />
+              </div>
+              <div className="space-y-0.5">
+                {dayItems.map((item) => (
+                  <ActivityCard key={item.id} item={item} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {(hasPrev || hasNext) && (
+        <div className="flex items-center justify-between pt-2">
+          <button
+            onClick={() => setOffset(Math.max(0, offset - limit))}
+            disabled={!hasPrev}
+            className="px-3 py-1.5 rounded-lg bg-bg-hover border border-border text-sm text-text disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <span className="text-xs text-text-muted">
+            {offset + 1}–{Math.min(offset + limit, total)} of {total}
+          </span>
+          <button
+            onClick={() => setOffset(offset + limit)}
+            disabled={!hasNext}
+            className="px-3 py-1.5 rounded-lg bg-bg-hover border border-border text-sm text-text disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
   ClusterSummary,
   ActiveSessions,
   RecentTasks,
+  RecentActivity,
   PodsList,
   WelcomeHero,
   PerformanceSummary,
@@ -156,7 +157,11 @@ export default function OverviewPage() {
       <ActiveSessions sessions={activeSessions} activeCount={activeSessionCount} />
 
       <div className="grid md:grid-cols-2 gap-8">
+        <RecentActivity />
         <RecentTasks tasks={recentTasks} />
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-8">
         <PodsList
           pods={pods}
           events={events}

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -9,4 +9,5 @@ export { EmptyState } from "./empty-state.js";
 export { PerformanceSummary } from "./performance-summary.js";
 export { AgentComparison } from "./agent-comparison.js";
 export { FailureInsights } from "./failure-insights.js";
+export { RecentActivity } from "./recent-activity.js";
 export type { TaskStats, UsageData, MetricsHistoryPoint } from "./types.js";

--- a/apps/web/src/components/dashboard/recent-activity.tsx
+++ b/apps/web/src/components/dashboard/recent-activity.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import {
+  Activity,
+  ListTodo,
+  FolderGit2,
+  GitBranch,
+  Plug,
+  KeyRound,
+  Webhook,
+  Terminal,
+  Settings,
+  Shield,
+  Server,
+  Zap,
+} from "lucide-react";
+import { api } from "@/lib/api-client";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import { EmptyState } from "./empty-state.js";
+
+type ActivityItem = {
+  id: string;
+  type: "action" | "task_event" | "auth_event" | "infra_event";
+  timestamp: string;
+  actor?: { id: string; displayName: string; avatarUrl?: string | null } | null;
+  action: string;
+  resourceType: string;
+  resourceId?: string | null;
+  summary: string;
+  details?: Record<string, unknown> | null;
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  action: "text-primary",
+  task_event: "text-blue-400",
+  auth_event: "text-warning",
+  infra_event: "text-error",
+};
+
+const TYPE_BG: Record<string, string> = {
+  action: "bg-primary/10",
+  task_event: "bg-blue-400/10",
+  auth_event: "bg-warning/10",
+  infra_event: "bg-error/10",
+};
+
+function getResourceIcon(resourceType: string) {
+  switch (resourceType) {
+    case "task":
+      return ListTodo;
+    case "repo":
+      return FolderGit2;
+    case "workflow":
+    case "workflow_run":
+    case "workflow_trigger":
+      return GitBranch;
+    case "connection":
+    case "connection_provider":
+    case "connection_assignment":
+      return Plug;
+    case "secret":
+      return KeyRound;
+    case "webhook":
+      return Webhook;
+    case "session":
+      return Terminal;
+    case "settings":
+    case "mcp_server":
+      return Settings;
+    case "auth":
+      return Shield;
+    case "pod":
+      return Server;
+    case "review":
+      return Zap;
+    default:
+      return Activity;
+  }
+}
+
+export function RecentActivity() {
+  const [items, setItems] = useState<ActivityItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchActivity = useCallback(async () => {
+    try {
+      const data = await api.getActivityFeed({ days: 1, limit: 8 });
+      setItems(data.items);
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchActivity();
+  }, [fetchActivity]);
+
+  // Listen for real-time updates
+  useEffect(() => {
+    const handler = () => fetchActivity();
+    window.addEventListener("optio:activity-new", handler);
+    return () => window.removeEventListener("optio:activity-new", handler);
+  }, [fetchActivity]);
+
+  if (loading) {
+    return (
+      <div className="min-w-0 overflow-hidden">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-medium text-text-heading">Recent Activity</h2>
+        </div>
+        <div className="space-y-2">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-12 skeleton-shimmer rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-w-0 overflow-hidden">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-medium text-text-heading">Recent Activity</h2>
+        <Link href="/activity" className="text-xs text-primary hover:underline">
+          All &rarr;
+        </Link>
+      </div>
+      {items.length === 0 ? (
+        <EmptyState
+          icon={Activity}
+          title="No recent activity"
+          description="Actions and events will appear here as you use Optio."
+        />
+      ) : (
+        <div className="space-y-0.5">
+          {items.map((item) => {
+            const Icon = getResourceIcon(item.resourceType);
+            const typeColor = TYPE_COLORS[item.type] ?? "text-text-muted";
+            const typeBg = TYPE_BG[item.type] ?? "bg-bg-hover";
+            return (
+              <div
+                key={item.id}
+                className="flex items-center gap-2.5 py-2 px-2 rounded-lg hover:bg-bg-hover/40 transition-colors"
+              >
+                <div
+                  className={cn(
+                    "w-6 h-6 rounded flex items-center justify-center shrink-0",
+                    typeBg,
+                  )}
+                >
+                  <Icon className={cn("w-3 h-3", typeColor)} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs text-text truncate">{item.summary}</p>
+                  <p className="text-[10px] text-text-muted">
+                    {item.actor?.displayName ? `${item.actor.displayName} · ` : ""}
+                    {formatRelativeTime(item.timestamp)}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Webhook,
   Plug,
   BarChart3,
+  Activity,
 } from "lucide-react";
 import { UserMenu } from "./user-menu";
 import { WorkspaceSwitcher } from "./workspace-switcher";
@@ -39,6 +40,7 @@ const MAIN_NAV = [
 const SECONDARY_NAV = [
   { href: "/secrets", label: "Secrets", icon: KeyRound },
   { href: "/webhooks", label: "Webhooks", icon: Webhook },
+  { href: "/activity", label: "Activity", icon: Activity },
   { href: "/workspace-settings", label: "Workspace", icon: Building2 },
   { href: "/settings", label: "Settings", icon: Settings },
 ];

--- a/apps/web/src/hooks/use-websocket.ts
+++ b/apps/web/src/hooks/use-websocket.ts
@@ -101,6 +101,11 @@ export function useGlobalWebSocket() {
       window.dispatchEvent(new CustomEvent("optio:workflow-run-state-changed", { detail: event }));
     });
 
+    client.on("activity:new", () => {
+      // Dispatch a DOM event so the activity page and dashboard widget can refresh
+      window.dispatchEvent(new Event("optio:activity-new"));
+    });
+
     return () => {
       client.disconnect();
     };

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1260,4 +1260,42 @@ export const api = {
 
   deleteConnectionAssignment: (id: string) =>
     request<void>(`/api/connection-assignments/${id}`, { method: "DELETE" }),
+
+  // Activity feed
+  getActivityFeed: (params?: {
+    days?: number;
+    type?: string;
+    userId?: string;
+    resourceType?: string;
+    limit?: number;
+    offset?: number;
+  }) => {
+    const qs = new URLSearchParams();
+    if (params) {
+      for (const [key, val] of Object.entries(params)) {
+        if (val != null && val !== "") qs.set(key, String(val));
+      }
+    }
+    const query = qs.toString();
+    return request<{
+      items: Array<{
+        id: string;
+        type: "action" | "task_event" | "auth_event" | "infra_event";
+        timestamp: string;
+        actor?: { id: string; displayName: string; avatarUrl?: string | null } | null;
+        action: string;
+        resourceType: string;
+        resourceId?: string | null;
+        summary: string;
+        details?: Record<string, unknown> | null;
+      }>;
+      total: number;
+      stats: {
+        actions: number;
+        taskEvents: number;
+        authEvents: number;
+        infraEvents: number;
+      };
+    }>(`/api/activity${query ? `?${query}` : ""}`);
+  },
 };

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -17,7 +17,8 @@ export type WsEvent =
   | TaskMessageEvent
   | TaskMessageDeliveredEvent
   | WorkflowRunStateChangedEvent
-  | WorkflowRunLogEvent;
+  | WorkflowRunLogEvent
+  | ActivityNewEvent;
 
 export interface TaskStateChangedEvent {
   type: "task:state_changed";
@@ -118,6 +119,18 @@ export interface TaskMessageDeliveredEvent {
   type: "task:message_delivered" | "task:message_acked";
   taskId: string;
   messageId: string;
+  timestamp: string;
+}
+
+// ── Activity Events ─────────────────────────────────────────────────────────
+
+export interface ActivityNewEvent {
+  type: "activity:new";
+  action: string;
+  userId?: string;
+  resourceType?: string;
+  resourceId?: string;
+  summary: string;
   timestamp: string;
 }
 


### PR DESCRIPTION
Closes #417

## What changed

### 1. Wire up `logAction()` across all mutation routes
Added `logAction()` calls to every state-changing API operation. The existing `optio-action-service.ts` already handles parameter sanitization and DB writes — this PR connects it to all routes:

- **tasks.ts**: create, cancel, retry, force-redo, review, run-now, reorder
- **repos.ts**: create, update, delete
- **workflows.ts**: create, update, enable/disable, clone, delete
- **workflow-triggers.ts**: create, update, delete
- **workflows.ts** (runs): create, retry, cancel
- **connections.ts**: create/update/delete connection, create provider, create/update/delete assignment
- **secrets.ts**: upsert, delete (name only, never value)
- **webhooks.ts**: create, update, delete
- **mcp-servers.ts**: create, update, delete (global and repo-scoped)
- **optio-settings.ts**: update settings
- **pr-reviews.ts**: launch review
- **sessions.ts**: create, end
- **bulk.ts**: bulk retry, bulk cancel

All `logAction()` calls use `.catch(() => {})` to ensure audit logging never fails the primary operation.

### 2. Unified activity feed API (`GET /api/activity`)
New endpoint that merges data from four sources via SQL UNION:
- `optio_actions` (user actions)
- `task_events` (task state transitions)
- `auth_events` (auth failures)
- `pod_health_events` (infrastructure events)

Supports filtering by `type`, `userId`, `resourceType`, `days`, and pagination (`limit`/`offset`). Returns chronologically sorted items with a unified shape plus aggregate stats.

### 3. Activity page (`/activity`)
New `/activity` route with:
- Quick stats header showing action/task/auth/infra event counts
- Filter bar (type, resource type, date range)
- Timeline view grouped by day
- Expandable event details
- Resource links for tasks/workflows/sessions
- Pagination

### 4. Dashboard widget
- `RecentActivity` component showing the last 8 events on the Overview page
- Added alongside the existing RecentTasks widget

### 5. Navigation & real-time
- "Activity" added to sidebar secondary nav (before Workspace/Settings)
- `ActivityNewEvent` WebSocket event type for real-time updates
- `logAction()` publishes `activity:new` events via the event bus
- Activity page and dashboard widget listen for real-time updates

### 6. Tests
- 6 tests for `GET /api/activity` route covering empty feed, items shape, type filter, pagination, system events, and error handling
- All 1886 existing API tests continue to pass
- All 257 shared package tests pass

## How to test

1. **API**: Call `GET /api/activity` — should return events from `optio_actions`, `task_events`, `auth_events`, and `pod_health_events`
2. **Audit logging**: Perform any mutation (create task, update repo, etc.) and verify a corresponding entry appears in `GET /api/activity`
3. **UI**: Navigate to `/activity` in the web UI — should show timeline with filters
4. **Dashboard**: Check the Overview page for the "Recent Activity" widget
5. **Real-time**: Open the activity page, perform a mutation in another tab, and verify the activity feed updates