### PR TITLE
fix(reconciler): guard PR-reactive actions to coding tasks only

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -98,6 +98,10 @@ export const tasks = pgTable(
     agentType: text("agent_type").notNull(),
     containerId: text("container_id"),
     sessionId: text("session_id"),
+    // Only set for coding tasks (taskType="coding"): the PR this task
+    // opened. External pr_review tasks reference a PR via review_drafts
+    // instead — do NOT write prUrl/prNumber for them, or the reconciler
+    // will treat the external PR as this task's own output and auto-merge it.
     prUrl: text("pr_url"),
     prNumber: integer("pr_number"),
     prState: text("pr_state"), // "open" | "merged" | "closed"

--- a/apps/api/src/services/reconcile-snapshot.ts
+++ b/apps/api/src/services/reconcile-snapshot.ts
@@ -87,7 +87,11 @@ async function buildRepoSnapshot(ref: RunRef): Promise<WorldSnapshot | null> {
       readErrors.push({ source: "capacity", message: String(err) });
       return null;
     }),
-    row.taskType === "review"
+    // Only coding tasks own a PR. "review" subtasks and external "pr_review"
+    // tasks reference PRs through other tables (parent task / review_drafts),
+    // so never load PR status for them — that's what keeps them out of the
+    // PR-reactive state machine (auto-merge, auto-resume, launch-review).
+    row.taskType !== "coding" && row.taskType !== null
       ? Promise.resolve(null)
       : loadPrStatus(run, row.createdBy ?? null).catch((err) => {
           readErrors.push({ source: "pr", message: String(err) });
@@ -180,7 +184,7 @@ function loadRepoRun(row: typeof tasks.$inferSelect, ref: RunRef): Run {
     agentType: row.agentType,
     prompt: row.prompt,
     title: row.title,
-    taskType: (row.taskType as "coding" | "review") ?? "coding",
+    taskType: (row.taskType as "coding" | "review" | "pr_review") ?? "coding",
     maxRetries: row.maxRetries,
     priority: row.priority,
     ignoreOffPeak: row.ignoreOffPeak,

--- a/packages/shared/src/reconcile/reconcile-repo.test.ts
+++ b/packages/shared/src/reconcile/reconcile-repo.test.ts
@@ -811,3 +811,135 @@ describe("reconcileRepo — terminal states", () => {
     expect(reconcileRepo(s).kind).toBe("noop");
   });
 });
+
+// ── Non-coding task types never drive PR-reactive actions ───────────────────
+
+describe("reconcileRepo — non-coding task types", () => {
+  const autoMergeReadySettings = {
+    stallThresholdMs: 300_000,
+    autoMerge: true,
+    cautiousMode: false,
+    autoResume: true,
+    reviewEnabled: true,
+    reviewTrigger: "on_ci_pass" as const,
+    offPeakOnly: false,
+    offPeakActive: false,
+    hasReviewSubtask: false,
+    maxAutoResumes: 10,
+    recentAutoResumeCount: 0,
+  };
+
+  it("sanity: coding task with the same inputs DOES auto-merge", () => {
+    // Paired positive test — if this breaks, the negative tests below are
+    // passing for the wrong reason.
+    const s = snapshot(
+      { taskType: "coding" },
+      {
+        state: TaskState.PR_OPENED,
+        prUrl: "https://github.com/acme/repo/pull/1",
+        prNumber: 1,
+        prChecksStatus: "passing",
+      },
+      {
+        pr: makePr({ checksStatus: "passing" }),
+        settings: autoMergeReadySettings,
+      },
+    );
+    expect(reconcileRepo(s).kind).toBe("autoMergePr");
+  });
+
+  it("pr_review with leaked prUrl + passing CI does NOT auto-merge (PR_OPENED)", () => {
+    // Regression guard for the external-PR-review bug: an external-review task
+    // whose prUrl points at someone else's PR must never trigger auto-merge,
+    // even if all the surface gates (autoMerge, CI, no blocking subtasks) line up.
+    const s = snapshot(
+      { taskType: "pr_review" },
+      {
+        state: TaskState.PR_OPENED,
+        prUrl: "https://github.com/acme/repo/pull/1",
+        prNumber: 1,
+        prChecksStatus: "passing",
+      },
+      {
+        pr: makePr({ checksStatus: "passing" }),
+        settings: autoMergeReadySettings,
+      },
+    );
+    const action = reconcileRepo(s);
+    expect(action.kind).not.toBe("autoMergePr");
+    expect(action.kind).not.toBe("launchReview");
+    expect(action.kind).not.toBe("resumeAgent");
+  });
+
+  it("pr_review with leaked prUrl does NOT launchReview on CI pass", () => {
+    const s = snapshot(
+      { taskType: "pr_review" },
+      {
+        state: TaskState.PR_OPENED,
+        prUrl: "https://github.com/acme/repo/pull/1",
+        prNumber: 1,
+        prChecksStatus: null,
+      },
+      {
+        pr: makePr({ checksStatus: "passing" }),
+        settings: autoMergeReadySettings,
+      },
+    );
+    expect(reconcileRepo(s).kind).not.toBe("launchReview");
+  });
+
+  it("pr_review RUNNING with leaked prUrl does NOT promote to PR_OPENED", () => {
+    // decideRunning must not inherit the PR lifecycle for non-coding types.
+    const s = snapshot(
+      { taskType: "pr_review" },
+      {
+        state: TaskState.RUNNING,
+        prUrl: "https://github.com/acme/repo/pull/1",
+        prNumber: 1,
+        lastActivityAt: NOW,
+      },
+    );
+    const action = reconcileRepo(s);
+    if (action.kind === "transition") {
+      expect(action.to).not.toBe(TaskState.PR_OPENED);
+    }
+  });
+
+  it("review subtask with leaked prUrl does NOT auto-merge", () => {
+    // Same guard protects internal review subtasks too — defence in depth,
+    // in case the snapshot loader ever regresses and populates PR state.
+    const s = snapshot(
+      { taskType: "review", parentTaskId: "parent-1", blocksParent: true },
+      {
+        state: TaskState.PR_OPENED,
+        prUrl: "https://github.com/acme/repo/pull/1",
+        prNumber: 1,
+        prChecksStatus: "passing",
+      },
+      {
+        pr: makePr({ checksStatus: "passing" }),
+        settings: autoMergeReadySettings,
+      },
+    );
+    expect(reconcileRepo(s).kind).not.toBe("autoMergePr");
+  });
+
+  it("pr_review FAILED with open PR does NOT auto-merge on recovery", () => {
+    // FAILED with an open PR still passes through decideFromPrStatus — ensure
+    // the non-coding guard covers that path too.
+    const s = snapshot(
+      { taskType: "pr_review" },
+      {
+        state: TaskState.FAILED,
+        prUrl: "https://github.com/acme/repo/pull/1",
+        prNumber: 1,
+        prChecksStatus: "passing",
+      },
+      {
+        pr: makePr({ checksStatus: "passing" }),
+        settings: autoMergeReadySettings,
+      },
+    );
+    expect(reconcileRepo(s).kind).not.toBe("autoMergePr");
+  });
+});

--- a/packages/shared/src/reconcile/reconcile-repo.ts
+++ b/packages/shared/src/reconcile/reconcile-repo.ts
@@ -269,10 +269,12 @@ function decideProvisioning(snapshot: WorldSnapshot): RepoAction {
 
 function decideRunning(snapshot: WorldSnapshot): RepoAction {
   if (snapshot.run.kind !== "repo") return { kind: "noop", reason: "wrong_kind" };
-  const { status } = snapshot.run;
+  const { spec, status } = snapshot.run;
 
-  // PR was just detected in agent output; promote.
-  if (status.prUrl && status.state === TaskState.RUNNING) {
+  // PR was just detected in agent output; promote. Only coding tasks follow
+  // the PR lifecycle — pr_review tasks reference someone else's PR and never
+  // enter PR_OPENED even if a prUrl is set on the row.
+  if (spec.taskType === "coding" && status.prUrl && status.state === TaskState.RUNNING) {
     return {
       kind: "transition",
       to: TaskState.PR_OPENED,
@@ -337,7 +339,15 @@ function decideFailed(snapshot: WorldSnapshot): RepoAction {
 /** Map PR status into an action. Mirrors determinePrAction in pr-watcher-worker. */
 function decideFromPrStatus(snapshot: WorldSnapshot, allowFailComplete: boolean): RepoAction {
   if (snapshot.run.kind !== "repo") return { kind: "noop", reason: "wrong_kind" };
-  const { status } = snapshot.run;
+  const { spec, status } = snapshot.run;
+  // Only coding tasks own the PR attached to their row. Review subtasks and
+  // external pr_review tasks must never drive PR-reactive actions (auto-merge,
+  // auto-resume, launch-review) — the PR they reference isn't theirs.
+  // Defence-in-depth: even if a stray prUrl write ever leaks through, this
+  // guard prevents the reconciler from acting on it.
+  if (spec.taskType !== "coding") {
+    return { kind: "noop", reason: `pr_machinery_disabled_for_${spec.taskType}` };
+  }
   const pr = snapshot.pr;
   if (!pr) {
     return { kind: "noop", reason: "pr_info_not_yet_available" };

--- a/packages/shared/src/reconcile/types.ts
+++ b/packages/shared/src/reconcile/types.ts
@@ -28,7 +28,17 @@ export interface RepoRunSpec {
   agentType: string;
   prompt: string;
   title: string;
-  taskType: "coding" | "review";
+  /**
+   * "coding" — agent opens a PR; full PR-reactive state machine applies
+   *   (auto-merge, auto-resume on CI fail, review triggers).
+   * "review" — internal review subtask of a coding task; no PR of its own.
+   * "pr_review" — external PR review; references a PR via `review_drafts`,
+   *   not `tasks.prUrl`. Reconciler treats this as non-PR-reactive.
+   *
+   * Only "coding" tasks drive PR-reactive behavior. New task types default
+   * to non-reactive unless explicitly opted into the coding branch.
+   */
+  taskType: "coding" | "review" | "pr_review";
   maxRetries: number;
   priority: number;
   ignoreOffPeak: boolean;


### PR DESCRIPTION
## Summary

External PR review tasks (`taskType=pr_review`) were inheriting the repo reconciler's PR machinery because `decideFromPrStatus` only checked whether a `prUrl` was set, not whether the task actually owned that PR. With `autoMerge` enabled on the repo, the reconciler happily squashed the external PR before the review agent could finish drafting — see PR #479.

This is the **defensive half** of the fix. It makes the reconciler correct-by-construction for non-coding task types without requiring any data migration. A follow-up PR stops writing `prUrl` on `pr_review` task rows entirely (the actual root-cause fix); this one is what guarantees it can't happen again even if a future task type leaks the column.

### What changed

- Widened `RepoRunSpec.taskType` to `"coding" | "review" | "pr_review"` so the type system forces new cases to be handled; documented the semantics inline.
- Snapshot loader (`reconcile-snapshot.ts`) now skips PR status loading for *all* non-coding task types, not just `"review"`. Previously `"pr_review"` slipped through the `=== "review"` check.
- `decideFromPrStatus` short-circuits to `noop` when `spec.taskType !== "coding"` — belt-and-braces against any path that reaches it (PR_OPENED, FAILED-with-open-PR).
- `decideRunning` no longer promotes a non-coding task into `PR_OPENED` even if `prUrl` is populated on the row.
- Noted the invariant on `tasks.prUrl` in the schema: only coding tasks; external reviews reference their PR via `review_drafts`.

### Regression coverage

`packages/shared/src/reconcile/reconcile-repo.test.ts` gains 6 tests — including a paired positive coding-task test, so the negatives can't pass for the wrong reason:

- `pr_review` with leaked `prUrl` + passing CI does NOT auto-merge
- `pr_review` does NOT `launchReview` on CI pass
- `pr_review` RUNNING with leaked `prUrl` does NOT promote to PR_OPENED
- `review` subtask with leaked `prUrl` does NOT auto-merge (depth)
- `pr_review` FAILED with open PR does NOT auto-merge on recovery
- Sanity: coding task with identical inputs DOES auto-merge

## Test plan

- [x] `pnpm turbo typecheck` — all 12 packages green
- [x] `pnpm turbo test` — all 2021 API + 389 shared tests green (reconcile-repo up to 57 from 51)
- [x] `pnpm format:check` — clean
- [ ] After merge: verify an external-review task with autoMerge-enabled repo does not get auto-merged on staging