### PR TITLE
feat(helm): add GKE & Gateway deployment enhancements

### DIFF
--- a/helm/optio/Chart.yaml
+++ b/helm/optio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: optio
 description: AI Agent Workflow Orchestration
-kubeVersion: ">=1.33.0"
+kubeVersion: ">=1.33.0-0"
 type: application
 version: 0.1.0
 appVersion: "0.1.0"

--- a/helm/optio/templates/api-deployment.yaml
+++ b/helm/optio/templates/api-deployment.yaml
@@ -160,6 +160,7 @@ spec:
   ports:
     - port: {{ .Values.api.port }}
       targetPort: {{ .Values.api.port }}
+      appProtocol: kubernetes.io/ws  # WebSocket support for /ws/* endpoints
       {{- if and (eq .Values.api.service.type "NodePort") .Values.api.service.nodePort }}
       nodePort: {{ .Values.api.service.nodePort }}
       {{- end }}

--- a/helm/optio/templates/gateway.yaml
+++ b/helm/optio/templates/gateway.yaml
@@ -1,5 +1,5 @@
 {{- include "optio.validateNetworking" . }}
-{{- if and .Values.gatewayAPI.enabled (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") }}
+{{- if and .Values.gatewayAPI.enabled (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") (not .Values.gatewayAPI.parentRefs) }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/helm/optio/templates/httproute.yaml
+++ b/helm/optio/templates/httproute.yaml
@@ -13,8 +13,12 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
+    {{- if .Values.gatewayAPI.parentRefs }}
+    {{- toYaml .Values.gatewayAPI.parentRefs | nindent 4 }}
+    {{- else }}
     - name: {{ .Release.Name }}-gateway
       namespace: {{ .Values.namespace }}
+    {{- end }}
   {{- if .Values.gatewayAPI.hostname }}
   hostnames:
     - {{ .Values.gatewayAPI.hostname | quote }}

--- a/images/build.sh
+++ b/images/build.sh
@@ -3,40 +3,66 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Parse arguments
 TAG="${1:-latest}"
+PLATFORM=""
+
+# Check for --platform flag in any position
+i=0
+next_is_platform=false
+for arg in "$@"; do
+  i=$((i + 1))
+  if [[ "$next_is_platform" == true ]]; then
+    PLATFORM="$arg"
+    next_is_platform=false
+  elif [[ "$arg" == --platform=* ]]; then
+    PLATFORM="${arg#*=}"
+  elif [[ "$arg" == "--platform" ]]; then
+    next_is_platform=true
+  fi
+done
+
+# Build platform flag if specified
+PLATFORM_FLAG=""
+if [ -n "${PLATFORM}" ]; then
+  PLATFORM_FLAG="--platform ${PLATFORM}"
+  echo "Building for platform: ${PLATFORM}"
+fi
 
 echo "=== Building Optio Agent Images ==="
+echo "Tag: ${TAG}"
 
 # Base image (all others depend on this)
 echo "[1/8] Building optio-base..."
-docker build -t "optio-base:${TAG}" -f "${SCRIPT_DIR}/base.Dockerfile" "${ROOT_DIR}"
+docker build ${PLATFORM_FLAG} -t "optio-base:${TAG}" -f "${SCRIPT_DIR}/base.Dockerfile" "${ROOT_DIR}"
 
 echo "Using base internal image: optio-base:${TAG}"
 BASE_IMAGE="optio-base:${TAG}"
 
 # Language-specific images (can be built in parallel)
 echo "[2/8] Building optio-node..."
-docker build -t "optio-node:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/node.Dockerfile" "${ROOT_DIR}" &
+docker build ${PLATFORM_FLAG} -t "optio-node:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/node.Dockerfile" "${ROOT_DIR}" &
 
 echo "[3/8] Building optio-python..."
-docker build -t "optio-python:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/python.Dockerfile" "${ROOT_DIR}" &
+docker build ${PLATFORM_FLAG} -t "optio-python:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/python.Dockerfile" "${ROOT_DIR}" &
 
 echo "[4/8] Building optio-go..."
-docker build -t "optio-go:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/go.Dockerfile" "${ROOT_DIR}" &
+docker build ${PLATFORM_FLAG} -t "optio-go:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/go.Dockerfile" "${ROOT_DIR}" &
 
 echo "[5/8] Building optio-rust..."
-docker build -t "optio-rust:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/rust.Dockerfile" "${ROOT_DIR}" &
+docker build ${PLATFORM_FLAG} -t "optio-rust:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/rust.Dockerfile" "${ROOT_DIR}" &
 
 echo "[6/8] Building optio-dind..."
-docker build -t "optio-dind:${TAG}" -f "${SCRIPT_DIR}/dind.Dockerfile" "${ROOT_DIR}" &
+docker build ${PLATFORM_FLAG} -t "optio-dind:${TAG}" -f "${SCRIPT_DIR}/dind.Dockerfile" "${ROOT_DIR}" &
 
 echo "[7/8] Building optio-optio (operations assistant)..."
-docker build -t "optio-optio:${TAG}" -f "${ROOT_DIR}/Dockerfile.optio" "${ROOT_DIR}" &
+docker build ${PLATFORM_FLAG} -t "optio-optio:${TAG}" -f "${ROOT_DIR}/Dockerfile.optio" "${ROOT_DIR}" &
 
 wait
 
 echo "[8/8] Building optio-full..."
-docker build -t "optio-full:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/full.Dockerfile" "${ROOT_DIR}"
+docker build ${PLATFORM_FLAG} -t "optio-full:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/full.Dockerfile" "${ROOT_DIR}"
 
 # Tag optio-base as the default
 docker tag "optio-base:${TAG}" "optio-agent:${TAG}"


### PR DESCRIPTION
## Summary

Adds support for deploying Optio on GKE clusters with Gateway API and enables multi-architecture container image builds.

## Changes

**Helm Chart:**
- Fix kubeVersion constraint to `>=1.33.0-0` (allows GKE pre-release versions)
- Add `appProtocol: kubernetes.io/ws` to API service for WebSocket routing via Gateway
- Support external Gateway via configurable `gatewayAPI.parentRefs` in HTTPRoute
- Only create Gateway resource when `parentRefs` is not configured

**Build Script:**
- Add `--platform` flag to `images/build.sh` for cross-platform builds (ARM/AMD64)

## Testing

- [ ] Tests pass (`pnpm turbo test`)
- [ ] Typechecks pass (`pnpm turbo typecheck`)
- [ ] Helm chart validates (`helm lint`)
- [ ] Deploys successfully on GKE 1.33.x cluster
- [ ] WebSocket connections work through Gateway API

## Related

Enables deployment on managed GKE clusters with external Gateway API configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)