### PR TITLE
feat(secrets): inject secrets into pod env for setup commands

### DIFF
--- a/apps/api/src/services/secret-service.test.ts
+++ b/apps/api/src/services/secret-service.test.ts
@@ -41,6 +41,42 @@ function legacyEncrypt(plaintext: string) {
   return { encrypted, iv, authTag: cipher.getAuthTag() };
 }
 
+// ── Mock Data Types ─────────────────────────────────────────────────────────
+
+interface MockSecretData {
+  name: string;
+  scope: string;
+  value: string; // plaintext - will be encrypted when retrieved
+}
+
+// ── Drizzle Expression Parser ───────────────────────────────────────────────
+
+/** Extract {column: value} filters from a Drizzle SQL condition (eq/and expressions) */
+function parseWhereCondition(condition: any): Record<string, string> {
+  const filters: Record<string, string> = {};
+  if (!condition?.queryChunks) return filters;
+
+  // Walk through queryChunks to find nested SQL objects (from and())
+  for (const chunk of condition.queryChunks) {
+    if (chunk?.queryChunks) {
+      Object.assign(filters, parseWhereCondition(chunk));
+    }
+  }
+
+  // Handle eq() - queryChunks structure: [StringChunk, column, StringChunk, value, StringChunk]
+  const chunks = condition.queryChunks;
+  if (chunks.length >= 4) {
+    const col = typeof chunks[1] === "string" ? chunks[1] : null;
+    const val = typeof chunks[3] === "string" ? chunks[3] : null;
+    if (col && val) {
+      const colName = col.replace("secrets.", ""); // "secrets.scope" -> "scope"
+      filters[colName] = val;
+    }
+  }
+
+  return filters;
+}
+
 describe("secret-service", () => {
   let encrypt: typeof import("./secret-service.js").encrypt;
   let decrypt: typeof import("./secret-service.js").decrypt;
@@ -50,7 +86,50 @@ describe("secret-service", () => {
   let listSecrets: typeof import("./secret-service.js").listSecrets;
   let deleteSecret: typeof import("./secret-service.js").deleteSecret;
   let resolveSecretsForTask: typeof import("./secret-service.js").resolveSecretsForTask;
+  let resolveSecretsForSetup: typeof import("./secret-service.js").resolveSecretsForSetup;
   let ALG_AES_256_GCM_V1: number;
+
+  // ── Data-Driven Mock Helper ─────────────────────────────────────────────────
+
+  /**
+   * Set up db.select mock with a data-driven approach.
+   * Queries are filtered based on the actual where clause conditions.
+   */
+  function setupSecretStoreMock(mockSecrets: MockSecretData[]) {
+    (db.select as any) = vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockImplementation((condition) => {
+          const filters = parseWhereCondition(condition);
+
+          // Filter mock data based on extracted conditions
+          const matches = mockSecrets.filter((s) => {
+            if (filters.scope && s.scope !== filters.scope) return false;
+            if (filters.name && s.name !== filters.name) return false;
+            return true;
+          });
+
+          // Return encrypted rows (simulating DB storage)
+          return Promise.resolve(
+            matches.map((s) => {
+              const aad = buildSecretAAD(s.name, s.scope, null);
+              const blob = encrypt(s.value, aad);
+              return {
+                id: `mock-${s.name}-${s.scope}`,
+                name: s.name,
+                scope: s.scope,
+                encryptedValue: blob.ciphertext,
+                iv: blob.iv,
+                authTag: blob.authTag,
+                alg: blob.alg,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              };
+            }),
+          );
+        }),
+      }),
+    }));
+  }
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -63,6 +142,7 @@ describe("secret-service", () => {
     listSecrets = mod.listSecrets;
     deleteSecret = mod.deleteSecret;
     resolveSecretsForTask = mod.resolveSecretsForTask;
+    resolveSecretsForSetup = mod.resolveSecretsForSetup;
     ALG_AES_256_GCM_V1 = mod.ALG_AES_256_GCM_V1;
   });
 
@@ -557,6 +637,40 @@ describe("secret-service", () => {
 
       const result = await resolveSecretsForTask(["TOKEN"], "https://github.com/owner/repo");
       expect(result.TOKEN).toBe("repo-specific-token");
+    });
+  });
+
+  describe("resolveSecretsForSetup", () => {
+    it("returns both global and repo-scoped secrets", async () => {
+      const repoUrl = "https://github.com/owner/repo";
+      setupSecretStoreMock([
+        { name: "GLOBAL_TOKEN", scope: "global", value: "global-value" },
+        { name: "REPO_TOKEN", scope: repoUrl, value: "repo-value" },
+      ]);
+
+      const result = await resolveSecretsForSetup(repoUrl);
+      expect(result.GLOBAL_TOKEN).toBe("global-value");
+      expect(result.REPO_TOKEN).toBe("repo-value");
+      expect(Object.keys(result)).toHaveLength(2);
+    });
+
+    it("repo-scoped secret overrides global secret with same name", async () => {
+      const repoUrl = "https://github.com/owner/repo";
+      setupSecretStoreMock([
+        { name: "SHARED_TOKEN", scope: "global", value: "global-value" },
+        { name: "SHARED_TOKEN", scope: repoUrl, value: "repo-override-value" },
+      ]);
+
+      const result = await resolveSecretsForSetup(repoUrl);
+      expect(result.SHARED_TOKEN).toBe("repo-override-value");
+      expect(Object.keys(result)).toHaveLength(1);
+    });
+
+    it("returns empty object when no secrets exist", async () => {
+      setupSecretStoreMock([]);
+
+      const result = await resolveSecretsForSetup("https://github.com/owner/empty-repo");
+      expect(result).toEqual({});
     });
   });
 });

--- a/apps/api/src/services/secret-service.ts
+++ b/apps/api/src/services/secret-service.ts
@@ -250,3 +250,26 @@ export async function resolveSecretsForTask(
   }
   return resolved;
 }
+
+/**
+ * Resolve all secrets available for setup commands (global + repo-scoped).
+ * Repo-scoped secrets take precedence over global secrets with the same name.
+ */
+export async function resolveSecretsForSetup(
+  repoUrl: string,
+  workspaceId?: string | null,
+): Promise<Record<string, string>> {
+  // Get all global and repo-scoped secret names
+  const globalSecrets = await listSecrets("global", workspaceId);
+  const repoSecrets = await listSecrets(repoUrl, workspaceId);
+
+  // Merge names (unique) - repo-scoped will override global in resolveSecretsForTask
+  const allNames = [
+    ...new Set([...globalSecrets.map((s) => s.name), ...repoSecrets.map((s) => s.name)]),
+  ];
+
+  if (allNames.length === 0) return {};
+
+  // Resolve with repo→global fallback
+  return resolveSecretsForTask(allNames, repoUrl, workspaceId);
+}

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -28,7 +28,11 @@ import { eq, sql } from "drizzle-orm";
 import * as taskService from "../services/task-service.js";
 import * as repoPool from "../services/repo-pool-service.js";
 import { publishEvent } from "../services/event-bus.js";
-import { resolveSecretsForTask, retrieveSecretWithFallback } from "../services/secret-service.js";
+import {
+  resolveSecretsForTask,
+  resolveSecretsForSetup,
+  retrieveSecretWithFallback,
+} from "../services/secret-service.js";
 import { getPromptTemplate } from "../services/prompt-template-service.js";
 import { isGitHubAppConfigured } from "../services/github-app-service.js";
 import { getCredentialSecret } from "../services/credential-secret-service.js";
@@ -676,6 +680,15 @@ export function startTaskWorker() {
             ? { OPTIO_SETUP_COMMANDS: allEnv.OPTIO_SETUP_COMMANDS }
             : {}),
         };
+
+        // Inject secrets into pod env for setup commands (global + repo-scoped).
+        // Repo-scoped secrets override global secrets with the same name.
+        const setupSecrets = await resolveSecretsForSetup(task.repoUrl, taskWorkspaceId);
+        const setupSecretCount = Object.keys(setupSecrets).length;
+        if (setupSecretCount > 0) {
+          Object.assign(podEnv, setupSecrets);
+          log.info({ count: setupSecretCount }, "Injected secrets for setup");
+        }
 
         // Get or create a repo pod (with multi-pod scheduling)
         log.info("Getting repo pod");


### PR DESCRIPTION
## Summary

Allow using secrets through environments in the setup commands stage.

## Changes

Adds resolveSecretsForSetup() that collects all global + repo-scoped secrets and injects them into the pod environment. This allows setup commands (run during repo initialization) to access secrets like npm tokens, API keys, etc.

Repo-scoped secrets override global secrets with the same name.

## Testing

We're running this and relying on this in our environment/cluster.

- [x] Tests pass (`pnpm turbo test`)
- [x] Typechecks pass (`pnpm turbo typecheck`)

## Related

N/A

## Screenshots

N/A
