### PR TITLE
Reorder overview panel sections

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -23,9 +23,9 @@ vi.mock("@/components/dashboard", () => ({
   UsagePanel: () => null,
   ClusterSummary: () => null,
   ActiveSessions: () => null,
-  RecentTasks: () => null,
-  RecentActivity: () => null,
-  PodsList: () => null,
+  RecentTasks: () => <div data-testid="recent-tasks" />,
+  RecentActivity: () => <div data-testid="recent-activity" />,
+  PodsList: () => <div data-testid="pods-list" />,
   WelcomeHero: () => <div data-testid="welcome-hero" />,
   PerformanceSummary: () => null,
   AgentComparison: () => null,
@@ -90,5 +90,28 @@ describe("OverviewPage — failed-tasks banner removed", () => {
 
     expect(screen.getByText("Overview")).toBeInTheDocument();
     expect(screen.getByTestId("pipeline-stats")).toBeInTheDocument();
+  });
+});
+
+describe("OverviewPage — section ordering", () => {
+  afterEach(() => cleanup());
+
+  it("renders Recent Tasks before Pods before Recent Activity", () => {
+    render(<OverviewPage />);
+
+    const recentTasks = screen.getByTestId("recent-tasks");
+    const podsList = screen.getByTestId("pods-list");
+    const recentActivity = screen.getByTestId("recent-activity");
+
+    // compareDocumentPosition bit 4 (DOCUMENT_POSITION_FOLLOWING) means the
+    // argument node comes after the reference node in document order.
+    const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
+
+    // Recent Tasks should come before Pods
+    expect(recentTasks.compareDocumentPosition(podsList) & FOLLOWING).toBeTruthy();
+    // Pods should come before Recent Activity
+    expect(podsList.compareDocumentPosition(recentActivity) & FOLLOWING).toBeTruthy();
+    // Recent Tasks should come before Recent Activity
+    expect(recentTasks.compareDocumentPosition(recentActivity) & FOLLOWING).toBeTruthy();
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -125,19 +125,16 @@ export default function OverviewPage() {
 
       <ActiveSessions sessions={activeSessions} activeCount={activeSessionCount} />
 
-      <div className="grid md:grid-cols-2 gap-8">
-        <RecentActivity />
-        <RecentTasks tasks={recentTasks} />
-      </div>
+      <RecentTasks tasks={recentTasks} />
 
-      <div className="grid md:grid-cols-2 gap-8">
-        <PodsList
-          pods={pods}
-          events={events}
-          recentTasks={recentTasks}
-          repoPodRecords={repoPodRecords ?? []}
-        />
-      </div>
+      <PodsList
+        pods={pods}
+        events={events}
+        recentTasks={recentTasks}
+        repoPodRecords={repoPodRecords ?? []}
+      />
+
+      <RecentActivity />
     </div>
   );
 }


### PR DESCRIPTION
Closes #451

## What changed
Reordered the overview panel sections so they appear in this order:
1. **Recent Tasks** (first)
2. **Pods** (with Recent Events)
3. **Recent Activity** (last)

Previously, Recent Activity and Recent Tasks were side-by-side in a 2-column grid before Pods. Now Recent Activity is moved to the end, after the Pods/Recent Events section. Each section renders full-width instead of being paired in a grid.

## How to test
1. Navigate to the Overview page (`/`)
2. Scroll down past the stats/cluster sections
3. Verify sections appear in order: Recent Tasks → Pods → Recent Activity
4. The new test in `page.test.tsx` validates DOM ordering via `compareDocumentPosition`