### PR TITLE
feat(agent-adapters): add diagnostic logging for raw error detection

### DIFF
--- a/packages/agent-adapters/src/codex.ts
+++ b/packages/agent-adapters/src/codex.ts
@@ -141,6 +141,8 @@ export class CodexAdapter implements AgentAdapter {
         if (!errorMessage && isRawTextError(line)) {
           errorMessage = line.trim();
           hasError = true;
+          // Log raw error for diagnostics (helps catch API key issues, auth failures, etc.)
+          console.warn(`[codex] Raw error: ${errorMessage}`);
         }
         continue;
       }

--- a/packages/agent-adapters/src/copilot.ts
+++ b/packages/agent-adapters/src/copilot.ts
@@ -112,6 +112,8 @@ export class CopilotAdapter implements AgentAdapter {
         if (!errorMessage && isRawTextError(line)) {
           errorMessage = line.trim();
           hasError = true;
+          // Log raw error for diagnostics (helps catch API key issues, auth failures, etc.)
+          console.warn(`[copilot] Raw error: ${errorMessage}`);
         }
         continue;
       }

--- a/packages/agent-adapters/src/gemini.ts
+++ b/packages/agent-adapters/src/gemini.ts
@@ -172,6 +172,8 @@ export class GeminiAdapter implements AgentAdapter {
         if (!errorMessage && isRawTextError(line)) {
           errorMessage = line.trim();
           hasError = true;
+          // Log raw error for diagnostics (helps catch API key issues, auth failures, etc.)
+          console.warn(`[gemini] Raw error: ${errorMessage}`);
         }
         continue;
       }

--- a/packages/agent-adapters/src/openclaw.ts
+++ b/packages/agent-adapters/src/openclaw.ts
@@ -133,6 +133,8 @@ export class OpenClawAdapter implements AgentAdapter {
         if (!errorMessage && isRawTextError(line)) {
           errorMessage = line.trim();
           hasError = true;
+          // Log raw error for diagnostics (helps catch API key issues, auth failures, etc.)
+          console.warn(`[openclaw] Raw error: ${errorMessage}`);
         }
         continue;
       }

--- a/packages/agent-adapters/src/opencode.ts
+++ b/packages/agent-adapters/src/opencode.ts
@@ -149,6 +149,8 @@ export class OpenCodeAdapter implements AgentAdapter {
         if (!errorMessage && isRawTextError(line)) {
           errorMessage = line.trim();
           hasError = true;
+          // Log raw error for diagnostics (helps catch API key issues, auth failures, etc.)
+          console.warn(`[opencode] Raw error: ${errorMessage}`);
         }
         continue;
       }


### PR DESCRIPTION
## Summary

Add `console.warn` logging when agent adapters detect raw text errors (authentication failures, API key issues, etc.) in non-JSON output. This improves debuggability by surfacing the actual error message in worker logs.

## Motivation

During debugging of a Gemini agent failure, we discovered the actual error message "API key not valid" was being detected and stored but never logged. The root cause turned out to be a duplicated/corrupted API key in the secrets store. With this change, such errors are immediately visible in the worker logs, making diagnosis much faster.

## Changes

- Added diagnostic `console.warn` logging in the error detection path for all agent adapters that parse raw text errors:
  - Gemini
  - Codex  
  - Copilot
  - OpenCode
  - OpenClaw

- The logs use a consistent format: `[adapter-name] Raw error: <error message>`
- Only triggered when `isRawTextError()` detects an authentication/API key/config error pattern

## Testing

- All agent-adapter tests pass (230/230)
- The new logging appears in test stderr (expected and harmless - tests verify error detection works)
- Manually tested with a Gemini task to confirm error logging works in production

## Example

Before this change, a corrupted GEMINI_API_KEY would result in:
```
Task failed with: API key not valid
```

After this change, worker logs show:
```
[gemini] Raw error: Error: API key not valid. Please pass a valid API key.
```

This makes it immediately clear that the issue is with the API key itself, not network/quota/other issues.

## Note on Test Failures

The CI shows 2 failing tests in `apps/api` (`server.test.ts` and `openapi.test.ts`). These are pre-existing failures on main branch (unrelated to this PR) - verified by running tests on main which shows the same 2 failures.