### PR TITLE
fix: correct sub-hour timezone drift in getETDate

### DIFF
--- a/packages/shared/src/utils/off-peak.ts
+++ b/packages/shared/src/utils/off-peak.ts
@@ -135,10 +135,11 @@ function getETDate(ref: Date, targetHourET: number): Date {
     `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}T${String(targetHourET).padStart(2, "0")}:00:00`,
   );
 
-  // Get what hour ET thinks this is
-  const { hour: guessHour } = getETComponents(guess);
-  const drift = guessHour - targetHourET;
-  guess.setHours(guess.getHours() - drift);
+  // Get what ET thinks this is, including minutes (sub-hour timezone offsets like IST = UTC+5:30
+  // would otherwise introduce a 30-minute drift when using setHours in local time).
+  const { hour: guessHour, minute: guessMinute } = getETComponents(guess);
+  const driftMs = (guessHour - targetHourET) * 60 * 60 * 1000 + guessMinute * 60 * 1000;
+  guess.setTime(guess.getTime() - driftMs);
 
   return guess;
 }


### PR DESCRIPTION
## Summary

Fixes off-peak time calculation errors on systems with sub-hour UTC offsets (e.g., IST = UTC+5:30). The existing drift correction used `setHours()` which only accounted for whole-hour offsets, introducing a 30-minute error for sub-hour timezones.

## Changes

- **`packages/shared/src/utils/off-peak.ts`**: Replace `setHours()` drift correction with `setTime()` using millisecond-precision calculation
- Include minute component from `getETComponents` in drift calculation to handle sub-hour timezone offsets

## Testing

- [x] Tests pass (`pnpm turbo test`)
- [x] Typechecks pass (`pnpm turbo typecheck`)

Tested on IST (UTC+5:30) system where off-peak transition times were previously off by 30 minutes.

## Related

Discovered during local development on system with sub-hour UTC offset.