### PR TITLE
Remove 'N tasks failed today - ask Optio to investigate' dashboard banner

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+// Stub hooks and heavy dependencies so the page renders in jsdom.
+vi.mock("@/hooks/use-page-title", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-optio-chat", () => ({
+  useOptioChatStore: () => ({
+    setPrefillInput: vi.fn(),
+    open: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/update-banner", () => ({
+  UpdateBanner: () => null,
+}));
+
+// Stub every dashboard sub-component to a simple placeholder.
+vi.mock("@/components/dashboard", () => ({
+  PipelineStatsBar: () => <div data-testid="pipeline-stats" />,
+  UsagePanel: () => null,
+  ClusterSummary: () => null,
+  ActiveSessions: () => null,
+  RecentTasks: () => null,
+  RecentActivity: () => null,
+  PodsList: () => null,
+  WelcomeHero: () => <div data-testid="welcome-hero" />,
+  PerformanceSummary: () => null,
+  AgentComparison: () => null,
+  FailureInsights: () => null,
+}));
+
+const makeDashboardData = (overrides: Record<string, unknown> = {}) => ({
+  taskStats: { total: 10, running: 1, failed: 3, needsAttention: 0 },
+  recentTasks: [],
+  repoCount: 2,
+  cluster: { pods: [], events: [], repoPods: [] },
+  loading: false,
+  activeSessions: [],
+  activeSessionCount: 0,
+  usage: null,
+  metricsAvailable: false,
+  metricsHistory: [],
+  refresh: vi.fn(),
+  refreshUsage: vi.fn(),
+  ...overrides,
+});
+
+vi.mock("@/hooks/use-dashboard-data", () => ({
+  useDashboardData: vi.fn(() => makeDashboardData()),
+}));
+
+import OverviewPage from "./page";
+import { useDashboardData } from "@/hooks/use-dashboard-data";
+
+describe("OverviewPage — failed-tasks banner removed", () => {
+  afterEach(() => cleanup());
+
+  it("does not render the 'failed today' banner even when tasks have failures", () => {
+    vi.mocked(useDashboardData).mockReturnValue(
+      makeDashboardData({
+        taskStats: { total: 10, running: 0, failed: 5, needsAttention: 0 },
+      }) as any,
+    );
+
+    render(<OverviewPage />);
+
+    // The old banner text should not appear anywhere.
+    expect(screen.queryByText(/failed today/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Ask Optio to help investigate/i)).not.toBeInTheDocument();
+  });
+
+  it("does not render the 'failed today' banner when failed count is 1", () => {
+    vi.mocked(useDashboardData).mockReturnValue(
+      makeDashboardData({
+        taskStats: { total: 5, running: 0, failed: 1, needsAttention: 0 },
+      }) as any,
+    );
+
+    render(<OverviewPage />);
+
+    expect(screen.queryByText(/failed today/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Ask Optio to help investigate/i)).not.toBeInTheDocument();
+  });
+
+  it("still renders the Overview heading and pipeline stats", () => {
+    render(<OverviewPage />);
+
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(screen.getByTestId("pipeline-stats")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { usePageTitle } from "@/hooks/use-page-title";
 import { useDashboardData } from "@/hooks/use-dashboard-data";
-import { RefreshCw, Bot } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import {
   PipelineStatsBar,
   UsagePanel,
@@ -14,12 +14,10 @@ import {
   WelcomeHero,
   AgentComparison,
 } from "@/components/dashboard";
-import { useOptioChatStore } from "@/hooks/use-optio-chat";
 import { UpdateBanner } from "@/components/update-banner";
 
 export default function OverviewPage() {
   usePageTitle("Overview");
-  const optioChat = useOptioChatStore();
   const {
     taskStats,
     recentTasks,
@@ -113,28 +111,6 @@ export default function OverviewPage() {
       <UpdateBanner />
 
       <PipelineStatsBar taskStats={taskStats} />
-
-      {(taskStats?.failed ?? 0) > 0 && (
-        <button
-          onClick={() => {
-            optioChat.setPrefillInput(
-              `${taskStats!.failed} task${taskStats!.failed === 1 ? "" : "s"} failed today - can you help me investigate?`,
-            );
-            optioChat.open();
-          }}
-          className="w-full flex items-center gap-3 px-4 py-3 rounded-lg border border-error/15 bg-error/5 hover:bg-error/8 transition-colors text-left group"
-        >
-          <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0 group-hover:bg-primary/15 transition-colors">
-            <Bot className="w-4 h-4 text-primary" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm text-text">
-              {taskStats!.failed} task{taskStats!.failed === 1 ? "" : "s"} failed today
-            </p>
-            <p className="text-xs text-text-muted mt-0.5">Ask Optio to help investigate</p>
-          </div>
-        </button>
-      )}
 
       <AgentComparison />
 


### PR DESCRIPTION
Closes #429

## What changed

Removed the conditional "failed today" banner from the dashboard overview page (`apps/web/src/app/page.tsx`). This banner appeared when `taskStats.failed > 0` and prompted users to open the Optio chat to investigate failures.

Changes:
- Removed the banner JSX block (previously lines 119-139)
- Removed the `Bot` icon import from `lucide-react` (no longer used)
- Removed the `useOptioChatStore` import and `optioChat` variable (no longer used on this page)
- Added `page.test.tsx` with tests verifying the banner no longer renders even when tasks have failures

## How to test

1. Run `pnpm turbo test` — all 245 tests pass including the 3 new ones
2. Run `pnpm turbo typecheck` — clean
3. Run `pnpm format:check` — clean
4. Load the dashboard with failed tasks — the "N tasks failed today" banner should no longer appear