### PR TITLE
fix: postgres volume perms on fresh installs and setup-wizard loop

### DIFF
--- a/apps/api/src/routes/setup.test.ts
+++ b/apps/api/src/routes/setup.test.ts
@@ -95,14 +95,14 @@ describe("GET /api/setup/status", () => {
     expect(res.json().steps.anyAgentKey.done).toBe(false);
   });
 
-  it("returns not set up when runtime is unhealthy", async () => {
+  it("stays set up when runtime is unhealthy but keys exist", async () => {
     mockListSecrets.mockResolvedValue([{ name: "ANTHROPIC_API_KEY" }, { name: "GITHUB_TOKEN" }]);
     mockRetrieveSecret.mockRejectedValue(new Error("not found"));
     mockCheckRuntimeHealth.mockResolvedValue(false);
 
     const res = await app.inject({ method: "GET", url: "/api/setup/status" });
 
-    expect(res.json().isSetUp).toBe(false);
+    expect(res.json().isSetUp).toBe(true);
     expect(res.json().steps.runtime.done).toBe(false);
   });
 

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -171,7 +171,9 @@ export async function setupRoutes(rawApp: FastifyInstance) {
         /* non-critical */
       }
 
-      const isSetUp = hasAnyAgentKey && hasGitToken && runtimeHealthy;
+      // Runtime health is a separate step for the wizard; it must not gate
+      // isSetUp, or a container-runtime blip traps users in the wizard.
+      const isSetUp = hasAnyAgentKey && hasGitToken;
 
       reply.send({
         isSetUp,

--- a/helm/optio/templates/postgres.yaml
+++ b/helm/optio/templates/postgres.yaml
@@ -50,11 +50,35 @@ spec:
         runAsUser: 999
         runAsGroup: 999
         fsGroup: 999
-      {{- if .Values.postgresql.tls.enabled }}
+        fsGroupChangePolicy: OnRootMismatch
       initContainers:
+        # Ensure the data volume is owned by uid/gid 999. Some CSI drivers
+        # don't reliably apply fsGroup to pre-existing directories on the
+        # mount, which leaves postgres unable to write and fails startup.
+        - name: init-data-perms
+          image: busybox:1.36
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command: ['sh', '-c']
+          args:
+            - |
+              mkdir -p /var/lib/postgresql/data/pgdata
+              chown -R 999:999 /var/lib/postgresql/data
+              chmod 700 /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+        {{- if .Values.postgresql.tls.enabled }}
         - name: init-tls
           image: busybox:1.36
           securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
             allowPrivilegeEscalation: false
             capabilities:
               drop:
@@ -64,6 +88,7 @@ spec:
             - |
               cp /tls-secret/tls.crt /etc/postgres-tls/tls.crt
               cp /tls-secret/tls.key /etc/postgres-tls/tls.key
+              chown 999:999 /etc/postgres-tls/tls.crt /etc/postgres-tls/tls.key
               chmod 600 /etc/postgres-tls/tls.key
               chmod 644 /etc/postgres-tls/tls.crt
           volumeMounts:
@@ -72,7 +97,7 @@ spec:
               readOnly: true
             - name: postgres-tls
               mountPath: /etc/postgres-tls
-      {{- end }}
+        {{- end }}
       containers:
         - name: postgres
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
@@ -102,6 +127,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-postgres-credentials
                   key: POSTGRES_PASSWORD
+            # Use a subdirectory for PGDATA so initdb doesn't trip over
+            # filesystem artifacts (e.g. lost+found on ext4 PVs).
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           ports:
             - containerPort: 5432
           volumeMounts:


### PR DESCRIPTION
## Summary

Two bugs reported together but with distinct root causes:

**#468 — Postgres fails to start on fresh Helm installs.** The deployment sets `runAsNonRoot: true` with UID 999 but has no way to take ownership of a freshly-provisioned PV. Some CSI drivers don't apply `fsGroup` to pre-existing directories on the mount, and on ext4 PVs `initdb` refuses to run in `/var/lib/postgresql/data` because it contains `lost+found`.

**#469 — Fresh installs are trapped in the setup wizard.** `GET /api/setup/status` marked `isSetUp: false` whenever `checkRuntimeHealth()` returned false, so any container-runtime blip after a successful wizard completion sent the user back to `/setup`.

## Changes

- `helm/optio/templates/postgres.yaml`:
  - New `init-data-perms` initContainer runs as root and `chown -R 999:999` the data volume so the main container (UID 999) can actually write to it.
  - Set `PGDATA=/var/lib/postgresql/data/pgdata` so `initdb` runs in a clean subdirectory.
  - Set `fsGroupChangePolicy: OnRootMismatch` (skips recursive chown cost after first boot).
  - TLS init container now also chowns the copied cert/key to 999:999 so the postgres process can read the private key.
- `apps/api/src/routes/setup.ts`: `isSetUp = hasAnyAgentKey && hasGitToken` (runtime health remains a separate step in the response for the wizard UI to display).
- `apps/api/src/routes/setup.test.ts`: updated the "runtime unhealthy" case to assert the new behavior.

## Test plan

- [x] `pnpm turbo typecheck` — 12/12 pass
- [x] `pnpm --filter @optio/api test` — 2005/2005 pass
- [x] `helm lint helm/optio` — clean
- [x] `helm template` renders correctly with TLS on and off
- [ ] Local k8s deploy: fresh install (delete PVC), confirm postgres starts without chown errors
- [ ] Local k8s deploy: complete setup wizard, toggle runtime off (kill agent image), confirm dashboard stays accessible

Fixes #468
Fixes #469