### PR TITLE
fix(ticket-sync): fall back to GitHub App / PAT when no provider secret

### DIFF
--- a/apps/api/src/services/ticket-sync-service.test.ts
+++ b/apps/api/src/services/ticket-sync-service.test.ts
@@ -45,6 +45,10 @@ vi.mock("./secret-service.js", () => ({
   retrieveSecret: vi.fn(),
 }));
 
+vi.mock("./github-token-service.js", () => ({
+  getGitHubToken: vi.fn(),
+}));
+
 vi.mock("../logger.js", () => ({
   logger: {
     info: vi.fn(),
@@ -60,6 +64,7 @@ import { getTicketProvider } from "@optio/ticket-providers";
 import * as taskService from "./task-service.js";
 import { taskQueue } from "../workers/task-worker.js";
 import { retrieveSecret } from "./secret-service.js";
+import { getGitHubToken } from "./github-token-service.js";
 import { syncAllTickets } from "./ticket-sync-service.js";
 import { logger } from "../logger.js";
 
@@ -106,6 +111,8 @@ describe("ticket-sync-service", () => {
     vi.clearAllMocks();
     // Default: no secrets stored
     vi.mocked(retrieveSecret).mockRejectedValue(new Error("Secret not found"));
+    // Default: no GitHub App / PAT available (triggers warn but doesn't throw)
+    vi.mocked(getGitHubToken).mockRejectedValue(new Error("No GitHub token available"));
   });
 
   it("syncs new tickets and creates tasks", async () => {
@@ -510,6 +517,83 @@ describe("ticket-sync-service", () => {
         enabled: false,
       }),
     );
+  });
+
+  it("falls back to getGitHubToken for GitHub providers without a configured token", async () => {
+    mockDbSelect([
+      {
+        id: "p1",
+        source: "github",
+        config: { owner: "o", repo: "r" },
+        enabled: true,
+      },
+    ]);
+
+    vi.mocked(getGitHubToken).mockResolvedValue("ghs_app_installation_token");
+
+    const mockProvider = {
+      fetchActionableTickets: vi.fn().mockResolvedValue([]),
+    };
+    vi.mocked(getTicketProvider).mockReturnValue(mockProvider as any);
+
+    await syncAllTickets();
+
+    expect(getGitHubToken).toHaveBeenCalledWith({ server: true });
+    const configPassedToProvider = mockProvider.fetchActionableTickets.mock.calls[0][0];
+    expect(configPassedToProvider.token).toBe("ghs_app_installation_token");
+  });
+
+  it("does not call getGitHubToken when a token is already supplied via config", async () => {
+    mockDbSelect([
+      {
+        id: "p1",
+        source: "github",
+        config: { owner: "o", repo: "r", token: "inline-token" },
+        enabled: true,
+      },
+    ]);
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    await syncAllTickets();
+
+    expect(getGitHubToken).not.toHaveBeenCalled();
+  });
+
+  it("does not call getGitHubToken when a token is supplied via provider secret", async () => {
+    mockDbSelect([
+      { id: "p1", source: "github", config: { owner: "o", repo: "r" }, enabled: true },
+    ]);
+    vi.mocked(retrieveSecret).mockResolvedValue(JSON.stringify({ token: "secret-token" }));
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    await syncAllTickets();
+
+    expect(getGitHubToken).not.toHaveBeenCalled();
+  });
+
+  it("does not call getGitHubToken for non-github providers", async () => {
+    mockDbSelect([
+      {
+        id: "p1",
+        source: "jira",
+        config: { baseUrl: "https://j.example.com", email: "a@b.com" },
+        enabled: true,
+      },
+    ]);
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    await syncAllTickets();
+
+    expect(getGitHubToken).not.toHaveBeenCalled();
   });
 
   it("downgrades repeated sync errors to debug level", async () => {

--- a/apps/api/src/services/ticket-sync-service.ts
+++ b/apps/api/src/services/ticket-sync-service.ts
@@ -8,6 +8,7 @@ import * as taskService from "./task-service.js";
 import * as taskConfigService from "./task-config-service.js";
 import { taskQueue } from "../workers/task-worker.js";
 import { retrieveSecret } from "./secret-service.js";
+import { getGitHubToken } from "./github-token-service.js";
 import { logger } from "../logger.js";
 import { recordAuthEvent } from "./auth-failure-detector.js";
 
@@ -38,6 +39,20 @@ export async function syncAllTickets(): Promise<number> {
         mergedConfig = { ...mergedConfig, ...credentials };
       } catch {
         // No secrets stored for this provider — use config as-is
+      }
+
+      // GitHub fallback: if no token was supplied via config or provider secret,
+      // resolve one via the centralized token service (GitHub App installation
+      // token → PAT). Lets users run ticket sync with only a GitHub App configured.
+      if (providerConfig.source === "github" && !(mergedConfig as { token?: string }).token) {
+        try {
+          (mergedConfig as { token?: string }).token = await getGitHubToken({ server: true });
+        } catch (err) {
+          logger.warn(
+            { err, providerId: providerConfig.id },
+            "[ticket-sync] No GitHub token available from app/PAT fallback",
+          );
+        }
       }
 
       const provider = getTicketProvider(providerConfig.source as TicketSource);


### PR DESCRIPTION
## Summary

- GitHub ticket sync threw `"GitHub provider requires token, owner, and repo in config"` whenever no provider-specific secret was stored, even if a GitHub App was configured server-wide.
- After merging config + provider secret, we now resolve a token via the existing `getGitHubToken({ server: true })` service (GitHub App installation token → PAT fallback) for `source === "github"` providers that still lack a `token`.
- Matches the resolver hierarchy already used elsewhere in the codebase (task worker, PR watcher, etc.).

## Test plan

- [x] Added unit tests covering: App-only configuration, inline config token, provider-secret token, and non-GitHub providers (no-op).
- [x] `pnpm --filter @optio/api test` — all 2005 tests pass
- [x] `pnpm turbo typecheck` — clean
- [ ] Manual verification with a GitHub App configured and no PAT present

Closes #458