### PR TITLE
fix(reviews): stop writing external PR URLs to pr_review task rows

### DIFF
--- a/apps/api/src/db/migrations/1777100000_backfill_pr_review_pr_url.sql
+++ b/apps/api/src/db/migrations/1777100000_backfill_pr_review_pr_url.sql
@@ -1,0 +1,17 @@
+-- Backfill: clear pr_url / pr_number on in-flight pr_review tasks.
+--
+-- The `tasks.pr_url` column means "the PR this task opened." External
+-- pr_review tasks were mistakenly persisting the PR they were REVIEWING
+-- into that column, which drove the reconciler's auto-merge path to
+-- squash the external PR as soon as CI went green. The application layer
+-- no longer writes pr_url / pr_number for pr_review rows; this migration
+-- cleans up any in-flight rows that predate the fix.
+--
+-- Terminal rows (completed / cancelled / failed) keep their data for
+-- audit. Per PR #480, the reconciler short-circuits on non-coding
+-- taskTypes, so leaving terminal data in place is safe.
+
+UPDATE tasks
+   SET pr_url = NULL, pr_number = NULL
+ WHERE task_type = 'pr_review'
+   AND state NOT IN ('completed', 'cancelled', 'failed');

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1777012800000,
       "tag": "1777012800_user_scoped_secrets",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1777100000000,
+      "tag": "1777100000_backfill_pr_review_pr_url",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/routes/query-validation.test.ts
+++ b/apps/api/src/routes/query-validation.test.ts
@@ -38,6 +38,7 @@ vi.mock("../services/task-service.js", () => ({
   transitionTask: vi.fn(),
   getAllTaskLogs: vi.fn().mockResolvedValue([]),
   forceRedoTask: vi.fn(),
+  hydratePrReviewPrUrls: async (rows: unknown[]) => rows,
 }));
 
 vi.mock("../services/dependency-service.js", () => ({

--- a/apps/api/src/routes/tasks.test.ts
+++ b/apps/api/src/routes/tasks.test.ts
@@ -26,6 +26,7 @@ vi.mock("../services/task-service.js", () => ({
   getAllTaskLogs: (...args: unknown[]) => mockGetAllTaskLogs(...args),
   getTaskEvents: (...args: unknown[]) => mockGetTaskEvents(...args),
   getTaskStats: (...args: unknown[]) => mockGetTaskStats(...args),
+  hydratePrReviewPrUrls: async (rows: unknown[]) => rows,
 }));
 
 const mockAddDependencies = vi.fn();

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -240,7 +240,8 @@ export async function taskRoutes(rawApp: FastifyInstance) {
         // Enrich running tasks with isStalled flag (lightweight — no lastLogSummary)
         const globalThreshold = parseIntEnv("OPTIO_STALL_THRESHOLD_MS", 300000);
         const now = new Date();
-        const enriched = taskList.map((t) => ({
+        const hydrated = await taskService.hydratePrReviewPrUrls(taskList);
+        const enriched = hydrated.map((t) => ({
           ...t,
           type: "repo-task" as const,
           isStalled: isTaskStalled(t, now, globalThreshold),
@@ -349,11 +350,12 @@ export async function taskRoutes(rawApp: FastifyInstance) {
       // Try the repo-task (tasks table) path first — this is the most common
       // case and returns the full enriched shape (pendingReason, pipelineProgress,
       // stallInfo).
-      const task = await taskService.getTask(id);
-      if (task) {
-        if (workspaceId && task.workspaceId !== workspaceId) {
+      const rawTask = await taskService.getTask(id);
+      if (rawTask) {
+        if (workspaceId && rawTask.workspaceId !== workspaceId) {
           return reply.status(404).send({ error: "Task not found" });
         }
+        const [task] = await taskService.hydratePrReviewPrUrls([rawTask]);
 
         let pendingReason: string | null = null;
         if (["pending", "waiting_on_deps", "queued"].includes(task.state)) {

--- a/apps/api/src/services/pr-review-service.ts
+++ b/apps/api/src/services/pr-review-service.ts
@@ -215,11 +215,11 @@ export async function launchPrReview(input: {
     workspaceId: input.workspaceId ?? null,
   });
 
-  // Set taskType to pr_review
-  await db
-    .update(tasks)
-    .set({ taskType: "pr_review", prUrl: input.prUrl, prNumber })
-    .where(eq(tasks.id, task.id));
+  // Set taskType to pr_review. Deliberately do NOT persist prUrl/prNumber on
+  // the task row — those columns mean "the PR this task opened" for coding
+  // tasks, and the reconciler will try to auto-merge anything it finds there.
+  // The external PR being reviewed is tracked on review_drafts instead.
+  await db.update(tasks).set({ taskType: "pr_review" }).where(eq(tasks.id, task.id));
 
   // Create or promote review draft row
   const origin = input.origin ?? "manual";
@@ -703,10 +703,8 @@ export async function postReviewChat(input: {
     workspaceId: input.workspaceId ?? null,
   });
 
-  await db
-    .update(tasks)
-    .set({ taskType: "pr_review", prUrl: draft.prUrl, prNumber: draft.prNumber })
-    .where(eq(tasks.id, turnTask.id));
+  // See note in launchPrReview: prUrl/prNumber stay null on pr_review rows.
+  await db.update(tasks).set({ taskType: "pr_review" }).where(eq(tasks.id, turnTask.id));
 
   // Look up the repo config — needed for claudeModel override on resume.
   const { getRepoByUrl } = await import("./repo-service.js");

--- a/apps/api/src/services/task-service.ts
+++ b/apps/api/src/services/task-service.ts
@@ -68,6 +68,50 @@ export async function getTask(id: string) {
   return task ?? null;
 }
 
+/**
+ * Fill `prUrl`/`prNumber` on pr_review tasks for HTTP responses. The columns
+ * stay null on the row — that's what keeps the reconciler from treating the
+ * external PR as our own — so we denormalize at the read boundary.
+ *
+ * Resolution order for pr_review rows: existing column value (legacy rows
+ * that predate the fix) → matching review_drafts row (root review tasks) →
+ * `metadata.prUrl`/`metadata.prNumber` (chat-turn tasks, which don't own a
+ * draft). Non-pr_review rows pass through unchanged.
+ */
+export async function hydratePrReviewPrUrls<T extends typeof tasks.$inferSelect>(
+  rows: T[],
+): Promise<T[]> {
+  const reviewIds = rows.filter((r) => r.taskType === "pr_review").map((r) => r.id);
+  if (reviewIds.length === 0) return rows;
+
+  const drafts = await db
+    .select({
+      taskId: reviewDrafts.taskId,
+      prUrl: reviewDrafts.prUrl,
+      prNumber: reviewDrafts.prNumber,
+    })
+    .from(reviewDrafts)
+    .where(
+      sql`${reviewDrafts.taskId} IN (${sql.join(
+        reviewIds.map((id) => sql`${id}`),
+        sql`, `,
+      )})`,
+    );
+
+  const byTaskId = new Map(drafts.map((d) => [d.taskId, d]));
+  return rows.map((r) => {
+    if (r.taskType !== "pr_review") return r;
+    if (r.prUrl) return r;
+    const d = byTaskId.get(r.id);
+    if (d) return { ...r, prUrl: d.prUrl, prNumber: d.prNumber };
+    const meta = r.metadata as { prUrl?: unknown; prNumber?: unknown } | null;
+    const metaPrUrl = typeof meta?.prUrl === "string" ? meta.prUrl : null;
+    const metaPrNumber = typeof meta?.prNumber === "number" ? meta.prNumber : null;
+    if (metaPrUrl) return { ...r, prUrl: metaPrUrl, prNumber: metaPrNumber };
+    return r;
+  });
+}
+
 export async function listTasks(opts?: {
   state?: string;
   limit?: number;
@@ -196,7 +240,8 @@ export async function searchTasks(opts: SearchTasksOpts) {
     nextCursor = Buffer.from(`${last.createdAt.toISOString()}|${last.id}`).toString("base64");
   }
 
-  return { tasks: items, nextCursor, hasMore };
+  const hydrated = await hydratePrReviewPrUrls(items);
+  return { tasks: hydrated, nextCursor, hasMore };
 }
 
 export async function transitionTask(


### PR DESCRIPTION
## Summary

Complements #480. That PR hardened the reconciler so it can't auto-merge non-coding task types. This PR fixes the actual root cause: `launchPrReview` was writing the external PR's URL into `tasks.pr_url`, a column whose only valid meaning is "the PR this task opened." Any caller that looked at `task.pr_url` (reconciler, watcher, `isOptioAuthored`) could be misled into acting on someone else's PR.

After this lands, the column is strictly enforced: only `taskType="coding"` rows have a populated `pr_url`. It becomes structurally impossible for the reconciler to mistake an external PR for its own output.

### What changed

- `pr-review-service.launchPrReview` and the chat-turn update no longer write `pr_url` / `pr_number` to the task row.
- New `hydratePrReviewPrUrls` helper in `task-service.ts` denormalizes `pr_url` / `pr_number` onto `pr_review` rows at the HTTP boundary, so shared UI chrome (task list, card, detail header) keeps rendering PR links without web changes. Resolution order: legacy column value → matching `review_drafts` row → `metadata.prUrl` for chat-turn tasks.
- Applied in `GET /api/tasks`, `GET /api/tasks/:id`, and `searchTasks`.
- Migration `1777100000_backfill_pr_review_pr_url.sql` clears `pr_url` / `pr_number` on in-flight `pr_review` rows (state NOT IN completed/cancelled/failed). Terminal rows keep their data for audit — #480's non-coding guard prevents any re-action on them.
- Updated existing test mocks of `task-service.js` to re-export the new helper as a pass-through.

### Dependency

Mergeable independently, but **merge #480 first** — that way the reconciler's non-coding guard is already in place before any existing in-flight rows get their `pr_url` cleared, avoiding a brief window where a reconciler tick could still see the old data.

## Test plan

- [x] `pnpm turbo typecheck` — 12 packages green
- [x] `pnpm turbo test` — 2024 API + 389 shared tests green
- [x] `pnpm format:check` — clean
- [x] `bash scripts/check-migration-prefixes.sh` — no duplicates
- [ ] After merge: trigger a manual review on an external PR with `autoMerge=true` on the repo; verify the PR does NOT get merged and the review draft appears in the UI as expected
- [ ] After merge: verify task list, task card, and task detail page all still show the PR link for `pr_review` tasks (denormalization is working)