### PR TITLE
Repo Task marked 'completed' when agent exits cleanly without opening a PR

### DIFF
--- a/apps/api/src/workers/task-worker.test.ts
+++ b/apps/api/src/workers/task-worker.test.ts
@@ -3,6 +3,7 @@ import {
   buildAgentCommand,
   buildInitialClaudeStreamMessage,
   inferExitCode,
+  shouldEscalateNoPr,
 } from "./task-worker.js";
 
 describe("buildAgentCommand", () => {
@@ -384,5 +385,58 @@ describe("inferExitCode", () => {
       expect(inferExitCode("some-future-agent", "fatal: error")).toBe(1);
       expect(inferExitCode("some-future-agent", "all good")).toBe(0);
     });
+  });
+});
+
+describe("shouldEscalateNoPr", () => {
+  const defaults = {
+    success: true,
+    isReviewTask: false,
+    isPlanningRun: false,
+    hasRepoUrl: true,
+    detectedPrUrl: undefined as string | undefined | null,
+  };
+
+  it("escalates when a repo task succeeds without a PR", () => {
+    expect(shouldEscalateNoPr(defaults)).toBe(true);
+  });
+
+  it("does not escalate when a PR was detected", () => {
+    expect(
+      shouldEscalateNoPr({ ...defaults, detectedPrUrl: "https://github.com/org/repo/pull/42" }),
+    ).toBe(false);
+  });
+
+  it("does not escalate when the agent failed", () => {
+    expect(shouldEscalateNoPr({ ...defaults, success: false })).toBe(false);
+  });
+
+  it("does not escalate for review tasks", () => {
+    expect(shouldEscalateNoPr({ ...defaults, isReviewTask: true })).toBe(false);
+  });
+
+  it("does not escalate for planning runs", () => {
+    expect(shouldEscalateNoPr({ ...defaults, isPlanningRun: true })).toBe(false);
+  });
+
+  it("does not escalate for standalone tasks (no repo)", () => {
+    expect(shouldEscalateNoPr({ ...defaults, hasRepoUrl: false })).toBe(false);
+  });
+
+  it("does not escalate when detectedPrUrl is null", () => {
+    // null is treated as falsy — same as undefined
+    expect(shouldEscalateNoPr({ ...defaults, detectedPrUrl: null })).toBe(true);
+  });
+
+  it("does not escalate when all exemptions apply simultaneously", () => {
+    expect(
+      shouldEscalateNoPr({
+        success: false,
+        isReviewTask: true,
+        isPlanningRun: true,
+        hasRepoUrl: false,
+        detectedPrUrl: "https://github.com/org/repo/pull/1",
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -1083,6 +1083,49 @@ export function startTaskWorker() {
               "Agent has created an implementation plan and is waiting for approval",
             );
             log.info("Planning phase complete — awaiting human review");
+          } else if (
+            shouldEscalateNoPr({
+              success: result.success,
+              isReviewTask,
+              isPlanningRun,
+              hasRepoUrl: !!task.repoUrl,
+              detectedPrUrl,
+            })
+          ) {
+            // Repo Task completed without opening a PR. Before escalating,
+            // check the API as a fallback — the agent may have pushed a PR
+            // that wasn't captured in log output.
+            let apiFallbackPr: ExistingPr | null = null;
+            try {
+              apiFallbackPr = await checkExistingPr(task.repoUrl, taskId, taskWorkspaceId);
+            } catch {
+              // Non-fatal — proceed with escalation
+            }
+
+            if (apiFallbackPr) {
+              await taskService.updateTaskPr(taskId, apiFallbackPr.url);
+              await repoPool.updateWorktreeState(taskId, "preserved");
+              await taskService.transitionTask(
+                taskId,
+                TaskState.PR_OPENED,
+                "pr_detected_api",
+                apiFallbackPr.url,
+              );
+              log.info(
+                { prUrl: apiFallbackPr.url },
+                "PR found via API fallback after successful agent exit",
+              );
+            } else {
+              await repoPool.updateWorktreeState(taskId, "preserved");
+              await taskService.transitionTask(
+                taskId,
+                TaskState.NEEDS_ATTENTION,
+                "completed_without_pr",
+                "Agent completed successfully but did not open a pull request. " +
+                  "The work may need to be committed and pushed manually, or the agent can be restarted to open a PR.",
+              );
+              log.warn("Repo Task completed without opening a PR — escalating to needs_attention");
+            }
           } else {
             await repoPool.updateWorktreeState(taskId, "removed");
             await taskService.transitionTask(
@@ -1641,6 +1684,29 @@ export function buildAgentCommand(
     default:
       return [`echo "Unknown agent type: ${agentType}" && exit 1`];
   }
+}
+
+/**
+ * Determines whether a Repo Task that completed successfully should be
+ * escalated to needs_attention because no PR was opened.
+ *
+ * Repo Tasks are expected to produce a PR. If the agent exits cleanly without
+ * opening one, the work didn't ship — the user should be notified so they can
+ * resume or restart the agent.
+ */
+export function shouldEscalateNoPr(opts: {
+  success: boolean;
+  isReviewTask: boolean;
+  isPlanningRun: boolean;
+  hasRepoUrl: boolean;
+  detectedPrUrl: string | undefined | null;
+}): boolean {
+  if (!opts.success) return false;
+  if (opts.isReviewTask) return false;
+  if (opts.isPlanningRun) return false;
+  if (!opts.hasRepoUrl) return false;
+  if (opts.detectedPrUrl) return false;
+  return true;
 }
 
 /** Infer exit code from agent logs based on agent-specific error patterns */

--- a/apps/web/src/components/task-card.tsx
+++ b/apps/web/src/components/task-card.tsx
@@ -26,6 +26,8 @@ function formatAttentionReason(reason: string): string {
   if (reason.includes("ci_failing") || reason.includes("CI checks")) return "CI checks failing";
   if (reason.includes("merge_conflicts") || reason.includes("conflicts")) return "Merge conflicts";
   if (reason.includes("changes_requested") || reason.includes("review")) return "Changes requested";
+  if (reason.includes("completed_without_pr") || reason.includes("did not open a pull request"))
+    return "Completed without PR";
   return reason.length > 60 ? reason.slice(0, 60) + "..." : reason;
 }
 

--- a/packages/shared/src/utils/state-machine.test.ts
+++ b/packages/shared/src/utils/state-machine.test.ts
@@ -157,6 +157,22 @@ describe("state-machine", () => {
     });
   });
 
+  describe("completed-without-PR escalation path", () => {
+    it("supports running → needs_attention → queued for repo tasks without a PR", () => {
+      let state = TaskState.RUNNING;
+      state = transition(state, TaskState.NEEDS_ATTENTION);
+      state = transition(state, TaskState.QUEUED);
+      expect(state).toBe(TaskState.QUEUED);
+    });
+
+    it("supports running → needs_attention → cancelled if user cancels", () => {
+      let state = TaskState.RUNNING;
+      state = transition(state, TaskState.NEEDS_ATTENTION);
+      state = transition(state, TaskState.CANCELLED);
+      expect(state).toBe(TaskState.CANCELLED);
+    });
+  });
+
   describe("dependency lifecycle (waiting_on_deps)", () => {
     it("allows pending → waiting_on_deps when task has dependencies", () => {
       expect(canTransition(TaskState.PENDING, TaskState.WAITING_ON_DEPS)).toBe(true);


### PR DESCRIPTION
Closes #433

## What changed

When a Repo Task's agent exits cleanly but never opens a PR, the task now transitions to `needs_attention` instead of `completed`. This prevents false-positive success badges — a Repo Task without a PR means the work didn't ship.

**Implementation (Option 1 from the issue):**

1. **`task-worker.ts`**: After the agent exits successfully, a new `shouldEscalateNoPr()` check detects when a Repo Task (has `repoUrl`, not a review/planning task) has no detected PR URL. Before escalating, it queries the Git provider API as a fallback — the agent may have pushed a PR that wasn't captured in log output. If a PR is found via API, the task transitions to `pr_opened` normally. Otherwise, it transitions to `needs_attention` with trigger `completed_without_pr` and a clear message.

2. **`task-card.tsx`**: Added "Completed without PR" to the `formatAttentionReason()` mapping so the UI shows a human-friendly label in the attention alert.

3. **Worktree preserved**: The worktree state is set to `preserved` (not `removed`) so the user can resume from the existing work via the existing `needs_attention → queued` retry flow.

**What's excluded from escalation:**
- Standalone Tasks (no `repoUrl`) — they don't produce PRs
- Review tasks (`isReviewTask`) — they review existing PRs, not create new ones
- Planning runs (`isPlanningRun`) — already handled by existing planning-mode logic
- Failed agents (`!success`) — already handled by existing failure logic

## How to test

1. **Unit tests**: `shouldEscalateNoPr()` is a pure exported function with 8 test cases covering all branches (success + no PR → escalate, PR detected → no escalate, review task → no escalate, standalone → no escalate, etc.)

2. **State machine tests**: New lifecycle tests verify `running → needs_attention → queued` and `running → needs_attention → cancelled` paths work correctly.

3. **Manual E2E**: Create a Repo Task with a prompt that makes changes but doesn't open a PR (e.g., "Search the codebase for X and list the files"). After the agent exits, the task should show "Attention" badge with "Completed without PR" instead of "Done".