### PR TITLE
fix(helm): restore chown caps in postgres init containers

### DIFF
--- a/helm/optio/templates/postgres.yaml
+++ b/helm/optio/templates/postgres.yaml
@@ -64,6 +64,12 @@ spec:
             capabilities:
               drop:
                 - ALL
+              # chown/chmod require these caps even when running as UID 0;
+              # `drop: ALL` alone leaves root unable to change ownership.
+              add:
+                - CHOWN
+                - FOWNER
+                - DAC_OVERRIDE
           command: ['sh', '-c']
           args:
             - |
@@ -83,6 +89,10 @@ spec:
             capabilities:
               drop:
                 - ALL
+              add:
+                - CHOWN
+                - FOWNER
+                - DAC_OVERRIDE
           command: ['sh', '-c']
           args:
             - |


### PR DESCRIPTION
## Summary

- Reopens #475: fresh Helm installs still fail because the init container added in #472 drops all Linux capabilities. Under `drop: [ALL]`, UID 0 no longer has `CAP_CHOWN`/`CAP_FOWNER`, and `chown(2)` returns `EPERM` — which is exactly the "Operation not permitted" output in the issue.
- Re-add the minimum caps needed (`CHOWN`, `FOWNER`, `DAC_OVERRIDE`) to both `init-data-perms` and `init-tls` while keeping `drop: ALL` as the baseline.

## Why root+drop-ALL fails

`runAsUser: 0` without `CAP_CHOWN` is not root for ownership purposes. The kernel checks the capability bit, not the UID, for `chown(2)`/`chmod(2)`. `init-tls` would have hit the same failure as soon as anyone enabled `postgresql.tls.enabled` — it just hadn't been exercised on a fresh install.

## Test plan

- [x] `helm lint helm/optio` passes
- [x] `helm template` renders the new `capabilities.add` block on both init containers (with and without `postgresql.tls.enabled`)
- [ ] Fresh install on a cluster where the CSI driver doesn't apply fsGroup (the repro case from #475) — postgres starts cleanly
- [ ] TLS-enabled install — `init-tls` chowns the copied cert/key successfully