### PR TITLE
feat(gemini): update Gemini model options with new preview models

### DIFF
--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -1230,7 +1230,9 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
               <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
               <option value="gemini-2.0-flash">Gemini 2.0 Flash</option>
               <option value="gemini-3-pro">Gemini 3 Pro</option>
-              <option value="gemini-3-flash">Gemini 3 Flash</option>
+              <option value="gemini-3-flash-preview">Gemini 3 Flash Preview</option>
+              <option value="gemini-3.1-pro-preview">Gemini 3.1 Pro</option>
+              <option value="gemini-3.1-flash-lite-preview">Gemini 3.1 Flash Lite Preview</option>
             </select>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- Update gemini-3-flash to gemini-3-flash-preview
- Add gemini-3.1-pro-preview option
- Add gemini-3.1-flash-lite-preview option

## Changes
Updated the Gemini model dropdown in the repository settings page to use the correct preview model identifiers and add support for the new Gemini 3.1 models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)