### PR TITLE
fix(api): derive agent mode from secret names on public /setup/status

### DIFF
--- a/apps/api/src/routes/setup.test.ts
+++ b/apps/api/src/routes/setup.test.ts
@@ -122,6 +122,57 @@ describe("GET /api/setup/status", () => {
     expect(res.json().isSetUp).toBe(true);
     expect(res.json().steps.anyAgentKey.done).toBe(true);
   });
+
+  it("detects OAuth token mode by name when CLAUDE_AUTH_MODE cannot be decrypted", async () => {
+    // Regression: public setup/status has no req.user context, so it can't
+    // build the AAD that workspace-scoped CLAUDE_AUTH_MODE rows need.
+    // The endpoint must infer the mode from CLAUDE_CODE_OAUTH_TOKEN's presence
+    // in the secret names rather than calling retrieveSecret.
+    mockListSecrets.mockResolvedValue([
+      { name: "GITHUB_TOKEN" },
+      { name: "CLAUDE_AUTH_MODE" },
+      { name: "CLAUDE_CODE_OAUTH_TOKEN" },
+    ]);
+    mockRetrieveSecret.mockRejectedValue(new Error("decrypt failed: AAD mismatch"));
+    mockCheckRuntimeHealth.mockResolvedValue(true);
+
+    const res = await app.inject({ method: "GET", url: "/api/setup/status" });
+
+    expect(res.json().isSetUp).toBe(true);
+    expect(res.json().steps.anyAgentKey.done).toBe(true);
+  });
+
+  it("detects Codex app-server mode by name when CODEX_AUTH_MODE cannot be decrypted", async () => {
+    mockListSecrets.mockResolvedValue([
+      { name: "GITHUB_TOKEN" },
+      { name: "CODEX_AUTH_MODE" },
+      { name: "CODEX_APP_SERVER_URL" },
+    ]);
+    mockRetrieveSecret.mockRejectedValue(new Error("decrypt failed: AAD mismatch"));
+    mockCheckRuntimeHealth.mockResolvedValue(true);
+
+    const res = await app.inject({ method: "GET", url: "/api/setup/status" });
+
+    expect(res.json().isSetUp).toBe(true);
+    expect(res.json().steps.codexAppServer.done).toBe(true);
+    expect(res.json().steps.anyAgentKey.done).toBe(true);
+  });
+
+  it("detects Gemini Vertex AI mode by name when GEMINI_AUTH_MODE cannot be decrypted", async () => {
+    mockListSecrets.mockResolvedValue([
+      { name: "GITHUB_TOKEN" },
+      { name: "GEMINI_AUTH_MODE" },
+      { name: "GOOGLE_CLOUD_PROJECT" },
+    ]);
+    mockRetrieveSecret.mockRejectedValue(new Error("decrypt failed: AAD mismatch"));
+    mockCheckRuntimeHealth.mockResolvedValue(true);
+
+    const res = await app.inject({ method: "GET", url: "/api/setup/status" });
+
+    expect(res.json().isSetUp).toBe(true);
+    expect(res.json().steps.geminiKey.done).toBe(true);
+    expect(res.json().steps.anyAgentKey.done).toBe(true);
+  });
 });
 
 describe("POST /api/setup/validate/github-token", () => {

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -106,6 +106,10 @@ export async function setupRoutes(rawApp: FastifyInstance) {
       const secrets = await listSecrets();
       const secretNames = secrets.map((s) => s.name);
 
+      // This endpoint is public (no req.user) so it cannot decrypt
+      // workspace-scoped secrets: the AAD binding (`name|scope|workspaceId`,
+      // see #319) requires the caller's workspaceId. Inferring mode from the
+      // set of stored secret names avoids that read-after-write asymmetry.
       const hasAnthropicKey = secretNames.includes("ANTHROPIC_API_KEY");
       const hasOpenAIKey = secretNames.includes("OPENAI_API_KEY");
       const hasGitToken =
@@ -113,29 +117,10 @@ export async function setupRoutes(rawApp: FastifyInstance) {
         isGitHubAppConfigured() ||
         secretNames.includes("GITLAB_TOKEN");
 
-      let usingSubscription = false;
-      let hasOauthToken = false;
-      try {
-        const authMode = await retrieveSecret("CLAUDE_AUTH_MODE").catch(() => null);
-        if (authMode === "max-subscription") {
-          usingSubscription = isSubscriptionAvailable();
-        }
-        if (authMode === "oauth-token") {
-          hasOauthToken = secretNames.includes("CLAUDE_CODE_OAUTH_TOKEN");
-        }
-      } catch {
-        /* non-critical */
-      }
+      const usingSubscription = isSubscriptionAvailable();
+      const hasOauthToken = secretNames.includes("CLAUDE_CODE_OAUTH_TOKEN");
 
-      let hasCodexAppServer = false;
-      try {
-        const codexAuthMode = await retrieveSecret("CODEX_AUTH_MODE").catch(() => null);
-        if (codexAuthMode === "app-server") {
-          hasCodexAppServer = secretNames.includes("CODEX_APP_SERVER_URL");
-        }
-      } catch {
-        /* non-critical */
-      }
+      const hasCodexAppServer = secretNames.includes("CODEX_APP_SERVER_URL");
 
       const hasCopilotToken = secretNames.includes("COPILOT_GITHUB_TOKEN");
 
@@ -143,15 +128,10 @@ export async function setupRoutes(rawApp: FastifyInstance) {
       const opencodeConfigured = hasAnthropicKey || hasOpenAIKey || hasOpencodeBaseUrl;
 
       const hasGeminiKey = secretNames.includes("GEMINI_API_KEY");
-      let hasGeminiVertexAi = false;
-      try {
-        const geminiAuthMode = await retrieveSecret("GEMINI_AUTH_MODE").catch(() => null);
-        if (geminiAuthMode === "vertex-ai") {
-          hasGeminiVertexAi = true;
-        }
-      } catch {
-        /* non-critical */
-      }
+      // Vertex AI mode is signaled by GOOGLE_CLOUD_PROJECT (written by the
+      // wizard alongside GEMINI_AUTH_MODE="vertex-ai") — distinct from API
+      // key mode.
+      const hasGeminiVertexAi = secretNames.includes("GOOGLE_CLOUD_PROJECT");
 
       const hasAnyAgentKey =
         hasAnthropicKey ||


### PR DESCRIPTION
## Summary

- Fixes the `/setup` redirect loop on fresh installs with auth enabled.
- Drops `retrieveSecret()` calls from the public `/api/setup/status` endpoint — it can't decrypt workspace-scoped rows because it has no `req.user` context.
- Infers Claude OAuth, Codex app-server, and Gemini Vertex AI modes from secret names alone, matching the pattern already used for API-key modes.

## Root cause

PR #319 added AAD binding `name|scope|workspaceId` to AES-256-GCM secrets. The setup wizard, now that the user is authenticated before completing it (and especially after #474's user-scoped secrets), POSTs `CLAUDE_AUTH_MODE` to `/api/secrets` with `workspaceId = req.user.workspaceId`. The AAD baked in at write becomes `CLAUDE_AUTH_MODE|global|<workspaceId>`.

`/api/setup/status` is listed in `PUBLIC_ROUTES` (`auth.ts:50`), so it has no `req.user`. Its call to `retrieveSecret("CLAUDE_AUTH_MODE")` falls through to `buildSecretAAD(name, "global", undefined)` which produces `CLAUDE_AUTH_MODE|global|global`. AAD mismatch → `decrypt` throws → `.catch(() => null)` swallows it silently → `authMode = null` → `hasOauthToken` never set → `isSetUp = false`. Frontend loops on `/setup`.

Same problem applies to `CODEX_AUTH_MODE` and `GEMINI_AUTH_MODE`. #472 touched this file but only decoupled `isSetUp` from runtime health — the AAD mismatch persisted.

## Fix

The endpoint already has `secretNames` from `listSecrets()`. Each mode has a unique sibling secret that's written alongside the `*_AUTH_MODE` row:

| Mode                    | Signal                     |
| ----------------------- | -------------------------- |
| Claude `oauth-token`    | `CLAUDE_CODE_OAUTH_TOKEN`  |
| Claude `api-key`        | `ANTHROPIC_API_KEY`        |
| Claude `max-subscription` | `isSubscriptionAvailable()` |
| Codex `app-server`      | `CODEX_APP_SERVER_URL`     |
| Codex `api-key`         | `OPENAI_API_KEY`           |
| Gemini `vertex-ai`      | `GOOGLE_CLOUD_PROJECT`     |
| Gemini `api-key`        | `GEMINI_API_KEY`           |

No decryption needed. The public endpoint stays public and read-after-write symmetric regardless of whether auth is enabled.

Addresss #476 

## Test plan

- [x] New regression tests in `setup.test.ts` reproduce the AAD-mismatch scenario (mock `retrieveSecret` to always reject) — all three modes still report `isSetUp: true` with the fix
- [x] Tests confirmed to fail on the pre-fix code
- [x] Full API test suite passes (2024/2024)
- [x] Typecheck clean
- [x] Verify manually on a fresh install with `OPTIO_AUTH_DISABLED=false` and OAuth token mode