### PR TITLE
feat: add Ruby and Dart agent image presets

### DIFF
--- a/apps/api/src/services/repo-detect-service.test.ts
+++ b/apps/api/src/services/repo-detect-service.test.ts
@@ -102,6 +102,24 @@ describe("repo-detect-service", () => {
     expect(result.imagePreset).toBe("python");
   });
 
+  it("detects ruby project", async () => {
+    mockPlatform.listRepoContents.mockResolvedValue([{ name: "Gemfile", type: "file" }]);
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result.imagePreset).toBe("ruby");
+    expect(result.languages).toContain("ruby");
+    expect(result.testCommand).toBe("bundle exec rspec");
+  });
+
+  it("detects dart project", async () => {
+    mockPlatform.listRepoContents.mockResolvedValue([{ name: "pubspec.yaml", type: "file" }]);
+
+    const result = await detectRepoConfig("https://github.com/owner/repo", "token");
+    expect(result.imagePreset).toBe("dart");
+    expect(result.languages).toContain("dart");
+    expect(result.testCommand).toBe("dart test");
+  });
+
   it("uses full preset for multi-language projects", async () => {
     mockPlatform.listRepoContents.mockResolvedValue([
       { name: "package.json", type: "file" },

--- a/apps/api/src/services/repo-detect-service.ts
+++ b/apps/api/src/services/repo-detect-service.ts
@@ -47,6 +47,11 @@ export async function detectRepoConfig(repoUrl: string, token: string): Promise<
     }
     if (fileNames.has("Gemfile")) {
       languages.push("ruby");
+      testCommand = testCommand ?? "bundle exec rspec";
+    }
+    if (fileNames.has("pubspec.yaml")) {
+      languages.push("dart");
+      testCommand = testCommand ?? "dart test";
     }
     if (fileNames.has("pom.xml") || fileNames.has("build.gradle")) {
       languages.push("java");
@@ -64,6 +69,10 @@ export async function detectRepoConfig(repoUrl: string, token: string): Promise<
       imagePreset = "go";
     } else if (languages.includes("python")) {
       imagePreset = "python";
+    } else if (languages.includes("ruby")) {
+      imagePreset = "ruby";
+    } else if (languages.includes("dart")) {
+      imagePreset = "dart";
     }
 
     logger.info({ repoUrl, imagePreset, languages, testCommand }, "Auto-detected repo config");

--- a/apps/api/src/services/repo-pool-service.test.ts
+++ b/apps/api/src/services/repo-pool-service.test.ts
@@ -186,6 +186,16 @@ describe("resolveImage", () => {
     expect(resolveImage({ preset: "dind" })).toBe("optio-dind:latest");
   });
 
+  it("returns preset image for ruby (no prefix env)", () => {
+    delete process.env.OPTIO_AGENT_IMAGE_PREFIX;
+    expect(resolveImage({ preset: "ruby" })).toBe("optio-ruby:latest");
+  });
+
+  it("returns preset image for dart (no prefix env)", () => {
+    delete process.env.OPTIO_AGENT_IMAGE_PREFIX;
+    expect(resolveImage({ preset: "dart" })).toBe("optio-dart:latest");
+  });
+
   it("falls through to default for invalid preset", () => {
     delete process.env.OPTIO_AGENT_IMAGE;
     expect(resolveImage({ preset: "nonexistent" as any })).toBe("optio-agent:latest");
@@ -208,6 +218,8 @@ describe("resolveImage", () => {
     expect(resolveImage({ preset: "python" })).toBe("ghcr.io/jonwiggins/optio-agent-python:latest");
     expect(resolveImage({ preset: "go" })).toBe("ghcr.io/jonwiggins/optio-agent-go:latest");
     expect(resolveImage({ preset: "rust" })).toBe("ghcr.io/jonwiggins/optio-agent-rust:latest");
+    expect(resolveImage({ preset: "ruby" })).toBe("ghcr.io/jonwiggins/optio-agent-ruby:latest");
+    expect(resolveImage({ preset: "dart" })).toBe("ghcr.io/jonwiggins/optio-agent-dart:latest");
     expect(resolveImage({ preset: "full" })).toBe("ghcr.io/jonwiggins/optio-agent-full:latest");
     expect(resolveImage({ preset: "dind" })).toBe("ghcr.io/jonwiggins/optio-agent-dind:latest");
   });

--- a/images/build.sh
+++ b/images/build.sh
@@ -34,34 +34,40 @@ echo "=== Building Optio Agent Images ==="
 echo "Tag: ${TAG}"
 
 # Base image (all others depend on this)
-echo "[1/8] Building optio-base..."
+echo "[1/10] Building optio-base..."
 docker build ${PLATFORM_FLAG} -t "optio-base:${TAG}" -f "${SCRIPT_DIR}/base.Dockerfile" "${ROOT_DIR}"
 
 echo "Using base internal image: optio-base:${TAG}"
 BASE_IMAGE="optio-base:${TAG}"
 
 # Language-specific images (can be built in parallel)
-echo "[2/8] Building optio-node..."
+echo "[2/10] Building optio-node..."
 docker build ${PLATFORM_FLAG} -t "optio-node:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/node.Dockerfile" "${ROOT_DIR}" &
 
-echo "[3/8] Building optio-python..."
+echo "[3/10] Building optio-python..."
 docker build ${PLATFORM_FLAG} -t "optio-python:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/python.Dockerfile" "${ROOT_DIR}" &
 
-echo "[4/8] Building optio-go..."
+echo "[4/10] Building optio-go..."
 docker build ${PLATFORM_FLAG} -t "optio-go:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/go.Dockerfile" "${ROOT_DIR}" &
 
-echo "[5/8] Building optio-rust..."
+echo "[5/10] Building optio-rust..."
 docker build ${PLATFORM_FLAG} -t "optio-rust:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/rust.Dockerfile" "${ROOT_DIR}" &
 
-echo "[6/8] Building optio-dind..."
+echo "[6/10] Building optio-ruby..."
+docker build ${PLATFORM_FLAG} -t "optio-ruby:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/ruby.Dockerfile" "${ROOT_DIR}" &
+
+echo "[7/10] Building optio-dart..."
+docker build ${PLATFORM_FLAG} -t "optio-dart:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/dart.Dockerfile" "${ROOT_DIR}" &
+
+echo "[8/10] Building optio-dind..."
 docker build ${PLATFORM_FLAG} -t "optio-dind:${TAG}" -f "${SCRIPT_DIR}/dind.Dockerfile" "${ROOT_DIR}" &
 
-echo "[7/8] Building optio-optio (operations assistant)..."
+echo "[9/10] Building optio-optio (operations assistant)..."
 docker build ${PLATFORM_FLAG} -t "optio-optio:${TAG}" -f "${ROOT_DIR}/Dockerfile.optio" "${ROOT_DIR}" &
 
 wait
 
-echo "[8/8] Building optio-full..."
+echo "[10/10] Building optio-full..."
 docker build ${PLATFORM_FLAG} -t "optio-full:${TAG}" --build-arg BASE_IMAGE="${BASE_IMAGE}" -f "${SCRIPT_DIR}/full.Dockerfile" "${ROOT_DIR}"
 
 # Tag optio-base as the default

--- a/images/dart.Dockerfile
+++ b/images/dart.Dockerfile
@@ -1,0 +1,23 @@
+ARG BASE_IMAGE=optio-base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Dart SDK
+RUN apt-get update && apt-get install -y apt-transport-https \
+    && curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/dart.gpg] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main" \
+    > /etc/apt/sources.list.d/dart_stable.list \
+    && apt-get update && apt-get install -y dart \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/usr/lib/dart/bin:${PATH}"
+
+USER agent
+
+# Dart pub cache in user home
+ENV PUB_CACHE="/home/agent/.pub-cache"
+ENV PATH="${PUB_CACHE}/bin:${PATH}"
+
+# Common tools
+RUN dart pub global activate dart_style

--- a/images/ruby.Dockerfile
+++ b/images/ruby.Dockerfile
@@ -1,0 +1,24 @@
+ARG BASE_IMAGE=optio-base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Ruby via rbenv
+RUN apt-get update && apt-get install -y \
+    build-essential libssl-dev libreadline-dev zlib1g-dev \
+    libyaml-dev libffi-dev libgmp-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+USER agent
+
+# Install rbenv and ruby-build
+ENV RBENV_ROOT="/home/agent/.rbenv"
+ENV PATH="${RBENV_ROOT}/bin:${RBENV_ROOT}/shims:${PATH}"
+RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv \
+    && git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
+
+# Install latest stable Ruby (3.3)
+RUN rbenv install 3.3.6 && rbenv global 3.3.6
+
+# Common tools
+RUN gem install bundler rake rubocop solargraph

--- a/packages/shared/src/types/image.ts
+++ b/packages/shared/src/types/image.ts
@@ -29,6 +29,18 @@ export const PRESET_IMAGES = {
     description: "Base + rustup, cargo, cargo-nextest.",
     languages: ["rust"],
   },
+  ruby: {
+    tag: "optio-ruby:latest",
+    label: "Ruby",
+    description: "Base + rbenv, Ruby 3.3, bundler, rake, rubocop, solargraph.",
+    languages: ["ruby"],
+  },
+  dart: {
+    tag: "optio-dart:latest",
+    label: "Dart",
+    description: "Base + Dart SDK, dart_style.",
+    languages: ["dart"],
+  },
   full: {
     tag: "optio-full:latest",
     label: "Full",


### PR DESCRIPTION
## Summary

Add dart and ruby images types.

## Changes

Add two new language-specific agent images:
- Ruby: rbenv + Ruby 3.3, bundler, rake, rubocop, solargraph
- Dart: Dart SDK, dart_style

Includes auto-detection (Gemfile → ruby, pubspec.yaml → dart) and updated build script.

## Testing

We've ran the dart packages inside a cron of ours which automatically updates CVE's.

Still todo: [ ] run the ruby images

- [x] Tests pass (`pnpm turbo test`)
- [x] Typechecks pass (`pnpm turbo typecheck`)
