### PR TITLE
fix(auth): add OIDC routes to public auth routes

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -81,6 +81,8 @@ const PUBLIC_AUTH_ROUTES = new Set([
   "/api/auth/google/callback",
   "/api/auth/gitlab/login",
   "/api/auth/gitlab/callback",
+  "/api/auth/oidc/login",
+  "/api/auth/oidc/callback",
   "/api/auth/cli/start",
   "/api/auth/cli/token",
 ]);


### PR DESCRIPTION
## Summary

Add OIDC login and callback routes to `PUBLIC_AUTH_ROUTES` to fix 401 errors during OIDC authentication flow.

## Problem

When using OIDC (OpenID Connect) authentication with Optio, users encounter 401 Unauthorized errors during the OAuth flow because `/api/auth/oidc/login` and `/api/auth/oidc/callback` require authentication.

This prevents OIDC providers (like Keycloak, Okta, Auth0) from completing the OAuth handshake.

## Solution

Add the two OIDC routes to the `PUBLIC_AUTH_ROUTES` set, following the same pattern as existing GitHub, Google, and GitLab OAuth routes.

```typescript
const PUBLIC_AUTH_ROUTES = new Set([
  // ... existing routes
  "/api/auth/oidc/login",
  "/api/auth/oidc/callback",
  // ...
]);
```

## Testing

- ✅ Manually tested with Keycloak IDP
- ✅ OIDC login flow now completes successfully
- ✅ No impact on other auth methods

## Files Changed

- `apps/api/src/plugins/auth.ts` - Added 2 routes to PUBLIC_AUTH_ROUTES