### PR TITLE
Usage endpoint should trigger auth banner when Claude OAuth token is expired

### DIFF
--- a/apps/api/src/services/auth-service.test.ts
+++ b/apps/api/src/services/auth-service.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+// Mock heavy dependencies so the module can be imported in isolation.
+
+const mockRecordAuthEvent = vi.fn().mockResolvedValue(undefined);
+vi.mock("./auth-failure-detector.js", () => ({
+  recordAuthEvent: (...args: unknown[]) => mockRecordAuthEvent(...args),
+}));
+
+const mockPublishEvent = vi.fn().mockResolvedValue(undefined);
+vi.mock("./event-bus.js", () => ({
+  publishEvent: (...args: unknown[]) => mockPublishEvent(...args),
+}));
+
+vi.mock("./secret-service.js", () => ({
+  retrieveSecret: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+// Stub getClaudeAuthToken — default: token available
+vi.mock("./auth-service.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./auth-service.js")>();
+  return {
+    ...original,
+  };
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+// We need to control `getClaudeAuthToken` and `fetch` from inside the module.
+// Since getClaudeAuthToken is a module-level function, we mock the child_process
+// and fs modules it depends on, then override the credential cache via
+// the module's own functions.  However, it's simpler to mock `fetch` and provide
+// a token via the secret-service fallback path.
+
+const { retrieveSecret } = await import("./secret-service.js");
+const mockedRetrieveSecret = vi.mocked(retrieveSecret);
+
+// Re-import the function under test AFTER mocks are in place.
+const { getClaudeUsage, invalidateUsageCache } = await import("./auth-service.js");
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("getClaudeUsage — auth failure handling", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateUsageCache();
+    originalFetch = globalThis.fetch;
+    // Provide a token via the secrets-store fallback path
+    mockedRetrieveSecret.mockResolvedValue("test-oauth-token");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("records auth event and publishes auth:failed on 401", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized"),
+    });
+
+    const result = await getClaudeUsage();
+
+    expect(result.available).toBe(false);
+    expect(result.error).toBe("Usage API returned 401");
+
+    // Should record the auth failure event
+    expect(mockRecordAuthEvent).toHaveBeenCalledWith(
+      "claude",
+      "Usage API returned 401",
+      "usage-endpoint",
+    );
+
+    // Should publish a WebSocket auth:failed event
+    expect(mockPublishEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "auth:failed",
+        message: expect.stringContaining("expired"),
+      }),
+    );
+  });
+
+  it("records auth event and publishes auth:failed on 403", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve("Forbidden"),
+    });
+
+    const result = await getClaudeUsage();
+
+    expect(result.available).toBe(false);
+    expect(result.error).toBe("Usage API returned 403");
+
+    expect(mockRecordAuthEvent).toHaveBeenCalledWith(
+      "claude",
+      "Usage API returned 403",
+      "usage-endpoint",
+    );
+    expect(mockPublishEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "auth:failed" }));
+  });
+
+  it("does NOT record auth event on non-auth errors (e.g. 500)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Internal Server Error"),
+    });
+
+    const result = await getClaudeUsage();
+
+    expect(result.available).toBe(false);
+    expect(result.error).toBe("Usage API returned 500");
+    expect(mockRecordAuthEvent).not.toHaveBeenCalled();
+    expect(mockPublishEvent).not.toHaveBeenCalled();
+  });
+
+  it("still returns the error result even if recordAuthEvent throws", async () => {
+    mockRecordAuthEvent.mockRejectedValueOnce(new Error("db down"));
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized"),
+    });
+
+    const result = await getClaudeUsage();
+
+    expect(result.available).toBe(false);
+    expect(result.error).toBe("Usage API returned 401");
+  });
+
+  it("still returns the error result even if publishEvent throws", async () => {
+    mockPublishEvent.mockRejectedValueOnce(new Error("redis down"));
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized"),
+    });
+
+    const result = await getClaudeUsage();
+
+    expect(result.available).toBe(false);
+    expect(result.error).toBe("Usage API returned 401");
+  });
+
+  it("returns cached result for successful usage calls", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          five_hour: { utilization: 0.5, resets_at: "2026-04-20T12:00:00Z" },
+          seven_day: null,
+          seven_day_sonnet: null,
+          seven_day_opus: null,
+        }),
+    });
+
+    const first = await getClaudeUsage();
+    expect(first.available).toBe(true);
+    expect(first.fiveHour?.utilization).toBe(0.5);
+
+    // Second call should use cache
+    const second = await getClaudeUsage();
+    expect(second).toEqual(first);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/auth-service.ts
+++ b/apps/api/src/services/auth-service.ts
@@ -216,6 +216,31 @@ export async function getClaudeUsage(): Promise<ClaudeUsageResult> {
     if (!res.ok) {
       const body = await res.text().catch(() => "");
       logger.warn({ status: res.status, body }, "Failed to fetch Claude usage");
+
+      // On auth-failure status codes, surface the failure immediately so the
+      // UI shows the re-auth banner without waiting for the next poll cycle.
+      if (res.status === 401 || res.status === 403) {
+        const errorMsg = `Usage API returned ${res.status}`;
+        try {
+          const { recordAuthEvent } = await import("./auth-failure-detector.js");
+          await recordAuthEvent("claude", errorMsg, "usage-endpoint");
+        } catch {
+          // non-fatal — best-effort recording
+        }
+        try {
+          const { publishEvent } = await import("./event-bus.js");
+          await publishEvent({
+            type: "auth:failed",
+            message:
+              "Claude Code OAuth token has expired. Go to Secrets to paste a new token, or re-run 'claude setup-token'.",
+            timestamp: new Date().toISOString(),
+          });
+        } catch {
+          // non-fatal — best-effort notification
+        }
+        invalidateUsageCache();
+      }
+
       return { available: false, error: `Usage API returned ${res.status}` };
     }
 


### PR DESCRIPTION
Closes #454

## What changed

When `getClaudeUsage()` in `auth-service.ts` receives a **401 or 403** from Anthropic's usage API (`https://api.anthropic.com/api/oauth/usage`), it now:

1. **Records an auth event** via `recordAuthEvent('claude', ..., 'usage-endpoint')` so the failure is visible to `getRecentAuthFailures()` and surfaces in `/api/auth/usage`'s `authFailures.claude` flag.
2. **Publishes a WebSocket `auth:failed` event** so connected clients trigger the `GlobalAuthBanner` immediately — without waiting for the next 5-minute `/api/auth/status` poll or a task launch failure.
3. **Invalidates the usage cache** so subsequent calls don't return stale "healthy" data.

This brings the usage endpoint path in line with the agent-output path (`task-worker.ts`) and the proactive-probe path (`token-validation-worker.ts`), both of which already publish `auth:failed` events.

Both `recordAuthEvent` and `publishEvent` are wrapped in try/catch so failures in these side-effects don't break the usage response itself.

## How to test

1. Set a deliberately invalid or expired `CLAUDE_CODE_OAUTH_TOKEN` in secrets
2. Open any page that calls `/api/auth/usage` (e.g., the dashboard)
3. The "Claude OAuth token expired" banner should appear within seconds
4. Run `npx vitest run apps/api/src/services/auth-service.test.ts` — all 6 tests pass, covering:
   - 401 triggers `recordAuthEvent` + `publishEvent`
   - 403 triggers `recordAuthEvent` + `publishEvent`
   - 500 does **not** trigger auth failure handling
   - Errors in `recordAuthEvent` or `publishEvent` don't break the response
   - Successful usage calls are cached correctly