### PR TITLE
feat(secrets): add user-scoped secrets to keep identity tokens out of pod env

### DIFF
--- a/apps/api/src/db/migrations/1777012800_user_scoped_secrets.sql
+++ b/apps/api/src/db/migrations/1777012800_user_scoped_secrets.sql
@@ -1,0 +1,31 @@
+-- User-scoped secrets.
+--
+-- Adds a `user_id` column to the `secrets` table so identity tokens
+-- (CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, etc.) can be stored at
+-- scope = 'user' and resolved per-user rather than shared globally.
+-- This keeps identity tokens out of the shared pod env.
+
+ALTER TABLE "secrets"
+  ADD COLUMN "user_id" uuid REFERENCES "users"("id");
+
+-- Replace the old unique constraint with one that includes user_id.
+-- The old constraint covered (name, scope, workspace_id); the new one
+-- adds user_id so multiple users can store the same secret name at
+-- user scope.
+ALTER TABLE "secrets"
+  DROP CONSTRAINT IF EXISTS "secrets_name_scope_ws_key";
+
+ALTER TABLE "secrets"
+  ADD CONSTRAINT "secrets_name_scope_ws_user_key"
+    UNIQUE ("name", "scope", "workspace_id", "user_id");
+
+CREATE INDEX "secrets_user_id_idx" ON "secrets" ("user_id");
+
+-- CHECK constraint: scope = 'user' iff user_id IS NOT NULL.
+ALTER TABLE "secrets"
+  ADD CONSTRAINT "secrets_user_scope_check"
+    CHECK (
+      (scope = 'user' AND user_id IS NOT NULL)
+      OR
+      (scope <> 'user' AND user_id IS NULL)
+    );

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -491,6 +491,13 @@
       "when": 1776825057000,
       "tag": "1776825057_external_pr_auto_review",
       "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1777012800000,
+      "tag": "1777012800_user_scoped_secrets",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -204,12 +204,19 @@ export const secrets = pgTable(
     authTag: bytea("auth_tag").notNull(),
     alg: smallint("alg").notNull().default(1), // 1 = AES_256_GCM_V1
     workspaceId: uuid("workspace_id"), // nullable for backward compat
+    userId: uuid("user_id").references(() => users.id), // nullable; set iff scope = "user"
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    unique("secrets_name_scope_ws_key").on(table.name, table.scope, table.workspaceId),
+    unique("secrets_name_scope_ws_user_key").on(
+      table.name,
+      table.scope,
+      table.workspaceId,
+      table.userId,
+    ),
     index("secrets_workspace_id_idx").on(table.workspaceId),
+    index("secrets_user_id_idx").on(table.userId),
   ],
 );
 

--- a/apps/api/src/routes/secrets.test.ts
+++ b/apps/api/src/routes/secrets.test.ts
@@ -30,17 +30,23 @@ describe("GET /api/secrets", () => {
     app = await buildTestApp();
   });
 
-  it("lists secrets with workspace scoping", async () => {
-    mockListSecrets.mockResolvedValue([
-      { name: "GITHUB_TOKEN", scope: "global" },
-      { name: "ANTHROPIC_API_KEY", scope: "global" },
-    ]);
+  it("lists secrets with workspace scoping and includes user-scoped secrets", async () => {
+    // First call: workspace-scoped secrets, second call: user-scoped secrets
+    mockListSecrets
+      .mockResolvedValueOnce([
+        { name: "GITHUB_TOKEN", scope: "global" },
+        { name: "NPM_TOKEN", scope: "global" },
+      ])
+      .mockResolvedValueOnce([{ name: "ANTHROPIC_API_KEY", scope: "user", userId: "user-1" }]);
 
     const res = await app.inject({ method: "GET", url: "/api/secrets" });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().secrets).toHaveLength(2);
-    expect(mockListSecrets).toHaveBeenCalledWith(undefined, "ws-1");
+    expect(res.json().secrets).toHaveLength(3);
+    // Workspace-scoped call: listSecrets(scope, workspaceId)
+    expect(mockListSecrets).toHaveBeenNthCalledWith(1, undefined, "ws-1");
+    // User-scoped call: listSecrets("user", null, userId)
+    expect(mockListSecrets).toHaveBeenNthCalledWith(2, "user", null, "user-1");
   });
 
   it("passes scope query parameter", async () => {
@@ -49,7 +55,23 @@ describe("GET /api/secrets", () => {
     const res = await app.inject({ method: "GET", url: "/api/secrets?scope=repo:my-repo" });
 
     expect(res.statusCode).toBe(200);
-    expect(mockListSecrets).toHaveBeenCalledWith("repo:my-repo", "ws-1");
+    // With scope filter, still queries both workspace and user-scoped
+    expect(mockListSecrets).toHaveBeenNthCalledWith(1, "repo:my-repo", "ws-1");
+    expect(mockListSecrets).toHaveBeenNthCalledWith(2, "user", null, "user-1");
+  });
+
+  it("returns only user-scoped secrets when scope=user", async () => {
+    mockListSecrets.mockResolvedValue([
+      { name: "ANTHROPIC_API_KEY", scope: "user", userId: "user-1" },
+    ]);
+
+    const res = await app.inject({ method: "GET", url: "/api/secrets?scope=user" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().secrets).toHaveLength(1);
+    // Only one call: user-scoped
+    expect(mockListSecrets).toHaveBeenCalledTimes(1);
+    expect(mockListSecrets).toHaveBeenCalledWith("user", null, "user-1");
   });
 });
 
@@ -77,6 +99,7 @@ describe("POST /api/secrets", () => {
       "super-secret-value",
       undefined,
       "ws-1",
+      null,
     );
   });
 
@@ -91,7 +114,28 @@ describe("POST /api/secrets", () => {
 
     expect(res.statusCode).toBe(201);
     expect(res.json()).toEqual({ name: "REPO_KEY", scope: "repo:my-repo" });
-    expect(mockStoreSecret).toHaveBeenCalledWith("REPO_KEY", "val", "repo:my-repo", "ws-1");
+    expect(mockStoreSecret).toHaveBeenCalledWith("REPO_KEY", "val", "repo:my-repo", "ws-1", null);
+  });
+
+  it("creates a user-scoped secret with caller userId", async () => {
+    mockStoreSecret.mockResolvedValue(undefined);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/secrets",
+      payload: { name: "MY_USER_TOKEN", value: "tok-123", scope: "user" },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual({ name: "MY_USER_TOKEN", scope: "user" });
+    // userId should be set to the caller's id ("user-1" from test harness)
+    expect(mockStoreSecret).toHaveBeenCalledWith(
+      "MY_USER_TOKEN",
+      "tok-123",
+      "user",
+      "ws-1",
+      "user-1",
+    );
   });
 
   it("rejects missing name (Zod throws)", async () => {
@@ -142,7 +186,7 @@ describe("DELETE /api/secrets/:name", () => {
     });
 
     expect(res.statusCode).toBe(204);
-    expect(mockDeleteSecret).toHaveBeenCalledWith("MY_SECRET", undefined, "ws-1");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("MY_SECRET", undefined, "ws-1", null);
   });
 
   it("passes scope query parameter when deleting", async () => {
@@ -154,6 +198,19 @@ describe("DELETE /api/secrets/:name", () => {
     });
 
     expect(res.statusCode).toBe(204);
-    expect(mockDeleteSecret).toHaveBeenCalledWith("MY_SECRET", "repo:r", "ws-1");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("MY_SECRET", "repo:r", "ws-1", null);
+  });
+
+  it("deletes user-scoped secret with caller userId", async () => {
+    mockDeleteSecret.mockResolvedValue(undefined);
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/api/secrets/MY_TOKEN?scope=user",
+    });
+
+    expect(res.statusCode).toBe(204);
+    // userId should be set to the caller's id ("user-1") for user-scoped deletion
+    expect(mockDeleteSecret).toHaveBeenCalledWith("MY_TOKEN", "user", "ws-1", "user-1");
   });
 });

--- a/apps/api/src/routes/secrets.ts
+++ b/apps/api/src/routes/secrets.ts
@@ -10,7 +10,7 @@ import { ErrorResponseSchema } from "../schemas/common.js";
 
 const scopeQuerySchema = z
   .object({
-    scope: z.string().optional().describe("Optional scope filter (e.g. `global`, `repo`)"),
+    scope: z.string().optional().describe("Optional scope filter (e.g. `global`, `repo`, `user`)"),
   })
   .describe("Query parameters for scope-filtering");
 
@@ -24,7 +24,10 @@ const createSecretSchema = z
   .object({
     name: z.string().min(1).describe("Secret name (uppercase env-var style)"),
     value: z.string().min(1).describe("Secret value (encrypted at rest)"),
-    scope: z.string().optional().describe("Optional scope; defaults to `global`"),
+    scope: z
+      .string()
+      .optional()
+      .describe("Optional scope; defaults to `global`. Use `user` for per-user secrets."),
   })
   .describe("Body for creating/updating a secret");
 
@@ -100,7 +103,9 @@ export async function secretRoutes(rawApp: FastifyInstance) {
         operationId: "listSecrets",
         summary: "List secrets",
         description:
-          "Return secret names (not values) in the current workspace. Any member can view.",
+          "Return secret names (not values) in the current workspace. " +
+          "Includes the caller's user-scoped secrets plus workspace global/repo secrets. " +
+          "Any member can view.",
         tags: ["Setup & Settings"],
         querystring: scopeQuerySchema,
         response: { 200: SecretsListResponseSchema },
@@ -108,8 +113,21 @@ export async function secretRoutes(rawApp: FastifyInstance) {
     },
     async (req, reply) => {
       const workspaceId = req.user?.workspaceId ?? null;
-      const secrets = await secretService.listSecrets(req.query.scope, workspaceId);
-      reply.send({ secrets });
+      const userId = req.user?.id ?? null;
+      const scope = req.query.scope;
+
+      if (scope === "user") {
+        // User-scoped: only return the caller's own secrets
+        const userSecrets = userId ? await secretService.listSecrets("user", null, userId) : [];
+        reply.send({ secrets: userSecrets });
+      } else {
+        // Workspace secrets (global/repo) + caller's user-scoped secrets
+        const wsSecrets = await secretService.listSecrets(scope, workspaceId);
+        const userSecrets = userId ? await secretService.listSecrets("user", null, userId) : [];
+        // Merge: workspace-level first, then user-level (dedup by name not needed — different scopes)
+        const allSecrets = [...wsSecrets, ...userSecrets];
+        reply.send({ secrets: allSecrets });
+      }
     },
   );
 
@@ -125,7 +143,9 @@ export async function secretRoutes(rawApp: FastifyInstance) {
           "(`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`) " +
           "trigger a best-effort validation probe, credential cache " +
           "invalidation, and a WebSocket `auth:status_changed` event so the " +
-          "UI picks up the change immediately. Requires `admin` role.",
+          "UI picks up the change immediately. Use `scope: 'user'` for " +
+          "per-user identity tokens. Requires `admin` role (or any role for " +
+          "user-scoped secrets).",
         tags: ["Setup & Settings"],
         body: createSecretSchema,
         response: { 201: SecretCreatedResponseSchema },
@@ -134,7 +154,18 @@ export async function secretRoutes(rawApp: FastifyInstance) {
     async (req, reply) => {
       const input = req.body;
       const workspaceId = req.user?.workspaceId ?? null;
-      await secretService.storeSecret(input.name, input.value, input.scope, workspaceId);
+      const userId = req.user?.id ?? null;
+
+      // For user-scoped secrets, force userId to the caller's own ID
+      const effectiveUserId = input.scope === "user" ? userId : null;
+
+      await secretService.storeSecret(
+        input.name,
+        input.value,
+        input.scope,
+        workspaceId,
+        effectiveUserId,
+      );
 
       const isAuthSecret = AUTH_SECRET_NAMES.has(input.name);
       let validation: { valid: boolean; error?: string } | undefined;
@@ -170,7 +201,9 @@ export async function secretRoutes(rawApp: FastifyInstance) {
       schema: {
         operationId: "deleteSecret",
         summary: "Delete a secret",
-        description: "Delete a secret by name. Requires `admin` role. Returns 204 on success.",
+        description:
+          "Delete a secret by name. User-scoped secrets can only be deleted by their owner. " +
+          "Requires `admin` role (or any role for user-scoped secrets). Returns 204 on success.",
         tags: ["Setup & Settings"],
         params: nameParamsSchema,
         querystring: scopeQuerySchema,
@@ -180,7 +213,13 @@ export async function secretRoutes(rawApp: FastifyInstance) {
     async (req, reply) => {
       const { name } = req.params;
       const workspaceId = req.user?.workspaceId ?? null;
-      await secretService.deleteSecret(name, req.query.scope, workspaceId);
+      const userId = req.user?.id ?? null;
+      const scope = req.query.scope;
+
+      // For user-scoped secrets, force userId to the caller's own ID
+      const effectiveUserId = scope === "user" ? userId : null;
+
+      await secretService.deleteSecret(name, scope, workspaceId, effectiveUserId);
       logAction({
         userId: req.user?.id,
         action: "secret.delete",

--- a/apps/api/src/services/secret-service.test.ts
+++ b/apps/api/src/services/secret-service.test.ts
@@ -18,6 +18,7 @@ vi.mock("../db/schema.js", () => ({
     name: "secrets.name",
     scope: "secrets.scope",
     workspaceId: "secrets.workspace_id",
+    userId: "secrets.user_id",
     encryptedValue: "secrets.encrypted_value",
     iv: "secrets.iv",
     authTag: "secrets.auth_tag",
@@ -47,6 +48,7 @@ interface MockSecretData {
   name: string;
   scope: string;
   value: string; // plaintext - will be encrypted when retrieved
+  userId?: string | null;
 }
 
 // ── Drizzle Expression Parser ───────────────────────────────────────────────
@@ -87,6 +89,8 @@ describe("secret-service", () => {
   let deleteSecret: typeof import("./secret-service.js").deleteSecret;
   let resolveSecretsForTask: typeof import("./secret-service.js").resolveSecretsForTask;
   let resolveSecretsForSetup: typeof import("./secret-service.js").resolveSecretsForSetup;
+  let retrieveSecretWithFallback: typeof import("./secret-service.js").retrieveSecretWithFallback;
+  let IDENTITY_SECRET_DENYLIST: typeof import("./secret-service.js").IDENTITY_SECRET_DENYLIST;
   let ALG_AES_256_GCM_V1: number;
 
   // ── Data-Driven Mock Helper ─────────────────────────────────────────────────
@@ -105,6 +109,7 @@ describe("secret-service", () => {
           const matches = mockSecrets.filter((s) => {
             if (filters.scope && s.scope !== filters.scope) return false;
             if (filters.name && s.name !== filters.name) return false;
+            if (filters.user_id && s.userId !== filters.user_id) return false;
             return true;
           });
 
@@ -143,6 +148,8 @@ describe("secret-service", () => {
     deleteSecret = mod.deleteSecret;
     resolveSecretsForTask = mod.resolveSecretsForTask;
     resolveSecretsForSetup = mod.resolveSecretsForSetup;
+    retrieveSecretWithFallback = mod.retrieveSecretWithFallback;
+    IDENTITY_SECRET_DENYLIST = mod.IDENTITY_SECRET_DENYLIST;
     ALG_AES_256_GCM_V1 = mod.ALG_AES_256_GCM_V1;
   });
 
@@ -671,6 +678,181 @@ describe("secret-service", () => {
 
       const result = await resolveSecretsForSetup("https://github.com/owner/empty-repo");
       expect(result).toEqual({});
+    });
+
+    it("excludes user-scoped secrets even when names match global/repo", async () => {
+      const repoUrl = "https://github.com/owner/repo";
+      setupSecretStoreMock([
+        { name: "NPM_TOKEN", scope: "global", value: "npm-global" },
+        { name: "CLAUDE_CODE_OAUTH_TOKEN", scope: "user", value: "user-oauth", userId: "u-1" },
+      ]);
+
+      const result = await resolveSecretsForSetup(repoUrl);
+      // user-scoped rows must not appear in setup secrets
+      expect(result.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+      expect(result.NPM_TOKEN).toBe("npm-global");
+    });
+
+    it("filters out identity-denylist names from setup secrets", async () => {
+      const repoUrl = "https://github.com/owner/repo";
+      setupSecretStoreMock([
+        { name: "NPM_TOKEN", scope: "global", value: "npm-value" },
+        { name: "CLAUDE_CODE_OAUTH_TOKEN", scope: "global", value: "should-be-blocked" },
+        { name: "ANTHROPIC_API_KEY", scope: "global", value: "should-be-blocked" },
+        { name: "OPENAI_API_KEY", scope: "global", value: "should-be-blocked" },
+        { name: "GEMINI_API_KEY", scope: "global", value: "should-be-blocked" },
+      ]);
+
+      const result = await resolveSecretsForSetup(repoUrl);
+      expect(result.NPM_TOKEN).toBe("npm-value");
+      expect(result.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+      expect(result.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(result.OPENAI_API_KEY).toBeUndefined();
+      expect(result.GEMINI_API_KEY).toBeUndefined();
+    });
+  });
+
+  describe("IDENTITY_SECRET_DENYLIST", () => {
+    it("contains the known identity secret names", () => {
+      expect(IDENTITY_SECRET_DENYLIST).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+      expect(IDENTITY_SECRET_DENYLIST).toContain("ANTHROPIC_API_KEY");
+      expect(IDENTITY_SECRET_DENYLIST).toContain("OPENAI_API_KEY");
+      expect(IDENTITY_SECRET_DENYLIST).toContain("GEMINI_API_KEY");
+    });
+  });
+
+  describe("user-scoped secrets", () => {
+    it("storeSecret with user scope requires userId", async () => {
+      await expect(storeSecret("TOKEN", "val", "user")).rejects.toThrow("userId is required");
+    });
+
+    it("storeSecret rejects userId for non-user scopes", async () => {
+      await expect(storeSecret("TOKEN", "val", "global", null, "u-1")).rejects.toThrow(
+        "userId can only be set",
+      );
+    });
+
+    it("retrieveSecretWithFallback resolves user → workspace-global → global", async () => {
+      // Set up mock to return user-scoped secret on first call
+      const aad = buildSecretAAD("ANTHROPIC_API_KEY", "user", null);
+      const blob = encrypt("user-api-key", aad);
+
+      let callCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            callCount++;
+            // First call: user-scoped lookup succeeds
+            if (callCount === 1) {
+              return Promise.resolve([
+                {
+                  id: "user-secret",
+                  name: "ANTHROPIC_API_KEY",
+                  scope: "user",
+                  encryptedValue: blob.ciphertext,
+                  iv: blob.iv,
+                  authTag: blob.authTag,
+                  alg: blob.alg,
+                },
+              ]);
+            }
+            return Promise.resolve([]);
+          }),
+        }),
+      }));
+
+      const result = await retrieveSecretWithFallback("ANTHROPIC_API_KEY", "global", "ws-1", "u-1");
+      expect(result).toBe("user-api-key");
+    });
+
+    it("retrieveSecretWithFallback falls back to global when user scope is empty", async () => {
+      const aad = buildSecretAAD("ANTHROPIC_API_KEY", "global", null);
+      const blob = encrypt("global-api-key", aad);
+
+      let callCount = 0;
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            callCount++;
+            // First call: user-scoped lookup fails (empty)
+            if (callCount === 1) return Promise.resolve([]);
+            // Second call: workspace-scoped lookup fails
+            if (callCount === 2) return Promise.resolve([]);
+            // Third call: global lookup succeeds
+            return Promise.resolve([
+              {
+                id: "global-secret",
+                name: "ANTHROPIC_API_KEY",
+                scope: "global",
+                encryptedValue: blob.ciphertext,
+                iv: blob.iv,
+                authTag: blob.authTag,
+                alg: blob.alg,
+              },
+            ]);
+          }),
+        }),
+      }));
+
+      const result = await retrieveSecretWithFallback("ANTHROPIC_API_KEY", "global", "ws-1", "u-1");
+      expect(result).toBe("global-api-key");
+    });
+
+    it("retrieveSecretWithFallback without userId gets existing behavior", async () => {
+      const aad = buildSecretAAD("GITHUB_TOKEN", "global", "ws-1");
+      const blob = encrypt("ws-github-token", aad);
+
+      (db.select as any) = vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              id: "ws-secret",
+              name: "GITHUB_TOKEN",
+              scope: "global",
+              encryptedValue: blob.ciphertext,
+              iv: blob.iv,
+              authTag: blob.authTag,
+              alg: blob.alg,
+            },
+          ]),
+        }),
+      }));
+
+      const result = await retrieveSecretWithFallback("GITHUB_TOKEN", "global", "ws-1");
+      expect(result).toBe("ws-github-token");
+    });
+
+    it("listSecrets filters by userId when provided", async () => {
+      const mockRows = [
+        {
+          id: "1",
+          name: "ANTHROPIC_API_KEY",
+          scope: "user",
+          userId: "u-1",
+          encryptedValue: Buffer.from("x"),
+          iv: Buffer.from("x"),
+          authTag: Buffer.from("x"),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(mockRows) }),
+      });
+
+      const result = await listSecrets("user", null, "u-1");
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("ANTHROPIC_API_KEY");
+    });
+
+    it("deleteSecret with user scope uses userId in conditions", async () => {
+      const whereMock = vi.fn().mockResolvedValue(undefined);
+      (db.delete as any) = vi.fn().mockReturnValue({ where: whereMock });
+
+      await deleteSecret("MY_TOKEN", "user", null, "u-1");
+      expect(db.delete).toHaveBeenCalled();
+      expect(whereMock).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/services/secret-service.ts
+++ b/apps/api/src/services/secret-service.ts
@@ -29,6 +29,18 @@ const WEAK_KEY_VALUES = new Set([
   "default",
 ]);
 
+/**
+ * Identity secret names that must never be injected into shared pod env
+ * via resolveSecretsForSetup. Belt-and-suspenders defense: even if someone
+ * stores an identity token at global scope, it won't leak into pod env.
+ */
+export const IDENTITY_SECRET_DENYLIST = new Set([
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+]);
+
 function getEncryptionKey(): Buffer {
   const key = process.env.OPTIO_ENCRYPTION_KEY;
   if (!key) throw new Error("OPTIO_ENCRYPTION_KEY is not set");
@@ -108,7 +120,16 @@ export async function storeSecret(
   value: string,
   scope = "global",
   workspaceId?: string | null,
+  userId?: string | null,
 ): Promise<void> {
+  // Enforce CHECK semantics: scope = "user" iff userId is set
+  if (scope === "user" && !userId) {
+    throw new Error("userId is required when scope is 'user'");
+  }
+  if (scope !== "user" && userId) {
+    throw new Error("userId can only be set when scope is 'user'");
+  }
+
   const aad = buildSecretAAD(name, scope, workspaceId);
   const { alg, ciphertext, iv, authTag } = encrypt(value, aad);
 
@@ -116,8 +137,14 @@ export async function storeSecret(
   const conditions = [eq(secrets.name, name), eq(secrets.scope, scope)];
   if (workspaceId) {
     conditions.push(eq(secrets.workspaceId, workspaceId));
-  } else if (scope !== "global") {
+  } else if (scope !== "global" && scope !== "user") {
     conditions.push(isNull(secrets.workspaceId));
+  }
+  if (userId) {
+    conditions.push(eq(secrets.userId, userId));
+  } else if (scope !== "user") {
+    // For non-user scopes, match rows with null userId
+    conditions.push(isNull(secrets.userId));
   }
 
   // Try update first, then insert
@@ -140,6 +167,7 @@ export async function storeSecret(
       authTag,
       alg,
       workspaceId: workspaceId ?? undefined,
+      userId: userId ?? undefined,
     });
   }
 }
@@ -148,14 +176,24 @@ export async function retrieveSecret(
   name: string,
   scope = "global",
   workspaceId?: string | null,
+  userId?: string | null,
 ): Promise<string> {
   const conditions = [eq(secrets.name, name), eq(secrets.scope, scope)];
-  if (workspaceId) {
-    conditions.push(eq(secrets.workspaceId, workspaceId));
-  } else if (scope !== "global") {
-    // For non-global scopes, always apply a workspace filter to prevent
-    // cross-workspace secret leakage when workspaceId is omitted.
-    conditions.push(isNull(secrets.workspaceId));
+  if (scope === "user") {
+    if (userId) {
+      conditions.push(eq(secrets.userId, userId));
+    } else {
+      throw new Error("userId is required to retrieve a user-scoped secret");
+    }
+  } else {
+    if (workspaceId) {
+      conditions.push(eq(secrets.workspaceId, workspaceId));
+    } else if (scope !== "global") {
+      // For non-global scopes, always apply a workspace filter to prevent
+      // cross-workspace secret leakage when workspaceId is omitted.
+      conditions.push(isNull(secrets.workspaceId));
+    }
+    conditions.push(isNull(secrets.userId));
   }
 
   const [secret] = await db
@@ -179,10 +217,12 @@ export async function retrieveSecret(
 export async function listSecrets(
   scope?: string,
   workspaceId?: string | null,
+  userId?: string | null,
 ): Promise<SecretRef[]> {
   const conditions = [];
   if (scope) conditions.push(eq(secrets.scope, scope));
   if (workspaceId) conditions.push(eq(secrets.workspaceId, workspaceId));
+  if (userId) conditions.push(eq(secrets.userId, userId));
 
   const query =
     conditions.length > 0
@@ -196,6 +236,7 @@ export async function listSecrets(
     id: r.id,
     name: r.name,
     scope: r.scope,
+    userId: r.userId,
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
   }));
@@ -205,21 +246,43 @@ export async function deleteSecret(
   name: string,
   scope = "global",
   workspaceId?: string | null,
+  userId?: string | null,
 ): Promise<void> {
   const conditions = [eq(secrets.name, name), eq(secrets.scope, scope)];
   if (workspaceId) conditions.push(eq(secrets.workspaceId, workspaceId));
+  if (userId) {
+    conditions.push(eq(secrets.userId, userId));
+  }
   await db.delete(secrets).where(and(...conditions));
 }
 
 /**
- * Retrieve a secret with workspace-then-global fallback.
- * If workspaceId is provided, tries workspace-scoped first, then global.
+ * Retrieve a secret with user → workspace → global fallback.
+ *
+ * Lookup order when userId is provided:
+ *   1. (name, scope="user", userId=userId)
+ *   2. (name, scope=scope, workspaceId=workspaceId)
+ *   3. (name, scope=scope, workspaceId=null)   [global fallback]
+ *
+ * When userId is not provided, falls back to the original behavior:
+ *   1. (name, scope=scope, workspaceId=workspaceId)
+ *   2. (name, scope=scope, workspaceId=null)
  */
 export async function retrieveSecretWithFallback(
   name: string,
   scope = "global",
   workspaceId?: string | null,
+  userId?: string | null,
 ): Promise<string> {
+  // Step 1: try user-scoped lookup if userId is provided
+  if (userId) {
+    try {
+      return await retrieveSecret(name, "user", undefined, userId);
+    } catch {
+      // Not found at user scope — fall through
+    }
+  }
+  // Step 2: try workspace-scoped lookup
   if (workspaceId) {
     try {
       return await retrieveSecret(name, scope, workspaceId);
@@ -227,6 +290,7 @@ export async function retrieveSecretWithFallback(
       // Not found in workspace — fall through to global
     }
   }
+  // Step 3: global fallback
   return retrieveSecret(name, scope);
 }
 
@@ -234,19 +298,20 @@ export async function resolveSecretsForTask(
   requiredSecrets: string[],
   scope = "global",
   workspaceId?: string | null,
+  userId?: string | null,
 ): Promise<Record<string, string>> {
   const resolved: Record<string, string> = {};
   for (const name of requiredSecrets) {
     if (scope !== "global") {
       // Try repo-scoped secret first, fall back to global
       try {
-        resolved[name] = await retrieveSecretWithFallback(name, scope, workspaceId);
+        resolved[name] = await retrieveSecretWithFallback(name, scope, workspaceId, userId);
         continue;
       } catch {
         // Not found at repo scope — fall through to global
       }
     }
-    resolved[name] = await retrieveSecretWithFallback(name, "global", workspaceId);
+    resolved[name] = await retrieveSecretWithFallback(name, "global", workspaceId, userId);
   }
   return resolved;
 }
@@ -254,12 +319,17 @@ export async function resolveSecretsForTask(
 /**
  * Resolve all secrets available for setup commands (global + repo-scoped).
  * Repo-scoped secrets take precedence over global secrets with the same name.
+ *
+ * SECURITY: User-scoped secrets (scope="user") are excluded by construction —
+ * listSecrets only queries "global" and repoUrl scopes. Additionally, known
+ * identity secret names are filtered via IDENTITY_SECRET_DENYLIST as a
+ * belt-and-suspenders defense against identity tokens leaking into pod env.
  */
 export async function resolveSecretsForSetup(
   repoUrl: string,
   workspaceId?: string | null,
 ): Promise<Record<string, string>> {
-  // Get all global and repo-scoped secret names
+  // Get all global and repo-scoped secret names (never "user" scope)
   const globalSecrets = await listSecrets("global", workspaceId);
   const repoSecrets = await listSecrets(repoUrl, workspaceId);
 
@@ -270,6 +340,11 @@ export async function resolveSecretsForSetup(
 
   if (allNames.length === 0) return {};
 
-  // Resolve with repo→global fallback
-  return resolveSecretsForTask(allNames, repoUrl, workspaceId);
+  // Filter out identity secret names that must never be in pod env
+  const safeNames = allNames.filter((n) => !IDENTITY_SECRET_DENYLIST.has(n));
+
+  if (safeNames.length === 0) return {};
+
+  // Resolve with repo→global fallback (no userId — setup is pod-level, not user-level)
+  return resolveSecretsForTask(safeNames, repoUrl, workspaceId);
 }

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -557,10 +557,12 @@ export function startTaskWorker() {
             ...(!isGitHubAppConfigured() ? ["GITHUB_TOKEN"] : []),
           ]),
         ];
+        const taskUserId = task.createdBy ?? null;
         const resolvedSecrets = await resolveSecretsForTask(
           secretNames,
           task.repoUrl,
           taskWorkspaceId,
+          taskUserId,
         );
         const allEnv: Record<string, string> = { ...agentConfig.env, ...resolvedSecrets };
 
@@ -646,6 +648,7 @@ export function startTaskWorker() {
             "CLAUDE_CODE_OAUTH_TOKEN",
             "global",
             taskWorkspaceId,
+            taskUserId,
           ).catch(() => null);
           if (oauthToken) {
             allEnv.CLAUDE_CODE_OAUTH_TOKEN = oauthToken as string;

--- a/apps/api/src/workers/workflow-worker.ts
+++ b/apps/api/src/workers/workflow-worker.ts
@@ -353,11 +353,13 @@ export function startWorkflowWorker() {
 
         // ── Resolve secrets ───────────────────────────────────────────
         const workspaceId = workflow.workspaceId ?? null;
+        const workflowUserId = workflow.createdBy ?? null;
         const adapter = getAdapter(workflow.agentRuntime);
         const resolvedSecrets = await resolveSecretsForTask(
           adapter.validateSecrets([]).missing,
           "",
           workspaceId,
+          workflowUserId,
         );
 
         // Resolve auth mode for the agent runtime
@@ -386,6 +388,7 @@ export function startWorkflowWorker() {
             "ANTHROPIC_API_KEY",
             "global",
             workspaceId,
+            workflowUserId,
           ).catch(() => null);
           if (apiKey) env.ANTHROPIC_API_KEY = apiKey as string;
         }
@@ -396,6 +399,7 @@ export function startWorkflowWorker() {
             "CLAUDE_CODE_OAUTH_TOKEN",
             "global",
             workspaceId,
+            workflowUserId,
           ).catch(() => null);
           if (oauthToken) {
             env.CLAUDE_CODE_OAUTH_TOKEN = oauthToken as string;

--- a/apps/api/src/ws/optio-chat.ts
+++ b/apps/api/src/ws/optio-chat.ts
@@ -332,18 +332,30 @@ export async function streamAnthropicResponse(
  * Retrieve the Anthropic API credentials from the secrets store.
  * Returns the raw key or token for use with the Messages API.
  */
-async function getAnthropicAuth(log: {
-  warn: (obj: unknown, msg: string) => void;
-}): Promise<{ apiKey?: string; oauthToken?: string }> {
+async function getAnthropicAuth(
+  log: { warn: (obj: unknown, msg: string) => void },
+  userId?: string | null,
+): Promise<{ apiKey?: string; oauthToken?: string }> {
   try {
-    const { retrieveSecret } = await import("../services/secret-service.js");
+    const { retrieveSecret, retrieveSecretWithFallback } =
+      await import("../services/secret-service.js");
     const authMode = (await retrieveSecret("CLAUDE_AUTH_MODE").catch(() => null)) as string | null;
 
     if (authMode === "api-key") {
-      const apiKey = await retrieveSecret("ANTHROPIC_API_KEY").catch(() => null);
+      const apiKey = await retrieveSecretWithFallback(
+        "ANTHROPIC_API_KEY",
+        "global",
+        undefined,
+        userId,
+      ).catch(() => null);
       return apiKey ? { apiKey: apiKey as string } : {};
     } else if (authMode === "oauth-token") {
-      const token = await retrieveSecret("CLAUDE_CODE_OAUTH_TOKEN").catch(() => null);
+      const token = await retrieveSecretWithFallback(
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "global",
+        undefined,
+        userId,
+      ).catch(() => null);
       return token ? { oauthToken: token as string } : {};
     } else if (authMode === "max-subscription") {
       const { getClaudeAuthToken } = await import("../services/auth-service.js");
@@ -589,7 +601,7 @@ export async function optioChatWs(app: FastifyInstance) {
       send({ type: "status", status: "thinking" });
 
       // Get Anthropic credentials
-      const auth = await getAnthropicAuth(log);
+      const auth = await getAnthropicAuth(log, userId);
       if (!auth.apiKey && !auth.oauthToken) {
         send({
           type: "error",
@@ -645,7 +657,7 @@ export async function optioChatWs(app: FastifyInstance) {
     const continueAfterDecision = async (approved: boolean, feedback?: string) => {
       send({ type: "status", status: approved ? "executing" : "thinking" });
 
-      const auth = await getAnthropicAuth(log);
+      const auth = await getAnthropicAuth(log, userId);
       if (!auth.apiKey && !auth.oauthToken) {
         send({ type: "error", message: "No Anthropic credentials configured" });
         isProcessing = false;

--- a/apps/api/src/ws/session-chat.ts
+++ b/apps/api/src/ws/session-chat.ts
@@ -123,7 +123,7 @@ export async function sessionChatWs(app: FastifyInstance) {
     let promptCount = 0;
 
     // Resolve auth env vars for the claude process
-    const authEnv = await buildAuthEnv(log);
+    const authEnv = await buildAuthEnv(log, user.id);
 
     const send = (msg: Record<string, unknown>) => {
       if (socket.readyState === 1) {
@@ -343,17 +343,24 @@ export async function sessionChatWs(app: FastifyInstance) {
 }
 
 /** Build auth environment variables for the claude process in the pod. */
-async function buildAuthEnv(log: {
-  warn: (obj: any, msg: string) => void;
-}): Promise<Record<string, string>> {
+async function buildAuthEnv(
+  log: { warn: (obj: any, msg: string) => void },
+  userId?: string | null,
+): Promise<Record<string, string>> {
   const env: Record<string, string> = {};
 
   try {
-    const { retrieveSecret } = await import("../services/secret-service.js");
+    const { retrieveSecret, retrieveSecretWithFallback } =
+      await import("../services/secret-service.js");
     const authMode = (await retrieveSecret("CLAUDE_AUTH_MODE").catch(() => null)) as string | null;
 
     if (authMode === "api-key") {
-      const apiKey = await retrieveSecret("ANTHROPIC_API_KEY").catch(() => null);
+      const apiKey = await retrieveSecretWithFallback(
+        "ANTHROPIC_API_KEY",
+        "global",
+        undefined,
+        userId,
+      ).catch(() => null);
       if (apiKey) {
         env.ANTHROPIC_API_KEY = apiKey as string;
       }
@@ -364,7 +371,12 @@ async function buildAuthEnv(log: {
         env.CLAUDE_CODE_OAUTH_TOKEN = result.token;
       }
     } else if (authMode === "oauth-token") {
-      const token = await retrieveSecret("CLAUDE_CODE_OAUTH_TOKEN").catch(() => null);
+      const token = await retrieveSecretWithFallback(
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "global",
+        undefined,
+        userId,
+      ).catch(() => null);
       if (token) {
         env.CLAUDE_CODE_OAUTH_TOKEN = token as string;
       }

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -404,10 +404,14 @@ export default function SetupPage() {
       await api.createSecret({ name: "CLAUDE_AUTH_MODE", value: claudeAuthMode });
 
       if (claudeAuthMode === "api-key" && anthropicKey.trim() && anthropicValidated) {
-        await api.createSecret({ name: "ANTHROPIC_API_KEY", value: anthropicKey });
+        await api.createSecret({ name: "ANTHROPIC_API_KEY", value: anthropicKey, scope: "user" });
       }
       if (claudeAuthMode === "oauth-token" && oauthToken.trim()) {
-        await api.createSecret({ name: "CLAUDE_CODE_OAUTH_TOKEN", value: oauthToken });
+        await api.createSecret({
+          name: "CLAUDE_CODE_OAUTH_TOKEN",
+          value: oauthToken,
+          scope: "user",
+        });
       }
       // Save Codex auth mode and credentials
       if (codexAuthMode === "app-server" && codexAppServerUrl.trim()) {
@@ -415,7 +419,7 @@ export default function SetupPage() {
         await api.createSecret({ name: "CODEX_APP_SERVER_URL", value: codexAppServerUrl.trim() });
       } else if (openaiKey.trim() && openaiValidated) {
         await api.createSecret({ name: "CODEX_AUTH_MODE", value: "api-key" });
-        await api.createSecret({ name: "OPENAI_API_KEY", value: openaiKey });
+        await api.createSecret({ name: "OPENAI_API_KEY", value: openaiKey, scope: "user" });
       }
       // Save Copilot token
       if (copilotToken.trim() && copilotValidated) {
@@ -446,7 +450,7 @@ export default function SetupPage() {
         }
       } else if (geminiKey.trim() && geminiValidated) {
         await api.createSecret({ name: "GEMINI_AUTH_MODE", value: "api-key" });
-        await api.createSecret({ name: "GEMINI_API_KEY", value: geminiKey });
+        await api.createSecret({ name: "GEMINI_API_KEY", value: geminiKey, scope: "user" });
       }
       goNext();
     } catch (err) {

--- a/apps/web/src/components/token-refresh-banner.tsx
+++ b/apps/web/src/components/token-refresh-banner.tsx
@@ -45,6 +45,7 @@ export function TokenRefreshBanner({ onSaved }: { onSaved?: () => void | Promise
       const result = await api.createSecret({
         name: "CLAUDE_CODE_OAUTH_TOKEN",
         value: token.trim(),
+        scope: "user",
       });
       if (result.validation && !result.validation.valid) {
         toast.error(`Token saved but validation failed: ${result.validation.error}`);

--- a/packages/shared/src/types/secret.ts
+++ b/packages/shared/src/types/secret.ts
@@ -2,6 +2,7 @@ export interface SecretRef {
   id: string;
   name: string;
   scope: string;
+  userId?: string | null;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
Closes #473

## What changed

Introduces `scope = "user"` for the `secrets` table so identity tokens
(`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`)
are stored per-user and resolved through the task's `createdBy` field. This prevents
identity tokens from leaking into the shared pod environment via `resolveSecretsForSetup`.

### Schema
- Added `secrets.user_id` column (FK → `users.id`) with CHECK constraint:
  `scope = 'user'` iff `user_id IS NOT NULL`
- Updated unique constraint to include `user_id` so multiple users can store
  same-named secrets at user scope
- Migration: `1777012800_user_scoped_secrets.sql`

### Service layer (`secret-service.ts`)
- All CRUD functions (`storeSecret`, `retrieveSecret`, `listSecrets`, `deleteSecret`)
  accept optional `userId` parameter
- `retrieveSecretWithFallback` implements user → workspace → global lookup order
- `resolveSecretsForSetup` now:
  1. Only queries `global` and repo-scoped secrets (user-scoped excluded by construction)
  2. Filters out `IDENTITY_SECRET_DENYLIST` names as belt-and-suspenders defense

### Identity callers plumbed with `userId`
- **task-worker**: passes `task.createdBy` for OAuth/API key resolution
- **workflow-worker**: passes `workflow.createdBy`
- **session-chat** (`buildAuthEnv`): passes `user.id` from WebSocket auth
- **optio-chat** (`getAnthropicAuth`): passes `userId` from WebSocket auth

### HTTP routes (`/api/secrets`)
- `GET`: returns workspace secrets + caller's user-scoped secrets merged
- `POST` with `scope: "user"`: forces `userId` to `req.user.id`
- `DELETE` with `scope=user`: scoped to caller's own userId

### UI
- Setup wizard writes `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`,
  `OPENAI_API_KEY`, `GEMINI_API_KEY` at `scope: "user"` by default
- Token refresh banner writes `CLAUDE_CODE_OAUTH_TOKEN` at `scope: "user"`

### Backward compatibility
- All `userId` params are optional; callers that don't pass `userId` get
  the existing behavior (workspace → global fallback)
- Existing global-scoped identity tokens continue to work via the fallback chain
- No automatic data migration — existing rows stay at global scope

## How to test

1. **Unit tests**: Run `cd apps/api && npx vitest run` — all 2021 tests pass including new tests for:
   - User → workspace → global lookup order
   - `resolveSecretsForSetup` excluding user-scoped rows
   - Identity denylist filtering known identity names from setup secrets
   - `storeSecret` CHECK constraint enforcement
   - Route-level user-scoped CRUD

2. **Integration verification**:
   - Create a user-scoped secret: `POST /api/secrets { name: "ANTHROPIC_API_KEY", value: "sk-...", scope: "user" }`
   - Verify it appears in `GET /api/secrets` for the owning user only
   - Verify `resolveSecretsForSetup` does NOT include identity secrets
   - Verify task execution resolves identity tokens from user scope when `task.createdBy` matches

3. **Typecheck**: `npx tsc --noEmit` passes for all packages
4. **Web build**: `cd apps/web && npx next build` succeeds