### PR TITLE
Ticket-provider auth failures should surface in UI, not just logs

### DIFF
--- a/apps/api/src/db/migrations/1776410298_ticket_provider_error_tracking.sql
+++ b/apps/api/src/db/migrations/1776410298_ticket_provider_error_tracking.sql
@@ -1,0 +1,6 @@
+-- Track sync errors per ticket provider so failures surface in the UI
+-- instead of only appearing in server logs.
+
+ALTER TABLE "ticket_providers" ADD COLUMN "last_error" text;
+ALTER TABLE "ticket_providers" ADD COLUMN "last_error_at" timestamptz;
+ALTER TABLE "ticket_providers" ADD COLUMN "consecutive_failures" integer NOT NULL DEFAULT 0;

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -463,6 +463,13 @@
       "when": 1776398039000,
       "tag": "1776398039_template_kind",
       "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1776410298000,
+      "tag": "1776410298_ticket_provider_error_tracking",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -298,6 +298,9 @@ export const ticketProviders = pgTable("ticket_providers", {
   source: text("source").notNull(),
   config: jsonb("config").$type<Record<string, unknown>>().notNull(),
   enabled: boolean("enabled").notNull().default(true),
+  lastError: text("last_error"),
+  lastErrorAt: timestamp("last_error_at", { withTimezone: true }),
+  consecutiveFailures: integer("consecutive_failures").notNull().default(0),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/apps/api/src/routes/tickets.ts
+++ b/apps/api/src/routes/tickets.ts
@@ -156,7 +156,9 @@ export async function ticketRoutes(rawApp: FastifyInstance) {
     async (_req, reply) => {
       const providers = await db.select().from(ticketProviders);
 
-      // Annotate each provider with recent auth failure status
+      // Annotate each provider with auth failure status from both:
+      // 1. The provider row itself (last_error, consecutive_failures)
+      // 2. Legacy auth_events table for backwards compat
       const cutoff = new Date(Date.now() - RECENT_AUTH_FAILURE_WINDOW_MS);
       const failedRows = await db
         .selectDistinct({ source: authEvents.source })
@@ -169,7 +171,7 @@ export async function ticketRoutes(rawApp: FastifyInstance) {
       );
       const annotated = providers.map((p) => ({
         ...p,
-        hasAuthFailure: failedIds.has(p.id),
+        hasAuthFailure: failedIds.has(p.id) || (p.consecutiveFailures ?? 0) > 0,
       }));
 
       reply.send({ providers: annotated });
@@ -262,6 +264,39 @@ export async function ticketRoutes(rawApp: FastifyInstance) {
       await db.delete(ticketProviders).where(eq(ticketProviders.id, id));
       await deleteSecret(`ticket-provider:${id}`, "ticket-provider");
       reply.status(204).send(null);
+    },
+  );
+
+  app.patch(
+    "/api/tickets/providers/:id/re-enable",
+    {
+      schema: {
+        operationId: "reEnableTicketProvider",
+        summary: "Re-enable a ticket provider",
+        description:
+          "Clear error state and re-enable a ticket provider that was auto-disabled " +
+          "after consecutive sync failures. Use after refreshing the provider's token.",
+        tags: ["Repos & Integrations"],
+        params: IdParamsSchema,
+        response: { 200: ProviderResponseSchema, 404: ErrorResponseSchema },
+      },
+    },
+    async (req, reply) => {
+      const { id } = req.params;
+      const [provider] = await db
+        .update(ticketProviders)
+        .set({
+          enabled: true,
+          lastError: null,
+          lastErrorAt: null,
+          consecutiveFailures: 0,
+        })
+        .where(eq(ticketProviders.id, id))
+        .returning();
+      if (!provider) {
+        return reply.status(404).send({ error: "Provider not found" });
+      }
+      reply.send({ provider });
     },
   );
 

--- a/apps/api/src/services/ticket-sync-service.test.ts
+++ b/apps/api/src/services/ticket-sync-service.test.ts
@@ -4,12 +4,17 @@ vi.mock("../db/client.js", () => ({
   db: {
     select: vi.fn(),
     insert: vi.fn(),
+    update: vi.fn(),
   },
 }));
 
 vi.mock("../db/schema.js", () => ({
   ticketProviders: {
     enabled: "ticket_providers.enabled",
+    id: "ticket_providers.id",
+    lastError: "ticket_providers.last_error",
+    lastErrorAt: "ticket_providers.last_error_at",
+    consecutiveFailures: "ticket_providers.consecutive_failures",
   },
   repos: {
     repoUrl: "repos.repoUrl",
@@ -45,6 +50,7 @@ vi.mock("../logger.js", () => ({
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
+    debug: vi.fn(),
   },
 }));
 
@@ -55,6 +61,7 @@ import * as taskService from "./task-service.js";
 import { taskQueue } from "../workers/task-worker.js";
 import { retrieveSecret } from "./secret-service.js";
 import { syncAllTickets } from "./ticket-sync-service.js";
+import { logger } from "../logger.js";
 
 /**
  * Mock db.select() to handle two query patterns, matching on the .from() argument:
@@ -75,6 +82,23 @@ function mockDbSelect(providers: any[], configuredRepos: any[] = []) {
       return { where: vi.fn().mockResolvedValue([]) };
     }),
   }));
+}
+
+/** Mock db.update() — captures the set/where calls for assertions. */
+function mockDbUpdate() {
+  const updateState = { setCalls: [] as any[], whereCalls: [] as any[] };
+  (db.update as any) = vi.fn().mockImplementation(() => ({
+    set: vi.fn().mockImplementation((values: any) => {
+      updateState.setCalls.push(values);
+      return {
+        where: vi.fn().mockImplementation((clause: any) => {
+          updateState.whereCalls.push(clause);
+          return Promise.resolve();
+        }),
+      };
+    }),
+  }));
+  return updateState;
 }
 
 describe("ticket-sync-service", () => {
@@ -259,7 +283,10 @@ describe("ticket-sync-service", () => {
   });
 
   it("handles provider errors gracefully", async () => {
-    mockDbSelect([{ id: "p1", source: "github", config: {}, enabled: true }]);
+    mockDbSelect([
+      { id: "p1", source: "github", config: {}, enabled: true, consecutiveFailures: 0 },
+    ]);
+    mockDbUpdate();
 
     vi.mocked(getTicketProvider).mockReturnValue({
       fetchActionableTickets: vi.fn().mockRejectedValue(new Error("API error")),
@@ -396,5 +423,120 @@ describe("ticket-sync-service", () => {
 
     // Secret should be retrieved with the provider ID
     expect(retrieveSecret).toHaveBeenCalledWith("ticket-provider:p1", "ticket-provider");
+  });
+
+  it("persists last_error and increments consecutive_failures on provider error", async () => {
+    mockDbSelect([
+      {
+        id: "p1",
+        source: "github",
+        config: { repoUrl: "https://github.com/o/r" },
+        enabled: true,
+        consecutiveFailures: 0,
+      },
+    ]);
+    const updateState = mockDbUpdate();
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockRejectedValue(new Error("Bad credentials")),
+    } as any);
+
+    await syncAllTickets();
+
+    // Should have called db.update to persist the error
+    expect(db.update).toHaveBeenCalled();
+    expect(updateState.setCalls[0]).toEqual(
+      expect.objectContaining({
+        lastError: "Bad credentials",
+        consecutiveFailures: 1,
+      }),
+    );
+  });
+
+  it("clears error fields on successful provider sync", async () => {
+    mockDbSelect([
+      {
+        id: "p1",
+        source: "github",
+        config: { repoUrl: "https://github.com/o/r" },
+        enabled: true,
+        consecutiveFailures: 3,
+        lastError: "Bad credentials",
+        lastErrorAt: new Date(),
+      },
+    ]);
+    const updateState = mockDbUpdate();
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    await syncAllTickets();
+
+    // Should reset error fields on success
+    expect(db.update).toHaveBeenCalled();
+    expect(updateState.setCalls[0]).toEqual(
+      expect.objectContaining({
+        lastError: null,
+        lastErrorAt: null,
+        consecutiveFailures: 0,
+      }),
+    );
+  });
+
+  it("auto-disables provider after 5 consecutive failures", async () => {
+    mockDbSelect([
+      {
+        id: "p1",
+        source: "github",
+        config: { repoUrl: "https://github.com/o/r" },
+        enabled: true,
+        consecutiveFailures: 4, // one more will hit 5
+      },
+    ]);
+    const updateState = mockDbUpdate();
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockRejectedValue(new Error("Bad credentials")),
+    } as any);
+
+    await syncAllTickets();
+
+    // Should have disabled the provider (enabled: false) on the 5th failure
+    expect(db.update).toHaveBeenCalled();
+    expect(updateState.setCalls[0]).toEqual(
+      expect.objectContaining({
+        consecutiveFailures: 5,
+        enabled: false,
+      }),
+    );
+  });
+
+  it("downgrades repeated sync errors to debug level", async () => {
+    mockDbSelect([
+      {
+        id: "p1",
+        source: "github",
+        config: { repoUrl: "https://github.com/o/r" },
+        enabled: true,
+        consecutiveFailures: 2,
+        lastError: "Bad credentials",
+      },
+    ]);
+    mockDbUpdate();
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockRejectedValue(new Error("Bad credentials")),
+    } as any);
+
+    await syncAllTickets();
+
+    // Repeated failure with same message — should log at debug, not error
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "github" }),
+      expect.stringContaining("sync tickets"),
+    );
+    // Should NOT have logged at error level
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/ticket-sync-service.ts
+++ b/apps/api/src/services/ticket-sync-service.ts
@@ -11,6 +11,9 @@ import { retrieveSecret } from "./secret-service.js";
 import { logger } from "../logger.js";
 import { recordAuthEvent } from "./auth-failure-detector.js";
 
+/** Auto-disable a provider after this many consecutive failures. */
+const MAX_CONSECUTIVE_FAILURES = 5;
+
 export async function syncAllTickets(): Promise<number> {
   const providers = await db
     .select()
@@ -39,6 +42,18 @@ export async function syncAllTickets(): Promise<number> {
 
       const provider = getTicketProvider(providerConfig.source as TicketSource);
       const tickets = await provider.fetchActionableTickets(mergedConfig);
+
+      // Success — clear any previous error state
+      if ((providerConfig as any).consecutiveFailures > 0 || (providerConfig as any).lastError) {
+        await db
+          .update(ticketProviders)
+          .set({
+            lastError: null,
+            lastErrorAt: null,
+            consecutiveFailures: 0,
+          })
+          .where(eq(ticketProviders.id, providerConfig.id));
+      }
 
       for (const ticket of tickets) {
         // Construct repo URL: use the ticket's repo field, or fall back to provider config
@@ -176,10 +191,46 @@ export async function syncAllTickets(): Promise<number> {
         }
       }
     } catch (err: any) {
-      logger.error(
-        { err, provider: providerConfig.source },
-        "Failed to sync tickets from provider",
-      );
+      const errorMessage = err?.message ?? String(err);
+      const prevFailures = (providerConfig as any).consecutiveFailures ?? 0;
+      const newFailures = prevFailures + 1;
+      const prevError = (providerConfig as any).lastError;
+
+      // Rate-limit logging: downgrade to debug when the same error repeats
+      const isRepeat = prevFailures > 0 && prevError === errorMessage;
+      if (isRepeat) {
+        logger.debug(
+          { err, provider: providerConfig.source },
+          "Repeated failure to sync tickets from provider",
+        );
+      } else {
+        logger.error(
+          { err, provider: providerConfig.source },
+          "Failed to sync tickets from provider",
+        );
+      }
+
+      // Persist the error on the provider row
+      const updateFields: Record<string, unknown> = {
+        lastError: errorMessage,
+        lastErrorAt: new Date(),
+        consecutiveFailures: newFailures,
+      };
+
+      // Auto-disable after N consecutive failures
+      if (newFailures >= MAX_CONSECUTIVE_FAILURES) {
+        updateFields.enabled = false;
+        logger.warn(
+          { provider: providerConfig.source, providerId: providerConfig.id, failures: newFailures },
+          "Auto-disabled ticket provider after repeated failures",
+        );
+      }
+
+      await db
+        .update(ticketProviders)
+        .set(updateFields)
+        .where(eq(ticketProviders.id, providerConfig.id));
+
       if (err?.status === 401 || err?.message?.includes("Bad credentials")) {
         recordAuthEvent(
           "github",

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1241,6 +1241,19 @@ export default function SettingsPage() {
     }
   };
 
+  const handleReEnableProvider = async (id: string) => {
+    try {
+      await api.reEnableTicketProvider(id);
+      const res = await api.listTicketProviders();
+      setProviders(res.providers);
+      toast.success("Provider re-enabled");
+    } catch (err) {
+      toast.error("Failed to re-enable provider", {
+        description: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  };
+
   const providerFields: Record<string, { key: string; label: string; type?: string }[]> = {
     github: [
       { key: "owner", label: "Owner" },
@@ -1311,33 +1324,64 @@ export default function SettingsPage() {
           {providers.length > 0 ? (
             <div className="space-y-2">
               {providers.map((p: any) => (
-                <div key={p.id} className="flex items-center justify-between text-sm">
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={`w-2 h-2 rounded-full ${p.hasAuthFailure ? "bg-error" : p.enabled ? "bg-success" : "bg-text-muted"}`}
-                    />
-                    <span className="capitalize">{p.source}</span>
-                    {p.hasAuthFailure && (
-                      <span className="text-xs text-error font-medium">Token invalid</span>
-                    )}
-                    <span className="text-xs text-text-muted">
-                      {p.source === "github" &&
-                        p.config?.owner &&
-                        `${p.config.owner}/${p.config.repo}`}
-                      {p.source === "notion" &&
-                        p.config?.databaseId &&
-                        `Database: ${p.config.databaseId}`}
-                      {p.source === "linear" && p.config?.teamId && `Team: ${p.config.teamId}`}
-                      {p.source === "jira" && p.config?.baseUrl && `${p.config.baseUrl}`}
-                    </span>
+                <div key={p.id} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`w-2 h-2 rounded-full ${p.hasAuthFailure ? "bg-error" : p.enabled ? "bg-success" : "bg-text-muted"}`}
+                      />
+                      <span className="capitalize">{p.source}</span>
+                      {!p.enabled && (
+                        <span className="text-xs text-error font-medium">Disabled</span>
+                      )}
+                      {p.hasAuthFailure && p.enabled && (
+                        <span className="text-xs text-error font-medium">Token invalid</span>
+                      )}
+                      <span className="text-xs text-text-muted">
+                        {p.source === "github" &&
+                          p.config?.owner &&
+                          `${p.config.owner}/${p.config.repo}`}
+                        {p.source === "notion" &&
+                          p.config?.databaseId &&
+                          `Database: ${p.config.databaseId}`}
+                        {p.source === "linear" && p.config?.teamId && `Team: ${p.config.teamId}`}
+                        {p.source === "jira" && p.config?.baseUrl && `${p.config.baseUrl}`}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      {(p.hasAuthFailure || !p.enabled) && (
+                        <button
+                          onClick={() => handleReEnableProvider(p.id)}
+                          className="flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+                          title="Clear errors and re-enable this provider"
+                        >
+                          <RefreshCw className="w-3 h-3" />
+                          Re-enable
+                        </button>
+                      )}
+                      <button
+                        onClick={() => handleDeleteProvider(p.id)}
+                        className="p-1 rounded hover:bg-error/10 text-text-muted hover:text-error transition-colors"
+                        title="Remove provider"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
                   </div>
-                  <button
-                    onClick={() => handleDeleteProvider(p.id)}
-                    className="p-1 rounded hover:bg-error/10 text-text-muted hover:text-error transition-colors"
-                    title="Remove provider"
-                  >
-                    <Trash2 className="w-3.5 h-3.5" />
-                  </button>
+                  {p.lastError && (
+                    <div className="ml-4 p-2 rounded bg-error/5 border border-error/20">
+                      <p className="text-xs text-error">{p.lastError}</p>
+                      <p className="text-xs text-text-muted mt-0.5">
+                        {p.lastErrorAt &&
+                          `Last failure: ${new Date(p.lastErrorAt).toLocaleString()}`}
+                        {p.consecutiveFailures > 0 &&
+                          ` (${p.consecutiveFailures} consecutive failures)`}
+                      </p>
+                      <p className="text-xs text-text-muted mt-1">
+                        Refresh your token and click Re-enable to resume syncing.
+                      </p>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -225,6 +225,9 @@ export const api = {
   deleteTicketProvider: (id: string) =>
     request<void>(`/api/tickets/providers/${id}`, { method: "DELETE" }),
 
+  reEnableTicketProvider: (id: string) =>
+    request<{ provider: any }>(`/api/tickets/providers/${id}/re-enable`, { method: "PATCH" }),
+
   // Prompt templates
   getEffectiveTemplate: (repoUrl?: string) => {
     const qs = repoUrl ? `?repoUrl=${encodeURIComponent(repoUrl)}` : "";


### PR DESCRIPTION
Closes #438

## What changed

Ticket-provider sync errors (e.g. GitHub 401 "Bad credentials") were only visible in server logs, creating noise without any user-facing signal. This PR:

- **Persists sync errors per provider**: Adds `last_error`, `last_error_at`, and `consecutive_failures` columns to the `ticket_providers` table. On each sync failure the error message and failure count are recorded; on success they are cleared.
- **Auto-disables after 5 consecutive failures**: Providers that keep failing are automatically disabled to stop log spam. A warning is logged once when this happens.
- **Rate-limits error logging**: Repeated failures with the same error message are downgraded to `debug` level instead of `error`, cutting log noise significantly.
- **Surfaces errors in the UI**: The Settings > Ticket Providers section now shows the error message, timestamp, failure count, and a "Re-enable" button when a provider has errors or is disabled.
- **Adds `PATCH /api/tickets/providers/:id/re-enable`**: Clears all error state and re-enables the provider — intended for use after the user refreshes their token.

## How to test

1. Configure a ticket provider (e.g. GitHub) with an invalid token
2. Trigger a sync (click "Sync Now") or wait for the periodic sync
3. Go to Settings > Ticket Integration — the provider should show a red error box with the failure message, "Re-enable" button, and failure count
4. After 5 consecutive failures the provider should be auto-disabled (status dot turns grey, "Disabled" label appears)
5. Fix the token (delete + re-add, or re-enter credentials), then click "Re-enable" — error state clears and syncing resumes
6. Verify that repeated sync failures only log at debug level (not error) after the first occurrence

**Tests**: 4 new test cases covering error persistence, success reset, auto-disable, and log downgrading. All 1934 tests pass. Typecheck and web build clean.