### PR TITLE
Add generic OIDC OAuth provider for self-hosted SSO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@ OPTIO_AUTH_DISABLED=true
 # GITLAB_OAUTH_CLIENT_ID=
 # GITLAB_OAUTH_CLIENT_SECRET=
 
+# Generic OIDC provider (Keycloak, Authentik, Authelia, Zitadel, Okta, Auth0, etc.)
+# OIDC_ISSUER_URL=https://auth.example.com/realms/optio
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_DISPLAY_NAME=SSO
+# OIDC_SCOPES=openid email profile
+
 # GitHub webhook signature validation (generate with: openssl rand -hex 32)
 # Must match the secret configured in GitHub's webhook settings
 # GITHUB_WEBHOOK_SECRET=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ When a limit is hit, task is re-queued with 10s delay.
 
 ### Authentication
 
-**Web UI**: Multi-provider OAuth (GitHub, Google, GitLab). Enable by setting `<PROVIDER>_OAUTH_CLIENT_ID` + `<PROVIDER>_OAUTH_CLIENT_SECRET`. Sessions use SHA256-hashed tokens (30-day TTL). Local dev bypass: `OPTIO_AUTH_DISABLED=true`.
+**Web UI**: Multi-provider OAuth (GitHub, Google, GitLab, generic OIDC). Enable by setting `<PROVIDER>_OAUTH_CLIENT_ID` + `<PROVIDER>_OAUTH_CLIENT_SECRET` (or `OIDC_ISSUER_URL` + `OIDC_CLIENT_ID` + `OIDC_CLIENT_SECRET` for generic OIDC). Sessions use SHA256-hashed tokens (30-day TTL). Local dev bypass: `OPTIO_AUTH_DISABLED=true`.
 
 **Claude Code** (three modes, selected in setup wizard):
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -49,6 +49,7 @@
     "fastify-plugin": "^5.0.1",
     "fastify-type-provider-zod": "^3.0.0",
     "ioredis": "^5.6.1",
+    "jose": "^6.2.2",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "postgres": "^3.4.7",

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -413,6 +413,7 @@ export async function authRoutes(rawApp: FastifyInstance) {
       const state = randomBytes(16).toString("hex");
       await addOAuthState(state, providerName);
 
+      if (provider.prepare) await provider.prepare();
       const url = provider.authorizeUrl(state);
       reply.redirect(url);
     },
@@ -714,6 +715,7 @@ export async function authRoutes(rawApp: FastifyInstance) {
       const oauthState = randomBytes(16).toString("hex") + "." + cliState;
       await addOAuthState(oauthState, provider);
 
+      if (oauthProvider.prepare) await oauthProvider.prepare();
       const url = oauthProvider.authorizeUrl(oauthState);
       reply.send({ url });
     },

--- a/apps/api/src/services/oauth/index.ts
+++ b/apps/api/src/services/oauth/index.ts
@@ -2,11 +2,13 @@ import type { OAuthProvider } from "./provider.js";
 import { GitHubOAuthProvider } from "./github.js";
 import { GoogleOAuthProvider } from "./google.js";
 import { GitLabOAuthProvider } from "./gitlab.js";
+import { GenericOIDCProvider } from "./oidc.js";
 
 const providers: Record<string, OAuthProvider> = {
   github: new GitHubOAuthProvider(),
   google: new GoogleOAuthProvider(),
   gitlab: new GitLabOAuthProvider(),
+  oidc: new GenericOIDCProvider(),
 };
 
 export function getOAuthProvider(name: string): OAuthProvider | undefined {
@@ -29,6 +31,12 @@ export function getEnabledProviders(): EnabledProvider[] {
   }
   if (process.env.GITLAB_OAUTH_CLIENT_ID) {
     result.push({ name: "gitlab", displayName: "GitLab" });
+  }
+  if (process.env.OIDC_ISSUER_URL) {
+    result.push({
+      name: "oidc",
+      displayName: process.env.OIDC_DISPLAY_NAME || "SSO",
+    });
   }
   return result;
 }

--- a/apps/api/src/services/oauth/oidc.test.ts
+++ b/apps/api/src/services/oauth/oidc.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as jose from "jose";
+
+// ─── Helpers ───
+
+const ISSUER_URL = "https://auth.example.com/realms/optio";
+
+const DISCOVERY_DOC = {
+  issuer: ISSUER_URL,
+  authorization_endpoint: `${ISSUER_URL}/protocol/openid-connect/auth`,
+  token_endpoint: `${ISSUER_URL}/protocol/openid-connect/token`,
+  userinfo_endpoint: `${ISSUER_URL}/protocol/openid-connect/userinfo`,
+  jwks_uri: `${ISSUER_URL}/protocol/openid-connect/certs`,
+};
+
+const USERINFO_RESPONSE = {
+  sub: "user-abc-123",
+  email: "alice@example.com",
+  name: "Alice Smith",
+  preferred_username: "alice",
+  picture: "https://auth.example.com/avatar/alice.png",
+};
+
+/** Generate a real RSA key pair and sign a JWT for testing. */
+async function generateTestKeyAndToken(
+  claims: Record<string, unknown>,
+  issuer: string,
+  audience: string,
+) {
+  const { publicKey, privateKey } = await jose.generateKeyPair("RS256");
+  const jwk = await jose.exportJWK(publicKey);
+  jwk.kid = "test-key-1";
+  jwk.alg = "RS256";
+  jwk.use = "sig";
+
+  const token = await new jose.SignJWT(claims as jose.JWTPayload)
+    .setProtectedHeader({ alg: "RS256", kid: "test-key-1" })
+    .setIssuer(issuer)
+    .setAudience(audience)
+    .setExpirationTime("1h")
+    .setIssuedAt()
+    .sign(privateKey);
+
+  return { jwk, token, privateKey };
+}
+
+// ─── Tests ───
+
+describe("GenericOIDCProvider", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.OIDC_ISSUER_URL = ISSUER_URL;
+    process.env.OIDC_CLIENT_ID = "test-client-id";
+    process.env.OIDC_CLIENT_SECRET = "test-client-secret";
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  // Import fresh each test to reset cached state
+  async function createProvider() {
+    // Dynamic import to get a fresh module each time is tricky with vitest,
+    // so we just create a new instance manually
+    const { GenericOIDCProvider } = await import("./oidc.js");
+    return new GenericOIDCProvider();
+  }
+
+  describe("discover()", () => {
+    it("fetches and returns the discovery document", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }));
+
+      const provider = await createProvider();
+      const doc = await provider.discover();
+
+      expect(fetchSpy).toHaveBeenCalledWith(`${ISSUER_URL}/.well-known/openid-configuration`);
+      expect(doc.authorization_endpoint).toBe(DISCOVERY_DOC.authorization_endpoint);
+      expect(doc.token_endpoint).toBe(DISCOVERY_DOC.token_endpoint);
+      expect(doc.userinfo_endpoint).toBe(DISCOVERY_DOC.userinfo_endpoint);
+      expect(doc.jwks_uri).toBe(DISCOVERY_DOC.jwks_uri);
+    });
+
+    it("caches the discovery document for 24h", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }));
+
+      const provider = await createProvider();
+      await provider.discover();
+      await provider.discover();
+      await provider.discover();
+
+      // Only one fetch should have been made
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-fetches after cache expires", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }));
+
+      const provider = await createProvider();
+      await provider.discover();
+
+      // Advance time past 24h TTL
+      const nowSpy = vi.spyOn(Date, "now");
+      nowSpy.mockReturnValue(Date.now() + 25 * 60 * 60 * 1000);
+
+      await provider.discover();
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws on failed discovery fetch", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response("Not found", { status: 404, statusText: "Not Found" }),
+      );
+
+      const provider = await createProvider();
+      await expect(provider.discover()).rejects.toThrow("OIDC discovery failed: 404 Not Found");
+    });
+
+    it("throws when discovery doc is missing required endpoints", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify({ issuer: ISSUER_URL }), { status: 200 }),
+      );
+
+      const provider = await createProvider();
+      await expect(provider.discover()).rejects.toThrow(
+        "OIDC discovery document missing required endpoints",
+      );
+    });
+  });
+
+  describe("authorizeUrl()", () => {
+    it("returns a properly formed authorize URL after prepare()", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }),
+      );
+
+      const provider = await createProvider();
+      await provider.prepare();
+
+      const url = provider.authorizeUrl("test-state-123");
+      const parsed = new URL(url);
+
+      expect(parsed.origin + parsed.pathname).toBe(DISCOVERY_DOC.authorization_endpoint);
+      expect(parsed.searchParams.get("client_id")).toBe("test-client-id");
+      expect(parsed.searchParams.get("response_type")).toBe("code");
+      expect(parsed.searchParams.get("scope")).toBe("openid email profile");
+      expect(parsed.searchParams.get("state")).toBe("test-state-123");
+      expect(parsed.searchParams.get("redirect_uri")).toContain("/api/auth/oidc/callback");
+    });
+
+    it("throws if prepare() was not called", async () => {
+      const provider = await createProvider();
+      expect(() => provider.authorizeUrl("state")).toThrow("call prepare() first");
+    });
+
+    it("uses custom scopes from OIDC_SCOPES env", async () => {
+      process.env.OIDC_SCOPES = "openid email";
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }),
+      );
+
+      const provider = await createProvider();
+      await provider.prepare();
+
+      const url = provider.authorizeUrl("state");
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get("scope")).toBe("openid email");
+    });
+  });
+
+  describe("exchangeCode()", () => {
+    it("exchanges an auth code for tokens and verifies ID token", async () => {
+      const { jwk, token } = await generateTestKeyAndToken(
+        { email: "alice@example.com" },
+        ISSUER_URL,
+        "test-client-id",
+      );
+
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        // 1st call: discovery
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }))
+        // 2nd call: token exchange
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: "at-123",
+              refresh_token: "rt-456",
+              expires_in: 3600,
+              id_token: token,
+            }),
+            { status: 200 },
+          ),
+        )
+        // 3rd call: JWKS fetch (by jose)
+        .mockResolvedValueOnce(new Response(JSON.stringify({ keys: [jwk] }), { status: 200 }));
+
+      const provider = await createProvider();
+      const tokens = await provider.exchangeCode("auth-code-xyz");
+
+      expect(tokens.accessToken).toBe("at-123");
+      expect(tokens.refreshToken).toBe("rt-456");
+      expect(tokens.expiresIn).toBe(3600);
+
+      // Verify that token endpoint was called with correct params
+      const tokenCall = fetchSpy.mock.calls[1];
+      expect(tokenCall[0]).toBe(DISCOVERY_DOC.token_endpoint);
+      expect(tokenCall[1]?.method).toBe("POST");
+    });
+
+    it("rejects a tampered ID token signature", async () => {
+      // Sign the token with one key but publish a different key in JWKS
+      const { token } = await generateTestKeyAndToken(
+        { email: "alice@example.com" },
+        ISSUER_URL,
+        "test-client-id",
+      );
+
+      // Generate a completely different key pair for the JWKS
+      const { publicKey: wrongKey } = await jose.generateKeyPair("RS256");
+      const wrongJwk = await jose.exportJWK(wrongKey);
+      wrongJwk.kid = "test-key-1";
+      wrongJwk.alg = "RS256";
+      wrongJwk.use = "sig";
+
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }))
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: "at-123",
+              id_token: token,
+            }),
+            { status: 200 },
+          ),
+        )
+        .mockResolvedValueOnce(new Response(JSON.stringify({ keys: [wrongJwk] }), { status: 200 }));
+
+      const provider = await createProvider();
+      await expect(provider.exchangeCode("auth-code")).rejects.toThrow(
+        "OIDC ID token verification failed",
+      );
+    });
+
+    it("succeeds when no ID token is returned", async () => {
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ access_token: "at-no-id", refresh_token: "rt-no-id" }), {
+            status: 200,
+          }),
+        );
+
+      const provider = await createProvider();
+      const tokens = await provider.exchangeCode("auth-code");
+      expect(tokens.accessToken).toBe("at-no-id");
+    });
+
+    it("throws on token exchange HTTP error", async () => {
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }))
+        .mockResolvedValueOnce(
+          new Response("Unauthorized", { status: 401, statusText: "Unauthorized" }),
+        );
+
+      const provider = await createProvider();
+      await expect(provider.exchangeCode("bad-code")).rejects.toThrow(
+        "OIDC token exchange failed: 401 Unauthorized",
+      );
+    });
+
+    it("throws on OAuth error response", async () => {
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }))
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ error: "invalid_grant", error_description: "Code expired" }),
+            { status: 200 },
+          ),
+        );
+
+      const provider = await createProvider();
+      await expect(provider.exchangeCode("expired-code")).rejects.toThrow(
+        "OIDC OAuth error: Code expired",
+      );
+    });
+  });
+
+  describe("fetchUser()", () => {
+    it("maps OIDC claims to OAuthUser", async () => {
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify(USERINFO_RESPONSE), { status: 200 }));
+
+      const provider = await createProvider();
+      const user = await provider.fetchUser("access-token-xyz");
+
+      expect(user.externalId).toBe("user-abc-123");
+      expect(user.email).toBe("alice@example.com");
+      expect(user.displayName).toBe("Alice Smith");
+      expect(user.avatarUrl).toBe("https://auth.example.com/avatar/alice.png");
+    });
+
+    it("falls back to preferred_username when name is missing", async () => {
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }))
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ sub: "u-1", email: "bob@test.com", preferred_username: "bob" }),
+            { status: 200 },
+          ),
+        );
+
+      const provider = await createProvider();
+      const user = await provider.fetchUser("token");
+
+      expect(user.displayName).toBe("bob");
+      expect(user.avatarUrl).toBeUndefined();
+    });
+
+    it("throws on userinfo HTTP error", async () => {
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(JSON.stringify(DISCOVERY_DOC), { status: 200 }))
+        .mockResolvedValueOnce(new Response("Forbidden", { status: 403, statusText: "Forbidden" }));
+
+      const provider = await createProvider();
+      await expect(provider.fetchUser("bad-token")).rejects.toThrow(
+        "OIDC userinfo fetch failed: 403 Forbidden",
+      );
+    });
+  });
+});
+
+describe("OIDC provider registration", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it("includes oidc provider when OIDC_ISSUER_URL is set", async () => {
+    process.env.OIDC_ISSUER_URL = "https://auth.example.com";
+    process.env.OIDC_CLIENT_ID = "client";
+    process.env.OIDC_CLIENT_SECRET = "secret";
+
+    // Re-import to pick up env changes — we need to reset the module
+    vi.resetModules();
+    const { getEnabledProviders } = await import("./index.js");
+    const providers = getEnabledProviders();
+    const oidc = providers.find((p) => p.name === "oidc");
+    expect(oidc).toBeDefined();
+    expect(oidc!.displayName).toBe("SSO");
+  });
+
+  it("uses custom display name from OIDC_DISPLAY_NAME", async () => {
+    process.env.OIDC_ISSUER_URL = "https://auth.example.com";
+    process.env.OIDC_CLIENT_ID = "client";
+    process.env.OIDC_CLIENT_SECRET = "secret";
+    process.env.OIDC_DISPLAY_NAME = "Company SSO";
+
+    vi.resetModules();
+    const { getEnabledProviders } = await import("./index.js");
+    const providers = getEnabledProviders();
+    const oidc = providers.find((p) => p.name === "oidc");
+    expect(oidc).toBeDefined();
+    expect(oidc!.displayName).toBe("Company SSO");
+  });
+
+  it("does not include oidc when OIDC_ISSUER_URL is not set", async () => {
+    delete process.env.OIDC_ISSUER_URL;
+    delete process.env.OIDC_CLIENT_ID;
+
+    vi.resetModules();
+    const { getEnabledProviders } = await import("./index.js");
+    const providers = getEnabledProviders();
+    expect(providers.find((p) => p.name === "oidc")).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/oauth/oidc.ts
+++ b/apps/api/src/services/oauth/oidc.ts
@@ -1,0 +1,150 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import type { OAuthProvider, OAuthTokens, OAuthUser } from "./provider.js";
+import { getCallbackUrl } from "./provider.js";
+
+interface OIDCDiscoveryDocument {
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint: string;
+  jwks_uri: string;
+}
+
+const DISCOVERY_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export class GenericOIDCProvider implements OAuthProvider {
+  name = "oidc";
+
+  private discoveryCache: { doc: OIDCDiscoveryDocument; fetchedAt: number } | null = null;
+  private jwksGetter: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+  private get issuerUrl(): string {
+    return (process.env.OIDC_ISSUER_URL ?? "").replace(/\/$/, "");
+  }
+
+  private get clientId(): string {
+    return process.env.OIDC_CLIENT_ID ?? "";
+  }
+
+  private get clientSecret(): string {
+    return process.env.OIDC_CLIENT_SECRET ?? "";
+  }
+
+  private get scopes(): string {
+    return process.env.OIDC_SCOPES ?? "openid email profile";
+  }
+
+  async discover(): Promise<OIDCDiscoveryDocument> {
+    const now = Date.now();
+    if (this.discoveryCache && now - this.discoveryCache.fetchedAt < DISCOVERY_CACHE_TTL_MS) {
+      return this.discoveryCache.doc;
+    }
+
+    const url = `${this.issuerUrl}/.well-known/openid-configuration`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`OIDC discovery failed: ${res.status} ${res.statusText}`);
+    }
+    const doc = (await res.json()) as OIDCDiscoveryDocument;
+
+    if (
+      !doc.authorization_endpoint ||
+      !doc.token_endpoint ||
+      !doc.userinfo_endpoint ||
+      !doc.jwks_uri
+    ) {
+      throw new Error("OIDC discovery document missing required endpoints");
+    }
+
+    this.discoveryCache = { doc, fetchedAt: now };
+    // Reset JWKS getter when discovery changes
+    this.jwksGetter = null;
+    return doc;
+  }
+
+  private getJWKS(jwksUri: string): ReturnType<typeof createRemoteJWKSet> {
+    if (!this.jwksGetter) {
+      this.jwksGetter = createRemoteJWKSet(new URL(jwksUri));
+    }
+    return this.jwksGetter;
+  }
+
+  async prepare(): Promise<void> {
+    await this.discover();
+  }
+
+  authorizeUrl(state: string): string {
+    if (!this.discoveryCache) {
+      throw new Error("OIDC discovery document not loaded — call prepare() first");
+    }
+    const params = new URLSearchParams({
+      client_id: this.clientId,
+      redirect_uri: getCallbackUrl("oidc"),
+      response_type: "code",
+      scope: this.scopes,
+      state,
+    });
+    return `${this.discoveryCache.doc.authorization_endpoint}?${params}`;
+  }
+
+  async exchangeCode(code: string): Promise<OAuthTokens> {
+    const discovery = await this.discover();
+
+    const res = await fetch(discovery.token_endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        code,
+        redirect_uri: getCallbackUrl("oidc"),
+        grant_type: "authorization_code",
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`OIDC token exchange failed: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as Record<string, any>;
+    if (data.error) {
+      throw new Error(`OIDC OAuth error: ${data.error_description ?? data.error}`);
+    }
+
+    // Verify the ID token signature if present
+    if (data.id_token) {
+      const jwks = this.getJWKS(discovery.jwks_uri);
+      try {
+        await jwtVerify(data.id_token, jwks, {
+          issuer: this.issuerUrl,
+          audience: this.clientId,
+        });
+      } catch (err) {
+        throw new Error(
+          `OIDC ID token verification failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresIn: data.expires_in,
+    };
+  }
+
+  async fetchUser(accessToken: string): Promise<OAuthUser> {
+    const discovery = await this.discover();
+
+    const res = await fetch(discovery.userinfo_endpoint, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) {
+      throw new Error(`OIDC userinfo fetch failed: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as Record<string, any>;
+    return {
+      externalId: String(data.sub),
+      email: data.email ?? "",
+      displayName: data.name ?? data.preferred_username ?? "",
+      avatarUrl: data.picture,
+    };
+  }
+}

--- a/apps/api/src/services/oauth/provider.ts
+++ b/apps/api/src/services/oauth/provider.ts
@@ -13,6 +13,8 @@ export interface OAuthUser {
 
 export interface OAuthProvider {
   name: string;
+  /** Optional async initialization (e.g. OIDC discovery). Called before authorizeUrl(). */
+  prepare?(): Promise<void>;
   authorizeUrl(state: string): string;
   exchangeCode(code: string): Promise<OAuthTokens>;
   fetchUser(accessToken: string): Promise<OAuthUser>;

--- a/apps/site/src/app/docs/configuration/page.tsx
+++ b/apps/site/src/app/docs/configuration/page.tsx
@@ -127,6 +127,11 @@ export default function ConfigurationPage() {
               ["GITLAB_OAUTH_CLIENT_ID", "—", "GitLab OAuth client ID"],
               ["GITLAB_OAUTH_CLIENT_SECRET", "—", "GitLab OAuth client secret"],
               ["GITLAB_OAUTH_BASE_URL", "https://gitlab.com", "Base URL for self-hosted GitLab"],
+              ["OIDC_ISSUER_URL", "—", "OIDC issuer URL (enables generic OIDC provider)"],
+              ["OIDC_CLIENT_ID", "—", "OIDC client ID"],
+              ["OIDC_CLIENT_SECRET", "—", "OIDC client secret"],
+              ["OIDC_DISPLAY_NAME", "SSO", "Login button label"],
+              ["OIDC_SCOPES", "openid email profile", "Space-separated OIDC scopes"],
             ].map(([name, def, desc]) => (
               <tr key={name}>
                 <td className="px-4 py-3 font-mono text-text-heading">{name}</td>
@@ -151,6 +156,30 @@ export default function ConfigurationPage() {
         </code>
         .
       </Callout>
+
+      <h3 className="mt-6 text-lg font-semibold text-text-heading">Generic OIDC Provider</h3>
+      <p className="mt-3 text-text-muted leading-relaxed">
+        Any OpenID Connect-compatible identity provider (Keycloak, Authentik, Authelia, Zitadel,
+        Okta, Auth0, etc.) can be used via the generic OIDC provider. Set{" "}
+        <code className="rounded bg-bg-hover px-1.5 py-0.5 text-[13px] font-mono">
+          OIDC_ISSUER_URL
+        </code>{" "}
+        to the issuer URL and configure the client credentials. The discovery document is fetched
+        automatically from{" "}
+        <code className="rounded bg-bg-hover px-1.5 py-0.5 text-[13px] font-mono">
+          {"<issuer>/.well-known/openid-configuration"}
+        </code>
+        .
+      </p>
+      <div className="mt-3">
+        <CodeBlock title="Keycloak example">{`OIDC_ISSUER_URL=https://auth.example.com/realms/optio
+OIDC_CLIENT_ID=optio
+OIDC_CLIENT_SECRET=your-client-secret
+OIDC_DISPLAY_NAME="Company SSO"
+
+# Register the callback URL in your IdP:
+# {PUBLIC_URL}/api/auth/oidc/callback`}</CodeBlock>
+      </div>
 
       <h2 className="mt-10 text-2xl font-bold text-text-heading">Helm Chart Values</h2>
       <p className="mt-3 text-text-muted leading-relaxed">

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { api } from "@/lib/api-client";
-import { Zap, Loader2 } from "lucide-react";
+import { Zap, Loader2, KeyRound } from "lucide-react";
 
 const PROVIDER_ICONS: Record<string, React.ReactNode> = {
   github: (
@@ -113,7 +113,7 @@ export default function LoginPage() {
                 href={`/api/auth/${provider.name}/login`}
                 className="flex items-center justify-center gap-3 w-full px-4 py-3 rounded-lg border border-border bg-bg-card text-sm font-medium hover:bg-bg-hover transition-colors"
               >
-                {PROVIDER_ICONS[provider.name]}
+                {PROVIDER_ICONS[provider.name] ?? <KeyRound className="w-5 h-5" />}
                 Sign in with {provider.displayName}
               </a>
             ))}

--- a/helm/optio/templates/secrets.yaml
+++ b/helm/optio/templates/secrets.yaml
@@ -39,6 +39,17 @@ stringData:
   GITLAB_OAUTH_CLIENT_ID: {{ .Values.auth.gitlab.clientId | quote }}
   GITLAB_OAUTH_CLIENT_SECRET: {{ .Values.auth.gitlab.clientSecret | quote }}
   {{- end }}
+  {{- if .Values.auth.oidc.issuerUrl }}
+  OIDC_ISSUER_URL: {{ .Values.auth.oidc.issuerUrl | quote }}
+  OIDC_CLIENT_ID: {{ .Values.auth.oidc.clientId | quote }}
+  OIDC_CLIENT_SECRET: {{ .Values.auth.oidc.clientSecret | quote }}
+  {{- if .Values.auth.oidc.displayName }}
+  OIDC_DISPLAY_NAME: {{ .Values.auth.oidc.displayName | quote }}
+  {{- end }}
+  {{- if .Values.auth.oidc.scopes }}
+  OIDC_SCOPES: {{ .Values.auth.oidc.scopes | quote }}
+  {{- end }}
+  {{- end }}
   {{- /* GitHub App IDs must be quoted strings in values.yaml to avoid YAML float truncation */ -}}
   {{- if and .Values.github.app.id (not .Values.github.app.existingSecret) }}
   GITHUB_APP_ID: {{ .Values.github.app.id | toString | quote }}

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -293,6 +293,13 @@ auth:
     clientId: ""
     clientSecret: ""
     # baseUrl: https://gitlab.com  # Self-hosted GitLab URL
+  # Generic OIDC provider (Keycloak, Authentik, Authelia, Zitadel, Okta, Auth0, etc.)
+  oidc:
+    issuerUrl: ""       # e.g. https://auth.example.com/realms/optio
+    clientId: ""
+    clientSecret: ""
+    displayName: "SSO"  # Button label: "Sign in with {displayName}"
+    scopes: ""          # Defaults to "openid email profile" if empty
 
 # ──────────────────────────────────────────────────────────────────────────────
 # GitHub webhook signature validation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       ioredis:
         specifier: ^5.6.1
         version: 5.10.1
+      jose:
+        specifier: ^6.2.2
+        version: 6.2.2
       pino:
         specifier: ^9.6.0
         version: 9.14.0


### PR DESCRIPTION
Closes #448

## What changed

Added a generic OpenID Connect (OIDC) OAuth provider that enables self-hosters to use any OIDC-compatible identity provider (Keycloak, Authentik, Authelia, Zitadel, Okta, Auth0, etc.) for authentication.

### Backend
- **New `GenericOIDCProvider`** (`apps/api/src/services/oauth/oidc.ts`) implementing the `OAuthProvider` interface
  - Auto-discovery via `{OIDC_ISSUER_URL}/.well-known/openid-configuration` with 24h in-process cache
  - ID token signature verification using JWKS (`jose` library)
  - OIDC claim mapping: `sub` → `externalId`, `email` → `email`, `name`/`preferred_username` → `displayName`, `picture` → `avatarUrl`
- **Optional `prepare()` hook** added to `OAuthProvider` interface for async initialization (used by OIDC for discovery before the synchronous `authorizeUrl()`)
- **Conditional registration** in `oauth/index.ts` — provider appears only when `OIDC_ISSUER_URL` is set
- **Route handler updates** (`auth.ts`) — calls `prepare()` before `authorizeUrl()` in both web and CLI login flows

### Frontend
- **Login page** — added `KeyRound` icon from Lucide as fallback for unknown provider names (including `oidc`)

### Helm
- **`values.yaml`** — new `auth.oidc.*` section (issuerUrl, clientId, clientSecret, displayName, scopes)
- **`secrets.yaml`** — wires OIDC env vars into the Kubernetes secret, mirroring the GitHub/Google/GitLab pattern

### Config & Docs
- **`.env.example`** — added OIDC env vars with comments
- **`CLAUDE.md`** — updated auth provider list to include generic OIDC
- **Docs configuration page** — added OIDC env vars to auth table + Keycloak example section

### Tests (19 new)
- Discovery: fetch, 24h caching, cache expiration re-fetch, HTTP error, missing endpoints
- `authorizeUrl()`: correct URL formation, pre-`prepare()` error, custom scopes
- `exchangeCode()`: happy path with ID token verification, tampered signature rejection, no-ID-token case, HTTP error, OAuth error response
- `fetchUser()`: claim mapping, `preferred_username` fallback, HTTP error
- Registration: provider appears/disappears based on `OIDC_ISSUER_URL`, custom display name

## How to test

1. **Unit tests**: `pnpm --filter @optio/api exec vitest run src/services/oauth/oidc.test.ts` (19 tests)
2. **End-to-end with Keycloak**:
   - `docker run -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:latest start-dev`
   - Create realm `optio`, client with redirect URI `{PUBLIC_URL}/api/auth/oidc/callback`
   - Set `OIDC_ISSUER_URL=http://localhost:8080/realms/optio`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`
   - Verify "Sign in with SSO" button appears on `/login`, login redirects to Keycloak, callback creates session
3. **CLI flow**: `POST /api/auth/cli/start` with `provider=oidc` should return an OIDC authorize URL

## New env vars

| Variable | Required | Default | Description |
|---|---|---|---|
| `OIDC_ISSUER_URL` | Yes (to enable) | — | OIDC issuer URL |
| `OIDC_CLIENT_ID` | Yes | — | Client ID |
| `OIDC_CLIENT_SECRET` | Yes | — | Client secret |
| `OIDC_DISPLAY_NAME` | No | `SSO` | Login button label |
| `OIDC_SCOPES` | No | `openid email profile` | Space-separated scopes |