### PR TITLE
fix(images): change agent user UID from 1000 to 1001

### DIFF
--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -69,11 +69,9 @@ COPY scripts/optio-gh-wrapper /usr/local/bin/optio-gh-wrapper
 COPY scripts/optio-glab-wrapper /usr/local/bin/optio-glab-wrapper
 RUN chmod +x /usr/local/bin/optio-git-credential /usr/local/bin/optio-gh-wrapper /usr/local/bin/optio-glab-wrapper
 
-# Non-root user (UID 1000 to match k8s securityContext)
-# Ubuntu 24.04 ships with 'ubuntu' user at UID 1000 — remove it first
-RUN userdel -r ubuntu 2>/dev/null || true \
-    && groupadd -g 1000 agent \
-    && useradd -m -s /bin/bash -u 1000 -g 1000 agent \
+# Non-root user (UID 1001 to match k8s securityContext)
+RUN groupadd -g 1001 agent \
+    && useradd -m -s /bin/bash -u 1001 -g 1001 agent \
     && chown -R agent:agent /workspace
 USER agent
 WORKDIR /workspace


### PR DESCRIPTION
## Problem

StatefulSet pods were crashing with git permission errors:
```
error: could not lock config file /.gitconfig: Permission denied
```

## Root Cause

Mismatch between Dockerfile and K8s securityContext:
- **Dockerfile** (`images/base.Dockerfile`): Created agent user with UID **1000**
- **K8s pod** (`k8s-workload-service.ts`): Runs as UID **1001**

When the pod runs as UID 1001 with no matching user in `/etc/passwd`:
- No HOME directory is set
- Git falls back to `/` for `.gitconfig`
- Permission denied on `/.gitconfig`

## History

- Commit `0a32e34` (Apr 15): Set both Dockerfile and K8s to UID 1000 ✅
- Commit `eeaa4ba` (later): Changed K8s spec to UID 1001, but **incorrectly assumed** the Dockerfile was already 1001 ❌

The commit message in `eeaa4ba` stated:
> "runAsUser: 1000 doesn't match image's agent UID 1001... Changed all three fields to 1001."

But the image was still at UID 1000, creating the mismatch.

## Solution

Changed agent user from UID 1000 to UID 1001 in `base.Dockerfile`:
- Removed ubuntu user deletion (no longer needed - agent naturally gets 1001 as next available UID)
- Simplified Dockerfile by removing unnecessary workaround steps
- Now matches K8s securityContext at UID 1001

## Testing

- ✅ Rebuilt all agent images (base, node, python, go, rust, full)
- ✅ Created StatefulSet pod - started successfully
- ✅ Git clone completed without permission errors
- ✅ All pre-commit hooks passed (lint, format, typecheck)
- ✅ All 2005 API tests passed

## Files Changed

- `images/base.Dockerfile` - Simplified agent user creation to use UID 1001

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>