### PR TITLE
Fix: empty-string OPTIO_REPO_INIT_TIMEOUT_MS crashes API on startup

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { parseIntEnv } from "@optio/shared";
 import { initTelemetry, shutdownTelemetry, registerMetricCallbacks } from "./telemetry.js";
 import { logger } from "./logger.js";
 
@@ -18,7 +19,7 @@ process.on("unhandledRejection", (reason, promise) => {
   throw reason;
 });
 
-const PORT = parseInt(process.env.API_PORT ?? "4000", 10);
+const PORT = parseIntEnv("API_PORT", 4000);
 const HOST = process.env.API_HOST ?? "0.0.0.0";
 
 async function checkMetricsServer() {

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { db } from "../db/client.js";
 import { checkRuntimeHealth } from "../services/container-service.js";
 import { sql } from "drizzle-orm";
+import { parseIntEnv } from "@optio/shared";
 import { isOtelEnabled } from "../telemetry.js";
 
 // Cache runtime health to avoid slow k8s API calls on every health check.
@@ -79,7 +80,7 @@ export async function healthRoutes(rawApp: FastifyInstance) {
       // unavailable (e.g. no ClusterRole, K8s API unreachable) is a degraded
       // state but should not cause liveness/readiness probes to fail.
       const healthy = checks.database;
-      const maxConcurrent = parseInt(process.env.OPTIO_MAX_CONCURRENT ?? "5", 10);
+      const maxConcurrent = parseIntEnv("OPTIO_MAX_CONCURRENT", 5);
       reply
         .status(healthy ? 200 : 503)
         .send({ healthy, checks, maxConcurrent, otelEnabled: isOtelEnabled() });

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
-import { TaskState, isTaskStalled, getSilentDuration } from "@optio/shared";
+import { TaskState, isTaskStalled, getSilentDuration, parseIntEnv } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
 import * as dependencyService from "../services/dependency-service.js";
 import * as unifiedTaskService from "../services/unified-task-service.js";
@@ -238,7 +238,7 @@ export async function taskRoutes(rawApp: FastifyInstance) {
         });
 
         // Enrich running tasks with isStalled flag (lightweight — no lastLogSummary)
-        const globalThreshold = parseInt(process.env.OPTIO_STALL_THRESHOLD_MS ?? "300000", 10);
+        const globalThreshold = parseIntEnv("OPTIO_STALL_THRESHOLD_MS", 300000);
         const now = new Date();
         const enriched = taskList.map((t) => ({
           ...t,

--- a/apps/api/src/services/dependency-service.ts
+++ b/apps/api/src/services/dependency-service.ts
@@ -1,7 +1,7 @@
 import { eq, and, inArray, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { taskDependencies, tasks } from "../db/schema.js";
-import { TaskState, detectCycle, type DagEdge, getOffPeakInfo } from "@optio/shared";
+import { TaskState, detectCycle, type DagEdge, getOffPeakInfo, parseIntEnv } from "@optio/shared";
 import * as taskService from "./task-service.js";
 import { taskQueue } from "../workers/task-worker.js";
 import { logger } from "../logger.js";
@@ -229,7 +229,7 @@ export async function computePendingReason(taskId: string): Promise<string | nul
 
   // Check concurrency limits for queued tasks
   if (task.state === "queued") {
-    const globalMax = parseInt(process.env.OPTIO_MAX_CONCURRENT ?? "5", 10);
+    const globalMax = parseIntEnv("OPTIO_MAX_CONCURRENT", 5);
     const [{ count: activeCount }] = await db
       .select({ count: sql<number>`count(*)` })
       .from(tasks)

--- a/apps/api/src/services/k8s-workload-service.ts
+++ b/apps/api/src/services/k8s-workload-service.ts
@@ -36,14 +36,12 @@ import {
   PatchStrategy,
 } from "@kubernetes/client-node";
 import type { ContainerSpec } from "@optio/shared";
+import { parseIntEnv } from "@optio/shared";
 import { logger } from "../logger.js";
 
 const NAMESPACE = process.env.OPTIO_NAMESPACE ?? "optio";
-const TERMINATION_GRACE_PERIOD = parseInt(
-  process.env.OPTIO_TERMINATION_GRACE_PERIOD_SECONDS ?? "300",
-  10,
-);
-const POD_READY_TIMEOUT_MS = parseInt(process.env.OPTIO_POD_READY_TIMEOUT_MS ?? "300000", 10);
+const TERMINATION_GRACE_PERIOD = parseIntEnv("OPTIO_TERMINATION_GRACE_PERIOD_SECONDS", 300);
+const POD_READY_TIMEOUT_MS = parseIntEnv("OPTIO_POD_READY_TIMEOUT_MS", 300000);
 const POD_READY_POLL_MS = 1_000;
 
 export class K8sWorkloadManager {

--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -27,10 +27,11 @@ import {
   PROXIED_SECRET_ENV_VARS,
   type SecretProxySecrets,
 } from "./envoy-sidecar.js";
+import { parseIntEnv } from "@optio/shared";
 import { withSpan } from "../telemetry/spans.js";
 
-const IDLE_TIMEOUT_MS = parseInt(process.env.OPTIO_REPO_POD_IDLE_MS ?? "600000", 10); // 10 min default
-const REPO_INIT_TIMEOUT_MS = parseInt(process.env.OPTIO_REPO_INIT_TIMEOUT_MS ?? "120000", 10); // 2 min default
+const IDLE_TIMEOUT_MS = parseIntEnv("OPTIO_REPO_POD_IDLE_MS", 600000); // 10 min default
+const REPO_INIT_TIMEOUT_MS = parseIntEnv("OPTIO_REPO_INIT_TIMEOUT_MS", 120000); // 2 min default
 if (Number.isNaN(REPO_INIT_TIMEOUT_MS) || REPO_INIT_TIMEOUT_MS <= 0) {
   throw new Error("OPTIO_REPO_INIT_TIMEOUT_MS must be a positive integer");
 }

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -6,6 +6,7 @@ import {
   transition,
   normalizeRepoUrl,
   DEFAULT_STALL_THRESHOLD_MS,
+  parseIntEnv,
   type CreateTaskInput,
 } from "@optio/shared";
 import { publishEvent } from "./event-bus.js";
@@ -650,7 +651,7 @@ export function getStallThresholdForRepo(
   if (repoConfig?.stallThresholdMs != null) {
     return repoConfig.stallThresholdMs;
   }
-  return parseInt(process.env.OPTIO_STALL_THRESHOLD_MS ?? String(DEFAULT_STALL_THRESHOLD_MS), 10);
+  return parseIntEnv("OPTIO_STALL_THRESHOLD_MS", DEFAULT_STALL_THRESHOLD_MS);
 }
 
 /**

--- a/apps/api/src/services/workflow-pool-service.ts
+++ b/apps/api/src/services/workflow-pool-service.ts
@@ -12,8 +12,9 @@ import { logger } from "../logger.js";
 import { resolveImage } from "./repo-pool-service.js";
 import { getWorkloadManager, isStatefulSetEnabled } from "./k8s-workload-service.js";
 import type { RepoImageConfig } from "@optio/shared";
+import { parseIntEnv } from "@optio/shared";
 
-const IDLE_TIMEOUT_MS = parseInt(process.env.OPTIO_WORKFLOW_POD_IDLE_MS ?? "600000", 10); // 10 min default
+const IDLE_TIMEOUT_MS = parseIntEnv("OPTIO_WORKFLOW_POD_IDLE_MS", 600000); // 10 min default
 
 export interface WorkflowPod {
   id: string;

--- a/apps/api/src/telemetry.ts
+++ b/apps/api/src/telemetry.ts
@@ -15,6 +15,8 @@
  * which only works before the instrumented modules are loaded.
  */
 
+import { parseIntEnv } from "@optio/shared";
+
 let shutdownFn: (() => Promise<void>) | null = null;
 
 /**
@@ -53,7 +55,7 @@ export async function initTelemetry(): Promise<void> {
   }
 
   const samplingRatio = parseFloat(process.env.OPTIO_OTEL_SAMPLING_RATIO ?? "1.0");
-  const metricsIntervalMs = parseInt(process.env.OPTIO_OTEL_METRICS_INTERVAL_MS ?? "60000", 10);
+  const metricsIntervalMs = parseIntEnv("OPTIO_OTEL_METRICS_INTERVAL_MS", 60000);
 
   const resource = new Resource({
     [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME ?? "optio-api",

--- a/apps/api/src/workers/pr-watcher-worker.ts
+++ b/apps/api/src/workers/pr-watcher-worker.ts
@@ -3,7 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { tasks, taskEvents, sessionPrs, interactiveSessions, reviewDrafts } from "../db/schema.js";
 import type { GitPlatform, RepoIdentifier } from "@optio/shared";
-import { TaskState, parsePrUrl } from "@optio/shared";
+import { TaskState, parsePrUrl, parseIntEnv } from "@optio/shared";
 import { getGitPlatformForRepo, getGitToken } from "../services/git-token-service.js";
 import type { GitTokenContext } from "../services/git-token-service.js";
 import { createGitPlatform } from "../services/git-platform/index.js";
@@ -147,7 +147,7 @@ export function startPrWatcherWorker() {
     {},
     {
       repeat: {
-        every: parseInt(process.env.OPTIO_PR_WATCH_INTERVAL ?? "30000", 10),
+        every: parseIntEnv("OPTIO_PR_WATCH_INTERVAL", 30000),
       },
     },
   );

--- a/apps/api/src/workers/repo-cleanup-worker.ts
+++ b/apps/api/src/workers/repo-cleanup-worker.ts
@@ -12,7 +12,7 @@ import {
 import { cleanupIdleWorkflowPods } from "../services/workflow-pool-service.js";
 import { getRuntime } from "../services/container-service.js";
 import { isStatefulSetEnabled, getWorkloadManager } from "../services/k8s-workload-service.js";
-import { TaskState, DEFAULT_STALL_THRESHOLD_MS } from "@optio/shared";
+import { TaskState, DEFAULT_STALL_THRESHOLD_MS, parseIntEnv } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
 import { cleanupExpiredSessions } from "../services/session-service.js";
 import { publishEvent } from "../services/event-bus.js";
@@ -54,7 +54,7 @@ export function startRepoCleanupWorker() {
     {},
     {
       repeat: {
-        every: parseInt(process.env.OPTIO_HEALTH_CHECK_INTERVAL ?? "60000", 10),
+        every: parseIntEnv("OPTIO_HEALTH_CHECK_INTERVAL", 60000),
       },
     },
   );
@@ -65,7 +65,7 @@ export function startRepoCleanupWorker() {
     {},
     {
       repeat: {
-        every: parseInt(process.env.OPTIO_STALL_CHECK_INTERVAL ?? "30000", 10),
+        every: parseIntEnv("OPTIO_STALL_CHECK_INTERVAL", 30000),
       },
     },
   );
@@ -403,7 +403,7 @@ export function startRepoCleanupWorker() {
       }
 
       // Detect stale running/provisioning tasks (agent exec died without updating state)
-      const STALE_TASK_MS = parseInt(process.env.OPTIO_STALE_TASK_MS ?? "600000", 10); // 10 min
+      const STALE_TASK_MS = parseIntEnv("OPTIO_STALE_TASK_MS", 600000); // 10 min
       const MAX_STALE_RETRIES = 3;
       const staleTasks = await db
         .select()

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -12,6 +12,7 @@ import {
   classifyError,
   parseRepoUrl,
   parsePrUrl,
+  parseIntEnv,
 } from "@optio/shared";
 import { getAdapter } from "@optio/agent-adapters";
 import { parseClaudeEvent } from "../services/agent-event-parser.js";
@@ -178,7 +179,7 @@ export function startTaskWorker() {
         const effectiveRepoConcurrency = maxAgentsPerPod * maxPodInstances;
 
         const claimed = await withClaimLock(async () => {
-          const globalMax = parseInt(process.env.OPTIO_MAX_CONCURRENT ?? "5", 10);
+          const globalMax = parseIntEnv("OPTIO_MAX_CONCURRENT", 5);
 
           // Global concurrency check
           const [{ count: activeCount }] = await db
@@ -1284,7 +1285,7 @@ export function startTaskWorker() {
     }),
     {
       connection: connectionOpts,
-      concurrency: parseInt(process.env.OPTIO_MAX_CONCURRENT ?? "5", 10),
+      concurrency: parseIntEnv("OPTIO_MAX_CONCURRENT", 5),
       // Task jobs run for minutes/hours — BullMQ defaults (30s lock, 30s stall
       // check, max 1 stall) are far too aggressive and cause "job stalled" failures.
       lockDuration: 600_000, // 10 min lock

--- a/apps/api/src/workers/ticket-sync-worker.ts
+++ b/apps/api/src/workers/ticket-sync-worker.ts
@@ -1,4 +1,5 @@
 import { Queue, Worker } from "bullmq";
+import { parseIntEnv } from "@optio/shared";
 import { logger } from "../logger.js";
 
 import { getBullMQConnectionOptions } from "../services/redis-config.js";
@@ -14,7 +15,7 @@ export function startTicketSyncWorker(syncFn: () => Promise<unknown>) {
     {},
     {
       repeat: {
-        every: parseInt(process.env.OPTIO_TICKET_SYNC_INTERVAL ?? "60000", 10), // default: 60s
+        every: parseIntEnv("OPTIO_TICKET_SYNC_INTERVAL", 60000), // default: 60s
       },
     },
   );

--- a/apps/api/src/workers/workflow-trigger-worker.ts
+++ b/apps/api/src/workers/workflow-trigger-worker.ts
@@ -1,6 +1,7 @@
 import { Queue, Worker } from "bullmq";
 import * as workflowService from "../services/workflow-service.js";
 import * as taskConfigService from "../services/task-config-service.js";
+import { parseIntEnv } from "@optio/shared";
 import { logger } from "../logger.js";
 import { getBullMQConnectionOptions } from "../services/redis-config.js";
 
@@ -21,7 +22,7 @@ export function startWorkflowTriggerWorker() {
     {},
     {
       repeat: {
-        every: parseInt(process.env.OPTIO_WORKFLOW_TRIGGER_INTERVAL ?? "60000", 10),
+        every: parseIntEnv("OPTIO_WORKFLOW_TRIGGER_INTERVAL", 60000),
       },
     },
   );

--- a/apps/api/src/workers/workflow-worker.ts
+++ b/apps/api/src/workers/workflow-worker.ts
@@ -3,6 +3,7 @@ import {
   WorkflowRunState,
   canTransitionWorkflowRun,
   DEFAULT_MAX_TURNS_CODING,
+  parseIntEnv,
 } from "@optio/shared";
 import { getAdapter } from "@optio/agent-adapters";
 import { parseClaudeEvent } from "../services/agent-event-parser.js";
@@ -288,7 +289,7 @@ export function startWorkflowWorker() {
         // ── Concurrency check ─────────────────────────────────────────
         const claimed = await withClaimLock(async () => {
           // Global workflow concurrency
-          const globalMax = parseInt(process.env.OPTIO_MAX_WORKFLOW_CONCURRENT ?? "5", 10);
+          const globalMax = parseIntEnv("OPTIO_MAX_WORKFLOW_CONCURRENT", 5);
           const allRuns = await db
             .select()
             .from(workflowRuns)
@@ -671,7 +672,7 @@ export function startWorkflowWorker() {
     }),
     {
       connection: connectionOpts,
-      concurrency: parseInt(process.env.OPTIO_MAX_WORKFLOW_CONCURRENT ?? "5", 10),
+      concurrency: parseIntEnv("OPTIO_MAX_WORKFLOW_CONCURRENT", 5),
       lockDuration: 600_000, // 10 min lock (workflows can run long)
       stalledInterval: 300_000, // check for stalls every 5 min
       maxStalledCount: 3,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,4 +24,5 @@ export * from "./types/optio-action.js";
 export * from "./types/git-platform.js";
 export * from "./utils/parse-repo-url.js";
 export * from "./utils/is-stalled.js";
+export * from "./utils/parse-int-env.js";
 export * from "./optio-tools.js";

--- a/packages/shared/src/utils/parse-int-env.test.ts
+++ b/packages/shared/src/utils/parse-int-env.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { parseIntEnv } from "./parse-int-env.js";
+
+describe("parseIntEnv", () => {
+  const ENV_KEY = "TEST_PARSE_INT_ENV";
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = saved;
+    }
+  });
+
+  it("returns the parsed value when env var is a valid integer", () => {
+    process.env[ENV_KEY] = "42";
+    expect(parseIntEnv(ENV_KEY, 100)).toBe(42);
+  });
+
+  it("returns the default when env var is undefined", () => {
+    delete process.env[ENV_KEY];
+    expect(parseIntEnv(ENV_KEY, 100)).toBe(100);
+  });
+
+  it("returns the default when env var is empty string", () => {
+    process.env[ENV_KEY] = "";
+    expect(parseIntEnv(ENV_KEY, 100)).toBe(100);
+  });
+
+  it("returns the default when env var is whitespace only", () => {
+    process.env[ENV_KEY] = "   ";
+    expect(parseIntEnv(ENV_KEY, 100)).toBe(100);
+  });
+
+  it("parses values with leading/trailing whitespace", () => {
+    process.env[ENV_KEY] = "  50  ";
+    expect(parseIntEnv(ENV_KEY, 100)).toBe(50);
+  });
+
+  it("returns NaN for non-numeric strings (caller validates)", () => {
+    process.env[ENV_KEY] = "abc";
+    expect(parseIntEnv(ENV_KEY, 100)).toBeNaN();
+  });
+
+  it("parses negative integers", () => {
+    process.env[ENV_KEY] = "-10";
+    expect(parseIntEnv(ENV_KEY, 100)).toBe(-10);
+  });
+
+  it("parses zero", () => {
+    process.env[ENV_KEY] = "0";
+    expect(parseIntEnv(ENV_KEY, 100)).toBe(0);
+  });
+
+  it("truncates decimal values (parseInt behavior)", () => {
+    process.env[ENV_KEY] = "3.14";
+    expect(parseIntEnv(ENV_KEY, 100)).toBe(3);
+  });
+});

--- a/packages/shared/src/utils/parse-int-env.ts
+++ b/packages/shared/src/utils/parse-int-env.ts
@@ -1,0 +1,12 @@
+/**
+ * Safely parse an integer environment variable.
+ *
+ * Treats empty / whitespace-only strings the same as `undefined` —
+ * both fall back to `defaultValue`.  This avoids the common pitfall where
+ * `parseInt(process.env.X ?? "default", 10)` still receives `""` (falsy but
+ * not nullish) when a Helm template renders a missing value as empty string.
+ */
+export function parseIntEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  return raw && raw.trim() !== "" ? parseInt(raw, 10) : defaultValue;
+}


### PR DESCRIPTION
## Summary

- Empty-string environment variables (e.g. `OPTIO_REPO_INIT_TIMEOUT_MS=''` from Helm rendering a missing value) caused `parseInt("", 10)` to return `NaN`, bypassing the `??` nullish-coalescing default and crashing the API pod on startup
- Introduced a shared `parseIntEnv(name, defaultValue)` utility in `@optio/shared` that treats empty/whitespace-only strings the same as `undefined`, falling back to the provided default
- Applied the fix to all 19 `parseInt(process.env.X ?? "default", 10)` call sites across 16 files

## What changed

The root cause was that `??` (nullish coalescing) only triggers on `null`/`undefined`, not empty string. When Helm rendered a missing value as `''`, `parseInt("", 10)` returned `NaN` and the validator threw, preventing the API from starting.

**New file:** `packages/shared/src/utils/parse-int-env.ts` — a small utility that checks `raw && raw.trim() !== ""` before parsing, falling back to the numeric default otherwise.

**Updated files (16):** All `parseInt(process.env.X ?? "default", 10)` patterns replaced with `parseIntEnv("X", default)` across services, workers, routes, and the API entry point.

## How to test

1. Run the test suite: `pnpm turbo test` — includes 9 new tests for `parseIntEnv` covering undefined, empty string, whitespace, valid values, zero, negatives, and non-numeric input
2. Verify typecheck: `pnpm turbo typecheck` — all 12 packages pass
3. Manual verification: set `OPTIO_REPO_INIT_TIMEOUT_MS=''` and confirm the API starts (uses 120000ms default) instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)