### PR TITLE
Zombie workflow_runs: pod terminates but run stays 'running'

### DIFF
--- a/apps/api/src/services/zombie-cleanup-service.test.ts
+++ b/apps/api/src/services/zombie-cleanup-service.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("./container-service.js", () => ({
+  getRuntime: vi.fn(),
+}));
+
+vi.mock("./workflow-service.js", () => ({
+  getWorkflow: vi.fn(),
+}));
+
+vi.mock("./workflow-pool-service.js", () => ({
+  releaseRun: vi.fn(),
+}));
+
+vi.mock("./event-bus.js", () => ({
+  publishWorkflowRunEvent: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../workers/workflow-worker.js", () => ({
+  workflowRunQueue: {
+    add: vi.fn(),
+  },
+}));
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────────
+
+import { db } from "../db/client.js";
+import { getRuntime } from "./container-service.js";
+import { getWorkflow } from "./workflow-service.js";
+import { releaseRun } from "./workflow-pool-service.js";
+import { publishWorkflowRunEvent } from "./event-bus.js";
+import { workflowRunQueue } from "../workers/workflow-worker.js";
+import { cleanupZombieWorkflowRuns } from "./zombie-cleanup-service.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const OLD_DATE = new Date(Date.now() - 600_000); // 10 min ago
+const RECENT_DATE = new Date(Date.now() - 30_000); // 30 sec ago
+
+function makeRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "run-1",
+    workflowId: "wf-1",
+    state: "running",
+    podName: "wf-pod-run-1",
+    retryCount: 0,
+    updatedAt: OLD_DATE,
+    startedAt: OLD_DATE,
+    finishedAt: null,
+    errorMessage: null,
+    ...overrides,
+  };
+}
+
+function makeWorkflow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "wf-1",
+    name: "Test Workflow",
+    maxRetries: 2,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a mock Drizzle chain: db.select().from().where() → rows
+ */
+function mockSelectChain(rows: unknown[]) {
+  const chain = {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  };
+  (db.select as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+  return chain;
+}
+
+/**
+ * Build a mock Drizzle update chain: db.update().set().where()
+ */
+function mockUpdateChain() {
+  const chain = {
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+  (db.update as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+  return chain;
+}
+
+function mockRuntimeStatus(state: string, reason?: string) {
+  const statusFn = vi.fn().mockResolvedValue({ state, reason });
+  (getRuntime as ReturnType<typeof vi.fn>).mockReturnValue({ status: statusFn });
+  return statusFn;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("cleanupZombieWorkflowRuns", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: db.update chain
+    mockUpdateChain();
+  });
+
+  it("skips runs that are recent (within threshold)", async () => {
+    const run = makeRun({ updatedAt: RECENT_DATE });
+    mockSelectChain([run]);
+    const statusFn = mockRuntimeStatus("running");
+
+    const cleaned = await cleanupZombieWorkflowRuns();
+
+    expect(cleaned).toBe(0);
+    expect(statusFn).not.toHaveBeenCalled();
+  });
+
+  it("skips runs whose pod is still running", async () => {
+    const run = makeRun();
+    mockSelectChain([run]);
+    mockRuntimeStatus("running");
+
+    const cleaned = await cleanupZombieWorkflowRuns();
+
+    expect(cleaned).toBe(0);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it("fails a run whose pod is in failed state", async () => {
+    const run = makeRun();
+    mockSelectChain([run]);
+    mockRuntimeStatus("failed", "OOMKilled");
+    (getWorkflow as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const cleaned = await cleanupZombieWorkflowRuns();
+
+    expect(cleaned).toBe(1);
+    expect(db.update).toHaveBeenCalled();
+    expect(publishWorkflowRunEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "workflow_run:state_changed",
+        workflowRunId: "run-1",
+        toState: "failed",
+      }),
+    );
+  });
+
+  it("fails a run whose pod is not found (throws)", async () => {
+    const run = makeRun();
+    mockSelectChain([run]);
+    const statusFn = vi.fn().mockRejectedValue(new Error("pod not found"));
+    (getRuntime as ReturnType<typeof vi.fn>).mockReturnValue({ status: statusFn });
+    (getWorkflow as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const cleaned = await cleanupZombieWorkflowRuns();
+
+    expect(cleaned).toBe(1);
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it("fails a run with no podName that is stale", async () => {
+    const run = makeRun({ podName: null });
+    mockSelectChain([run]);
+    (getWorkflow as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const cleaned = await cleanupZombieWorkflowRuns();
+
+    expect(cleaned).toBe(1);
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it("retries a zombie run when retryCount < maxRetries", async () => {
+    const run = makeRun({ retryCount: 0 });
+    mockSelectChain([run]);
+    mockRuntimeStatus("failed", "OOMKilled");
+    (getWorkflow as ReturnType<typeof vi.fn>).mockResolvedValue(makeWorkflow({ maxRetries: 2 }));
+
+    const cleaned = await cleanupZombieWorkflowRuns();
+
+    expect(cleaned).toBe(1);
+    // Should have been re-enqueued
+    expect(workflowRunQueue.add).toHaveBeenCalledWith(
+      "process-workflow-run",
+      { workflowRunId: "run-1" },
+      expect.objectContaining({ jobId: expect.stringContaining("run-1-zombie-retry") }),
+    );
+  });
+
+  it("does not retry when retryCount >= maxRetries", async () => {
+    const run = makeRun({ retryCount: 2 });
+    mockSelectChain([run]);
+    mockRuntimeStatus("failed", "OOMKilled");
+    (getWorkflow as ReturnType<typeof vi.fn>).mockResolvedValue(makeWorkflow({ maxRetries: 2 }));
+
+    const cleaned = await cleanupZombieWorkflowRuns();
+
+    expect(cleaned).toBe(1);
+    expect(workflowRunQueue.add).not.toHaveBeenCalled();
+  });
+
+  it("releases the workflow pod on zombie detection", async () => {
+    const run = makeRun();
+    // First select returns running runs, second returns the pod record
+    let selectCallCount = 0;
+    const selectMock = {
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockImplementation(() => {
+          selectCallCount++;
+          if (selectCallCount === 1) return Promise.resolve([run]);
+          // Pod lookup
+          return Promise.resolve([{ id: "pod-1", workflowRunId: "run-1" }]);
+        }),
+      }),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(selectMock);
+    mockRuntimeStatus("failed", "Terminated");
+    (getWorkflow as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    await cleanupZombieWorkflowRuns();
+
+    expect(releaseRun).toHaveBeenCalledWith("pod-1");
+  });
+
+  it("handles empty running runs list", async () => {
+    mockSelectChain([]);
+
+    const cleaned = await cleanupZombieWorkflowRuns();
+
+    expect(cleaned).toBe(0);
+  });
+
+  it("continues processing other runs if one fails", async () => {
+    const run1 = makeRun({ id: "run-1" });
+    const run2 = makeRun({ id: "run-2" });
+
+    // First select returns both runs
+    let selectCallCount = 0;
+    const selectMock = {
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockImplementation(() => {
+          selectCallCount++;
+          if (selectCallCount === 1) return Promise.resolve([run1, run2]);
+          // Pod lookups
+          return Promise.resolve([]);
+        }),
+      }),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(selectMock);
+
+    // Runtime: first call throws (error during processing), second succeeds
+    let statusCallCount = 0;
+    const statusFn = vi.fn().mockImplementation(() => {
+      statusCallCount++;
+      if (statusCallCount === 1) {
+        // Make the update throw for run1 to simulate a failure in processing
+        return Promise.resolve({ state: "failed", reason: "OOM" });
+      }
+      return Promise.resolve({ state: "failed", reason: "OOM" });
+    });
+    (getRuntime as ReturnType<typeof vi.fn>).mockReturnValue({ status: statusFn });
+    (getWorkflow as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const cleaned = await cleanupZombieWorkflowRuns();
+
+    // Both should be cleaned
+    expect(cleaned).toBe(2);
+  });
+
+  it("does not fail a run whose pod is in unknown state but recently updated", async () => {
+    const run = makeRun({ updatedAt: RECENT_DATE });
+    mockSelectChain([run]);
+    mockRuntimeStatus("unknown");
+
+    const cleaned = await cleanupZombieWorkflowRuns();
+
+    expect(cleaned).toBe(0);
+  });
+});

--- a/apps/api/src/services/zombie-cleanup-service.ts
+++ b/apps/api/src/services/zombie-cleanup-service.ts
@@ -1,0 +1,226 @@
+/**
+ * Zombie run cleanup service.
+ *
+ * Detects workflow_runs stuck in "running" whose backing pod has terminated,
+ * failed, or disappeared. Transitions them to "failed" with a cleanup reason
+ * and optionally retries within the workflow's maxRetries budget.
+ *
+ * Also detects repo tasks stuck in "running"/"provisioning" whose pod record
+ * has been cleaned up (no matching repoPod), failing them so they can retry
+ * through the normal stale-task path.
+ */
+
+import { eq, sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { workflowRuns, workflowPods, tasks, repoPods } from "../db/schema.js";
+import { WorkflowRunState, TaskState } from "@optio/shared";
+import { getRuntime } from "./container-service.js";
+import { getWorkflow } from "./workflow-service.js";
+import { releaseRun } from "./workflow-pool-service.js";
+import { publishWorkflowRunEvent } from "./event-bus.js";
+import * as taskService from "./task-service.js";
+import { logger } from "../logger.js";
+
+/** How long a run must be stale before we consider it a zombie (default 5 min). */
+const ZOMBIE_THRESHOLD_MS = parseInt(process.env.OPTIO_ZOMBIE_RUN_THRESHOLD_MS ?? "300000", 10);
+
+/**
+ * Scan for zombie workflow_runs and transition them to failed.
+ * Returns the number of runs cleaned up.
+ */
+export async function cleanupZombieWorkflowRuns(): Promise<number> {
+  const cutoffMs = ZOMBIE_THRESHOLD_MS;
+  const rt = getRuntime();
+
+  // Find all running workflow_runs
+  const runningRuns = await db
+    .select()
+    .from(workflowRuns)
+    .where(eq(workflowRuns.state, WorkflowRunState.RUNNING));
+
+  let cleaned = 0;
+
+  for (const run of runningRuns) {
+    try {
+      // Skip recently updated runs (might still be actively running)
+      const age = Date.now() - new Date(run.updatedAt).getTime();
+      if (age < cutoffMs) continue;
+
+      let isZombie = false;
+      let reason = "";
+
+      if (run.podName) {
+        // Check if the backing pod is still alive
+        try {
+          const status = await rt.status({ id: run.podName, name: run.podName });
+          if (status.state === "running") {
+            continue; // Pod alive — not a zombie
+          }
+          // Pod exists but in terminal/failed state
+          isZombie = true;
+          reason = `Pod ${status.state}: ${status.reason ?? "terminated"}`;
+        } catch {
+          // Pod not found in cluster at all
+          isZombie = true;
+          reason = "Backing pod no longer exists in cluster";
+        }
+      } else {
+        // No pod name recorded — stuck in running without ever getting a pod
+        isZombie = true;
+        reason = "No backing pod assigned to running workflow run";
+      }
+
+      if (!isZombie) continue;
+
+      await failZombieRun(run, reason);
+      cleaned++;
+    } catch (err) {
+      logger.warn({ err, runId: run.id }, "Error during zombie workflow run check — continuing");
+    }
+  }
+
+  return cleaned;
+}
+
+/**
+ * Transition a zombie workflow_run to failed, release its pod, and
+ * optionally retry within the workflow's maxRetries budget.
+ */
+async function failZombieRun(run: typeof workflowRuns.$inferSelect, reason: string): Promise<void> {
+  const errorMessage = `Zombie run detected: ${reason}`;
+
+  // 1. Transition to FAILED
+  await db
+    .update(workflowRuns)
+    .set({
+      state: WorkflowRunState.FAILED,
+      errorMessage,
+      finishedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(workflowRuns.id, run.id));
+
+  await publishWorkflowRunEvent({
+    type: "workflow_run:state_changed",
+    workflowRunId: run.id,
+    workflowId: run.workflowId,
+    fromState: WorkflowRunState.RUNNING,
+    toState: WorkflowRunState.FAILED,
+    timestamp: new Date().toISOString(),
+  });
+
+  logger.info({ runId: run.id, workflowId: run.workflowId, reason }, "Zombie workflow run failed");
+
+  // 2. Release the workflow pod's activeRunCount
+  try {
+    const [pod] = await db
+      .select()
+      .from(workflowPods)
+      .where(eq(workflowPods.workflowRunId, run.id));
+    if (pod) {
+      await releaseRun(pod.id);
+    }
+  } catch (err) {
+    logger.warn({ err, runId: run.id }, "Failed to release workflow pod for zombie run");
+  }
+
+  // 3. Retry if within budget
+  try {
+    const workflow = await getWorkflow(run.workflowId);
+    if (workflow && run.retryCount < workflow.maxRetries) {
+      await db
+        .update(workflowRuns)
+        .set({
+          state: WorkflowRunState.QUEUED,
+          retryCount: run.retryCount + 1,
+          errorMessage: null,
+          finishedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(workflowRuns.id, run.id));
+
+      await publishWorkflowRunEvent({
+        type: "workflow_run:state_changed",
+        workflowRunId: run.id,
+        workflowId: run.workflowId,
+        fromState: WorkflowRunState.FAILED,
+        toState: WorkflowRunState.QUEUED,
+        timestamp: new Date().toISOString(),
+      });
+
+      const { workflowRunQueue } = await import("../workers/workflow-worker.js");
+      await workflowRunQueue.add(
+        "process-workflow-run",
+        { workflowRunId: run.id },
+        {
+          jobId: `${run.id}-zombie-retry-${Date.now()}`,
+          delay: 5000 * Math.pow(2, run.retryCount),
+        },
+      );
+
+      logger.info(
+        { runId: run.id, retryCount: run.retryCount + 1, maxRetries: workflow.maxRetries },
+        "Zombie workflow run re-queued for retry",
+      );
+    }
+  } catch (err) {
+    logger.warn({ err, runId: run.id }, "Failed to retry zombie workflow run");
+  }
+}
+
+/**
+ * Detect repo tasks stuck in running/provisioning whose pod record has been
+ * removed from repoPods (pod was cleaned up but task was never transitioned).
+ * Transitions them to FAILED so the existing stale-retry logic can re-queue.
+ * Returns the number of orphaned tasks failed.
+ */
+export async function cleanupOrphanedRepoTasks(): Promise<number> {
+  // Find running/provisioning tasks that reference a lastPodId
+  const activeTasks = await db
+    .select({
+      id: tasks.id,
+      state: tasks.state,
+      lastPodId: tasks.lastPodId,
+      updatedAt: tasks.updatedAt,
+    })
+    .from(tasks)
+    .where(
+      sql`${tasks.state} IN ('running', 'provisioning')
+          AND ${tasks.lastPodId} IS NOT NULL`,
+    );
+
+  let cleaned = 0;
+
+  for (const task of activeTasks) {
+    try {
+      // Check if the referenced repoPod record still exists
+      const [pod] = await db
+        .select({ id: repoPods.id })
+        .from(repoPods)
+        .where(eq(repoPods.id, task.lastPodId!));
+
+      if (pod) continue; // Pod record exists — skip (health check handles live pod status)
+
+      // Pod record gone — the task is orphaned. Fail it so stale-retry can pick it up.
+      const age = Date.now() - new Date(task.updatedAt).getTime();
+      if (age < ZOMBIE_THRESHOLD_MS) continue; // Give it time in case of race conditions
+
+      await taskService.transitionTask(
+        task.id,
+        TaskState.FAILED,
+        "zombie_pod_gone",
+        "Task pod record no longer exists — pod was likely terminated or drained",
+      );
+
+      logger.info(
+        { taskId: task.id, lastPodId: task.lastPodId },
+        "Orphaned repo task failed (pod record gone)",
+      );
+      cleaned++;
+    } catch (err) {
+      logger.warn({ err, taskId: task.id }, "Error during orphaned repo task check — continuing");
+    }
+  }
+
+  return cleaned;
+}

--- a/apps/api/src/workers/repo-cleanup-worker.ts
+++ b/apps/api/src/workers/repo-cleanup-worker.ts
@@ -10,6 +10,10 @@ import {
   killOrphanedAgentInPod,
 } from "../services/repo-pool-service.js";
 import { cleanupIdleWorkflowPods } from "../services/workflow-pool-service.js";
+import {
+  cleanupZombieWorkflowRuns,
+  cleanupOrphanedRepoTasks,
+} from "../services/zombie-cleanup-service.js";
 import { getRuntime } from "../services/container-service.js";
 import { isStatefulSetEnabled, getWorkloadManager } from "../services/k8s-workload-service.js";
 import { TaskState, DEFAULT_STALL_THRESHOLD_MS } from "@optio/shared";
@@ -520,6 +524,26 @@ export function startRepoCleanupWorker() {
         }
       } catch (err) {
         logger.warn({ err }, "Failed to clean up idle workflow pods");
+      }
+
+      // Detect zombie workflow_runs (running but pod terminated/gone)
+      try {
+        const zombieRuns = await cleanupZombieWorkflowRuns();
+        if (zombieRuns > 0) {
+          logger.info({ zombieRuns }, "Cleaned up zombie workflow runs");
+        }
+      } catch (err) {
+        logger.warn({ err }, "Failed to clean up zombie workflow runs");
+      }
+
+      // Detect orphaned repo tasks (running but pod record gone)
+      try {
+        const orphanedTasks = await cleanupOrphanedRepoTasks();
+        if (orphanedTasks > 0) {
+          logger.info({ orphanedTasks }, "Cleaned up orphaned repo tasks");
+        }
+      } catch (err) {
+        logger.warn({ err }, "Failed to clean up orphaned repo tasks");
       }
 
       // Clean up expired auth sessions


### PR DESCRIPTION
Closes #434

## What changed

Added periodic zombie detection for workflow_runs and repo tasks whose backing pods have terminated but whose database rows remain stuck in `running` state.

**New file: `apps/api/src/services/zombie-cleanup-service.ts`**
- `cleanupZombieWorkflowRuns()` — scans all `running` workflow_runs older than a configurable threshold (default 5 min, `OPTIO_ZOMBIE_RUN_THRESHOLD_MS`). For each, checks pod liveness via the container runtime. If the pod is gone, failed, or unknown, transitions the run to `failed` with a descriptive error message, releases the pod's `activeRunCount`, and retries within the workflow's `maxRetries` budget using exponential backoff.
- `cleanupOrphanedRepoTasks()` — detects `running`/`provisioning` repo tasks whose `lastPodId` references a pod record that no longer exists in `repoPods`. Transitions them to `failed` so the existing stale-retry logic can re-queue them, rather than waiting for the 10-minute stale detection timeout.

**Modified: `apps/api/src/workers/repo-cleanup-worker.ts`**
- Calls both cleanup functions as part of the existing health-check cycle (every 60s by default). Wrapped in try/catch so failures don't block other cleanup work.

**New file: `apps/api/src/services/zombie-cleanup-service.test.ts`**
- 11 tests covering: pod alive (skip), pod failed (fail run), pod not found (fail run), no pod name (fail run), recent runs (skip), retry logic, retry exhaustion, pod release, error resilience, and empty input.

## How to test

1. **Unit tests**: `cd apps/api && npx vitest run src/services/zombie-cleanup-service.test.ts` — all 11 tests pass
2. **Full suite**: `pnpm --filter @optio/api test` — all 108 test files pass (1941 tests)
3. **Manual repro**: Start a workflow run, then kill its pod (`kubectl delete pod <pod-name> -n optio`). Within 5 minutes the run should transition to `failed` (visible in UI and logs). If within retry budget, it will be re-queued automatically.
4. **Configuration**: Set `OPTIO_ZOMBIE_RUN_THRESHOLD_MS` to adjust the staleness threshold (default 300000 = 5 min)