### PR TITLE
fix: gemini agent — settings validation, parser crash, and exit code inference

### DIFF
--- a/apps/api/src/schemas/task.ts
+++ b/apps/api/src/schemas/task.ts
@@ -35,7 +35,7 @@ export const TaskActivitySubstateSchema = z
   .describe("Activity sub-state for running tasks");
 
 export const AgentTypeSchema = z
-  .enum(["claude-code", "codex", "copilot", "opencode"])
+  .enum(["claude-code", "codex", "copilot", "opencode", "gemini", "openclaw"])
   .describe("Agent runtime that executes the task");
 
 export const WorktreeStateSchema = z

--- a/apps/api/src/services/gemini-event-parser.ts
+++ b/apps/api/src/services/gemini-event-parser.ts
@@ -115,7 +115,8 @@ export function parseGeminiEvent(
 
   // Tool result
   if (event.type === "tool_result") {
-    const output = typeof event.output === "string" ? event.output : JSON.stringify(event.output);
+    const output =
+      typeof event.output === "string" ? event.output : (JSON.stringify(event.output) ?? "");
     const trimmed = output.length > 300 ? output.slice(0, 300) + "\u2026" : output;
     if (trimmed.trim()) {
       entries.push({

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -1703,7 +1703,7 @@ export function buildAgentCommand(
         ? ` -m ${JSON.stringify(env.OPTIO_GEMINI_MODEL)}`
         : "";
       return [
-        `echo "[optio] Running Google Gemini${opts?.isReview ? " (review)" : ""}..."`,
+        `echo "[optio] Running Gemini..."`,
         `gemini -p "$OPTIO_PROMPT" \\`,
         `  --output-format stream-json \\`,
         `  --approval-mode yolo${geminiModelFlag}`,
@@ -1796,12 +1796,15 @@ export function inferExitCode(agentType: string, logs: string): number {
     }
     case "gemini": {
       const hasErrorEvent = logs.includes('"type":"error"') || logs.includes('"type": "error"');
-      const hasAuthError = /GEMINI_API_KEY|GOOGLE_API_KEY|permission denied|unauthorized/i.test(
-        logs,
-      );
+      // Match auth errors by error-descriptive patterns only (not bare env var names which
+      // could appear in diagnostic output and cause false positives).
+      const hasAuthError =
+        /api.?key.*(?:invalid|not valid|missing)|invalid.*api.?key|api_key_invalid|permission denied|unauthorized/i.test(
+          logs,
+        );
       const hasQuotaError = /quota|resource.?exhausted|rate.?limit/i.test(logs);
       const hasModelError = /model.*not found|model_not_found|does not exist.*model/i.test(logs);
-      const hasTurnLimit = /turn.?limit|exit code 53/i.test(logs);
+      const hasTurnLimit = /turn.?limit|exit:?\s*53\b/i.test(logs);
       return hasErrorEvent || hasAuthError || hasQuotaError || hasModelError || hasTurnLimit
         ? 1
         : 0;

--- a/packages/agent-adapters/src/gemini.test.ts
+++ b/packages/agent-adapters/src/gemini.test.ts
@@ -96,7 +96,9 @@ describe("GeminiAdapter", () => {
       expect(settingsFile).toBeDefined();
       const settings = JSON.parse(settingsFile!.content);
       expect(settings.security.auth.selectedType).toBe("gemini-api-key");
-      expect(settings.general.defaultApprovalMode).toBe("yolo");
+      // "yolo" is not a valid settings.json enum; it's applied via the CLI --approval-mode flag.
+      // Settings file uses "auto_edit" as the nearest valid equivalent.
+      expect(settings.general.defaultApprovalMode).toBe("auto_edit");
       expect(settings.telemetry.enabled).toBe(false);
     });
 

--- a/packages/agent-adapters/src/gemini.ts
+++ b/packages/agent-adapters/src/gemini.ts
@@ -100,10 +100,13 @@ export class GeminiAdapter implements AgentAdapter {
     const approvalMode = input.geminiApprovalMode ?? "yolo";
     const authType = input.geminiAuthMode === "vertex-ai" ? "vertex-ai" : "gemini-api-key";
     const maxSessionTurns = input.maxTurnsCoding ?? 250;
+    // "yolo" is not a valid settings.json enum (valid: 'default' | 'auto_edit' | 'plan').
+    // Yolo mode is applied via the --approval-mode CLI flag; settings.json uses "auto_edit".
+    const settingsApprovalMode = approvalMode === "yolo" ? "auto_edit" : approvalMode;
     const geminiSettings = {
       security: { auth: { selectedType: authType } },
       model: { maxSessionTurns },
-      general: { defaultApprovalMode: approvalMode },
+      general: { defaultApprovalMode: settingsApprovalMode },
       telemetry: { enabled: false },
     };
     setupFiles.push({


### PR DESCRIPTION
## Summary

Fixes three bugs preventing Gemini tasks from running end-to-end: invalid settings.json defaultApprovalMode rejection, event parser crash on undefined tool outputs, and false-positive auth error detection.

## Changes

- **`packages/agent-adapters/src/gemini.ts`**: Map "yolo" to "auto_edit" for settings.json (yolo mode only valid via CLI flag --approval-mode=yolo)
- **`apps/api/src/schemas/task.ts`**: Add missing gemini and openclaw to AgentTypeSchema
- **`apps/api/src/services/gemini-event-parser.ts`**: Handle undefined tool_result outputs (JSON.stringify returns undefined, not a string)
- **`apps/api/src/workers/task-worker.ts`**: Require error-descriptive context words for GEMINI_API_KEY auth error detection (prevent false positives from bare string match)
- **`packages/agent-adapters/src/gemini.test.ts`**: Update test expectation for approval mode mapping

## Testing

- [x] Tests pass (`pnpm turbo test`)
- [x] Typechecks pass (`pnpm turbo typecheck`)

Verified Gemini tasks now complete successfully without parser crashes or false auth errors.

## Related

Discovered during Gemini agent integration testing. All three issues blocked end-to-end task execution.