### PR TITLE
API reference docs: consolidate Schedules + Workflows sections into unified /api/tasks

### DIFF
--- a/apps/site/src/app/docs/api-reference/page.tsx
+++ b/apps/site/src/app/docs/api-reference/page.tsx
@@ -589,29 +589,24 @@ export default function ApiReferencePage() {
         ]}
       />
 
-      <h2 className="mt-10 text-2xl font-bold text-text-heading">Schedules</h2>
-      <RouteTable
-        routes={[
-          { method: "GET", path: "/api/schedules", description: "List scheduled/recurring tasks" },
-          { method: "POST", path: "/api/schedules", description: "Create a schedule" },
-          { method: "PATCH", path: "/api/schedules/:id", description: "Update a schedule" },
-          { method: "DELETE", path: "/api/schedules/:id", description: "Delete a schedule" },
-        ]}
-      />
-
-      <h2 className="mt-10 text-2xl font-bold text-text-heading">Workflows</h2>
+      <h2 className="mt-10 text-2xl font-bold text-text-heading">Legacy Aliases</h2>
       <p className="mt-3 text-text-muted leading-relaxed">
-        Multi-step workflow automation with templates and run tracking.
+        The following endpoints are retained for backward compatibility. New integrations should use
+        the unified{" "}
+        <code className="rounded bg-bg-hover px-1.5 py-0.5 text-[13px] font-mono">/api/tasks</code>{" "}
+        surface documented above.
       </p>
       <RouteTable
         routes={[
-          { method: "GET", path: "/api/jobs", description: "List workflow templates" },
-          { method: "POST", path: "/api/jobs", description: "Create a workflow template" },
-          { method: "POST", path: "/api/jobs/:id/run", description: "Execute a workflow" },
           {
             method: "GET",
-            path: "/api/jobs/:id/runs",
-            description: "List runs for a workflow",
+            path: "/api/jobs/*",
+            description: "Standalone Task alias (use /api/tasks?type=standalone)",
+          },
+          {
+            method: "GET",
+            path: "/api/task-configs/*",
+            description: "Repo Task blueprint alias (use /api/tasks?type=repo-blueprint)",
           },
         ]}
       />


### PR DESCRIPTION
Closes #436

## What changed

Removed the stale **Schedules** section (leftover from the removed schedules feature with non-existent `/api/schedules` endpoints) and the separate **Workflows** section (which listed `/api/jobs/*` endpoints as the primary API) from the API reference page.

Replaced both with a single **Legacy Aliases** note that points readers to the canonical `/api/tasks` polymorphic surface and lists `/api/jobs/*` and `/api/task-configs/*` as backward-compatible aliases.

The main **Tasks** section (already documenting the unified `/api/tasks` endpoint) remains the canonical reference.

## How to test

1. Run `pnpm format:check` — passes
2. Run `npx turbo typecheck --filter=@optio/site` — passes
3. Open `/docs/api-reference` in the site — the Schedules and Workflows sections are gone, replaced by a concise Legacy Aliases note between Webhooks and Cluster