### PR TITLE
Ticket trigger UI — expose the feature that only has backend support today

### DIFF
--- a/apps/site/src/app/docs/guides/scheduled-tasks/page.tsx
+++ b/apps/site/src/app/docs/guides/scheduled-tasks/page.tsx
@@ -57,7 +57,11 @@ export default function ScheduledTasksPage() {
           to <strong className="text-text-heading">Schedule</strong>.
         </li>
         <li>Fill in the usual repo + title + prompt + agent fields.</li>
-        <li>Pick a trigger type (schedule or webhook) and provide its config.</li>
+        <li>
+          Pick a trigger type (schedule, webhook, or ticket) and provide its config. For ticket
+          triggers, choose the source (GitHub, Linear, Jira, or Notion) and optionally filter by
+          labels.
+        </li>
         <li>
           Click <strong className="text-text-heading">Create Schedule</strong>.
         </li>

--- a/apps/web/src/app/tasks/new/page.tsx
+++ b/apps/web/src/app/tasks/new/page.tsx
@@ -152,7 +152,12 @@ export default function NewTaskPage() {
             ? { cronExpression: trigger.cronExpression!.trim() }
             : trigger.type === "webhook"
               ? { path: trigger.webhookPath }
-              : {};
+              : trigger.type === "ticket"
+                ? {
+                    source: trigger.ticketSource ?? "github",
+                    ...(trigger.ticketLabels?.length ? { labels: trigger.ticketLabels } : {}),
+                  }
+                : {};
         await api.createTaskTrigger(createdId, {
           type: trigger.type,
           config,

--- a/apps/web/src/app/tasks/scheduled/[id]/page.tsx
+++ b/apps/web/src/app/tasks/scheduled/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   PlayCircle,
   Plus,
   Save,
+  Ticket,
   Trash2,
   Webhook,
   AlertCircle,
@@ -183,7 +184,12 @@ function ScheduledTaskDetailInner({ id }: { id: string }) {
           ? { cronExpression: newTrigger.cronExpression!.trim() }
           : newTrigger.type === "webhook"
             ? { path: newTrigger.webhookPath }
-            : {};
+            : newTrigger.type === "ticket"
+              ? {
+                  source: newTrigger.ticketSource ?? "github",
+                  ...(newTrigger.ticketLabels?.length ? { labels: newTrigger.ticketLabels } : {}),
+                }
+              : {};
       await api.createTaskConfigTrigger(id, {
         type: newTrigger.type,
         config: cfg,
@@ -439,6 +445,7 @@ function ScheduledTaskDetailInner({ id }: { id: string }) {
                   <div className="flex items-center gap-2 mb-1">
                     {t.type === "schedule" && <Clock className="w-4 h-4 text-text-muted" />}
                     {t.type === "webhook" && <Webhook className="w-4 h-4 text-text-muted" />}
+                    {t.type === "ticket" && <Ticket className="w-4 h-4 text-text-muted" />}
                     <span className="font-medium capitalize">{t.type}</span>
                     <span
                       className={`text-xs px-2 py-0.5 rounded ${t.enabled ? "bg-primary/10 text-primary" : "bg-bg text-text-muted"}`}

--- a/apps/web/src/app/tasks/scheduled/page.tsx
+++ b/apps/web/src/app/tasks/scheduled/page.tsx
@@ -4,12 +4,22 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { api } from "@/lib/api-client";
 import { usePageTitle } from "@/hooks/use-page-title";
-import { Clock, Loader2, Pause, Play, PlayCircle, Plus, Trash2, Webhook } from "lucide-react";
+import {
+  Clock,
+  Loader2,
+  Pause,
+  Play,
+  PlayCircle,
+  Plus,
+  Ticket,
+  Trash2,
+  Webhook,
+} from "lucide-react";
 import { toast } from "sonner";
 
 interface Trigger {
   id: string;
-  type: "manual" | "schedule" | "webhook";
+  type: "manual" | "schedule" | "webhook" | "ticket";
   config: Record<string, any> | null;
   enabled: boolean;
   lastFiredAt: string | null;
@@ -137,7 +147,8 @@ export default function ScheduledTasksPage() {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Scheduled Tasks</h1>
           <p className="text-sm text-text-muted mt-1">
-            Reusable task blueprints that spawn fresh tasks on a schedule, webhook, or manual run.
+            Reusable task blueprints that spawn fresh tasks on a schedule, webhook, ticket event, or
+            manual run.
           </p>
         </div>
         <Link
@@ -169,6 +180,7 @@ export default function ScheduledTasksPage() {
           {configs.map((config) => {
             const schedTrigger = config.triggers?.find((t) => t.type === "schedule");
             const webhookTrigger = config.triggers?.find((t) => t.type === "webhook");
+            const ticketTrigger = config.triggers?.find((t) => t.type === "ticket");
             return (
               <div
                 key={config.id}
@@ -199,6 +211,15 @@ export default function ScheduledTasksPage() {
                         <span className="inline-flex items-center gap-1.5">
                           <Webhook className="w-3 h-3" />
                           {webhookTrigger.config?.path}
+                        </span>
+                      )}
+                      {ticketTrigger && (
+                        <span className="inline-flex items-center gap-1.5">
+                          <Ticket className="w-3 h-3" />
+                          {ticketTrigger.config?.source}
+                          {Array.isArray(ticketTrigger.config?.labels) &&
+                            ticketTrigger.config!.labels.length > 0 &&
+                            ` [${(ticketTrigger.config!.labels as string[]).join(", ")}]`}
                         </span>
                       )}
                       {schedTrigger && (

--- a/apps/web/src/components/trigger-selector.test.tsx
+++ b/apps/web/src/components/trigger-selector.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { TriggerSelector, cronIsValid, describeCronPreset } from "./trigger-selector";
+import type { TriggerConfig } from "./trigger-selector";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TriggerSelector", () => {
+  describe("trigger type buttons", () => {
+    it("renders manual, schedule, webhook, and ticket buttons by default", () => {
+      const onChange = vi.fn();
+      render(<TriggerSelector value={{ type: "manual" }} onChange={onChange} />);
+      expect(screen.getByText("Manual")).toBeInTheDocument();
+      expect(screen.getByText("Schedule")).toBeInTheDocument();
+      expect(screen.getByText("Webhook")).toBeInTheDocument();
+      expect(screen.getByText("Ticket")).toBeInTheDocument();
+    });
+
+    it("hides manual when hideManual is true", () => {
+      const onChange = vi.fn();
+      render(
+        <TriggerSelector
+          value={{ type: "schedule", cronExpression: "0 9 * * *" }}
+          onChange={onChange}
+          hideManual
+        />,
+      );
+      expect(screen.queryByText("Manual")).not.toBeInTheDocument();
+      expect(screen.getByText("Schedule")).toBeInTheDocument();
+      expect(screen.getByText("Webhook")).toBeInTheDocument();
+      expect(screen.getByText("Ticket")).toBeInTheDocument();
+    });
+  });
+
+  describe("ticket trigger config panel", () => {
+    it("shows source dropdown and labels input when ticket type is selected", () => {
+      const onChange = vi.fn();
+      render(
+        <TriggerSelector
+          value={{ type: "ticket", ticketSource: "github", ticketLabels: [] }}
+          onChange={onChange}
+        />,
+      );
+      expect(screen.getByLabelText(/source/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/labels/i)).toBeInTheDocument();
+    });
+
+    it("renders source dropdown with github, linear, jira, notion options", () => {
+      const onChange = vi.fn();
+      render(
+        <TriggerSelector
+          value={{ type: "ticket", ticketSource: "github", ticketLabels: [] }}
+          onChange={onChange}
+        />,
+      );
+      const select = screen.getByLabelText(/source/i) as HTMLSelectElement;
+      expect(select.tagName).toBe("SELECT");
+      const options = Array.from(select.options).map((o) => o.value);
+      expect(options).toContain("github");
+      expect(options).toContain("linear");
+      expect(options).toContain("jira");
+      expect(options).toContain("notion");
+    });
+
+    it("calls onChange with updated source when source is changed", () => {
+      const onChange = vi.fn();
+      render(
+        <TriggerSelector
+          value={{ type: "ticket", ticketSource: "github", ticketLabels: [] }}
+          onChange={onChange}
+        />,
+      );
+      const select = screen.getByLabelText(/source/i) as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: "linear" } });
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "ticket", ticketSource: "linear" }),
+      );
+    });
+
+    it("defaults ticket source to github when switching to ticket type", () => {
+      const onChange = vi.fn();
+      render(<TriggerSelector value={{ type: "manual" }} onChange={onChange} />);
+      fireEvent.click(screen.getByText("Ticket"));
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "ticket", ticketSource: "github", ticketLabels: [] }),
+      );
+    });
+
+    it("preserves existing ticket config when re-selecting ticket type", () => {
+      const onChange = vi.fn();
+      render(
+        <TriggerSelector
+          value={{ type: "ticket", ticketSource: "linear", ticketLabels: ["bug"] }}
+          onChange={onChange}
+        />,
+      );
+      // Source should show current value
+      const select = screen.getByLabelText(/source/i) as HTMLSelectElement;
+      expect(select.value).toBe("linear");
+    });
+
+    it("does not show ticket config panel for other trigger types", () => {
+      const onChange = vi.fn();
+      render(
+        <TriggerSelector
+          value={{ type: "schedule", cronExpression: "0 9 * * *" }}
+          onChange={onChange}
+        />,
+      );
+      expect(screen.queryByLabelText(/source/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("ticket labels", () => {
+    it("adds a label when typed and Enter is pressed", () => {
+      const onChange = vi.fn();
+      render(
+        <TriggerSelector
+          value={{ type: "ticket", ticketSource: "github", ticketLabels: [] }}
+          onChange={onChange}
+        />,
+      );
+      const input = screen.getByLabelText(/labels/i) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "cve" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ ticketLabels: ["cve"] }));
+    });
+
+    it("renders existing labels as removable badges", () => {
+      const onChange = vi.fn();
+      render(
+        <TriggerSelector
+          value={{ type: "ticket", ticketSource: "github", ticketLabels: ["cve", "bug"] }}
+          onChange={onChange}
+        />,
+      );
+      expect(screen.getByText("cve")).toBeInTheDocument();
+      expect(screen.getByText("bug")).toBeInTheDocument();
+    });
+  });
+
+  describe("schedule trigger (existing behavior)", () => {
+    it("shows cron expression input when schedule is selected", () => {
+      const onChange = vi.fn();
+      render(
+        <TriggerSelector
+          value={{ type: "schedule", cronExpression: "0 9 * * *" }}
+          onChange={onChange}
+        />,
+      );
+      expect(screen.getByDisplayValue("0 9 * * *")).toBeInTheDocument();
+    });
+  });
+
+  describe("webhook trigger (existing behavior)", () => {
+    it("shows webhook path input when webhook is selected", () => {
+      const onChange = vi.fn();
+      render(
+        <TriggerSelector value={{ type: "webhook", webhookPath: "my-hook" }} onChange={onChange} />,
+      );
+      expect(screen.getByDisplayValue("my-hook")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("cronIsValid", () => {
+  it("returns true for valid five-field cron", () => {
+    expect(cronIsValid("0 9 * * *")).toBe(true);
+  });
+
+  it("returns false for empty/null", () => {
+    expect(cronIsValid("")).toBe(false);
+    expect(cronIsValid(null)).toBe(false);
+    expect(cronIsValid(undefined)).toBe(false);
+  });
+
+  it("returns false for wrong field count", () => {
+    expect(cronIsValid("0 9 * *")).toBe(false);
+    expect(cronIsValid("0 9 * * * *")).toBe(false);
+  });
+});
+
+describe("describeCronPreset", () => {
+  it("returns label for known presets", () => {
+    expect(describeCronPreset("0 9 * * *")).toBe("Daily 09:00 UTC");
+  });
+
+  it("returns null for unknown expressions", () => {
+    expect(describeCronPreset("0 12 * * *")).toBeNull();
+  });
+});

--- a/apps/web/src/components/trigger-selector.tsx
+++ b/apps/web/src/components/trigger-selector.tsx
@@ -8,15 +8,20 @@
  * shape. Webhook paths are auto-generated if the user doesn't supply one.
  */
 
-import { useMemo } from "react";
-import { Clock, Play, Webhook } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Clock, Play, Webhook, Ticket } from "lucide-react";
 
-export type TriggerType = "manual" | "schedule" | "webhook";
+export type TriggerType = "manual" | "schedule" | "webhook" | "ticket";
+
+export const TICKET_SOURCES = ["github", "linear", "jira", "notion"] as const;
+export type TicketSource = (typeof TICKET_SOURCES)[number];
 
 export interface TriggerConfig {
   type: TriggerType;
   cronExpression?: string;
   webhookPath?: string;
+  ticketSource?: TicketSource;
+  ticketLabels?: string[];
 }
 
 const CRON_PRESETS: Array<{ label: string; expr: string }> = [
@@ -59,6 +64,10 @@ export function TriggerSelector({ value, onChange, hideManual = false, label }: 
     if (t === "schedule") next.cronExpression = value.cronExpression ?? "0 9 * * *";
     if (t === "webhook")
       next.webhookPath = value.webhookPath ?? `hook-${Math.random().toString(36).slice(2, 10)}`;
+    if (t === "ticket") {
+      next.ticketSource = value.ticketSource ?? "github";
+      next.ticketLabels = value.ticketLabels ?? [];
+    }
     onChange(next);
   };
 
@@ -85,6 +94,12 @@ export function TriggerSelector({ value, onChange, hideManual = false, label }: 
           label="Webhook"
           active={value.type === "webhook"}
           onClick={() => setType("webhook")}
+        />
+        <TriggerTypeButton
+          icon={<Ticket className="w-3.5 h-3.5" />}
+          label="Ticket"
+          active={value.type === "ticket"}
+          onClick={() => setType("ticket")}
         />
       </div>
 
@@ -130,6 +145,115 @@ export function TriggerSelector({ value, onChange, hideManual = false, label }: 
           </p>
         </div>
       )}
+
+      {value.type === "ticket" && (
+        <TicketConfigPanel
+          source={value.ticketSource ?? "github"}
+          labels={value.ticketLabels ?? []}
+          onSourceChange={(source) => onChange({ ...value, ticketSource: source })}
+          onLabelsChange={(labels) => onChange({ ...value, ticketLabels: labels })}
+        />
+      )}
+    </div>
+  );
+}
+
+function TicketConfigPanel({
+  source,
+  labels,
+  onSourceChange,
+  onLabelsChange,
+}: {
+  source: TicketSource;
+  labels: string[];
+  onSourceChange: (source: TicketSource) => void;
+  onLabelsChange: (labels: string[]) => void;
+}) {
+  const [labelInput, setLabelInput] = useState("");
+
+  const addLabel = () => {
+    const trimmed = labelInput.trim();
+    if (trimmed && !labels.includes(trimmed)) {
+      onLabelsChange([...labels, trimmed]);
+    }
+    setLabelInput("");
+  };
+
+  const removeLabel = (label: string) => {
+    onLabelsChange(labels.filter((l) => l !== label));
+  };
+
+  return (
+    <div className="p-3 rounded-lg bg-bg-card border border-border space-y-3">
+      <div>
+        <label htmlFor="ticket-source" className="block text-xs text-text-muted mb-1">
+          Source
+        </label>
+        <select
+          id="ticket-source"
+          value={source}
+          onChange={(e) => onSourceChange(e.target.value as TicketSource)}
+          className="w-full px-3 py-2 rounded bg-bg border border-border text-sm focus:outline-none focus:border-primary"
+        >
+          {TICKET_SOURCES.map((s) => (
+            <option key={s} value={s}>
+              {s.charAt(0).toUpperCase() + s.slice(1)}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label htmlFor="ticket-labels" className="block text-xs text-text-muted mb-1">
+          Labels <span className="text-text-muted/60">(optional)</span>
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            id="ticket-labels"
+            type="text"
+            value={labelInput}
+            onChange={(e) => setLabelInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addLabel();
+              }
+            }}
+            placeholder="e.g. cve, bug"
+            className="flex-1 px-3 py-2 rounded bg-bg border border-border text-sm focus:outline-none focus:border-primary"
+          />
+          <button
+            type="button"
+            onClick={addLabel}
+            className="px-3 py-2 rounded bg-bg border border-border text-sm text-text-muted hover:text-text transition-colors"
+          >
+            Add
+          </button>
+        </div>
+        {labels.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {labels.map((label) => (
+              <span
+                key={label}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-primary/10 text-primary text-xs"
+              >
+                {label}
+                <button
+                  type="button"
+                  onClick={() => removeLabel(label)}
+                  className="hover:text-primary/70 transition-colors"
+                  aria-label={`Remove ${label}`}
+                >
+                  &times;
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <p className="text-xs text-text-muted/60 mt-1">
+          Only tickets with at least one matching label will fire this trigger. Leave empty to match
+          all tickets from the source.
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1465,7 +1465,7 @@ export const api = {
   createTaskConfigTrigger: (
     id: string,
     data: {
-      type: "manual" | "schedule" | "webhook";
+      type: "manual" | "schedule" | "webhook" | "ticket";
       config?: Record<string, unknown>;
       paramMapping?: Record<string, unknown>;
       enabled?: boolean;


### PR DESCRIPTION
Closes #431

## What changed

The backend already supports ticket triggers (`type="ticket"` with `config={source, labels?}`), wired through `task-config-service.fireTicketTriggers()` and `ticket-sync-service`. But the UI only offered Manual / Schedule / Webhook — users couldn't configure ticket triggers without `curl`.

This PR adds full ticket trigger UI support:

- **TriggerSelector component**: Added a "Ticket" pill with a config panel containing a source dropdown (GitHub, Linear, Jira, Notion) and an optional labels array with add/remove UI
- **/tasks/new form**: Ticket trigger config (`{source, labels?}`) is now properly serialized when creating scheduled tasks with a ticket trigger
- **/tasks/scheduled/:id detail page**: Ticket triggers can be added from the Triggers tab, with proper config serialization and Ticket icon display
- **/tasks/scheduled list page**: Ticket triggers display their source and labels in the task list, with Ticket icon
- **api-client.ts**: Added `"ticket"` to `createTaskConfigTrigger` type union (the unified `createTaskTrigger` already had it)
- **Docs guide**: Updated the scheduled-tasks walkthrough to mention ticket triggers alongside schedule and webhook

## How to test

1. Navigate to **Tasks > New Task**
2. Select any task type, switch to **Schedule** mode
3. In the trigger selector, click **Ticket** — verify source dropdown and labels input appear
4. Select a source (e.g., Linear), add labels (type + Enter or click Add), verify labels appear as removable badges
5. Submit the form and verify the trigger is created with correct config
6. Navigate to **/tasks/scheduled/:id** > Triggers tab > Add trigger > select Ticket
7. Verify the ticket trigger appears in the list with source and labels displayed
8. Check **/tasks/scheduled** list view shows ticket trigger info with the Ticket icon