### PR TITLE
Surface stale Claude OAuth tokens before they 401

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -61,6 +61,7 @@ async function main() {
   const { startWebhookWorker } = await import("./workers/webhook-worker.js");
   const { startWorkflowWorker } = await import("./workers/workflow-worker.js");
   const { startWorkflowTriggerWorker } = await import("./workers/workflow-trigger-worker.js");
+  const { startTokenValidationWorker } = await import("./workers/token-validation-worker.js");
   const { getBullMQConnectionOptions } = await import("./services/redis-config.js");
   const { logTlsStackInfo, initTlsObservability } = await import("./services/tls-observability.js");
 
@@ -184,6 +185,7 @@ async function main() {
     cleanRepeatJobs("ticket-sync"),
     cleanRepeatJobs("workflow-runs"),
     cleanRepeatJobs("workflow-trigger-checker"),
+    cleanRepeatJobs("token-validation"),
   ]);
 
   // Start BullMQ workers (each re-registers its repeat job)
@@ -209,6 +211,9 @@ async function main() {
   const workflowTriggerWorker = startWorkflowTriggerWorker();
   logger.info("Workflow trigger worker started");
 
+  const tokenValidationWorker = startTokenValidationWorker();
+  logger.info("Token validation worker started");
+
   // Check if metrics-server is available
   checkMetricsServer().catch(() => {});
 
@@ -228,6 +233,7 @@ async function main() {
     await webhookWorker.close();
     await workflowWorker.close();
     await workflowTriggerWorker.close();
+    await tokenValidationWorker.close();
     await app.close();
     // Flush pending OTel spans/metrics with 5s timeout
     await shutdownTelemetry();

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -73,6 +73,7 @@ const AuthStatusResponseSchema = z
         expiresAt: z.string().optional().nullable(),
         error: z.string().optional(),
         expired: z.boolean(),
+        lastValidated: z.string().optional().nullable(),
       })
       .passthrough(),
   })
@@ -252,9 +253,27 @@ export async function authRoutes(rawApp: FastifyInstance) {
         } catch {}
       }
 
-      // Validate the token against the Anthropic API if we have one
+      // Check the background worker's cached validation first to avoid
+      // an extra API call on every status poll
       let expired = false;
-      if (result.available && result.token) {
+      let lastValidated: string | null = null;
+      try {
+        const { getCachedTokenValidation } = await import("../workers/token-validation-worker.js");
+        const cached = await getCachedTokenValidation();
+        if (cached) {
+          lastValidated = cached.lastValidated;
+          if (cached.tokenExists && !cached.valid) {
+            expired = true;
+            result.available = false;
+            result.error = cached.error ?? "OAuth token has expired — please paste a new one";
+          }
+        }
+      } catch {
+        // Worker cache unavailable — fall through to live validation
+      }
+
+      // If no cached result, validate the token against the Anthropic API directly
+      if (!expired && lastValidated === null && result.available && result.token) {
         try {
           const res = await fetch("https://api.anthropic.com/api/oauth/usage", {
             headers: {
@@ -267,6 +286,7 @@ export async function authRoutes(rawApp: FastifyInstance) {
             result.available = false;
             result.error = "OAuth token has expired — please paste a new one";
           }
+          lastValidated = new Date().toISOString();
         } catch {
           // Network error — don't mark as expired, just skip validation
         }
@@ -278,6 +298,7 @@ export async function authRoutes(rawApp: FastifyInstance) {
           expiresAt: result.expiresAt,
           error: result.error,
           expired,
+          lastValidated,
         },
       });
     },

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -618,6 +618,24 @@ export function startTaskWorker() {
 
         // For oauth-token mode, read the token from the secrets store
         if (claudeAuthMode === "oauth-token") {
+          // Pre-flight: check the cached validation from the background worker
+          // to fail fast before wasting ~10s on pod provisioning + worktree setup
+          try {
+            const { getCachedTokenValidation } = await import("./token-validation-worker.js");
+            const cached = await getCachedTokenValidation();
+            if (cached?.tokenExists && !cached.valid) {
+              throw new Error(
+                "Claude OAuth token is expired (detected by pre-flight validation). " +
+                  "Go to Secrets to update CLAUDE_CODE_OAUTH_TOKEN, or re-run 'claude setup-token'.",
+              );
+            }
+          } catch (preflight) {
+            // Re-throw if it's our own validation error; swallow infra errors
+            if (preflight instanceof Error && preflight.message.includes("pre-flight")) {
+              throw preflight;
+            }
+          }
+
           const oauthToken = await retrieveSecretWithFallback(
             "CLAUDE_CODE_OAUTH_TOKEN",
             "global",

--- a/apps/api/src/workers/token-validation-worker.test.ts
+++ b/apps/api/src/workers/token-validation-worker.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks (must come before imports) ───────────────────────────────────────
+
+const mockRedis = {
+  get: vi.fn(),
+  setex: vi.fn(),
+  publish: vi.fn(),
+};
+
+vi.mock("../services/event-bus.js", () => ({
+  getRedisClient: () => mockRedis,
+  publishEvent: vi.fn(),
+}));
+
+vi.mock("../services/redis-config.js", () => ({
+  getBullMQConnectionOptions: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("bullmq", () => {
+  class MockQueue {
+    add = vi.fn().mockResolvedValue({});
+    close = vi.fn().mockResolvedValue(undefined);
+  }
+  class MockWorker {
+    on = vi.fn();
+    close = vi.fn().mockResolvedValue(undefined);
+    constructor(_name: string, _fn: unknown, _opts?: unknown) {}
+  }
+  return { Queue: MockQueue, Worker: MockWorker };
+});
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────
+
+import {
+  validateClaudeToken,
+  getCachedTokenValidation,
+  TOKEN_VALIDATION_CACHE_KEY,
+} from "./token-validation-worker.js";
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("validateClaudeToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it("returns valid: true when API returns 200", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ usage: {} }), { status: 200 }),
+    );
+    const result = await validateClaudeToken("test-token");
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns valid: false when API returns 401", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+    const result = await validateClaudeToken("expired-token");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("expired");
+  });
+
+  it("returns valid: true on network error (fail-open)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const result = await validateClaudeToken("some-token");
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns valid: true when API returns 429 (rate limited but token still valid)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Too Many Requests", { status: 429 }),
+    );
+    const result = await validateClaudeToken("rate-limited-token");
+    expect(result.valid).toBe(true);
+  });
+
+  it("sends correct headers to Anthropic API", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await validateClaudeToken("my-token");
+    expect(fetchSpy).toHaveBeenCalledWith("https://api.anthropic.com/api/oauth/usage", {
+      headers: {
+        Authorization: "Bearer my-token",
+        "anthropic-beta": "oauth-2025-04-20",
+      },
+    });
+  });
+});
+
+describe("getCachedTokenValidation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns parsed result when cache exists", async () => {
+    const cached = {
+      valid: false,
+      lastValidated: "2026-04-17T10:00:00.000Z",
+      tokenExists: true,
+      error: "OAuth token has expired",
+    };
+    mockRedis.get.mockResolvedValueOnce(JSON.stringify(cached));
+
+    const result = await getCachedTokenValidation();
+    expect(result).toEqual(cached);
+    expect(mockRedis.get).toHaveBeenCalledWith(TOKEN_VALIDATION_CACHE_KEY);
+  });
+
+  it("returns null when no cache exists", async () => {
+    mockRedis.get.mockResolvedValueOnce(null);
+    const result = await getCachedTokenValidation();
+    expect(result).toBeNull();
+  });
+
+  it("returns null on Redis error", async () => {
+    mockRedis.get.mockRejectedValueOnce(new Error("Redis down"));
+    const result = await getCachedTokenValidation();
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/workers/token-validation-worker.ts
+++ b/apps/api/src/workers/token-validation-worker.ts
@@ -1,0 +1,180 @@
+import { Queue, Worker } from "bullmq";
+import { logger } from "../logger.js";
+import { getBullMQConnectionOptions } from "../services/redis-config.js";
+import { getRedisClient } from "../services/event-bus.js";
+
+const connectionOpts = getBullMQConnectionOptions();
+
+export const tokenValidationQueue = new Queue("token-validation", {
+  connection: connectionOpts,
+});
+
+/**
+ * Redis key where the latest token validation result is cached.
+ * Read by GET /api/auth/status and the task-worker pre-flight check.
+ */
+export const TOKEN_VALIDATION_CACHE_KEY = "optio:token-validation";
+
+/** TTL for the cached result — 10 minutes (2x the check interval). */
+const CACHE_TTL_SECS = 600;
+
+export interface TokenValidationResult {
+  valid: boolean;
+  lastValidated: string; // ISO-8601
+  error?: string;
+  /** Whether a CLAUDE_CODE_OAUTH_TOKEN secret exists at all. */
+  tokenExists: boolean;
+}
+
+/**
+ * Read the cached token validation result from Redis.
+ * Returns null if no cached result exists.
+ */
+export async function getCachedTokenValidation(): Promise<TokenValidationResult | null> {
+  try {
+    const redis = getRedisClient();
+    const raw = await redis.get(TOKEN_VALIDATION_CACHE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as TokenValidationResult;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate a Claude OAuth token against the Anthropic API.
+ * Returns { valid: true } if the token is accepted, or { valid: false, error } if rejected.
+ */
+export async function validateClaudeToken(
+  token: string,
+): Promise<{ valid: boolean; error?: string }> {
+  try {
+    const res = await fetch("https://api.anthropic.com/api/oauth/usage", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "anthropic-beta": "oauth-2025-04-20",
+      },
+    });
+    if (res.status === 401) {
+      return { valid: false, error: "OAuth token has expired — please paste a new one" };
+    }
+    // Any non-401 response (200, 429, etc.) means the token is still valid
+    return { valid: true };
+  } catch {
+    // Network error — don't mark as invalid, just skip
+    return { valid: true };
+  }
+}
+
+/**
+ * Periodic background worker that validates the stored CLAUDE_CODE_OAUTH_TOKEN.
+ *
+ * When the token is expired, publishes an `auth:failed` WebSocket event so the
+ * UI can show a warning banner before any task is launched. Results are cached
+ * in Redis so the auth status endpoint and task-worker pre-flight check can
+ * read them without re-probing the Anthropic API.
+ */
+export function startTokenValidationWorker() {
+  const intervalMs = parseInt(process.env.OPTIO_TOKEN_VALIDATION_INTERVAL ?? "300000", 10); // 5 min
+
+  tokenValidationQueue.add(
+    "validate-token",
+    {},
+    {
+      repeat: {
+        every: intervalMs,
+      },
+    },
+  );
+
+  const worker = new Worker(
+    "token-validation",
+    async () => {
+      const redis = getRedisClient();
+
+      // Try to retrieve the stored OAuth token from the secrets store
+      let token: string | null = null;
+      try {
+        const { retrieveSecret } = await import("../services/secret-service.js");
+        token = await retrieveSecret("CLAUDE_CODE_OAUTH_TOKEN").catch(() => null);
+      } catch {
+        // No secret-service available or encryption key not set — skip
+      }
+
+      // Also check host credentials (max-subscription mode)
+      if (!token) {
+        try {
+          const { getClaudeAuthToken } = await import("../services/auth-service.js");
+          const authResult = getClaudeAuthToken();
+          if (authResult.available && authResult.token) {
+            token = authResult.token;
+          }
+        } catch {
+          // auth-service not available
+        }
+      }
+
+      const now = new Date().toISOString();
+
+      if (!token) {
+        // No token configured — nothing to validate. Cache that fact.
+        const result: TokenValidationResult = {
+          valid: true,
+          lastValidated: now,
+          tokenExists: false,
+        };
+        await redis.setex(TOKEN_VALIDATION_CACHE_KEY, CACHE_TTL_SECS, JSON.stringify(result));
+        return;
+      }
+
+      // Validate the token
+      const validation = await validateClaudeToken(token);
+
+      const result: TokenValidationResult = {
+        valid: validation.valid,
+        lastValidated: now,
+        tokenExists: true,
+        ...(validation.error ? { error: validation.error } : {}),
+      };
+
+      await redis.setex(TOKEN_VALIDATION_CACHE_KEY, CACHE_TTL_SECS, JSON.stringify(result));
+
+      if (!validation.valid) {
+        logger.warn("Claude OAuth token validation failed — token is expired or invalid");
+
+        // Invalidate the usage cache so the dashboard shows fresh data
+        try {
+          const { invalidateUsageCache } = await import("../services/auth-service.js");
+          invalidateUsageCache();
+        } catch {
+          // non-fatal
+        }
+
+        // Publish auth:failed event so the UI shows a banner immediately
+        try {
+          const { publishEvent } = await import("../services/event-bus.js");
+          await publishEvent({
+            type: "auth:failed",
+            message:
+              "Claude Code OAuth token has expired. Go to Secrets to paste a new token, or re-run 'claude setup-token'.",
+            timestamp: now,
+          });
+        } catch {
+          // non-fatal — UI will pick it up on next poll
+        }
+      } else {
+        logger.debug("Claude OAuth token validation passed");
+      }
+    },
+    {
+      connection: connectionOpts,
+      concurrency: 1,
+    },
+  );
+
+  worker.on("failed", (job, err) => {
+    logger.error({ jobId: job?.id, err }, "Token validation job failed");
+  });
+
+  return worker;
+}

--- a/apps/web/src/components/layout/global-auth-banner.tsx
+++ b/apps/web/src/components/layout/global-auth-banner.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { AlertTriangle } from "lucide-react";
+import { api } from "@/lib/api-client";
+
+/**
+ * Global banner shown on all pages when the Claude OAuth token is expired.
+ * Listens for auth:failed WebSocket events and periodically checks auth status
+ * so the banner appears proactively — before a task is launched and fails.
+ */
+export function GlobalAuthBanner() {
+  const [expired, setExpired] = useState(false);
+  const [lastValidated, setLastValidated] = useState<string | null>(null);
+
+  const checkAuth = useCallback(async () => {
+    try {
+      const res = await api.getAuthStatus();
+      setExpired(res.subscription.expired === true);
+      setLastValidated((res.subscription as any).lastValidated ?? null);
+    } catch {
+      // Network error — don't show banner
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial check
+    checkAuth();
+
+    // Poll every 5 minutes (matches the background worker interval)
+    const interval = setInterval(checkAuth, 5 * 60 * 1000);
+
+    // Listen for auth:failed events from WebSocket to show banner immediately
+    const onAuthFailed = () => {
+      setExpired(true);
+    };
+
+    // Listen for token updates to dismiss banner immediately
+    const onAuthStatusChanged = () => {
+      checkAuth();
+    };
+
+    window.addEventListener("optio:auth-failed", onAuthFailed);
+    window.addEventListener("optio:auth-status-changed", onAuthStatusChanged);
+
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("optio:auth-failed", onAuthFailed);
+      window.removeEventListener("optio:auth-status-changed", onAuthStatusChanged);
+    };
+  }, [checkAuth]);
+
+  if (!expired) return null;
+
+  const validatedAgo = lastValidated ? formatTimeAgo(lastValidated) : null;
+
+  return (
+    <div className="shrink-0 bg-warning/10 border-b border-warning/30 px-4 py-2 flex items-center gap-2 text-sm">
+      <AlertTriangle className="w-4 h-4 text-warning shrink-0" />
+      <span className="text-text-heading font-medium">Claude OAuth token expired</span>
+      <span className="text-text-muted">
+        — tasks will fail until updated.{" "}
+        <a href="/secrets" className="underline hover:text-text transition-colors">
+          Go to Secrets
+        </a>{" "}
+        to paste a new token.
+      </span>
+      {validatedAgo && (
+        <span className="ml-auto text-xs text-text-muted/60">checked {validatedAgo}</span>
+      )}
+    </div>
+  );
+}
+
+function formatTimeAgo(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/apps/web/src/components/layout/layout-shell.tsx
+++ b/apps/web/src/components/layout/layout-shell.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "./theme-provider";
 import { ThemedToaster } from "./themed-toaster";
 import { OptioChatPanel } from "@/components/optio-chat";
 import { PushSwRegistrar } from "@/components/notifications/push-sw-registrar";
+import { GlobalAuthBanner } from "./global-auth-banner";
 
 export function LayoutShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -24,37 +25,40 @@ export function LayoutShell({ children }: { children: React.ReactNode }) {
       {isSetup || isLogin ? (
         <main className="min-h-screen">{children}</main>
       ) : (
-        <div className="flex h-screen">
-          {/* Mobile overlay */}
-          {sidebarOpen && (
-            <div
-              className="fixed inset-0 z-20 bg-black/50 md:hidden"
-              onClick={() => setSidebarOpen(false)}
-            />
-          )}
-          <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-          <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-            {/* Mobile header */}
-            <div className="md:hidden shrink-0 flex items-center gap-3 px-4 py-3 border-b border-border bg-bg-card">
-              <button
-                onClick={() => setSidebarOpen(true)}
-                className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted transition-colors"
-                aria-label="Open menu"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4 6h16M4 12h16M4 18h16"
-                  />
-                </svg>
-              </button>
-              <span className="font-semibold text-sm">Optio</span>
+        <div className="flex flex-col h-screen">
+          <GlobalAuthBanner />
+          <div className="flex flex-1 min-h-0">
+            {/* Mobile overlay */}
+            {sidebarOpen && (
+              <div
+                className="fixed inset-0 z-20 bg-black/50 md:hidden"
+                onClick={() => setSidebarOpen(false)}
+              />
+            )}
+            <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+            <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+              {/* Mobile header */}
+              <div className="md:hidden shrink-0 flex items-center gap-3 px-4 py-3 border-b border-border bg-bg-card">
+                <button
+                  onClick={() => setSidebarOpen(true)}
+                  className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted transition-colors"
+                  aria-label="Open menu"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 6h16M4 12h16M4 18h16"
+                    />
+                  </svg>
+                </button>
+                <span className="font-semibold text-sm">Optio</span>
+              </div>
+              <main className="flex-1 overflow-auto">{children}</main>
             </div>
-            <main className="flex-1 overflow-auto">{children}</main>
+            <OptioChatPanel />
           </div>
-          <OptioChatPanel />
         </div>
       )}
       <ThemedToaster />

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -419,7 +419,13 @@ export const api = {
 
   getAuthStatus: () =>
     request<{
-      subscription: { available: boolean; expiresAt?: string; error?: string; expired?: boolean };
+      subscription: {
+        available: boolean;
+        expiresAt?: string;
+        error?: string;
+        expired?: boolean;
+        lastValidated?: string | null;
+      };
     }>("/api/auth/status"),
 
   refreshAuth: () =>

--- a/packages/shared/src/error-classifier.test.ts
+++ b/packages/shared/src/error-classifier.test.ts
@@ -135,4 +135,26 @@ describe("classifyError", () => {
     expect(classifyError(undefined).category).toBe("unknown");
     expect(classifyError("").category).toBe("unknown");
   });
+
+  it("classifies expired OAuth token and links to Secrets page", () => {
+    const result = classifyError("OAuth token has expired during task execution");
+    expect(result.category).toBe("auth");
+    expect(result.title).toBe("Authentication token expired");
+    expect(result.remedy).toContain("Secrets");
+    expect(result.remedy).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+
+  it("classifies 401 authentication error with secrets link", () => {
+    const result = classifyError("401 authentication error from Anthropic API");
+    expect(result.category).toBe("auth");
+    expect(result.remedy).toContain("Secrets");
+  });
+
+  it("classifies token expired with pre-flight check message", () => {
+    const result = classifyError(
+      "Claude OAuth token is expired (detected by pre-flight validation). Go to Secrets to update CLAUDE_CODE_OAUTH_TOKEN.",
+    );
+    expect(result.category).toBe("auth");
+    expect(result.title).toBe("Authentication token expired");
+  });
 });

--- a/packages/shared/src/error-classifier.ts
+++ b/packages/shared/src/error-classifier.ts
@@ -58,14 +58,20 @@ const ERROR_PATTERNS: Array<{
     }),
   },
   {
-    pattern: /OAuth token has expired|authentication_failed|token.*expired|401.*authentication/i,
+    pattern:
+      /OAuth token has expired|authentication_failed|token.*expired|401.*authentication|pre-flight validation/i,
     classify: () => ({
       category: "auth",
       title: "Authentication token expired",
       description:
-        "The Claude Code OAuth token has expired. The agent cannot authenticate with the Anthropic API.",
+        "The Claude Code OAuth token has expired. The agent cannot authenticate with the Anthropic API. " +
+        "Keychain-sourced tokens expire roughly every hour.",
       remedy:
-        "Refresh your token by running this in a terminal:\n\nsecurity find-generic-password -s \"Claude Code-credentials\" -w | python3 -c \"import sys,json; print(json.load(sys.stdin)['claudeAiOauth']['accessToken'])\" | pbcopy\n\nThen go to Secrets, update CLAUDE_CODE_OAUTH_TOKEN with the new token, and retry the failed tasks.",
+        "Go to Secrets and update CLAUDE_CODE_OAUTH_TOKEN with a fresh token.\n\n" +
+        "To copy from your macOS Keychain, run:\n" +
+        "  security find-generic-password -s \"Claude Code-credentials\" -w | python3 -c \"import sys,json; print(json.load(sys.stdin)['claudeAiOauth']['accessToken'])\" | pbcopy\n\n" +
+        "Or re-run 'claude setup-token' to go through the setup flow again.\n" +
+        "Retry the failed tasks after updating the token.",
       retryable: true,
     }),
   },


### PR DESCRIPTION
Closes #435

## What changed

When a task runs with a stale `CLAUDE_CODE_OAUTH_TOKEN`, the agent fails with a `401` after ~10s of infra work (pod provisioning + worktree creation). This PR adds proactive detection and surfacing of expired tokens so users see warnings *before* tasks fail.

### Backend
- **New `token-validation-worker`**: BullMQ repeating job (every 5 min, configurable via `OPTIO_TOKEN_VALIDATION_INTERVAL`) that validates the stored OAuth token against the Anthropic API and caches the result in Redis. Publishes `auth:failed` WebSocket event when expired.
- **Pre-flight check in `task-worker`**: Before injecting the OAuth token for `oauth-token` mode, checks the cached validation result. If the token is known-expired, the task fails immediately with a clear error message linking to Secrets — instead of wasting ~10s on pod provisioning.
- **Extended `GET /api/auth/status`**: Now includes a `lastValidated` timestamp from the background worker's cache, avoiding redundant Anthropic API probes on each poll. Falls back to live validation if no cache exists yet.
- **Improved error classifier**: The "Authentication token expired" remedy now leads with "Go to Secrets" instead of burying it after a shell command. Pattern also matches the new pre-flight validation error.

### Frontend
- **Global auth warning banner**: Persistent banner in `LayoutShell` visible on *all* pages (not just the dashboard) when the token is expired. Includes a direct link to `/secrets` and shows when the token was last checked. Listens to `auth:failed` and `auth:status_changed` WebSocket events for immediate updates.
- **Updated API client types**: `getAuthStatus()` response now includes `lastValidated`.

### Worker registration
- Token validation worker registered in `index.ts` startup alongside other workers, with proper cleanup of stale repeat jobs and graceful shutdown.

## How to test

1. **Verify background validation**: Start the API server and check logs for "Token validation worker started". If a `CLAUDE_CODE_OAUTH_TOKEN` secret exists, the worker validates it every 5 minutes.
2. **Test expired token detection**: Store an expired/invalid OAuth token in Secrets. Within 5 minutes, the global banner should appear on all pages. The dashboard's usage panel should also show the `TokenRefreshBanner`.
3. **Test pre-flight check**: With an expired token cached, create a new task. It should fail immediately with "Claude OAuth token is expired (detected by pre-flight validation)" instead of waiting for pod provisioning.
4. **Test banner dismissal**: Update the token in Secrets with a valid one. The global banner should disappear immediately (via `auth:status_changed` WebSocket event).
5. **Test error classifier**: Check that a task that failed with "OAuth token has expired" shows the improved remedy text with "Go to Secrets" prominently.