### PR TITLE
refactor(web): unify task and PR-review detail views on shared primitives

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -61,6 +61,7 @@ import { sessionTerminalWs } from "./ws/session-terminal.js";
 import { sessionChatWs } from "./ws/session-chat.js";
 import { optioChatWs } from "./ws/optio-chat.js";
 import { workflowRunLogStreamWs } from "./ws/workflow-run-log-stream.js";
+import { prReviewLogStreamWs } from "./ws/pr-review-log-stream.js";
 import authPlugin from "./plugins/auth.js";
 import { httpMetricsPlugin } from "./plugins/http-metrics.js";
 
@@ -295,6 +296,7 @@ export async function buildServer() {
   await app.register(sessionChatWs);
   await app.register(optioChatWs);
   await app.register(workflowRunLogStreamWs);
+  await app.register(prReviewLogStreamWs);
 
   // Global error handler.
   //

--- a/apps/api/src/services/event-bus.ts
+++ b/apps/api/src/services/event-bus.ts
@@ -22,9 +22,12 @@ export async function publishEvent(event: WsEvent): Promise<void> {
 
   await redis.publish(channel, JSON.stringify(enrichedEvent));
 
-  // Also publish to task-specific channel for targeted subscriptions
+  // Also publish to entity-specific channels for targeted subscriptions
   if ("taskId" in event) {
     await redis.publish(`optio:task:${event.taskId}`, JSON.stringify(enrichedEvent));
+  }
+  if ("prReviewId" in event && event.prReviewId) {
+    await redis.publish(`optio:pr-review:${event.prReviewId}`, JSON.stringify(enrichedEvent));
   }
 }
 

--- a/apps/api/src/workers/pr-review-worker.ts
+++ b/apps/api/src/workers/pr-review-worker.ts
@@ -619,12 +619,17 @@ export function startPrReviewWorker() {
           await transitionRun(runId, PrReviewRunState.FAILED, {
             errorMessage: result.error ?? "Agent failed",
           });
-          await prReviewService.transitionPrReview(
-            run.prReviewId,
-            PrReviewState.FAILED,
-            "run_failed",
-            { message: result.error ?? "Agent run failed", runId },
-          );
+          // Chat runs are follow-up turns on an already-produced draft; their
+          // failure is a conversational hiccup, not grounds to invalidate the
+          // review. Only initial/rereview runs flip the parent to FAILED.
+          if (run.kind !== "chat") {
+            await prReviewService.transitionPrReview(
+              run.prReviewId,
+              PrReviewState.FAILED,
+              "run_failed",
+              { message: result.error ?? "Agent run failed", runId },
+            );
+          }
         }
 
         await enqueueReconcile(
@@ -635,12 +640,14 @@ export function startPrReviewWorker() {
         log.error({ err }, "PR review run failed");
         const msg = err instanceof Error ? err.message : String(err);
         await transitionRun(runId, PrReviewRunState.FAILED, { errorMessage: msg }).catch(() => {});
-        await prReviewService
-          .transitionPrReview(run.prReviewId, PrReviewState.FAILED, "worker_exception", {
-            message: msg,
-            runId,
-          })
-          .catch(() => {});
+        if (run.kind !== "chat") {
+          await prReviewService
+            .transitionPrReview(run.prReviewId, PrReviewState.FAILED, "worker_exception", {
+              message: msg,
+              runId,
+            })
+            .catch(() => {});
+        }
       } finally {
         if (repoPodId) {
           await repoPool.releaseRepoPodTask(repoPodId).catch(() => {});

--- a/apps/api/src/ws/pr-review-log-stream.ts
+++ b/apps/api/src/ws/pr-review-log-stream.ts
@@ -1,0 +1,102 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { createSubscriber } from "../services/event-bus.js";
+import { authenticateWs } from "./ws-auth.js";
+import { getPrReview, getLatestRun } from "../services/pr-review-service.js";
+import { db } from "../db/client.js";
+import { taskLogs } from "../db/schema.js";
+import {
+  getClientIp,
+  trackConnection,
+  releaseConnection,
+  WS_CLOSE_CONNECTION_LIMIT,
+} from "./ws-limits.js";
+
+export async function prReviewLogStreamWs(app: FastifyInstance) {
+  app.get("/ws/pr-reviews/:id/logs", { websocket: true }, async (socket, req) => {
+    const clientIp = getClientIp(req);
+
+    if (!trackConnection(clientIp)) {
+      socket.close(WS_CLOSE_CONNECTION_LIMIT, "Too many connections");
+      return;
+    }
+
+    const user = await authenticateWs(socket, req);
+    if (!user) {
+      releaseConnection(clientIp);
+      return;
+    }
+
+    const { id } = z.object({ id: z.string() }).parse(req.params);
+
+    const review = await getPrReview(id);
+    if (!review) {
+      socket.close(4404, "PR review not found");
+      releaseConnection(clientIp);
+      return;
+    }
+    if (user.workspaceId && review.workspaceId && review.workspaceId !== user.workspaceId) {
+      socket.close(4403, "Access denied");
+      releaseConnection(clientIp);
+      return;
+    }
+
+    // Send catch-up: recent logs from the latest run so reconnecting clients
+    // don't miss data. Logs are stored in task_logs keyed by pr_review_run_id.
+    try {
+      const latest = await getLatestRun(id);
+      if (latest) {
+        const recent = await db
+          .select()
+          .from(taskLogs)
+          .where(eq(taskLogs.prReviewRunId, latest.id))
+          .orderBy(taskLogs.timestamp)
+          .limit(50);
+        for (const log of recent) {
+          socket.send(
+            JSON.stringify({
+              type: "pr_review_run:log",
+              prReviewId: id,
+              runId: latest.id,
+              content: log.content,
+              stream: log.stream,
+              timestamp: log.timestamp,
+              logType: log.logType,
+              metadata: log.metadata,
+              catchUp: true,
+            }),
+          );
+        }
+      }
+    } catch {
+      // ignore catch-up errors — still subscribe to live events
+    }
+
+    const subscriber = createSubscriber();
+    const channel = `optio:pr-review:${id}`;
+    subscriber.subscribe(channel);
+
+    subscriber.on("message", (_ch: string, message: string) => {
+      try {
+        const event = JSON.parse(message);
+        if (
+          event.type === "pr_review_run:log" ||
+          event.type === "pr_review_run:state_changed" ||
+          event.type === "pr_review:state_changed" ||
+          event.type === "pr_review:stale"
+        ) {
+          socket.send(message);
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    socket.on("close", () => {
+      releaseConnection(clientIp);
+      subscriber.unsubscribe(channel);
+      subscriber.disconnect();
+    });
+  });
+}

--- a/apps/web/src/app/jobs/[id]/page.tsx
+++ b/apps/web/src/app/jobs/[id]/page.tsx
@@ -22,16 +22,15 @@ import {
   Zap,
   Webhook,
   Calendar,
-  CheckCircle2,
   XCircle,
   CircleDot,
-  Timer,
   Pencil,
   Copy,
   CopyPlus,
 } from "lucide-react";
 import { RunWorkflowDialog } from "@/components/run-workflow-dialog";
 import { StateBadge } from "@/components/state-badge";
+import { DetailHeader } from "@/components/detail-header";
 import { MetadataCard } from "@/components/metadata-card";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -232,169 +231,164 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ id: s
   const successRate = runs.length > 0 ? Math.round((completedRuns / runs.length) * 100) : 0;
 
   return (
-    <div className="p-6 max-w-5xl mx-auto">
-      {/* Header */}
-      <Link
-        href="/jobs"
-        className="inline-flex items-center gap-1.5 text-sm text-text-muted hover:text-text mb-4"
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Back to Standalone
-      </Link>
-
-      <div className="flex flex-col gap-3 mb-6 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <div
-            className={cn(
-              "w-2.5 h-2.5 rounded-full shrink-0",
-              workflow.enabled ? "bg-green-500" : "bg-zinc-400",
-            )}
-          />
-          <div>
-            <h1 className="text-2xl font-semibold tracking-tight">{workflow.name}</h1>
-            {workflow.description && (
-              <p className="text-sm text-text-muted mt-0.5">{workflow.description}</p>
-            )}
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => setShowRunDialog(true)}
-            disabled={!workflow.enabled || actionLoading}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm bg-primary text-white hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            title={workflow.enabled ? "Run this task" : "Task is disabled"}
-          >
-            <Play className="w-4 h-4" /> Run
-          </button>
-          <Link
-            href={`/jobs/${id}/edit`}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm text-text-muted hover:text-text hover:bg-bg-hover transition-colors"
-          >
-            <Pencil className="w-4 h-4" /> Edit
+    <>
+      <DetailHeader
+        title={workflow.name}
+        subtitle={
+          <Link href="/jobs" className="inline-flex items-center gap-1 hover:text-primary">
+            <ArrowLeft className="w-3 h-3" />
+            Standalone
           </Link>
-          <button
-            onClick={handleDuplicate}
-            disabled={actionLoading}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm text-text-muted hover:text-text hover:bg-bg-hover transition-colors"
-            title="Duplicate workflow"
-          >
-            <CopyPlus className="w-4 h-4" /> Duplicate
-          </button>
+        }
+        state={workflow.enabled ? "enabled" : "disabled"}
+        metaItems={
+          workflow.description
+            ? [<span className="text-text-muted">{workflow.description}</span>]
+            : undefined
+        }
+        rightSlot={
           <button
             onClick={() => refresh()}
             disabled={actionLoading}
-            className="p-2 rounded-md hover:bg-bg-hover text-text-muted hover:text-text transition-colors"
+            className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted transition-colors"
             title="Refresh"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
-          <button
-            onClick={handleToggleEnabled}
-            disabled={actionLoading}
-            className={cn(
-              "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm transition-colors",
-              workflow.enabled
-                ? "hover:bg-warning/10 text-text-muted hover:text-warning"
-                : "hover:bg-success/10 text-text-muted hover:text-success",
-            )}
-          >
-            {workflow.enabled ? (
-              <>
-                <Pause className="w-4 h-4" /> Disable
-              </>
-            ) : (
-              <>
-                <Play className="w-4 h-4" /> Enable
-              </>
-            )}
-          </button>
-          <button
-            onClick={handleDelete}
-            disabled={actionLoading}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm text-text-muted hover:text-error hover:bg-error/10 transition-colors"
-          >
-            <Trash2 className="w-4 h-4" /> Delete
-          </button>
+        }
+        actions={
+          <>
+            <button
+              onClick={() => setShowRunDialog(true)}
+              disabled={!workflow.enabled || actionLoading}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-white text-xs hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title={workflow.enabled ? "Run this task" : "Task is disabled"}
+            >
+              <Play className="w-3 h-3" /> Run
+            </button>
+            <Link
+              href={`/jobs/${id}/edit`}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-bg text-text-muted text-xs hover:bg-bg-hover hover:text-text transition-colors"
+            >
+              <Pencil className="w-3 h-3" /> Edit
+            </Link>
+            <button
+              onClick={handleDuplicate}
+              disabled={actionLoading}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-bg text-text-muted text-xs hover:bg-bg-hover hover:text-text transition-colors"
+              title="Duplicate workflow"
+            >
+              <CopyPlus className="w-3 h-3" /> Duplicate
+            </button>
+            <button
+              onClick={handleToggleEnabled}
+              disabled={actionLoading}
+              className={cn(
+                "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs transition-colors",
+                workflow.enabled
+                  ? "bg-warning/10 text-warning hover:bg-warning/20"
+                  : "bg-success/10 text-success hover:bg-success/20",
+              )}
+            >
+              {workflow.enabled ? (
+                <>
+                  <Pause className="w-3 h-3" /> Disable
+                </>
+              ) : (
+                <>
+                  <Play className="w-3 h-3" /> Enable
+                </>
+              )}
+            </button>
+            <button
+              onClick={handleDelete}
+              disabled={actionLoading}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-error/10 text-error text-xs hover:bg-error/20 transition-colors"
+            >
+              <Trash2 className="w-3 h-3" /> Delete
+            </button>
+          </>
+        }
+      />
+
+      <div className="p-6 max-w-5xl mx-auto">
+        {/* Stats bar */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+          <MetadataCard icon={Hash} label="Total Runs" value={workflow.runCount} size="lg" />
+          <MetadataCard
+            icon={Activity}
+            label="Success Rate"
+            value={runs.length > 0 ? `${successRate}%` : "\u2014"}
+            size="lg"
+          />
+          <MetadataCard
+            icon={DollarSign}
+            label="Total Cost"
+            value={`$${parseFloat(workflow.totalCostUsd).toFixed(2)}`}
+            size="lg"
+          />
+          <MetadataCard
+            icon={Clock}
+            label="Last Run"
+            value={workflow.lastRunAt ? formatRelativeTime(workflow.lastRunAt) : "\u2014"}
+            size="lg"
+          />
         </div>
-      </div>
 
-      {/* Stats bar */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
-        <MetadataCard icon={Hash} label="Total Runs" value={workflow.runCount} size="lg" />
-        <MetadataCard
-          icon={Activity}
-          label="Success Rate"
-          value={runs.length > 0 ? `${successRate}%` : "\u2014"}
-          size="lg"
-        />
-        <MetadataCard
-          icon={DollarSign}
-          label="Total Cost"
-          value={`$${parseFloat(workflow.totalCostUsd).toFixed(2)}`}
-          size="lg"
-        />
-        <MetadataCard
-          icon={Clock}
-          label="Last Run"
-          value={workflow.lastRunAt ? formatRelativeTime(workflow.lastRunAt) : "\u2014"}
-          size="lg"
-        />
-      </div>
+        {/* Active runs indicator */}
+        {activeRuns > 0 && (
+          <div className="mb-4 flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/5 border border-primary/20 text-sm text-primary">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            {activeRuns} run{activeRuns !== 1 ? "s" : ""} active — auto-refreshing
+          </div>
+        )}
 
-      {/* Active runs indicator */}
-      {activeRuns > 0 && (
-        <div className="mb-4 flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/5 border border-primary/20 text-sm text-primary">
-          <Loader2 className="w-4 h-4 animate-spin" />
-          {activeRuns} run{activeRuns !== 1 ? "s" : ""} active — auto-refreshing
+        {/* Tabs */}
+        <div className="flex gap-1 mb-4 border-b border-border">
+          {(["runs", "triggers", "config"] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={cn(
+                "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+                activeTab === tab
+                  ? "border-primary text-text"
+                  : "border-transparent text-text-muted hover:text-text",
+              )}
+            >
+              {tab === "runs" && `Runs (${runs.length})`}
+              {tab === "triggers" && `Triggers (${triggers.length})`}
+              {tab === "config" && "Configuration"}
+            </button>
+          ))}
         </div>
-      )}
 
-      {/* Tabs */}
-      <div className="flex gap-1 mb-4 border-b border-border">
-        {(["runs", "triggers", "config"] as const).map((tab) => (
-          <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
-            className={cn(
-              "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              activeTab === tab
-                ? "border-primary text-text"
-                : "border-transparent text-text-muted hover:text-text",
-            )}
-          >
-            {tab === "runs" && `Runs (${runs.length})`}
-            {tab === "triggers" && `Triggers (${triggers.length})`}
-            {tab === "config" && "Configuration"}
-          </button>
-        ))}
+        {/* Tab content */}
+        {activeTab === "runs" && (
+          <RunsTable
+            runs={runs}
+            workflowId={id}
+            onRunClick={() => workflow.enabled && setShowRunDialog(true)}
+            canRun={workflow.enabled}
+          />
+        )}
+        {activeTab === "triggers" && <TriggersList triggers={triggers} workflowId={id} />}
+        {activeTab === "config" && (
+          <ConfigPanel workflow={workflow} showPrompt={showPrompt} setShowPrompt={setShowPrompt} />
+        )}
+
+        {/* Run dialog */}
+        {showRunDialog && (
+          <RunWorkflowDialog
+            workflowId={workflow.id}
+            workflowName={workflow.name}
+            paramsSchema={workflow.paramsSchema}
+            onClose={() => setShowRunDialog(false)}
+            onRun={refresh}
+          />
+        )}
       </div>
-
-      {/* Tab content */}
-      {activeTab === "runs" && (
-        <RunsTable
-          runs={runs}
-          workflowId={id}
-          onRunClick={() => workflow.enabled && setShowRunDialog(true)}
-          canRun={workflow.enabled}
-        />
-      )}
-      {activeTab === "triggers" && <TriggersList triggers={triggers} workflowId={id} />}
-      {activeTab === "config" && (
-        <ConfigPanel workflow={workflow} showPrompt={showPrompt} setShowPrompt={setShowPrompt} />
-      )}
-
-      {/* Run dialog */}
-      {showRunDialog && (
-        <RunWorkflowDialog
-          workflowId={workflow.id}
-          workflowName={workflow.name}
-          paramsSchema={workflow.paramsSchema}
-          onClose={() => setShowRunDialog(false)}
-          onRun={refresh}
-        />
-      )}
-    </div>
+    </>
   );
 }
 

--- a/apps/web/src/app/jobs/[id]/runs/[runId]/page.tsx
+++ b/apps/web/src/app/jobs/[id]/runs/[runId]/page.tsx
@@ -74,7 +74,7 @@ export default function WorkflowRunDetailPage({
   const [actionLoading, setActionLoading] = useState(false);
   const [showTimeline, setShowTimeline] = useState(true);
   const [outputCollapsed, setOutputCollapsed] = useState(false);
-  const [paramsCollapsed, setParamsCollapsed] = useState(true);
+  const [paramsCollapsed, setParamsCollapsed] = useState(false);
 
   usePageTitle(run ? `Run ${run.id.slice(0, 8)}` : "Task Run");
 
@@ -335,65 +335,69 @@ export default function WorkflowRunDetailPage({
       {/* Main content: log column + timeline sidebar — mirrors /tasks/[id] */}
       <div className="flex-1 flex overflow-hidden">
         <div className="flex-1 min-w-0 flex flex-col">
-          {/* Output widget — collapsible, only when present */}
-          {hasOutput && (
-            <div className="shrink-0 border-b border-border bg-bg-card">
-              <button
-                onClick={() => setOutputCollapsed((v) => !v)}
-                className="w-full flex items-center gap-2 px-4 py-2 text-xs hover:bg-bg-hover transition-colors"
-              >
-                {outputCollapsed ? (
-                  <ChevronRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
-                ) : (
-                  <ChevronDown className="w-3.5 h-3.5 text-text-muted shrink-0" />
-                )}
-                <Braces className="w-3.5 h-3.5 text-text-muted shrink-0" />
-                <span className="font-medium text-text-muted">Output</span>
-                <span className="text-[10px] text-text-muted/70">
-                  {Object.keys(run.output ?? {}).length}{" "}
-                  {Object.keys(run.output ?? {}).length === 1 ? "field" : "fields"}
-                </span>
-              </button>
-              {!outputCollapsed && (
-                <div className="px-4 pb-3 max-h-[40vh] overflow-y-auto">
-                  <pre className="text-xs text-text/80 bg-bg rounded-md p-3 overflow-x-auto whitespace-pre-wrap border border-border/30 font-mono">
-                    {JSON.stringify(run.output, null, 2)}
-                  </pre>
+          {/* Output + Params widgets — side-by-side when both present so the
+              params row stays glanceable next to the run's structured output.
+              Each is independently collapsible. */}
+          {(hasOutput || hasParams) && (
+            <div className="shrink-0 border-b border-border bg-bg-card grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border">
+              {hasParams && (
+                <div className="min-w-0">
+                  <button
+                    onClick={() => setParamsCollapsed((v) => !v)}
+                    className="w-full flex items-center gap-2 px-4 py-2 text-xs hover:bg-bg-hover transition-colors"
+                  >
+                    {paramsCollapsed ? (
+                      <ChevronRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                    ) : (
+                      <ChevronDown className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                    )}
+                    <Hash className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                    <span className="font-medium text-text-muted">Parameters</span>
+                    <span className="text-[10px] text-text-muted/70">
+                      {Object.keys(run.params ?? {}).length}
+                    </span>
+                  </button>
+                  {!paramsCollapsed && (
+                    <div className="px-4 pb-3 space-y-1.5 max-h-[40vh] overflow-y-auto">
+                      {Object.entries(run.params ?? {}).map(([key, value]) => (
+                        <div key={key} className="flex items-start gap-3 text-xs">
+                          <span className="text-text-muted font-mono shrink-0 pt-0.5 min-w-[100px]">
+                            {key}
+                          </span>
+                          <span className="text-text font-mono break-all">
+                            {typeof value === "string" ? value : JSON.stringify(value)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               )}
-            </div>
-          )}
-
-          {/* Params widget — collapsible, only when present, default collapsed */}
-          {hasParams && (
-            <div className="shrink-0 border-b border-border bg-bg-card">
-              <button
-                onClick={() => setParamsCollapsed((v) => !v)}
-                className="w-full flex items-center gap-2 px-4 py-2 text-xs hover:bg-bg-hover transition-colors"
-              >
-                {paramsCollapsed ? (
-                  <ChevronRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
-                ) : (
-                  <ChevronDown className="w-3.5 h-3.5 text-text-muted shrink-0" />
-                )}
-                <Hash className="w-3.5 h-3.5 text-text-muted shrink-0" />
-                <span className="font-medium text-text-muted">Parameters</span>
-                <span className="text-[10px] text-text-muted/70">
-                  {Object.keys(run.params ?? {}).length}
-                </span>
-              </button>
-              {!paramsCollapsed && (
-                <div className="px-4 pb-3 space-y-1.5 max-h-[30vh] overflow-y-auto">
-                  {Object.entries(run.params ?? {}).map(([key, value]) => (
-                    <div key={key} className="flex items-start gap-3 text-xs">
-                      <span className="text-text-muted font-mono shrink-0 pt-0.5 min-w-[120px]">
-                        {key}
-                      </span>
-                      <span className="text-text font-mono break-all">
-                        {typeof value === "string" ? value : JSON.stringify(value)}
-                      </span>
+              {hasOutput && (
+                <div className="min-w-0">
+                  <button
+                    onClick={() => setOutputCollapsed((v) => !v)}
+                    className="w-full flex items-center gap-2 px-4 py-2 text-xs hover:bg-bg-hover transition-colors"
+                  >
+                    {outputCollapsed ? (
+                      <ChevronRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                    ) : (
+                      <ChevronDown className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                    )}
+                    <Braces className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                    <span className="font-medium text-text-muted">Output</span>
+                    <span className="text-[10px] text-text-muted/70">
+                      {Object.keys(run.output ?? {}).length}{" "}
+                      {Object.keys(run.output ?? {}).length === 1 ? "field" : "fields"}
+                    </span>
+                  </button>
+                  {!outputCollapsed && (
+                    <div className="px-4 pb-3 max-h-[40vh] overflow-y-auto">
+                      <pre className="text-xs text-text/80 bg-bg rounded-md p-3 overflow-x-auto whitespace-pre-wrap border border-border/30 font-mono">
+                        {JSON.stringify(run.output, null, 2)}
+                      </pre>
                     </div>
-                  ))}
+                  )}
                 </div>
               )}
             </div>

--- a/apps/web/src/app/jobs/[id]/runs/[runId]/page.tsx
+++ b/apps/web/src/app/jobs/[id]/runs/[runId]/page.tsx
@@ -6,8 +6,10 @@ import { usePageTitle } from "@/hooks/use-page-title";
 import { useWorkflowRunLogs } from "@/hooks/use-workflow-run-logs";
 import { LogViewer } from "@/components/log-viewer";
 import { TokenRefreshBanner } from "@/components/token-refresh-banner";
-import { StateBadge } from "@/components/state-badge";
-import { MetadataCard } from "@/components/metadata-card";
+import { DetailHeader } from "@/components/detail-header";
+import { PrStatusBar } from "@/components/pr-status-bar";
+import { WorkflowRunPipelineTimeline } from "@/components/workflow-run-pipeline-timeline";
+import { ErrorBoundary } from "@/components/error-boundary";
 import { api } from "@/lib/api-client";
 import { classifyError } from "@optio/shared";
 import { cn, formatRelativeTime, formatDuration } from "@/lib/utils";
@@ -20,18 +22,12 @@ import {
   RotateCcw,
   StopCircle,
   Clock,
-  DollarSign,
-  Hash,
   Bot,
-  Server,
+  Hash,
   ChevronDown,
   ChevronRight,
-  AlertTriangle,
-  CheckCircle2,
-  Timer,
+  AlertCircle,
   Braces,
-  FileText,
-  Activity,
 } from "lucide-react";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -76,8 +72,9 @@ export default function WorkflowRunDetailPage({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
-  const [activeTab, setActiveTab] = useState<"logs" | "output" | "params">("logs");
-  const [showParams, setShowParams] = useState(true);
+  const [showTimeline, setShowTimeline] = useState(true);
+  const [outputCollapsed, setOutputCollapsed] = useState(false);
+  const [paramsCollapsed, setParamsCollapsed] = useState(true);
 
   usePageTitle(run ? `Run ${run.id.slice(0, 8)}` : "Task Run");
 
@@ -103,15 +100,14 @@ export default function WorkflowRunDetailPage({
     refresh();
   }, [refresh]);
 
-  // Auto-refresh while active
   useEffect(() => {
     if (!isActive) return;
     const interval = setInterval(refresh, 5000);
     return () => clearInterval(interval);
   }, [isActive, refresh]);
 
-  // Logs hook
-  const logData = useWorkflowRunLogs(runId, isActive ?? false);
+  // Live log streaming via WebSocket — same hook contract as task/review pages.
+  const externalLogs = useWorkflowRunLogs(runId, isActive ?? false);
 
   const handleRetry = async () => {
     setActionLoading(true);
@@ -139,13 +135,11 @@ export default function WorkflowRunDetailPage({
     }
   };
 
-  // ── Loading / Error states ─────────────────────────────────────────────────
-
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-20 text-text-muted">
+      <div className="flex items-center justify-center h-full text-text-muted">
         <Loader2 className="w-5 h-5 animate-spin mr-2" />
-        Loading job run...
+        Loading run...
       </div>
     );
   }
@@ -168,282 +162,267 @@ export default function WorkflowRunDetailPage({
     );
   }
 
-  // ── Computed values ─────────────────────────────────────────────────────────
-
   const classifiedError = run.errorMessage ? classifyError(run.errorMessage) : null;
   const duration = run.startedAt
     ? formatDuration(run.startedAt, run.finishedAt ?? undefined)
     : null;
   const canRetry = run.state === "failed";
   const canCancel = run.state === "running" || run.state === "queued";
+  const hasOutput = run.output && Object.keys(run.output).length > 0;
+  const hasParams = run.params && Object.keys(run.params).length > 0;
 
   return (
-    <div className="p-6 max-w-5xl mx-auto">
-      {/* Breadcrumb */}
-      <div className="flex items-center gap-1.5 text-sm text-text-muted mb-4">
-        <Link href="/jobs" className="hover:text-text transition-colors">
-          Standalone
-        </Link>
-        <span>/</span>
-        <Link href={`/jobs/${workflowId}`} className="hover:text-text transition-colors">
-          {workflow?.name ?? "Task"}
-        </Link>
-        <span>/</span>
-        <span className="text-text">Run {run.id.slice(0, 8)}</span>
-      </div>
-
-      {/* Header */}
-      <div className="flex flex-col gap-3 mb-6 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <StateBadge state={run.state} />
-          <div>
-            <h1 className="text-xl font-semibold tracking-tight">Run {run.id.slice(0, 8)}</h1>
-            <p className="text-sm text-text-muted mt-0.5">
-              Created {formatRelativeTime(run.createdAt)}
-            </p>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2">
+    <div className="flex flex-col h-full">
+      <DetailHeader
+        title={`Run ${run.id.slice(0, 8)}`}
+        subtitle={
+          <Link
+            href={`/jobs/${workflowId}`}
+            className="inline-flex items-center gap-1 hover:text-primary"
+          >
+            <ArrowLeft className="w-3 h-3" />
+            {workflow?.name ?? "Standalone task"}
+          </Link>
+        }
+        state={run.state}
+        metaItems={
+          [
+            run.modelUsed ? (
+              <>
+                <Bot className="w-3 h-3" />
+                {run.modelUsed}
+              </>
+            ) : null,
+            duration ? (
+              <>
+                <Clock className="w-3 h-3" />
+                {duration}
+              </>
+            ) : (
+              <>
+                <Clock className="w-3 h-3" />
+                {formatRelativeTime(run.createdAt)}
+              </>
+            ),
+            run.retryCount > 0 ? (
+              <>
+                <RotateCcw className="w-3 h-3" />
+                retry {run.retryCount}
+              </>
+            ) : null,
+          ].filter(Boolean) as React.ReactNode[]
+        }
+        rightSlot={
           <button
-            onClick={() => refresh()}
-            disabled={actionLoading}
-            className="p-2 rounded-md hover:bg-bg-hover text-text-muted hover:text-text transition-colors"
+            onClick={refresh}
+            className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted transition-colors"
             title="Refresh"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
-          {canRetry && (
-            <button
-              onClick={handleRetry}
-              disabled={actionLoading}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm hover:bg-primary/10 text-text-muted hover:text-primary transition-colors"
-            >
-              <RotateCcw className="w-4 h-4" />
-              Retry
-            </button>
-          )}
-          {canCancel && (
-            <button
-              onClick={handleCancel}
-              disabled={actionLoading}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm text-text-muted hover:text-error hover:bg-error/10 transition-colors"
-            >
-              <StopCircle className="w-4 h-4" />
-              Cancel
-            </button>
-          )}
-        </div>
-      </div>
+        }
+        actions={
+          <>
+            {canRetry && (
+              <button
+                onClick={handleRetry}
+                disabled={actionLoading}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary/10 text-primary text-xs hover:bg-primary/20 transition-colors disabled:opacity-50"
+              >
+                <RotateCcw className="w-3 h-3" />
+                Retry
+              </button>
+            )}
+            {canCancel && (
+              <button
+                onClick={handleCancel}
+                disabled={actionLoading}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-error/10 text-error text-xs hover:bg-error/20 transition-colors disabled:opacity-50"
+              >
+                <StopCircle className="w-3 h-3" />
+                Cancel
+              </button>
+            )}
+          </>
+        }
+      />
 
-      {/* Active indicator */}
-      {isActive && (
-        <div className="mb-4 flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/5 border border-primary/20 text-sm text-primary">
-          <Loader2 className="w-4 h-4 animate-spin" />
-          Run is {run.state} — auto-refreshing
-        </div>
-      )}
-
-      {/* Metadata bar */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
-        <MetadataCard icon={Timer} label="Duration" value={duration ?? "\u2014"} />
-        <MetadataCard
-          icon={DollarSign}
-          label="Cost"
-          value={run.costUsd ? `$${parseFloat(run.costUsd).toFixed(2)}` : "\u2014"}
-        />
-        <MetadataCard icon={Bot} label="Model" value={run.modelUsed ?? "\u2014"} />
-        <MetadataCard
-          icon={Hash}
-          label="Tokens"
-          value={
-            run.inputTokens != null && run.outputTokens != null
-              ? `${(run.inputTokens / 1000).toFixed(1)}k / ${(run.outputTokens / 1000).toFixed(1)}k`
-              : "\u2014"
-          }
-        />
-      </div>
-
-      {/* Secondary metadata */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
-        <MetadataCard icon={Server} label="Pod" value={run.podName ?? "\u2014"} />
-        <MetadataCard
-          icon={Activity}
-          label="Session"
-          value={run.sessionId?.slice(0, 8) ?? "\u2014"}
-        />
-        <MetadataCard icon={RotateCcw} label="Retry Count" value={String(run.retryCount)} />
-        <MetadataCard
-          icon={Clock}
-          label="Started"
-          value={run.startedAt ? formatRelativeTime(run.startedAt) : "\u2014"}
-        />
-      </div>
-
-      {/* Auth-specific banner — matches the overview panel + normal task page */}
-      {classifiedError?.category === "auth" && (
-        <div className="mb-6">
-          <TokenRefreshBanner onSaved={refresh} />
-        </div>
-      )}
-
-      {/* Error panel (non-auth errors only — auth has its own rich banner above) */}
-      {classifiedError && classifiedError.category !== "auth" && (
-        <div className="mb-6 rounded-lg border border-error/30 bg-error/5 p-4">
-          <div className="flex items-start gap-3">
-            <AlertTriangle className="w-5 h-5 text-error shrink-0 mt-0.5" />
-            <div className="min-w-0 flex-1">
-              <h3 className="text-sm font-medium text-error">{classifiedError.title}</h3>
-              <p className="text-sm text-text-muted mt-1">{classifiedError.description}</p>
-              {classifiedError.remedy && (
-                <div className="mt-2 text-xs text-text-muted bg-bg rounded-md p-2 font-mono whitespace-pre-wrap border border-border/30">
-                  {classifiedError.remedy}
-                </div>
-              )}
-              <div className="flex items-center gap-3 mt-2 text-xs text-text-muted">
-                <span className="capitalize">{classifiedError.category}</span>
-                {classifiedError.retryable && (
-                  <span className="text-primary flex items-center gap-1">
-                    <CheckCircle2 className="w-3 h-3" /> Retryable
+      {/* Status bar — hosts the Timeline toggle on the right and surfaces
+          glanceable run economics (cost, tokens) on the left when present. */}
+      <div className="shrink-0 border-b border-border bg-bg-card px-4 py-2">
+        <div className="max-w-5xl mx-auto">
+          <PrStatusBar
+            actions={
+              <>
+                {run.costUsd && (
+                  <span className="text-text-muted">
+                    Cost: ${parseFloat(run.costUsd).toFixed(4)}
                   </span>
                 )}
+                {run.inputTokens != null && run.outputTokens != null && (
+                  <span className="text-text-muted">
+                    {(run.inputTokens / 1000).toFixed(1)}k / {(run.outputTokens / 1000).toFixed(1)}k
+                  </span>
+                )}
+                <button
+                  onClick={() => setShowTimeline(!showTimeline)}
+                  className={cn(
+                    "px-2 py-0.5 rounded text-xs transition-colors",
+                    showTimeline
+                      ? "bg-primary/10 text-primary"
+                      : "text-text-muted hover:bg-bg-hover",
+                  )}
+                >
+                  Timeline
+                </button>
+              </>
+            }
+          />
+        </div>
+      </div>
+
+      {/* Auth banner — same recovery surface as task/review pages */}
+      {classifiedError?.category === "auth" && (
+        <div className="shrink-0 border-b border-border bg-bg-card">
+          <div className="max-w-5xl mx-auto px-4 py-3">
+            <TokenRefreshBanner onSaved={refresh} />
+          </div>
+        </div>
+      )}
+
+      {/* Classified error banner — matches /tasks/[id] and /reviews/[id] */}
+      {classifiedError && classifiedError.category !== "auth" && (
+        <div className="shrink-0 border-b border-error/20 bg-error/5">
+          <div className="max-w-5xl mx-auto px-4 py-3">
+            <div className="flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 text-error shrink-0 mt-0.5" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <div>
+                  <h3 className="text-sm font-medium text-error">{classifiedError.title}</h3>
+                  <p className="text-xs text-error/70 mt-0.5">{classifiedError.description}</p>
+                </div>
+                {classifiedError.remedy && (
+                  <div className="p-2.5 rounded-md bg-bg/50 border border-border">
+                    <div className="text-[10px] uppercase tracking-wider text-text-muted mb-1">
+                      Suggested fix
+                    </div>
+                    <pre className="text-xs text-text/80 whitespace-pre-wrap font-mono">
+                      {classifiedError.remedy}
+                    </pre>
+                  </div>
+                )}
+                <div className="flex items-center gap-2">
+                  {classifiedError.retryable && canRetry && (
+                    <button
+                      onClick={handleRetry}
+                      disabled={actionLoading}
+                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-white text-xs hover:bg-primary-hover disabled:opacity-50 btn-press transition-all"
+                    >
+                      <RotateCcw className="w-3 h-3" />
+                      Retry
+                    </button>
+                  )}
+                  <span className="text-[10px] px-2 py-0.5 rounded-full bg-error/10 text-error">
+                    {classifiedError.category}
+                  </span>
+                </div>
               </div>
             </div>
           </div>
-          {run.errorMessage && (
-            <details className="mt-3">
-              <summary className="text-xs text-text-muted cursor-pointer hover:text-text">
-                Raw error message
-              </summary>
-              <pre className="mt-2 text-xs text-error/80 bg-bg rounded-md p-2 overflow-x-auto whitespace-pre-wrap border border-border/30">
-                {run.errorMessage}
-              </pre>
-            </details>
+        </div>
+      )}
+
+      {/* Main content: log column + timeline sidebar — mirrors /tasks/[id] */}
+      <div className="flex-1 flex overflow-hidden">
+        <div className="flex-1 min-w-0 flex flex-col">
+          {/* Output widget — collapsible, only when present */}
+          {hasOutput && (
+            <div className="shrink-0 border-b border-border bg-bg-card">
+              <button
+                onClick={() => setOutputCollapsed((v) => !v)}
+                className="w-full flex items-center gap-2 px-4 py-2 text-xs hover:bg-bg-hover transition-colors"
+              >
+                {outputCollapsed ? (
+                  <ChevronRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                ) : (
+                  <ChevronDown className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                )}
+                <Braces className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                <span className="font-medium text-text-muted">Output</span>
+                <span className="text-[10px] text-text-muted/70">
+                  {Object.keys(run.output ?? {}).length}{" "}
+                  {Object.keys(run.output ?? {}).length === 1 ? "field" : "fields"}
+                </span>
+              </button>
+              {!outputCollapsed && (
+                <div className="px-4 pb-3 max-h-[40vh] overflow-y-auto">
+                  <pre className="text-xs text-text/80 bg-bg rounded-md p-3 overflow-x-auto whitespace-pre-wrap border border-border/30 font-mono">
+                    {JSON.stringify(run.output, null, 2)}
+                  </pre>
+                </div>
+              )}
+            </div>
           )}
+
+          {/* Params widget — collapsible, only when present, default collapsed */}
+          {hasParams && (
+            <div className="shrink-0 border-b border-border bg-bg-card">
+              <button
+                onClick={() => setParamsCollapsed((v) => !v)}
+                className="w-full flex items-center gap-2 px-4 py-2 text-xs hover:bg-bg-hover transition-colors"
+              >
+                {paramsCollapsed ? (
+                  <ChevronRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                ) : (
+                  <ChevronDown className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                )}
+                <Hash className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                <span className="font-medium text-text-muted">Parameters</span>
+                <span className="text-[10px] text-text-muted/70">
+                  {Object.keys(run.params ?? {}).length}
+                </span>
+              </button>
+              {!paramsCollapsed && (
+                <div className="px-4 pb-3 space-y-1.5 max-h-[30vh] overflow-y-auto">
+                  {Object.entries(run.params ?? {}).map(([key, value]) => (
+                    <div key={key} className="flex items-start gap-3 text-xs">
+                      <span className="text-text-muted font-mono shrink-0 pt-0.5 min-w-[120px]">
+                        {key}
+                      </span>
+                      <span className="text-text font-mono break-all">
+                        {typeof value === "string" ? value : JSON.stringify(value)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Logs */}
+          <div className="flex-1 overflow-hidden">
+            <ErrorBoundary label="Workflow run log viewer">
+              <LogViewer externalLogs={externalLogs} />
+            </ErrorBoundary>
+          </div>
         </div>
-      )}
 
-      {/* Tabs */}
-      <div className="flex gap-1 mb-4 border-b border-border">
-        {(
-          [
-            { key: "logs", label: "Logs", icon: FileText },
-            { key: "output", label: "Output", icon: Braces },
-            { key: "params", label: "Parameters", icon: Hash },
-          ] as const
-        ).map(({ key, label, icon: Icon }) => (
-          <button
-            key={key}
-            onClick={() => setActiveTab(key)}
-            className={cn(
-              "flex items-center gap-1.5 px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              activeTab === key
-                ? "border-primary text-text"
-                : "border-transparent text-text-muted hover:text-text",
-            )}
-          >
-            <Icon className="w-3.5 h-3.5" />
-            {label}
-          </button>
-        ))}
-      </div>
-
-      {/* Tab content */}
-      {activeTab === "logs" && (
-        <div className="rounded-lg border border-border/50 overflow-hidden">
-          <LogViewer
-            externalLogs={{
-              logs: logData.logs,
-              connected: logData.connected,
-              capped: logData.capped,
-              clear: logData.clear,
-            }}
-          />
-        </div>
-      )}
-
-      {activeTab === "output" && <OutputPanel output={run.output} />}
-
-      {activeTab === "params" && (
-        <ParamsPanel params={run.params} showParams={showParams} setShowParams={setShowParams} />
-      )}
-    </div>
-  );
-}
-
-// ── Output panel ────────────────────────────────────────────────────────────
-
-function OutputPanel({ output }: { output: Record<string, unknown> | null }) {
-  if (!output) {
-    return (
-      <div className="text-center py-8 text-text-muted border border-dashed border-border rounded-lg">
-        <Braces className="w-6 h-6 mx-auto mb-2 opacity-50" />
-        <p className="text-sm">No output data</p>
-        <p className="text-xs mt-1">Output will appear here when the run completes.</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="rounded-lg border border-border/50 bg-bg-card p-4">
-      <h3 className="text-sm font-medium mb-3 flex items-center gap-2">
-        <Braces className="w-4 h-4 text-text-muted" />
-        Run Output
-      </h3>
-      <pre className="text-xs text-text-muted bg-bg rounded-md p-3 overflow-x-auto whitespace-pre-wrap border border-border/30 max-h-[500px] overflow-y-auto">
-        {JSON.stringify(output, null, 2)}
-      </pre>
-    </div>
-  );
-}
-
-// ── Params panel ────────────────────────────────────────────────────────────
-
-function ParamsPanel({
-  params,
-  showParams,
-  setShowParams,
-}: {
-  params: Record<string, unknown> | null;
-  showParams: boolean;
-  setShowParams: (v: boolean) => void;
-}) {
-  if (!params || Object.keys(params).length === 0) {
-    return (
-      <div className="text-center py-8 text-text-muted border border-dashed border-border rounded-lg">
-        <Hash className="w-6 h-6 mx-auto mb-2 opacity-50" />
-        <p className="text-sm">No parameters</p>
-        <p className="text-xs mt-1">This run was started without any parameters.</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="rounded-lg border border-border/50 bg-bg-card p-4">
-      <button
-        onClick={() => setShowParams(!showParams)}
-        className="text-sm font-medium flex items-center gap-2 w-full text-left"
-      >
-        {showParams ? (
-          <ChevronDown className="w-4 h-4 text-text-muted" />
-        ) : (
-          <ChevronRight className="w-4 h-4 text-text-muted" />
-        )}
-        <span className="flex-1">Run Parameters</span>
-        <span className="text-xs text-text-muted">{Object.keys(params).length} params</span>
-      </button>
-      {showParams && (
-        <div className="mt-3 space-y-2">
-          {Object.entries(params).map(([key, value]) => (
-            <div key={key} className="flex items-start gap-3 text-sm">
-              <span className="text-text-muted font-mono text-xs shrink-0 pt-0.5">{key}</span>
-              <span className="text-text font-mono text-xs break-all">
-                {typeof value === "string" ? value : JSON.stringify(value)}
+        {/* Timeline sidebar — mirrors /tasks/[id] and /reviews/[id] */}
+        {showTimeline && (
+          <div className="hidden md:flex w-80 shrink-0 border-l border-border overflow-auto bg-bg-card flex-col">
+            <div className="flex items-center gap-1 p-2 border-b border-border">
+              <span className="px-2.5 py-1 rounded text-xs bg-primary/10 text-primary font-medium">
+                Pipeline
               </span>
             </div>
-          ))}
-        </div>
-      )}
+            <div className="flex-1 overflow-auto p-3">
+              <ErrorBoundary label="Workflow run pipeline timeline">
+                <WorkflowRunPipelineTimeline run={run} />
+              </ErrorBoundary>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/reviews/[id]/page.tsx
+++ b/apps/web/src/app/reviews/[id]/page.tsx
@@ -13,7 +13,8 @@ import { LogViewer } from "@/components/log-viewer";
 import { DetailHeader } from "@/components/detail-header";
 import { StatePipelineStrip } from "@/components/state-pipeline-strip";
 import { PrStatusBar } from "@/components/pr-status-bar";
-import { ChatTranscript, ChatComposer, type ChatMessage } from "@/components/chat-box";
+import { ChatComposer } from "@/components/chat-box";
+import type { UserMessage } from "@/components/log-viewer";
 import { ReviewPipelineTimeline } from "@/components/review-pipeline-timeline";
 import {
   Loader2,
@@ -81,7 +82,10 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
   const [loading, setLoading] = useState(true);
   const [runs, setRuns] = useState<any[]>([]);
   const [prStatus, setPrStatus] = useState<any>(null);
-  const [chat, setChat] = useState<ChatMessage[]>([]);
+  // User-sent chat turns, rendered inline in the log stream via LogViewer's
+  // userMessages prop. Hydrated from the persisted chat history on load so
+  // past user turns still appear after a refresh.
+  const [userMessages, setUserMessages] = useState<UserMessage[]>([]);
   const [chatInput, setChatInput] = useState("");
   const [chatSending, setChatSending] = useState(false);
   const [showTimeline, setShowTimeline] = useState(true);
@@ -124,10 +128,25 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
           .catch(() => {});
       }
 
+      // Hydrate inline user messages from persisted chat history (user role
+      // only — assistant replies live in the log stream already).
       if (["ready", "stale", "submitted"].includes(r.review.state)) {
         api
           .listPrReviewChat(id)
-          .then((res) => setChat(res.messages))
+          .then((res) => {
+            setUserMessages((prev) => {
+              // Don't clobber locally-sent messages whose IDs start with "local-".
+              const localOnly = prev.filter((m) => m.timestamp.startsWith("local-"));
+              const hydrated: UserMessage[] = res.messages
+                .filter((m) => m.role === "user")
+                .map((m) => ({
+                  text: m.content,
+                  timestamp: m.createdAt,
+                  status: "sent" as const,
+                }));
+              return [...hydrated, ...localOnly];
+            });
+          })
           .catch(() => {});
       }
     } catch (err: any) {
@@ -251,25 +270,26 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
   const handleSendChat = async () => {
     if (!chatInput.trim() || chatSending) return;
     const msg = chatInput.trim();
+    const sentAt = new Date().toISOString();
     setChatInput("");
-    setChat((prev) => [
-      ...prev,
-      {
-        id: `local-${Date.now()}`,
-        role: "user",
-        content: msg,
-        createdAt: new Date().toISOString(),
-      },
-    ]);
+    setUserMessages((prev) => [...prev, { text: msg, timestamp: sentAt, status: "sending" }]);
     setChatSending(true);
     try {
       await api.postPrReviewChat(id, msg);
-      toast.success("Sent to agent");
+      setUserMessages((prev) =>
+        prev.map((m) =>
+          m.text === msg && m.timestamp === sentAt && m.status === "sending"
+            ? { ...m, status: "sent" }
+            : m,
+        ),
+      );
+      // Refresh the review periodically so state transitions (and any verdict
+      // patch the agent makes during chat) surface quickly. The assistant's
+      // textual reply shows up in the log stream.
       const start = Date.now();
       const tick = setInterval(async () => {
         const res = await api.listPrReviewChat(id).catch(() => null);
         if (res) {
-          setChat(res.messages);
           const hasAssistantReply = res.messages.some(
             (m) => m.role === "assistant" && new Date(m.createdAt).getTime() > start,
           );
@@ -281,6 +301,13 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
         }
       }, 3000);
     } catch (err: any) {
+      setUserMessages((prev) =>
+        prev.map((m) =>
+          m.text === msg && m.timestamp === sentAt && m.status === "sending"
+            ? { ...m, status: "failed" }
+            : m,
+        ),
+      );
       toast.error(err.message || "Failed to send");
       setChatSending(false);
     }
@@ -765,14 +792,16 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
           {/* Logs */}
           <div className="flex-1 overflow-hidden">
             <ErrorBoundary label="Review log viewer">
-              <LogViewer externalLogs={externalLogs} />
+              <LogViewer externalLogs={externalLogs} userMessages={userMessages} />
             </ErrorBoundary>
           </div>
 
-          {/* Chat composer at the bottom — only when the agent has produced a draft */}
+          {/* Chat composer at the bottom — only when the agent has produced a
+              draft. User turns render inline in the log stream above (via
+              LogViewer's userMessages), and the agent's reply comes back as
+              part of the chat run's log output. */}
           {hasDraft && (
             <div className="shrink-0 border-t border-border bg-bg-card px-4 py-2.5">
-              <ChatTranscript messages={chat} pending={chatSending} />
               <ChatComposer
                 value={chatInput}
                 onChange={setChatInput}

--- a/apps/web/src/app/reviews/[id]/page.tsx
+++ b/apps/web/src/app/reviews/[id]/page.tsx
@@ -14,6 +14,7 @@ import { DetailHeader } from "@/components/detail-header";
 import { StatePipelineStrip } from "@/components/state-pipeline-strip";
 import { PrStatusBar } from "@/components/pr-status-bar";
 import { ChatTranscript, ChatComposer, type ChatMessage } from "@/components/chat-box";
+import { ReviewPipelineTimeline } from "@/components/review-pipeline-timeline";
 import {
   Loader2,
   Check,
@@ -25,13 +26,11 @@ import {
   RefreshCw,
   GitMerge,
   ChevronDown,
-  ChevronUp,
   Plus,
   Trash2,
   ExternalLink,
   Clock,
   Zap,
-  Bot,
   GitPullRequest,
   XCircle,
   RotateCcw,
@@ -68,10 +67,9 @@ const PIPELINE_STEPS = [
 ];
 
 function pipelineCurrentIndex(state: string): number {
-  if (state === "stale") return 3; // sits on "Ready" but coloured as error via flag
+  if (state === "stale") return 3;
   if (state === "failed" || state === "cancelled") return -1;
-  const idx = PIPELINE_STEPS.findIndex((s) => s.key === state);
-  return idx;
+  return PIPELINE_STEPS.findIndex((s) => s.key === state);
 }
 
 export default function ReviewDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -81,11 +79,11 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
   const [review, setReview] = useState<Review | null>(null);
   const [loading, setLoading] = useState(true);
   const [runs, setRuns] = useState<any[]>([]);
-  const [showLogs, setShowLogs] = useState(false);
   const [prStatus, setPrStatus] = useState<any>(null);
   const [chat, setChat] = useState<ChatMessage[]>([]);
   const [chatInput, setChatInput] = useState("");
   const [chatSending, setChatSending] = useState(false);
+  const [showTimeline, setShowTimeline] = useState(true);
 
   // Editable fields
   const [summary, setSummary] = useState("");
@@ -124,7 +122,6 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
           .catch(() => {});
       }
 
-      // Chat only if the draft has produced output.
       if (["ready", "stale", "submitted"].includes(r.review.state)) {
         api
           .listPrReviewChat(id)
@@ -167,11 +164,9 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
 
   const isEditable = ["ready", "stale"].includes(review.state);
   const isWorking = ["queued", "waiting_ci", "reviewing"].includes(review.state);
+  const hasDraft = ["ready", "stale", "submitted"].includes(review.state);
   const prIsOpen = prStatus?.prState === "open";
   const checksOk = prStatus?.checksStatus === "passing" || prStatus?.checksStatus === "none";
-  // We only hard-disable merge when the PR is already merged/closed — merging
-  // with failing CI is the user's call (GitHub will enforce branch protection
-  // rules server-side).
   const canMerge = prIsOpen;
   const mergeBlockedReason = !prStatus
     ? "Loading PR status..."
@@ -399,7 +394,6 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
         }
       />
 
-      {/* PR status bar (CI / review / merge state) */}
       {(prStatus?.checksStatus || prStatus?.reviewStatus || prStatus?.prState) && (
         <div className="shrink-0 border-b border-border bg-bg-card px-4 py-3">
           <div className="max-w-5xl mx-auto">
@@ -412,7 +406,6 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
         </div>
       )}
 
-      {/* Error banner with classified remedy */}
       {review.errorMessage &&
         review.state === "failed" &&
         (() => {
@@ -457,7 +450,6 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
           );
         })()}
 
-      {/* Stale banner */}
       {review.state === "stale" && (
         <div className="shrink-0 border-b border-warning/20 bg-warning/5 px-4 py-3">
           <div className="max-w-5xl mx-auto flex items-center gap-2 text-sm text-warning">
@@ -467,327 +459,301 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
         </div>
       )}
 
-      {/* Body */}
-      <div className="flex-1 overflow-auto">
-        <div className="max-w-5xl mx-auto p-4 space-y-4">
-          {/* Working state */}
-          {isWorking && (
-            <div className="rounded-lg border border-border bg-bg-card p-4">
-              <div className="flex items-center gap-2 text-sm">
-                {review.state === "waiting_ci" ? (
-                  <Clock className="w-4 h-4 text-text-muted" />
-                ) : (
-                  <Loader2 className="w-4 h-4 animate-spin text-primary" />
-                )}
-                <span className="font-medium">
-                  {review.state === "waiting_ci"
-                    ? "Waiting for CI to finish..."
-                    : review.state === "queued"
-                      ? "Queued — run will start shortly"
-                      : "Agent is reviewing the PR..."}
-                </span>
-              </div>
-              <p className="text-xs text-text-muted mt-1">
-                The draft will appear here when the agent is done.
-              </p>
-            </div>
-          )}
-
-          {/* Draft editor (ready/stale/submitted) */}
-          {(isEditable || review.state === "submitted") && (
-            <div className="rounded-lg border border-border bg-bg-card p-4 space-y-4">
-              {/* Verdict */}
-              <div>
-                <label className="text-xs font-medium text-text-muted mb-2 block">Verdict</label>
-                <div className="flex gap-2">
-                  {[
-                    { value: "approve", label: "Approve", Icon: Check, color: "success" },
-                    {
-                      value: "request_changes",
-                      label: "Request Changes",
-                      Icon: X,
-                      color: "error",
-                    },
-                    {
-                      value: "comment",
-                      label: "Comment",
-                      Icon: MessageSquare,
-                      color: "text-muted",
-                    },
-                  ].map(({ value, label, Icon, color }) => (
-                    <button
-                      key={value}
-                      disabled={!isEditable}
-                      onClick={() => {
-                        setVerdict(value);
-                        setDirty(true);
-                      }}
-                      className={cn(
-                        "flex items-center gap-1.5 px-3 py-2 rounded-md text-xs font-medium border transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
-                        verdict === value
-                          ? `bg-${color}/10 text-${color} border-${color}/30`
-                          : "bg-bg border-border text-text-muted hover:bg-bg-hover",
-                      )}
-                    >
-                      <Icon className="w-3.5 h-3.5" />
-                      {label}
-                    </button>
-                  ))}
+      {/* Main content: logs + sidebar — mirrors /tasks/[id] */}
+      <div className="flex-1 flex overflow-hidden">
+        {/* Log column */}
+        <div className="flex-1 min-w-0 flex flex-col">
+          {/* Verdict + summary widget — only when the draft is ready */}
+          {hasDraft && (
+            <div className="shrink-0 border-b border-border bg-bg-card max-h-[55vh] overflow-y-auto">
+              <div className="max-w-5xl mx-auto p-4 space-y-4">
+                {/* Verdict */}
+                <div>
+                  <label className="text-xs font-medium text-text-muted mb-2 block">Verdict</label>
+                  <div className="flex gap-2">
+                    {[
+                      { value: "approve", label: "Approve", Icon: Check, color: "success" },
+                      {
+                        value: "request_changes",
+                        label: "Request Changes",
+                        Icon: X,
+                        color: "error",
+                      },
+                      {
+                        value: "comment",
+                        label: "Comment",
+                        Icon: MessageSquare,
+                        color: "text-muted",
+                      },
+                    ].map(({ value, label, Icon, color }) => (
+                      <button
+                        key={value}
+                        disabled={!isEditable}
+                        onClick={() => {
+                          setVerdict(value);
+                          setDirty(true);
+                        }}
+                        className={cn(
+                          "flex items-center gap-1.5 px-3 py-2 rounded-md text-xs font-medium border transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+                          verdict === value
+                            ? `bg-${color}/10 text-${color} border-${color}/30`
+                            : "bg-bg border-border text-text-muted hover:bg-bg-hover",
+                        )}
+                      >
+                        <Icon className="w-3.5 h-3.5" />
+                        {label}
+                      </button>
+                    ))}
+                  </div>
                 </div>
-              </div>
 
-              {/* Summary */}
-              <div>
-                <label className="text-xs font-medium text-text-muted mb-2 block">
-                  Review Summary
-                </label>
-                <textarea
-                  value={summary}
-                  readOnly={!isEditable}
-                  onChange={(e) => {
-                    setSummary(e.target.value);
-                    setDirty(true);
-                  }}
-                  rows={6}
-                  className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:border-primary focus:ring-1 focus:ring-primary/20 focus:outline-none resize-y disabled:opacity-70"
-                  placeholder="Review summary..."
-                />
-              </div>
+                {/* Summary */}
+                <div>
+                  <label className="text-xs font-medium text-text-muted mb-2 block">
+                    Review Summary
+                  </label>
+                  <textarea
+                    value={summary}
+                    readOnly={!isEditable}
+                    onChange={(e) => {
+                      setSummary(e.target.value);
+                      setDirty(true);
+                    }}
+                    rows={5}
+                    className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:border-primary focus:ring-1 focus:ring-primary/20 focus:outline-none resize-y disabled:opacity-70"
+                    placeholder="Review summary..."
+                  />
+                </div>
 
-              {/* Inline comments */}
-              <div>
-                <label className="text-xs font-medium text-text-muted mb-2 block">
-                  Inline Comments ({comments.length})
-                </label>
-                <div className="space-y-2">
-                  {comments.map((c, i) => (
-                    <div key={i} className="flex gap-2 p-2 rounded-md bg-bg border border-border">
-                      <div className="flex-1 space-y-1.5">
-                        <div className="flex gap-2">
-                          <input
-                            value={c.path ?? ""}
+                {/* Inline comments */}
+                <div>
+                  <label className="text-xs font-medium text-text-muted mb-2 block">
+                    Inline Comments ({comments.length})
+                  </label>
+                  <div className="space-y-2">
+                    {comments.map((c, i) => (
+                      <div key={i} className="flex gap-2 p-2 rounded-md bg-bg border border-border">
+                        <div className="flex-1 space-y-1.5">
+                          <div className="flex gap-2">
+                            <input
+                              value={c.path ?? ""}
+                              readOnly={!isEditable}
+                              onChange={(e) => updateComment(i, "path", e.target.value)}
+                              placeholder="file/path.ts"
+                              className="flex-1 px-2 py-1 rounded bg-bg-card border border-border text-xs focus:border-primary focus:outline-none"
+                            />
+                            <input
+                              value={c.line ?? ""}
+                              readOnly={!isEditable}
+                              onChange={(e) =>
+                                updateComment(
+                                  i,
+                                  "line",
+                                  e.target.value ? parseInt(e.target.value) : undefined,
+                                )
+                              }
+                              placeholder="Line"
+                              type="text"
+                              inputMode="numeric"
+                              className="w-20 px-2 py-1 rounded bg-bg-card border border-border text-xs focus:border-primary focus:outline-none"
+                            />
+                          </div>
+                          <textarea
+                            value={c.body ?? ""}
                             readOnly={!isEditable}
-                            onChange={(e) => updateComment(i, "path", e.target.value)}
-                            placeholder="file/path.ts"
-                            className="flex-1 px-2 py-1 rounded bg-bg-card border border-border text-xs focus:border-primary focus:outline-none"
-                          />
-                          <input
-                            value={c.line ?? ""}
-                            readOnly={!isEditable}
-                            onChange={(e) =>
-                              updateComment(
-                                i,
-                                "line",
-                                e.target.value ? parseInt(e.target.value) : undefined,
-                              )
-                            }
-                            placeholder="Line"
-                            type="text"
-                            inputMode="numeric"
-                            className="w-20 px-2 py-1 rounded bg-bg-card border border-border text-xs focus:border-primary focus:outline-none"
+                            onChange={(e) => updateComment(i, "body", e.target.value)}
+                            placeholder="Comment..."
+                            rows={2}
+                            className="w-full px-2 py-1 rounded bg-bg-card border border-border text-xs focus:border-primary focus:outline-none resize-y"
                           />
                         </div>
-                        <textarea
-                          value={c.body ?? ""}
-                          readOnly={!isEditable}
-                          onChange={(e) => updateComment(i, "body", e.target.value)}
-                          placeholder="Comment..."
-                          rows={2}
-                          className="w-full px-2 py-1 rounded bg-bg-card border border-border text-xs focus:border-primary focus:outline-none resize-y"
-                        />
-                      </div>
-                      {isEditable && (
-                        <button
-                          onClick={() => removeComment(i)}
-                          className="text-text-muted hover:text-error transition-colors p-1 self-start"
-                        >
-                          <Trash2 className="w-3.5 h-3.5" />
-                        </button>
-                      )}
-                    </div>
-                  ))}
-                  {isEditable && (
-                    <button
-                      onClick={addComment}
-                      className="flex items-center gap-1 text-xs text-primary hover:text-primary-hover"
-                    >
-                      <Plus className="w-3 h-3" />
-                      Add comment
-                    </button>
-                  )}
-                </div>
-              </div>
-
-              {/* Actions */}
-              <div className="flex items-center justify-between gap-3 pt-2 border-t border-border">
-                <div className="flex items-center gap-2">
-                  {isEditable && dirty && (
-                    <button
-                      onClick={handleSave}
-                      disabled={saving}
-                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-bg border border-border text-xs text-text-muted hover:bg-bg-hover disabled:opacity-50"
-                    >
-                      {saving ? <Loader2 className="w-3 h-3 animate-spin" /> : null}
-                      Save Draft
-                    </button>
-                  )}
-                  {isEditable && (
-                    <button
-                      onClick={handleSubmit}
-                      disabled={submitting || !verdict}
-                      className="flex items-center gap-1.5 px-4 py-1.5 rounded-md bg-primary text-white text-xs font-medium hover:bg-primary-hover disabled:opacity-50"
-                    >
-                      {submitting ? (
-                        <Loader2 className="w-3 h-3 animate-spin" />
-                      ) : (
-                        <Send className="w-3 h-3" />
-                      )}
-                      Submit Review
-                    </button>
-                  )}
-                  {review.state === "submitted" && (
-                    <span className="inline-flex items-center gap-1 text-xs text-success">
-                      <Check className="w-3.5 h-3.5" />
-                      Submitted{review.autoSubmitted ? " automatically" : ""}
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className="relative">
-                    <div className="flex">
-                      <button
-                        onClick={handleMerge}
-                        disabled={merging || !canMerge}
-                        title={mergeBlockedReason || `Merge with ${mergeMethod} strategy`}
-                        className={cn(
-                          "flex items-center gap-1.5 px-3 py-1.5 rounded-l-md text-xs font-medium border disabled:opacity-50",
-                          !checksOk && prIsOpen
-                            ? "bg-warning/10 text-warning hover:bg-warning/20 border-warning/30"
-                            : "bg-success/10 text-success hover:bg-success/20 border-success/20",
+                        {isEditable && (
+                          <button
+                            onClick={() => removeComment(i)}
+                            className="text-text-muted hover:text-error transition-colors p-1 self-start"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
                         )}
+                      </div>
+                    ))}
+                    {isEditable && (
+                      <button
+                        onClick={addComment}
+                        className="flex items-center gap-1 text-xs text-primary hover:text-primary-hover"
                       >
-                        {merging ? (
+                        <Plus className="w-3 h-3" />
+                        Add comment
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                {/* Actions */}
+                <div className="flex items-center justify-between gap-3 pt-2 border-t border-border">
+                  <div className="flex items-center gap-2">
+                    {isEditable && dirty && (
+                      <button
+                        onClick={handleSave}
+                        disabled={saving}
+                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-bg border border-border text-xs text-text-muted hover:bg-bg-hover disabled:opacity-50"
+                      >
+                        {saving ? <Loader2 className="w-3 h-3 animate-spin" /> : null}
+                        Save Draft
+                      </button>
+                    )}
+                    {isEditable && (
+                      <button
+                        onClick={handleSubmit}
+                        disabled={submitting || !verdict}
+                        className="flex items-center gap-1.5 px-4 py-1.5 rounded-md bg-primary text-white text-xs font-medium hover:bg-primary-hover disabled:opacity-50"
+                      >
+                        {submitting ? (
                           <Loader2 className="w-3 h-3 animate-spin" />
                         ) : (
-                          <GitMerge className="w-3 h-3" />
+                          <Send className="w-3 h-3" />
                         )}
-                        {!checksOk && prIsOpen ? "Merge anyway" : "Merge"}
+                        Submit Review
                       </button>
-                      <button
-                        onClick={() => setMergeMenuOpen((v) => !v)}
-                        className={cn(
-                          "px-1.5 py-1.5 rounded-r-md text-xs border border-l-0",
-                          !checksOk && prIsOpen
-                            ? "bg-warning/10 text-warning hover:bg-warning/20 border-warning/30"
-                            : "bg-success/10 text-success hover:bg-success/20 border-success/20",
-                        )}
-                      >
-                        <ChevronDown className="w-3 h-3" />
-                      </button>
-                    </div>
-                    {mergeMenuOpen && (
-                      <div className="absolute right-0 top-full mt-1 bg-bg-card border border-border rounded-md shadow-lg z-10 py-1 min-w-[140px]">
-                        {(["squash", "merge", "rebase"] as const).map((m) => (
-                          <button
-                            key={m}
-                            onClick={() => {
-                              setMergeMethod(m);
-                              setMergeMenuOpen(false);
-                            }}
-                            className={cn(
-                              "w-full text-left px-3 py-1.5 text-xs hover:bg-bg-hover",
-                              mergeMethod === m ? "text-primary font-medium" : "text-text",
-                            )}
-                          >
-                            {m === "squash"
-                              ? "Squash and merge"
-                              : m === "rebase"
-                                ? "Rebase and merge"
-                                : "Create a merge commit"}
-                          </button>
-                        ))}
-                      </div>
                     )}
+                    {review.state === "submitted" && (
+                      <span className="inline-flex items-center gap-1 text-xs text-success">
+                        <Check className="w-3.5 h-3.5" />
+                        Submitted{review.autoSubmitted ? " automatically" : ""}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="relative">
+                      <div className="flex">
+                        <button
+                          onClick={handleMerge}
+                          disabled={merging || !canMerge}
+                          title={mergeBlockedReason || `Merge with ${mergeMethod} strategy`}
+                          className={cn(
+                            "flex items-center gap-1.5 px-3 py-1.5 rounded-l-md text-xs font-medium border disabled:opacity-50",
+                            !checksOk && prIsOpen
+                              ? "bg-warning/10 text-warning hover:bg-warning/20 border-warning/30"
+                              : "bg-success/10 text-success hover:bg-success/20 border-success/20",
+                          )}
+                        >
+                          {merging ? (
+                            <Loader2 className="w-3 h-3 animate-spin" />
+                          ) : (
+                            <GitMerge className="w-3 h-3" />
+                          )}
+                          {!checksOk && prIsOpen ? "Merge anyway" : "Merge"}
+                        </button>
+                        <button
+                          onClick={() => setMergeMenuOpen((v) => !v)}
+                          className={cn(
+                            "px-1.5 py-1.5 rounded-r-md text-xs border border-l-0",
+                            !checksOk && prIsOpen
+                              ? "bg-warning/10 text-warning hover:bg-warning/20 border-warning/30"
+                              : "bg-success/10 text-success hover:bg-success/20 border-success/20",
+                          )}
+                        >
+                          <ChevronDown className="w-3 h-3" />
+                        </button>
+                      </div>
+                      {mergeMenuOpen && (
+                        <div className="absolute right-0 top-full mt-1 bg-bg-card border border-border rounded-md shadow-lg z-10 py-1 min-w-[140px]">
+                          {(["squash", "merge", "rebase"] as const).map((m) => (
+                            <button
+                              key={m}
+                              onClick={() => {
+                                setMergeMethod(m);
+                                setMergeMenuOpen(false);
+                              }}
+                              className={cn(
+                                "w-full text-left px-3 py-1.5 text-xs hover:bg-bg-hover",
+                                mergeMethod === m ? "text-primary font-medium" : "text-text",
+                              )}
+                            >
+                              {m === "squash"
+                                ? "Squash and merge"
+                                : m === "rebase"
+                                  ? "Rebase and merge"
+                                  : "Create a merge commit"}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           )}
 
-          {/* Chat */}
-          {["ready", "stale", "submitted"].includes(review.state) && (
-            <div className="rounded-lg border border-border bg-bg-card p-4">
-              <div className="flex items-center gap-2 mb-2">
-                <Bot className="w-3.5 h-3.5 text-primary" />
-                <span className="text-xs font-medium">Chat with the reviewer</span>
+          {/* Working state hint while there's nothing to show yet */}
+          {isWorking && (
+            <div className="shrink-0 border-b border-border bg-bg px-4 py-2">
+              <div className="max-w-5xl mx-auto flex items-center gap-2 text-xs text-text-muted">
+                {review.state === "waiting_ci" ? (
+                  <Clock className="w-3.5 h-3.5" />
+                ) : (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin text-primary" />
+                )}
+                {review.state === "waiting_ci"
+                  ? "Waiting for CI to finish — the agent will start reviewing once checks complete."
+                  : review.state === "queued"
+                    ? "Queued — a worker will pick this up shortly."
+                    : "Agent is reviewing the PR. The draft will appear above when it's done."}
               </div>
-              <p className="text-[11px] text-text-muted mb-2">
-                Ask follow-up questions. The agent may update the draft above.
-              </p>
+            </div>
+          )}
+
+          {/* Toolbar (timeline toggle) — same shape as the task page */}
+          <div className="shrink-0 flex items-center justify-end px-4 py-1 border-b border-border bg-bg">
+            <button
+              onClick={() => setShowTimeline(!showTimeline)}
+              className={cn(
+                "px-2 py-0.5 rounded text-xs transition-colors",
+                showTimeline ? "bg-primary/10 text-primary" : "text-text-muted hover:bg-bg-hover",
+              )}
+            >
+              Timeline
+            </button>
+          </div>
+
+          {/* Logs */}
+          <div className="flex-1 overflow-hidden">
+            <ErrorBoundary label="Review log viewer">
+              <LogViewer externalLogs={externalLogs} />
+            </ErrorBoundary>
+          </div>
+
+          {/* Chat composer at the bottom — only when the agent has produced a draft */}
+          {hasDraft && (
+            <div className="shrink-0 border-t border-border bg-bg-card px-4 py-2.5">
               <ChatTranscript messages={chat} pending={chatSending} />
               <ChatComposer
                 value={chatInput}
                 onChange={setChatInput}
                 onSend={handleSendChat}
                 sending={chatSending}
-                placeholder="Ask the reviewer a question, or request a change..."
-                rows={2}
+                placeholder="Ask the reviewer a follow-up, or request a change..."
               />
             </div>
           )}
-
-          {/* Runs (collapsible header) + agent logs */}
-          <div className="rounded-lg border border-border bg-bg-card">
-            <button
-              onClick={() => setShowLogs((v) => !v)}
-              className="w-full flex items-center justify-between gap-2 p-3 text-xs font-medium text-text-muted hover:bg-bg-hover transition-colors"
-            >
-              <span className="flex items-center gap-1.5">
-                {showLogs ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
-                Agent runs ({runs.length}) &amp; logs
-              </span>
-            </button>
-            {showLogs && (
-              <div className="border-t border-border p-3 space-y-3">
-                {runs.map((r) => (
-                  <div key={r.id} className="p-2 rounded bg-bg border border-border text-xs">
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium capitalize">{r.kind}</span>
-                      <span
-                        className={cn(
-                          "px-1.5 py-0.5 rounded-md text-[10px]",
-                          r.state === "completed"
-                            ? "bg-success/10 text-success"
-                            : r.state === "failed"
-                              ? "bg-error/10 text-error"
-                              : r.state === "running"
-                                ? "bg-warning/10 text-warning"
-                                : "bg-bg-card text-text-muted",
-                        )}
-                      >
-                        {r.state}
-                      </span>
-                      <span className="text-text-muted ml-auto">
-                        {formatRelativeTime(r.createdAt)}
-                      </span>
-                      {r.costUsd && (
-                        <span className="text-text-muted">${parseFloat(r.costUsd).toFixed(4)}</span>
-                      )}
-                    </div>
-                    {r.errorMessage && (
-                      <div className="mt-1 text-error text-[11px]">{r.errorMessage}</div>
-                    )}
-                  </div>
-                ))}
-                <div className="h-96 border border-border rounded overflow-hidden">
-                  <ErrorBoundary label="Review log viewer">
-                    <LogViewer externalLogs={externalLogs} />
-                  </ErrorBoundary>
-                </div>
-              </div>
-            )}
-          </div>
         </div>
+
+        {/* Timeline sidebar — mirrors /tasks/[id] */}
+        {showTimeline && (
+          <div className="hidden md:flex w-80 shrink-0 border-l border-border overflow-auto bg-bg-card flex-col">
+            <div className="flex items-center gap-1 p-2 border-b border-border">
+              <span className="px-2.5 py-1 rounded text-xs bg-primary/10 text-primary font-medium">
+                Pipeline
+              </span>
+            </div>
+            <div className="flex-1 overflow-auto p-3">
+              <ErrorBoundary label="Review pipeline timeline">
+                <ReviewPipelineTimeline review={review} runs={runs} />
+              </ErrorBoundary>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/reviews/[id]/page.tsx
+++ b/apps/web/src/app/reviews/[id]/page.tsx
@@ -26,6 +26,7 @@ import {
   RefreshCw,
   GitMerge,
   ChevronDown,
+  ChevronRight,
   Plus,
   Trash2,
   ExternalLink,
@@ -84,6 +85,7 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
   const [chatInput, setChatInput] = useState("");
   const [chatSending, setChatSending] = useState(false);
   const [showTimeline, setShowTimeline] = useState(true);
+  const [verdictCollapsed, setVerdictCollapsed] = useState(false);
 
   // Editable fields
   const [summary, setSummary] = useState("");
@@ -463,10 +465,57 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
       <div className="flex-1 flex overflow-hidden">
         {/* Log column */}
         <div className="flex-1 min-w-0 flex flex-col">
-          {/* Verdict + summary widget — only when the draft is ready */}
+          {/* Verdict + summary widget — collapsible. When collapsed, the
+              header strip stays visible so the user can see the verdict at a
+              glance without expanding. */}
           {hasDraft && (
+            <div className="shrink-0 border-b border-border bg-bg-card">
+              <button
+                onClick={() => setVerdictCollapsed((v) => !v)}
+                className="w-full flex items-center gap-2 px-4 py-2 text-xs hover:bg-bg-hover transition-colors"
+                title={verdictCollapsed ? "Expand draft" : "Collapse to focus on logs"}
+              >
+                {verdictCollapsed ? (
+                  <ChevronRight className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                ) : (
+                  <ChevronDown className="w-3.5 h-3.5 text-text-muted shrink-0" />
+                )}
+                <span className="font-medium text-text-muted">Review draft</span>
+                {verdict && (
+                  <span
+                    className={cn(
+                      "px-1.5 py-0.5 rounded text-[10px] font-medium",
+                      verdict === "approve"
+                        ? "bg-success/10 text-success"
+                        : verdict === "request_changes"
+                          ? "bg-error/10 text-error"
+                          : "bg-bg text-text-muted",
+                    )}
+                  >
+                    {verdict === "approve"
+                      ? "Approve"
+                      : verdict === "request_changes"
+                        ? "Request changes"
+                        : "Comment"}
+                  </span>
+                )}
+                {comments.length > 0 && (
+                  <span className="text-[10px] text-text-muted">
+                    {comments.length} comment{comments.length === 1 ? "" : "s"}
+                  </span>
+                )}
+                {dirty && <span className="text-[10px] text-warning">• unsaved</span>}
+                {verdictCollapsed && summary && (
+                  <span className="text-[11px] text-text-muted/70 truncate min-w-0 flex-1 text-left">
+                    {summary.split("\n")[0]}
+                  </span>
+                )}
+              </button>
+            </div>
+          )}
+          {hasDraft && !verdictCollapsed && (
             <div className="shrink-0 border-b border-border bg-bg-card max-h-[55vh] overflow-y-auto">
-              <div className="max-w-5xl mx-auto p-4 space-y-4">
+              <div className="max-w-5xl mx-auto px-4 pb-4 space-y-4">
                 {/* Verdict */}
                 <div>
                   <label className="text-xs font-medium text-text-muted mb-2 block">Verdict</label>

--- a/apps/web/src/app/reviews/[id]/page.tsx
+++ b/apps/web/src/app/reviews/[id]/page.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import { use, useCallback, useEffect, useRef, useState } from "react";
+import { use, useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { api } from "@/lib/api-client";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import { usePageTitle } from "@/hooks/use-page-title";
+import { usePrReviewLogs } from "@/hooks/use-pr-review-logs";
+import { classifyError } from "@optio/shared";
+import { ErrorBoundary } from "@/components/error-boundary";
+import { LogViewer } from "@/components/log-viewer";
+import { DetailHeader } from "@/components/detail-header";
+import { StatePipelineStrip } from "@/components/state-pipeline-strip";
+import { PrStatusBar } from "@/components/pr-status-bar";
+import { ChatTranscript, ChatComposer, type ChatMessage } from "@/components/chat-box";
 import {
   Loader2,
   Check,
@@ -13,6 +21,7 @@ import {
   MessageSquare,
   Send,
   AlertTriangle,
+  AlertCircle,
   RefreshCw,
   GitMerge,
   ChevronDown,
@@ -50,7 +59,7 @@ interface Review {
   updatedAt: string;
 }
 
-const STATE_STRIP = [
+const PIPELINE_STEPS = [
   { key: "queued", label: "Queued" },
   { key: "waiting_ci", label: "CI" },
   { key: "reviewing", label: "Reviewing" },
@@ -58,61 +67,23 @@ const STATE_STRIP = [
   { key: "submitted", label: "Submitted" },
 ];
 
-function StateStrip({ state }: { state: string }) {
-  const idx = STATE_STRIP.findIndex((s) => s.key === state);
-  const effectiveIdx = state === "stale" ? 3 : state === "failed" ? -1 : idx;
-  return (
-    <div className="flex items-center gap-1 text-[11px]">
-      {STATE_STRIP.map((s, i) => (
-        <div key={s.key} className="flex items-center gap-1">
-          <span
-            className={cn(
-              "px-2 py-0.5 rounded-md font-medium",
-              i < effectiveIdx
-                ? "bg-success/10 text-success"
-                : i === effectiveIdx
-                  ? state === "stale"
-                    ? "bg-error/10 text-error"
-                    : "bg-primary/10 text-primary"
-                  : "bg-bg text-text-muted",
-            )}
-          >
-            {s.label}
-          </span>
-          {i < STATE_STRIP.length - 1 && <span className="text-text-muted/30">›</span>}
-        </div>
-      ))}
-      {state === "stale" && (
-        <span className="ml-2 px-2 py-0.5 rounded-md bg-error/10 text-error font-medium">
-          Stale
-        </span>
-      )}
-      {state === "failed" && (
-        <span className="ml-2 px-2 py-0.5 rounded-md bg-error/10 text-error font-medium">
-          Failed
-        </span>
-      )}
-      {state === "cancelled" && (
-        <span className="ml-2 px-2 py-0.5 rounded-md bg-bg text-text-muted font-medium">
-          Cancelled
-        </span>
-      )}
-    </div>
-  );
+function pipelineCurrentIndex(state: string): number {
+  if (state === "stale") return 3; // sits on "Ready" but coloured as error via flag
+  if (state === "failed" || state === "cancelled") return -1;
+  const idx = PIPELINE_STEPS.findIndex((s) => s.key === state);
+  return idx;
 }
 
 export default function ReviewDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const router = useRouter();
+  const _router = useRouter();
 
   const [review, setReview] = useState<Review | null>(null);
   const [loading, setLoading] = useState(true);
   const [runs, setRuns] = useState<any[]>([]);
-  const [logs, setLogs] = useState<any[]>([]);
-  const [logRunId, setLogRunId] = useState<string | null>(null);
   const [showLogs, setShowLogs] = useState(false);
   const [prStatus, setPrStatus] = useState<any>(null);
-  const [chat, setChat] = useState<any[]>([]);
+  const [chat, setChat] = useState<ChatMessage[]>([]);
   const [chatInput, setChatInput] = useState("");
   const [chatSending, setChatSending] = useState(false);
 
@@ -130,6 +101,10 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
   const [mergeMethod, setMergeMethod] = useState<"squash" | "merge" | "rebase">("squash");
   const [mergeMenuOpen, setMergeMenuOpen] = useState(false);
 
+  // Live log streaming via WebSocket — same hook contract as the task page's
+  // useLogs, plugged into LogViewer's externalLogs prop.
+  const externalLogs = usePrReviewLogs(id);
+
   usePageTitle(review ? `Review: PR #${review.prNumber}` : "Review");
 
   const fetchAll = useCallback(async () => {
@@ -142,7 +117,6 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
       setComments(r.review.fileComments ?? []);
       setDirty(false);
 
-      // PR status (CI etc.)
       if (r.review.prUrl) {
         api
           .getPrStatus(r.review.prUrl)
@@ -176,26 +150,6 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
     const t = setInterval(fetchAll, 5000);
     return () => clearInterval(t);
   }, [review?.state, chatSending, fetchAll]);
-
-  const loadLogs = useCallback(async () => {
-    try {
-      const res = await api.listPrReviewLogs(id);
-      setLogs(res.logs);
-      setLogRunId(res.runId ?? null);
-    } catch {}
-  }, [id]);
-
-  useEffect(() => {
-    if (showLogs) loadLogs();
-  }, [showLogs, loadLogs]);
-
-  // Refresh logs while reviewing.
-  useEffect(() => {
-    if (!review || !showLogs) return;
-    if (review.state !== "reviewing" && review.state !== "queued") return;
-    const t = setInterval(loadLogs, 3000);
-    return () => clearInterval(t);
-  }, [review?.state, showLogs, loadLogs]);
 
   if (loading) {
     return (
@@ -305,8 +259,6 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
       ...prev,
       {
         id: `local-${Date.now()}`,
-        prReviewId: id,
-        runId: null,
         role: "user",
         content: msg,
         createdAt: new Date().toISOString(),
@@ -316,14 +268,13 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
     try {
       await api.postPrReviewChat(id, msg);
       toast.success("Sent to agent");
-      // Poll for response
       const start = Date.now();
       const tick = setInterval(async () => {
         const res = await api.listPrReviewChat(id).catch(() => null);
         if (res) {
           setChat(res.messages);
           const hasAssistantReply = res.messages.some(
-            (m, i) => m.role === "assistant" && new Date(m.createdAt).getTime() > start,
+            (m) => m.role === "assistant" && new Date(m.createdAt).getTime() > start,
           );
           if (hasAssistantReply || Date.now() - start > 300_000) {
             clearInterval(tick);
@@ -357,93 +308,154 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
     setDirty(true);
   };
 
+  const pipelineCurrent = pipelineCurrentIndex(review.state);
+  const terminal =
+    review.state === "stale"
+      ? { label: "Stale", tone: "error" as const }
+      : review.state === "failed"
+        ? { label: "Failed", tone: "error" as const }
+        : review.state === "cancelled"
+          ? { label: "Cancelled", tone: "muted" as const }
+          : undefined;
+
   return (
     <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="shrink-0 p-4 border-b border-border bg-bg-card">
-        <div className="max-w-5xl mx-auto flex flex-col gap-3">
-          <div className="flex items-start justify-between gap-3 flex-wrap">
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2 mb-1 text-xs text-text-muted">
-                <GitPullRequest className="w-3.5 h-3.5" />
-                <span>
-                  {review.repoOwner}/{review.repoName} · #{review.prNumber}
-                </span>
-                <a
-                  href={review.prUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 hover:text-primary"
-                >
-                  View on {review.prUrl.includes("gitlab") ? "GitLab" : "GitHub"}
-                  <ExternalLink className="w-3 h-3" />
-                </a>
-              </div>
-              <h1 className="text-lg font-bold tracking-tight">Review: PR #{review.prNumber}</h1>
-              <div className="flex items-center gap-3 mt-2 flex-wrap">
-                <StateStrip state={review.state} />
-                {review.origin === "auto" && (
-                  <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-md bg-primary/10 text-primary">
-                    <Zap className="w-3 h-3" />
-                    Auto
-                  </span>
-                )}
-                <span className="text-[11px] text-text-muted">
-                  Updated {formatRelativeTime(review.updatedAt)}
-                </span>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 flex-wrap">
-              {["ready", "stale", "submitted", "failed"].includes(review.state) && (
-                <button
-                  onClick={handleReReview}
-                  disabled={reReviewing}
-                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary/10 text-primary text-xs hover:bg-primary/20 disabled:opacity-50"
-                  title="Launch a fresh review run"
-                >
-                  {reReviewing ? (
-                    <Loader2 className="w-3 h-3 animate-spin" />
-                  ) : (
-                    <RotateCcw className="w-3 h-3" />
-                  )}
-                  Re-review
-                </button>
-              )}
-              {!["cancelled", "submitted"].includes(review.state) && (
-                <button
-                  onClick={handleCancel}
-                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-error/10 text-error text-xs hover:bg-error/20"
-                >
-                  <XCircle className="w-3 h-3" />
-                  Cancel
-                </button>
-              )}
+      <DetailHeader
+        title={`Review: PR #${review.prNumber}`}
+        subtitle={
+          <>
+            <GitPullRequest className="w-3.5 h-3.5" />
+            <span>
+              {review.repoOwner}/{review.repoName} · #{review.prNumber}
+            </span>
+            <a
+              href={review.prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 hover:text-primary"
+            >
+              View on {review.prUrl.includes("gitlab") ? "GitLab" : "GitHub"}
+              <ExternalLink className="w-3 h-3" />
+            </a>
+          </>
+        }
+        state={review.state}
+        extraBadges={
+          review.origin === "auto" ? (
+            <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-md bg-primary/10 text-primary">
+              <Zap className="w-3 h-3" />
+              Auto
+            </span>
+          ) : null
+        }
+        metaItems={[
+          <>
+            <Clock className="w-3 h-3" />
+            Updated {formatRelativeTime(review.updatedAt)}
+          </>,
+        ]}
+        rightSlot={
+          <>
+            {["ready", "stale", "submitted", "failed"].includes(review.state) && (
               <button
-                onClick={fetchAll}
-                className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted"
-                title="Refresh"
+                onClick={handleReReview}
+                disabled={reReviewing}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary/10 text-primary text-xs hover:bg-primary/20 disabled:opacity-50"
+                title="Launch a fresh review run"
               >
-                <RefreshCw className="w-4 h-4" />
+                {reReviewing ? (
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                ) : (
+                  <RotateCcw className="w-3 h-3" />
+                )}
+                Re-review
               </button>
-            </div>
-          </div>
-        </div>
-      </div>
+            )}
+            {!["cancelled", "submitted"].includes(review.state) && (
+              <button
+                onClick={handleCancel}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-error/10 text-error text-xs hover:bg-error/20"
+              >
+                <XCircle className="w-3 h-3" />
+                Cancel
+              </button>
+            )}
+            <button
+              onClick={fetchAll}
+              className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted"
+              title="Refresh"
+            >
+              <RefreshCw className="w-4 h-4" />
+            </button>
+          </>
+        }
+        actions={
+          <StatePipelineStrip
+            steps={PIPELINE_STEPS}
+            current={pipelineCurrent}
+            errorAtCurrent={review.state === "stale"}
+            terminal={terminal}
+          />
+        }
+      />
 
-      {/* Error banner */}
-      {review.errorMessage && review.state === "failed" && (
-        <div className="shrink-0 border-b border-error/20 bg-error/5 px-4 py-3">
-          <div className="max-w-5xl mx-auto flex items-start gap-2 text-sm text-error">
-            <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
-            <div>
-              <div className="font-medium">Review failed</div>
-              <div className="text-xs opacity-80 mt-0.5 whitespace-pre-wrap">
-                {review.errorMessage}
-              </div>
-            </div>
+      {/* PR status bar (CI / review / merge state) */}
+      {(prStatus?.checksStatus || prStatus?.reviewStatus || prStatus?.prState) && (
+        <div className="shrink-0 border-b border-border bg-bg-card px-4 py-3">
+          <div className="max-w-5xl mx-auto">
+            <PrStatusBar
+              checksStatus={prStatus?.checksStatus}
+              reviewStatus={prStatus?.reviewStatus}
+              prState={prStatus?.prState}
+            />
           </div>
         </div>
       )}
+
+      {/* Error banner with classified remedy */}
+      {review.errorMessage &&
+        review.state === "failed" &&
+        (() => {
+          const classified = classifyError(review.errorMessage);
+          return (
+            <div className="shrink-0 border-b border-error/20 bg-error/5">
+              <div className="max-w-5xl mx-auto px-4 py-3">
+                <div className="flex items-start gap-3">
+                  <AlertCircle className="w-5 h-5 text-error shrink-0 mt-0.5" />
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <div>
+                      <h3 className="text-sm font-medium text-error">{classified.title}</h3>
+                      <p className="text-xs text-error/70 mt-0.5">{classified.description}</p>
+                    </div>
+                    <div className="p-2.5 rounded-md bg-bg/50 border border-border">
+                      <div className="text-[10px] uppercase tracking-wider text-text-muted mb-1">
+                        Suggested fix
+                      </div>
+                      <pre className="text-xs text-text/80 whitespace-pre-wrap font-mono">
+                        {classified.remedy}
+                      </pre>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {classified.retryable && (
+                        <button
+                          onClick={handleReReview}
+                          disabled={reReviewing}
+                          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-white text-xs hover:bg-primary-hover disabled:opacity-50 btn-press transition-all"
+                        >
+                          <RotateCcw className="w-3 h-3" />
+                          Re-review
+                        </button>
+                      )}
+                      <span className="text-[10px] px-2 py-0.5 rounded-full bg-error/10 text-error">
+                        {classified.category}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })()}
 
       {/* Stale banner */}
       {review.state === "stale" && (
@@ -641,23 +653,6 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
                   )}
                 </div>
                 <div className="flex items-center gap-2">
-                  {prStatus && (
-                    <span className="flex items-center gap-1.5 text-xs text-text-muted">
-                      <span
-                        className={cn(
-                          "w-2 h-2 rounded-full",
-                          prStatus.checksStatus === "passing"
-                            ? "bg-success"
-                            : prStatus.checksStatus === "failing"
-                              ? "bg-error"
-                              : prStatus.checksStatus === "pending"
-                                ? "bg-warning animate-pulse"
-                                : "bg-text-muted/30",
-                        )}
-                      />
-                      CI: {prStatus.checksStatus}
-                    </span>
-                  )}
                   <div className="relative">
                     <div className="flex">
                       <button
@@ -729,64 +724,19 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
               <p className="text-[11px] text-text-muted mb-2">
                 Ask follow-up questions. The agent may update the draft above.
               </p>
-              {chat.length > 0 && (
-                <div className="space-y-2 mb-3 max-h-72 overflow-y-auto pr-1">
-                  {chat.map((m) => (
-                    <div
-                      key={m.id}
-                      className={cn(
-                        "rounded-md p-2 text-xs whitespace-pre-wrap",
-                        m.role === "user"
-                          ? "bg-primary/10 text-text border border-primary/20"
-                          : "bg-bg border border-border text-text-muted",
-                      )}
-                    >
-                      <div className="text-[10px] uppercase tracking-wide opacity-60 mb-1">
-                        {m.role === "user" ? "You" : "Agent"}
-                      </div>
-                      {m.content}
-                    </div>
-                  ))}
-                  {chatSending && (
-                    <div className="flex items-center gap-2 text-xs text-text-muted">
-                      <Loader2 className="w-3 h-3 animate-spin" />
-                      Agent is thinking...
-                    </div>
-                  )}
-                </div>
-              )}
-              <div className="flex items-end gap-2">
-                <textarea
-                  value={chatInput}
-                  onChange={(e) => setChatInput(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      handleSendChat();
-                    }
-                  }}
-                  rows={2}
-                  placeholder="Ask the reviewer a question, or request a change..."
-                  disabled={chatSending}
-                  className="flex-1 px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:border-primary focus:ring-1 focus:ring-primary/20 focus:outline-none resize-y disabled:opacity-60"
-                />
-                <button
-                  onClick={handleSendChat}
-                  disabled={chatSending || !chatInput.trim()}
-                  className="flex items-center gap-1.5 px-3 py-2 rounded-md bg-primary text-white text-xs font-medium hover:bg-primary-hover disabled:opacity-50"
-                >
-                  {chatSending ? (
-                    <Loader2 className="w-3 h-3 animate-spin" />
-                  ) : (
-                    <Send className="w-3 h-3" />
-                  )}
-                  Send
-                </button>
-              </div>
+              <ChatTranscript messages={chat} pending={chatSending} />
+              <ChatComposer
+                value={chatInput}
+                onChange={setChatInput}
+                onSend={handleSendChat}
+                sending={chatSending}
+                placeholder="Ask the reviewer a question, or request a change..."
+                rows={2}
+              />
             </div>
           )}
 
-          {/* Runs + logs (collapsible) */}
+          {/* Runs (collapsible header) + agent logs */}
           <div className="rounded-lg border border-border bg-bg-card">
             <button
               onClick={() => setShowLogs((v) => !v)}
@@ -829,19 +779,11 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
                     )}
                   </div>
                 ))}
-                {logs.length > 0 && (
-                  <div className="font-mono text-[11px] bg-bg border border-border rounded p-2 max-h-80 overflow-auto">
-                    <div className="text-text-muted mb-1">Logs for run {logRunId?.slice(0, 8)}</div>
-                    {logs.map((l: any) => (
-                      <div key={l.id} className="whitespace-pre-wrap break-all">
-                        {l.logType && (
-                          <span className="text-text-muted/60 mr-1">[{l.logType}]</span>
-                        )}
-                        {l.content}
-                      </div>
-                    ))}
-                  </div>
-                )}
+                <div className="h-96 border border-border rounded overflow-hidden">
+                  <ErrorBoundary label="Review log viewer">
+                    <LogViewer externalLogs={externalLogs} />
+                  </ErrorBoundary>
+                </div>
               </div>
             )}
           </div>

--- a/apps/web/src/app/reviews/[id]/page.tsx
+++ b/apps/web/src/app/reviews/[id]/page.tsx
@@ -396,17 +396,26 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
         }
       />
 
-      {(prStatus?.checksStatus || prStatus?.reviewStatus || prStatus?.prState) && (
-        <div className="shrink-0 border-b border-border bg-bg-card px-4 py-3">
-          <div className="max-w-5xl mx-auto">
-            <PrStatusBar
-              checksStatus={prStatus?.checksStatus}
-              reviewStatus={prStatus?.reviewStatus}
-              prState={prStatus?.prState}
-            />
-          </div>
+      <div className="shrink-0 border-b border-border bg-bg-card px-4 py-2">
+        <div className="max-w-5xl mx-auto">
+          <PrStatusBar
+            checksStatus={prStatus?.checksStatus}
+            reviewStatus={prStatus?.reviewStatus}
+            prState={prStatus?.prState}
+            actions={
+              <button
+                onClick={() => setShowTimeline(!showTimeline)}
+                className={cn(
+                  "px-2 py-0.5 rounded text-xs transition-colors",
+                  showTimeline ? "bg-primary/10 text-primary" : "text-text-muted hover:bg-bg-hover",
+                )}
+              >
+                Timeline
+              </button>
+            }
+          />
         </div>
-      )}
+      </div>
 
       {review.errorMessage &&
         review.state === "failed" &&
@@ -752,19 +761,6 @@ export default function ReviewDetailPage({ params }: { params: Promise<{ id: str
               </div>
             </div>
           )}
-
-          {/* Toolbar (timeline toggle) — same shape as the task page */}
-          <div className="shrink-0 flex items-center justify-end px-4 py-1 border-b border-border bg-bg">
-            <button
-              onClick={() => setShowTimeline(!showTimeline)}
-              className={cn(
-                "px-2 py-0.5 rounded text-xs transition-colors",
-                showTimeline ? "bg-primary/10 text-primary" : "text-text-muted hover:bg-bg-hover",
-              )}
-            >
-              Timeline
-            </button>
-          </div>
 
           {/* Logs */}
           <div className="flex-1 overflow-hidden">

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -543,58 +543,63 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
           );
         })()}
 
-      {/* PR Status */}
-      {task.prUrl &&
-        ((task.prChecksStatus && task.prChecksStatus !== "none") ||
-          (task.prReviewStatus && task.prReviewStatus !== "none") ||
-          (task.prState && task.prState !== "open")) && (
-          <div className="shrink-0 border-b border-border bg-bg-card px-4 py-3">
-            <div className="max-w-5xl mx-auto">
-              <PrStatusBar
-                checksStatus={task.prChecksStatus}
-                reviewStatus={task.prReviewStatus}
-                prState={task.prState}
-                actions={
-                  <>
-                    {task.costUsd && (
-                      <span className="text-text-muted">
-                        Cost: ${parseFloat(task.costUsd).toFixed(4)}
-                      </span>
-                    )}
-                    {task.state === "pr_opened" && (
-                      <button
-                        onClick={async () => {
-                          setActionLoading(true);
-                          try {
-                            await api.launchReview(id);
-                            toast.success("Review agent launched");
-                            refresh();
-                          } catch (err) {
-                            toast.error(
-                              err instanceof Error ? err.message : "Failed to launch review",
-                            );
-                          }
-                          setActionLoading(false);
-                        }}
-                        disabled={actionLoading}
-                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary/10 text-primary text-xs hover:bg-primary/20 disabled:opacity-50"
-                      >
-                        <Eye className="w-3 h-3" />
-                        Request Review
-                      </button>
-                    )}
-                  </>
-                }
-              />
-              {task.prReviewStatus === "changes_requested" && task.prReviewComments && (
-                <div className="mt-2 p-2 rounded-md bg-warning/5 border border-warning/20 text-xs">
-                  <div className="font-medium text-warning mb-1">Review feedback:</div>
-                  <pre className="text-text-muted whitespace-pre-wrap">{task.prReviewComments}</pre>
-                </div>
-              )}
+      {/* PR Status — also hosts the Timeline toggle so both pages put it in
+          the same place. The row always renders to give Timeline a stable home. */}
+      <div className="shrink-0 border-b border-border bg-bg-card px-4 py-2">
+        <div className="max-w-5xl mx-auto">
+          <PrStatusBar
+            checksStatus={task.prChecksStatus}
+            reviewStatus={task.prReviewStatus}
+            prState={task.prState}
+            actions={
+              <>
+                {task.costUsd && (
+                  <span className="text-text-muted">
+                    Cost: ${parseFloat(task.costUsd).toFixed(4)}
+                  </span>
+                )}
+                {task.state === "pr_opened" && (
+                  <button
+                    onClick={async () => {
+                      setActionLoading(true);
+                      try {
+                        await api.launchReview(id);
+                        toast.success("Review agent launched");
+                        refresh();
+                      } catch (err) {
+                        toast.error(err instanceof Error ? err.message : "Failed to launch review");
+                      }
+                      setActionLoading(false);
+                    }}
+                    disabled={actionLoading}
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary/10 text-primary text-xs hover:bg-primary/20 disabled:opacity-50"
+                  >
+                    <Eye className="w-3 h-3" />
+                    Request Review
+                  </button>
+                )}
+                <button
+                  onClick={() => setShowTimeline(!showTimeline)}
+                  className={cn(
+                    "px-2 py-0.5 rounded text-xs transition-colors",
+                    showTimeline
+                      ? "bg-primary/10 text-primary"
+                      : "text-text-muted hover:bg-bg-hover",
+                  )}
+                >
+                  Timeline
+                </button>
+              </>
+            }
+          />
+          {task.prReviewStatus === "changes_requested" && task.prReviewComments && (
+            <div className="mt-2 p-2 rounded-md bg-warning/5 border border-warning/20 text-xs">
+              <div className="font-medium text-warning mb-1">Review feedback:</div>
+              <pre className="text-text-muted whitespace-pre-wrap">{task.prReviewComments}</pre>
             </div>
-          </div>
-        )}
+          )}
+        </div>
+      </div>
 
       {/* Dependencies */}
       <div className="shrink-0 border-b border-border bg-bg px-4 py-2.5">
@@ -842,19 +847,6 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
       <div className="flex-1 flex overflow-hidden">
         {/* Log panel */}
         <div className="flex-1 min-w-0 flex flex-col">
-          {/* Log viewer + events toggle */}
-          <div className="shrink-0 flex items-center justify-end px-4 py-1 border-b border-border bg-bg">
-            <button
-              onClick={() => setShowTimeline(!showTimeline)}
-              className={cn(
-                "px-2 py-0.5 rounded text-xs transition-colors",
-                showTimeline ? "bg-primary/10 text-primary" : "text-text-muted hover:bg-bg-hover",
-              )}
-            >
-              Timeline
-            </button>
-          </div>
-
           {/* Log content via LogViewer */}
           <div className="flex-1 overflow-hidden">
             <ErrorBoundary label="Log viewer">

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -2,12 +2,15 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { use, useState, useEffect, useRef, useCallback } from "react";
+import { use, useState, useEffect } from "react";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { useTask } from "@/hooks/use-task";
 import { LogViewer } from "@/components/log-viewer";
 import { PipelineTimeline } from "@/components/pipeline-timeline";
 import { ActivityFeed } from "@/components/activity-feed";
+import { DetailHeader } from "@/components/detail-header";
+import { PrStatusBar } from "@/components/pr-status-bar";
+import { ChatComposer } from "@/components/chat-box";
 import { StateBadge } from "@/components/state-badge";
 import { TokenRefreshBanner } from "@/components/token-refresh-banner";
 import { api } from "@/lib/api-client";
@@ -31,9 +34,6 @@ import {
   Eye,
   Plus,
   X,
-  Link2,
-  MessageSquare,
-  Square,
   CheckCircle,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -148,14 +148,6 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   const [userMessages, setUserMessages] = useState<
     { text: string; timestamp: string; status: "sending" | "sent" | "failed" }[]
   >([]);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  const autoResizeTextarea = useCallback(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
-  }, []);
 
   const handleSendMessage = async (mode: "soft" | "interrupt" = "soft") => {
     if (!messageInput.trim()) return;
@@ -168,9 +160,6 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
     try {
       await api.sendTaskMessage(id, text, mode);
       setMessageInput("");
-      if (textareaRef.current) {
-        textareaRef.current.style.height = "auto";
-      }
       setUserMessages((prev) =>
         prev.map((m) => (m.text === text && m.status === "sending" ? { ...m, status: "sent" } : m)),
       );
@@ -282,32 +271,35 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="shrink-0 p-4 border-b border-border bg-bg-card">
-        <div className="flex flex-col gap-3 max-w-5xl mx-auto">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-3 flex-wrap">
-                <h1 className="text-lg font-bold tracking-tight">{task.title}</h1>
-                <StateBadge state={task.state} isStalled={stallInfo?.isStalled} />
-              </div>
-              <div className="flex items-center gap-4 mt-2 text-xs text-text-muted flex-wrap">
-                <span className="flex items-center gap-1">
-                  <GitBranch className="w-3 h-3" />
-                  {repoName}
-                </span>
-                <span className="flex items-center gap-1 capitalize">
-                  <Bot className="w-3 h-3" />
-                  {task.agentType.replace("-", " ")}
-                </span>
-                <span className="flex items-center gap-1">
-                  <Clock className="w-3 h-3" />
-                  {formatRelativeTime(task.createdAt)}
-                </span>
-              </div>
-            </div>
-          </div>
-          <div className="flex items-center gap-2 flex-wrap">
+      <DetailHeader
+        title={task.title}
+        state={task.state}
+        isStalled={stallInfo?.isStalled}
+        metaItems={[
+          <>
+            <GitBranch className="w-3 h-3" />
+            {repoName}
+          </>,
+          <span className="flex items-center gap-1 capitalize">
+            <Bot className="w-3 h-3" />
+            {task.agentType.replace("-", " ")}
+          </span>,
+          <>
+            <Clock className="w-3 h-3" />
+            {formatRelativeTime(task.createdAt)}
+          </>,
+        ]}
+        rightSlot={
+          <button
+            onClick={refresh}
+            className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted transition-colors"
+            title="Refresh"
+          >
+            <RefreshCw className="w-4 h-4" />
+          </button>
+        }
+        actions={
+          <>
             {task.prUrl && (
               <a
                 href={task.prUrl}
@@ -372,16 +364,9 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
               <Bot className="w-3 h-3" />
               Ask Optio
             </button>
-            <button
-              onClick={refresh}
-              className="p-1.5 rounded-md hover:bg-bg-hover text-text-muted transition-colors"
-              title="Refresh"
-            >
-              <RefreshCw className="w-4 h-4" />
-            </button>
-          </div>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       {/* Pending reason */}
       {pendingReason && (
@@ -565,90 +550,42 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
           (task.prState && task.prState !== "open")) && (
           <div className="shrink-0 border-b border-border bg-bg-card px-4 py-3">
             <div className="max-w-5xl mx-auto">
-              <div className="flex items-center gap-4 text-xs">
-                {/* CI Checks */}
-                {task.prChecksStatus && task.prChecksStatus !== "none" && (
-                  <span
-                    className={cn(
-                      "flex items-center gap-1",
-                      task.prChecksStatus === "passing"
-                        ? "text-success"
-                        : task.prChecksStatus === "failing"
-                          ? "text-error"
-                          : "text-warning",
+              <PrStatusBar
+                checksStatus={task.prChecksStatus}
+                reviewStatus={task.prReviewStatus}
+                prState={task.prState}
+                actions={
+                  <>
+                    {task.costUsd && (
+                      <span className="text-text-muted">
+                        Cost: ${parseFloat(task.costUsd).toFixed(4)}
+                      </span>
                     )}
-                  >
-                    <span
-                      className={cn(
-                        "w-2 h-2 rounded-full",
-                        task.prChecksStatus === "passing"
-                          ? "bg-success"
-                          : task.prChecksStatus === "failing"
-                            ? "bg-error"
-                            : "bg-warning",
-                      )}
-                    />
-                    CI: {task.prChecksStatus}
-                  </span>
-                )}
-
-                {/* Review Status */}
-                {task.prReviewStatus && task.prReviewStatus !== "none" && (
-                  <span
-                    className={cn(
-                      "flex items-center gap-1",
-                      task.prReviewStatus === "approved"
-                        ? "text-success"
-                        : task.prReviewStatus === "changes_requested"
-                          ? "text-warning"
-                          : "text-text-muted",
+                    {task.state === "pr_opened" && (
+                      <button
+                        onClick={async () => {
+                          setActionLoading(true);
+                          try {
+                            await api.launchReview(id);
+                            toast.success("Review agent launched");
+                            refresh();
+                          } catch (err) {
+                            toast.error(
+                              err instanceof Error ? err.message : "Failed to launch review",
+                            );
+                          }
+                          setActionLoading(false);
+                        }}
+                        disabled={actionLoading}
+                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary/10 text-primary text-xs hover:bg-primary/20 disabled:opacity-50"
+                      >
+                        <Eye className="w-3 h-3" />
+                        Request Review
+                      </button>
                     )}
-                  >
-                    Review:{" "}
-                    {task.prReviewStatus === "changes_requested"
-                      ? "changes requested"
-                      : task.prReviewStatus}
-                  </span>
-                )}
-
-                {/* PR State */}
-                {task.prState && task.prState !== "open" && (
-                  <span className={task.prState === "merged" ? "text-success" : "text-text-muted"}>
-                    {task.prState}
-                  </span>
-                )}
-
-                {/* Cost */}
-                {task.costUsd && (
-                  <span className="text-text-muted ml-auto">
-                    Cost: ${parseFloat(task.costUsd).toFixed(4)}
-                  </span>
-                )}
-
-                {/* Request Review */}
-                {task.state === "pr_opened" && (
-                  <button
-                    onClick={async () => {
-                      setActionLoading(true);
-                      try {
-                        const res = await api.launchReview(id);
-                        toast.success("Review agent launched");
-                        refresh();
-                      } catch (err) {
-                        toast.error(err instanceof Error ? err.message : "Failed to launch review");
-                      }
-                      setActionLoading(false);
-                    }}
-                    disabled={actionLoading}
-                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary/10 text-primary text-xs hover:bg-primary/20 disabled:opacity-50 ml-auto"
-                  >
-                    <Eye className="w-3 h-3" />
-                    Request Review
-                  </button>
-                )}
-              </div>
-
-              {/* Review comments if changes requested */}
+                  </>
+                }
+              />
               {task.prReviewStatus === "changes_requested" && task.prReviewComments && (
                 <div className="mt-2 p-2 rounded-md bg-warning/5 border border-warning/20 text-xs">
                   <div className="font-medium text-warning mb-1">Review feedback:</div>
@@ -929,47 +866,16 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
           <div className="shrink-0 border-t border-border bg-bg-card px-4 py-2.5">
             {canMessage ? (
               /* Mid-task messaging bar (running claude-code tasks) */
-              <div className="flex gap-2 items-end">
-                <textarea
-                  ref={textareaRef}
-                  value={messageInput}
-                  onChange={(e) => {
-                    setMessageInput(e.target.value);
-                    autoResizeTextarea();
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      handleSendMessage("soft");
-                    }
-                  }}
-                  placeholder="Send a message to the running agent..."
-                  rows={1}
-                  className="flex-1 px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-none"
-                />
-                <button
-                  onClick={() => handleSendMessage("soft")}
-                  disabled={!messageInput.trim() || messageSending}
-                  title="Send message (agent picks it up at next turn)"
-                  className="px-3 py-2 rounded-md text-sm font-medium transition-colors bg-primary text-white hover:bg-primary-hover disabled:opacity-30 disabled:cursor-not-allowed flex items-center gap-1.5"
-                >
-                  {messageSending ? (
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                  ) : (
-                    <Send className="w-4 h-4" />
-                  )}
-                  <span className="hidden sm:inline">Send</span>
-                </button>
-                <button
-                  onClick={() => handleSendMessage("interrupt")}
-                  disabled={!messageInput.trim() || messageSending}
-                  title="Stop — interrupt with urgent message"
-                  className="px-3 py-2 rounded-md text-sm font-medium transition-colors bg-warning text-white hover:bg-warning/90 disabled:opacity-30 disabled:cursor-not-allowed flex items-center gap-1.5"
-                >
-                  <Square className="w-4 h-4" />
-                  <span className="hidden sm:inline">Stop</span>
-                </button>
-              </div>
+              <ChatComposer
+                value={messageInput}
+                onChange={setMessageInput}
+                onSend={() => handleSendMessage("soft")}
+                onInterrupt={() => handleSendMessage("interrupt")}
+                sending={messageSending}
+                placeholder="Send a message to the running agent..."
+                sendLabel="Send"
+                interruptLabel="Stop"
+              />
             ) : isPlanReview && canResume ? (
               /* Plan review bar */
               <div className="space-y-2">

--- a/apps/web/src/components/chat-box.tsx
+++ b/apps/web/src/components/chat-box.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useCallback, useRef, type KeyboardEvent } from "react";
+import { Loader2, Send, Square } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  createdAt: string;
+}
+
+/**
+ * Scrollable bubble list for a back-and-forth between user and agent. Used by
+ * the PR-review chat panel; the task page renders user messages inline in the
+ * log viewer instead and does not use this component.
+ */
+export function ChatTranscript({
+  messages,
+  pending,
+}: {
+  messages: ChatMessage[];
+  pending?: boolean;
+}) {
+  if (messages.length === 0 && !pending) return null;
+  return (
+    <div className="space-y-2 mb-3 max-h-72 overflow-y-auto pr-1">
+      {messages.map((m) => (
+        <div
+          key={m.id}
+          className={cn(
+            "rounded-md p-2 text-xs whitespace-pre-wrap",
+            m.role === "user"
+              ? "bg-primary/10 text-text border border-primary/20"
+              : "bg-bg border border-border text-text-muted",
+          )}
+        >
+          <div className="text-[10px] uppercase tracking-wide opacity-60 mb-1">
+            {m.role === "user" ? "You" : "Agent"}
+          </div>
+          {m.content}
+        </div>
+      ))}
+      {pending && (
+        <div className="flex items-center gap-2 text-xs text-text-muted">
+          <Loader2 className="w-3 h-3 animate-spin" />
+          Agent is thinking...
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Auto-resizing textarea + send button + optional interrupt button. Used by
+ * both the task page's mid-task messaging bar and the PR-review chat panel,
+ * so they share the same Enter-to-send / Shift+Enter-for-newline behaviour
+ * and auto-resize feel.
+ */
+export function ChatComposer({
+  value,
+  onChange,
+  onSend,
+  sending,
+  disabled,
+  placeholder = "Send a message...",
+  rows = 1,
+  /** Renders the destructive "Stop" button next to send. Receives the same
+   * input value; the parent decides what to do (e.g. send with mode=interrupt). */
+  onInterrupt,
+  interruptLabel = "Stop",
+  /** Override the send button label (icon-only by default on small screens). */
+  sendLabel = "Send",
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  onSend: () => void;
+  sending?: boolean;
+  disabled?: boolean;
+  placeholder?: string;
+  rows?: number;
+  onInterrupt?: () => void;
+  interruptLabel?: string;
+  sendLabel?: string;
+}) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const autoResize = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+  }, []);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      if (!sending && value.trim()) onSend();
+    }
+  };
+
+  const trimmed = value.trim();
+  const canSend = !disabled && !sending && !!trimmed;
+
+  return (
+    <div className="flex gap-2 items-end">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          autoResize();
+        }}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled || sending}
+        rows={rows}
+        className="flex-1 px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20 resize-none disabled:opacity-60"
+      />
+      <button
+        onClick={onSend}
+        disabled={!canSend}
+        title={sendLabel}
+        className="px-3 py-2 rounded-md text-sm font-medium transition-colors bg-primary text-white hover:bg-primary-hover disabled:opacity-30 disabled:cursor-not-allowed flex items-center gap-1.5"
+      >
+        {sending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+        <span className="hidden sm:inline">{sendLabel}</span>
+      </button>
+      {onInterrupt && (
+        <button
+          onClick={onInterrupt}
+          disabled={!canSend}
+          title={interruptLabel}
+          className="px-3 py-2 rounded-md text-sm font-medium transition-colors bg-warning text-white hover:bg-warning/90 disabled:opacity-30 disabled:cursor-not-allowed flex items-center gap-1.5"
+        >
+          <Square className="w-4 h-4" />
+          <span className="hidden sm:inline">{interruptLabel}</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/detail-header.tsx
+++ b/apps/web/src/components/detail-header.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import { StateBadge } from "@/components/state-badge";
+
+/**
+ * Shared header for task and PR-review detail pages.
+ *
+ * Layout: a centered max-w-5xl column with two stacked rows. The top row holds
+ * the title block (subtitle + title + state badge + meta) and an inline action
+ * cluster on the right. The optional `actions` slot below holds the primary
+ * action button row.
+ */
+export function DetailHeader({
+  title,
+  subtitle,
+  state,
+  isStalled,
+  metaItems,
+  rightSlot,
+  actions,
+  extraBadges,
+}: {
+  title: ReactNode;
+  /** Optional subtitle line shown above the title (e.g. "owner/repo · #123"). */
+  subtitle?: ReactNode;
+  /** Task or review state — rendered as a `<StateBadge>`. */
+  state: string;
+  isStalled?: boolean;
+  /** Small chips below the title (repo, agent, age, …). */
+  metaItems?: ReactNode[];
+  /** Inline content rendered next to the state badge (e.g. origin chip, "Updated 2m ago"). */
+  extraBadges?: ReactNode;
+  /** Action cluster rendered top-right (refresh, etc.). */
+  rightSlot?: ReactNode;
+  /** Primary action button row, rendered below the title block. */
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="shrink-0 p-4 border-b border-border bg-bg-card">
+      <div className="flex flex-col gap-3 max-w-5xl mx-auto">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            {subtitle && (
+              <div className="flex items-center gap-2 mb-1 text-xs text-text-muted">{subtitle}</div>
+            )}
+            <div className="flex items-center gap-3 flex-wrap">
+              <h1 className="text-lg font-bold tracking-tight">{title}</h1>
+              <StateBadge state={state} isStalled={isStalled} />
+              {extraBadges}
+            </div>
+            {metaItems && metaItems.length > 0 && (
+              <div className="flex items-center gap-4 mt-2 text-xs text-text-muted flex-wrap">
+                {metaItems.map((item, i) => (
+                  <span key={i} className="flex items-center gap-1">
+                    {item}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+          {rightSlot && <div className="flex items-center gap-2 flex-wrap">{rightSlot}</div>}
+        </div>
+        {actions && <div className="flex items-center gap-2 flex-wrap">{actions}</div>}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pipeline-timeline.tsx
+++ b/apps/web/src/components/pipeline-timeline.tsx
@@ -22,9 +22,9 @@ import type { LucideIcon } from "lucide-react";
 // Types
 // ---------------------------------------------------------------------------
 
-type StageStatus = "completed" | "active" | "upcoming" | "failed" | "cancelled" | "skipped";
+export type StageStatus = "completed" | "active" | "upcoming" | "failed" | "cancelled" | "skipped";
 
-interface PipelineStage {
+export interface PipelineStage {
   id: string;
   label: string;
   status: StageStatus;
@@ -395,7 +395,7 @@ const STAGE_TOOLTIPS: Record<string, string> = {
 // Stage row component
 // ---------------------------------------------------------------------------
 
-function PipelineStageRow({ stage, isLast }: { stage: PipelineStage; isLast: boolean }) {
+export function PipelineStageRow({ stage, isLast }: { stage: PipelineStage; isLast: boolean }) {
   const Icon = stage.icon;
 
   // Icon & dot styling per status

--- a/apps/web/src/components/pr-status-bar.tsx
+++ b/apps/web/src/components/pr-status-bar.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type ChecksStatus = "passing" | "failing" | "pending" | "none" | string | null | undefined;
+type ReviewStatus =
+  | "approved"
+  | "changes_requested"
+  | "commented"
+  | "none"
+  | string
+  | null
+  | undefined;
+type PrState = "open" | "merged" | "closed" | string | null | undefined;
+
+/**
+ * Compact CI / review / merge-state row used by both task and PR-review
+ * detail pages. All fields are optional — pass only what you have. The
+ * `actions` slot renders right-aligned (e.g. "Request Review" button, cost
+ * chip, merge button).
+ */
+export function PrStatusBar({
+  checksStatus,
+  reviewStatus,
+  prState,
+  actions,
+}: {
+  checksStatus?: ChecksStatus;
+  reviewStatus?: ReviewStatus;
+  prState?: PrState;
+  actions?: ReactNode;
+}) {
+  const hasChecks = checksStatus && checksStatus !== "none";
+  const hasReview = reviewStatus && reviewStatus !== "none";
+  const hasPrState = prState && prState !== "open";
+  if (!hasChecks && !hasReview && !hasPrState && !actions) return null;
+
+  return (
+    <div className="flex items-center gap-4 text-xs flex-wrap">
+      {hasChecks && (
+        <span
+          className={cn(
+            "flex items-center gap-1.5",
+            checksStatus === "passing"
+              ? "text-success"
+              : checksStatus === "failing"
+                ? "text-error"
+                : "text-warning",
+          )}
+        >
+          <span
+            className={cn(
+              "w-2 h-2 rounded-full",
+              checksStatus === "passing"
+                ? "bg-success"
+                : checksStatus === "failing"
+                  ? "bg-error"
+                  : checksStatus === "pending"
+                    ? "bg-warning animate-pulse"
+                    : "bg-warning",
+            )}
+          />
+          CI: {checksStatus}
+        </span>
+      )}
+      {hasReview && (
+        <span
+          className={cn(
+            "flex items-center gap-1",
+            reviewStatus === "approved"
+              ? "text-success"
+              : reviewStatus === "changes_requested"
+                ? "text-warning"
+                : "text-text-muted",
+          )}
+        >
+          Review: {reviewStatus === "changes_requested" ? "changes requested" : reviewStatus}
+        </span>
+      )}
+      {hasPrState && (
+        <span className={prState === "merged" ? "text-success" : "text-text-muted"}>{prState}</span>
+      )}
+      {actions && <div className="ml-auto flex items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/components/review-pipeline-timeline.tsx
+++ b/apps/web/src/components/review-pipeline-timeline.tsx
@@ -1,0 +1,117 @@
+import { Clock, Server, Eye, CircleCheckBig, CheckCircle2 } from "lucide-react";
+import { PipelineStageRow, type PipelineStage } from "./pipeline-timeline.js";
+import { formatDuration } from "@/lib/utils";
+
+/**
+ * Vertical pipeline timeline for PR reviews. Mirrors the visual language of
+ * `<PipelineTimeline>` (used on the task detail page) so the two pages feel
+ * native to each other — the difference is just which stages are derived.
+ *
+ * Stages: Queued → Waiting CI → Reviewing → Ready → Submitted. The timeline
+ * also surfaces re-run history under the Reviewing stage so the user can see
+ * past attempts at a glance.
+ */
+export function ReviewPipelineTimeline({ review, runs }: { review: any; runs: any[] }) {
+  const stages = deriveReviewStages(review, runs);
+  return (
+    <div className="space-y-4">
+      <div className="relative">
+        {stages.map((stage, i) => (
+          <PipelineStageRow key={stage.id} stage={stage} isLast={i === stages.length - 1} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function deriveReviewStages(review: any, runs: any[]): PipelineStage[] {
+  const state = review.state as string;
+  const stageOrder = ["queued", "waiting_ci", "reviewing", "ready", "submitted"];
+  const currentIdx = (() => {
+    if (state === "stale") return stageOrder.indexOf("ready");
+    if (state === "failed" || state === "cancelled") return -1;
+    return stageOrder.indexOf(state);
+  })();
+
+  const status = (idx: number): PipelineStage["status"] => {
+    if (state === "failed" && idx === activeIdxOnFailure(runs)) return "failed";
+    if (state === "cancelled" && idx === currentCancelIdx(state, runs)) return "cancelled";
+    if (currentIdx === -1) return "upcoming";
+    if (idx < currentIdx) return "completed";
+    if (idx === currentIdx) return state === "submitted" ? "completed" : "active";
+    return "upcoming";
+  };
+
+  // Pick the most recent run that's relevant for the "Reviewing" stage detail.
+  const latestRun = runs[0];
+  const reviewingDetail =
+    runs.length > 0
+      ? `${runs.length} run${runs.length > 1 ? "s" : ""}${
+          latestRun?.costUsd ? ` · $${parseFloat(latestRun.costUsd).toFixed(4)}` : ""
+        }`
+      : undefined;
+
+  // Reviewing duration = first run startedAt → latest run completedAt
+  const reviewingStart = runs.length > 0 ? runs[runs.length - 1]?.startedAt : undefined;
+  const reviewingEnd = latestRun?.completedAt;
+  const reviewingDuration =
+    reviewingStart && reviewingEnd ? formatDuration(reviewingStart, reviewingEnd) : undefined;
+
+  return [
+    {
+      id: "queued",
+      label: "Queued",
+      status: status(0),
+      icon: Clock,
+      timestamp: review.createdAt,
+    },
+    {
+      id: "waiting_ci",
+      label: "Waiting for CI",
+      status: status(1),
+      icon: Server,
+      detail: state === "waiting_ci" ? "Holding for required checks" : undefined,
+    },
+    {
+      id: "reviewing",
+      label: "Agent reviewing",
+      status: state === "failed" && latestRun?.state === "failed" ? "failed" : status(2),
+      icon: Eye,
+      detail: reviewingDetail,
+      duration: reviewingDuration,
+      timestamp: latestRun?.startedAt ?? latestRun?.createdAt,
+      errorMessage:
+        state === "failed" ? (review.errorMessage ?? latestRun?.errorMessage) : undefined,
+    },
+    {
+      id: "ready",
+      label: state === "stale" ? "Ready (stale)" : "Ready for review",
+      status: state === "stale" ? "failed" : status(3),
+      icon: CircleCheckBig,
+      detail: state === "stale" ? "PR has new commits since this review" : undefined,
+      timestamp: ["ready", "stale", "submitted"].includes(state) ? review.updatedAt : undefined,
+    },
+    {
+      id: "submitted",
+      label: "Submitted",
+      status: status(4),
+      icon: CheckCircle2,
+      timestamp: review.submittedAt ?? undefined,
+      detail: review.autoSubmitted ? "Auto-submitted" : undefined,
+    },
+  ];
+}
+
+// When state=failed, mark the stage that was active when the failure happened
+// as "failed" rather than letting the regular logic paint everything as upcoming.
+function activeIdxOnFailure(runs: any[]): number {
+  const latest = runs[0];
+  if (!latest) return 2; // assume reviewing
+  // If we never started, the failure is at queued. If we started but never finished, reviewing.
+  return latest.startedAt ? 2 : 0;
+}
+
+function currentCancelIdx(state: string, runs: any[]): number {
+  // Cancelled before review started → stage 0; otherwise reviewing.
+  return runs[0]?.startedAt ? 2 : 0;
+}

--- a/apps/web/src/components/state-badge.tsx
+++ b/apps/web/src/components/state-badge.tsx
@@ -75,6 +75,40 @@ const STATE_CONFIG: Record<
     dotColor: "bg-text-muted",
     glowClass: "badge-glow-muted",
   },
+  // PR review-specific states
+  waiting_ci: {
+    label: "Waiting CI",
+    color: "text-warning",
+    dotColor: "bg-warning",
+    glowClass: "badge-glow-warning",
+    pulse: true,
+  },
+  reviewing: {
+    label: "Reviewing",
+    color: "text-primary",
+    dotColor: "bg-primary",
+    glowClass: "badge-glow-primary",
+    pulse: true,
+  },
+  ready: {
+    label: "Ready",
+    color: "text-success",
+    dotColor: "bg-success",
+    glowClass: "badge-glow-success",
+  },
+  stale: {
+    label: "Stale",
+    color: "text-warning",
+    dotColor: "bg-warning",
+    glowClass: "badge-glow-warning",
+    emphasis: true,
+  },
+  submitted: {
+    label: "Submitted",
+    color: "text-success",
+    dotColor: "bg-success",
+    glowClass: "badge-glow-success",
+  },
 };
 
 export function StateBadge({

--- a/apps/web/src/components/state-badge.tsx
+++ b/apps/web/src/components/state-badge.tsx
@@ -109,6 +109,19 @@ const STATE_CONFIG: Record<
     dotColor: "bg-success",
     glowClass: "badge-glow-success",
   },
+  // Workflow blueprint enablement states
+  enabled: {
+    label: "Enabled",
+    color: "text-success",
+    dotColor: "bg-success",
+    glowClass: "badge-glow-success",
+  },
+  disabled: {
+    label: "Disabled",
+    color: "text-text-muted",
+    dotColor: "bg-text-muted",
+    glowClass: "badge-glow-muted",
+  },
 };
 
 export function StateBadge({

--- a/apps/web/src/components/state-pipeline-strip.tsx
+++ b/apps/web/src/components/state-pipeline-strip.tsx
@@ -1,0 +1,69 @@
+import { cn } from "@/lib/utils";
+
+export interface PipelineStep {
+  key: string;
+  label: string;
+}
+
+/**
+ * Compact horizontal pipeline strip — used in detail page headers to show
+ * progression through a fixed sequence of states (e.g. Queued → CI →
+ * Reviewing → Ready → Submitted for PR reviews).
+ *
+ * Visual language matches `<StateBadge>` so the strip feels native to the
+ * rest of the app: completed steps in success, the active step in primary,
+ * upcoming steps muted, and an explicit error/cancelled tail when the flow
+ * has terminated abnormally.
+ */
+export function StatePipelineStrip({
+  steps,
+  current,
+  /** When true, the current step is rendered as an error (e.g. "stale"). */
+  errorAtCurrent = false,
+  /** Trailing badge for terminal states that don't sit on the strip itself. */
+  terminal,
+}: {
+  steps: PipelineStep[];
+  /** Index of the active step. -1 means none of the steps are active. */
+  current: number;
+  errorAtCurrent?: boolean;
+  terminal?: { label: string; tone: "error" | "muted" | "warning" };
+}) {
+  return (
+    <div className="flex items-center gap-1 text-[11px]">
+      {steps.map((s, i) => (
+        <div key={s.key} className="flex items-center gap-1">
+          <span
+            className={cn(
+              "px-2 py-0.5 rounded-md font-medium",
+              i < current
+                ? "bg-success/10 text-success"
+                : i === current
+                  ? errorAtCurrent
+                    ? "bg-error/10 text-error"
+                    : "bg-primary/10 text-primary"
+                  : "bg-bg text-text-muted",
+            )}
+          >
+            {s.label}
+          </span>
+          {i < steps.length - 1 && <span className="text-text-muted/30">›</span>}
+        </div>
+      ))}
+      {terminal && (
+        <span
+          className={cn(
+            "ml-2 px-2 py-0.5 rounded-md font-medium",
+            terminal.tone === "error"
+              ? "bg-error/10 text-error"
+              : terminal.tone === "warning"
+                ? "bg-warning/10 text-warning"
+                : "bg-bg text-text-muted",
+          )}
+        >
+          {terminal.label}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/workflow-run-pipeline-timeline.tsx
+++ b/apps/web/src/components/workflow-run-pipeline-timeline.tsx
@@ -1,0 +1,116 @@
+import { Clock, Server, Code, CircleCheckBig } from "lucide-react";
+import { PipelineStageRow, type PipelineStage } from "./pipeline-timeline.js";
+import { formatDuration } from "@/lib/utils";
+
+/**
+ * Vertical pipeline timeline for standalone (workflow) task runs. Mirrors
+ * the visual language of `<PipelineTimeline>` (tasks) and
+ * `<ReviewPipelineTimeline>` (PR reviews) so the three execution surfaces
+ * feel native to each other — only the stage derivation differs.
+ *
+ * Stages: Queued → Provisioning → Running → Done. The Running stage
+ * surfaces cost, model, and retry count as detail when available.
+ */
+export function WorkflowRunPipelineTimeline({ run }: { run: any }) {
+  const stages = deriveStages(run);
+  return (
+    <div className="space-y-4">
+      <div className="relative">
+        {stages.map((stage, i) => (
+          <PipelineStageRow key={stage.id} stage={stage} isLast={i === stages.length - 1} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function deriveStages(run: any): PipelineStage[] {
+  const state = run.state as string;
+  const order = ["queued", "provisioning", "running", "done"];
+  const currentIdx = (() => {
+    if (state === "completed" || state === "failed" || state === "cancelled") {
+      return order.indexOf("done");
+    }
+    return order.indexOf(state);
+  })();
+
+  const status = (idx: number): PipelineStage["status"] => {
+    if (state === "failed") {
+      // Mark the stage active when failure happened; mark earlier stages completed.
+      const failureIdx = run.startedAt ? order.indexOf("running") : order.indexOf("queued");
+      if (idx === failureIdx) return "failed";
+      if (idx < failureIdx) return "completed";
+      if (idx === order.indexOf("done")) return "failed";
+      return "upcoming";
+    }
+    if (state === "cancelled") {
+      const cancelIdx = run.startedAt ? order.indexOf("running") : order.indexOf("queued");
+      if (idx === cancelIdx) return "cancelled";
+      if (idx < cancelIdx) return "completed";
+      if (idx === order.indexOf("done")) return "cancelled";
+      return "upcoming";
+    }
+    if (currentIdx === -1) return "upcoming";
+    if (idx < currentIdx) return "completed";
+    if (idx === currentIdx) return state === "completed" ? "completed" : "active";
+    return "upcoming";
+  };
+
+  // Derive durations from timestamps where available.
+  const queuedToProvisioning =
+    run.createdAt && run.startedAt ? formatDuration(run.createdAt, run.startedAt) : undefined;
+  const runningDuration = run.startedAt
+    ? formatDuration(run.startedAt, run.finishedAt ?? undefined)
+    : undefined;
+
+  // Compose detail line for the Running stage from cost/model/retry.
+  const runningDetail = (() => {
+    const parts: string[] = [];
+    if (run.modelUsed) parts.push(run.modelUsed);
+    if (run.costUsd) parts.push(`$${parseFloat(run.costUsd).toFixed(4)}`);
+    if (run.retryCount > 0) parts.push(`retry ${run.retryCount}`);
+    return parts.length > 0 ? parts.join(" · ") : undefined;
+  })();
+
+  return [
+    {
+      id: "queued",
+      label: "Queued",
+      status: status(0),
+      icon: Clock,
+      timestamp: run.createdAt,
+      duration: queuedToProvisioning,
+    },
+    {
+      id: "provisioning",
+      label: "Provisioning pod",
+      status: status(1),
+      icon: Server,
+      timestamp: state === "provisioning" || run.startedAt ? run.startedAt : undefined,
+    },
+    {
+      id: "running",
+      label: "Agent running",
+      status: status(2),
+      icon: Code,
+      timestamp: run.startedAt,
+      duration: runningDuration,
+      detail: runningDetail,
+      errorMessage: state === "failed" ? run.errorMessage : undefined,
+    },
+    {
+      id: "done",
+      label:
+        state === "completed"
+          ? "Completed"
+          : state === "failed"
+            ? "Failed"
+            : state === "cancelled"
+              ? "Cancelled"
+              : "Done",
+      status: status(3),
+      icon: CircleCheckBig,
+      timestamp: run.finishedAt ?? undefined,
+    },
+  ];
+}

--- a/apps/web/src/hooks/use-pr-review-logs.ts
+++ b/apps/web/src/hooks/use-pr-review-logs.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { api } from "@/lib/api-client";
+import { createPrReviewLogClient, type WsClient } from "@/lib/ws-client";
+import { getWsTokenProvider } from "@/lib/ws-auth";
+import type { LogEntry } from "./use-logs";
+
+const HISTORICAL_LIMIT = 10000;
+
+/**
+ * Mirror of `useLogs` for PR reviews. Returns the same `{ logs, connected,
+ * capped, clear }` shape so it can be passed straight into `<LogViewer>` via
+ * the `externalLogs` prop.
+ *
+ * Logs live in `task_logs` keyed by `pr_review_run_id`. The hook:
+ *   1. Opens a WS to `/ws/pr-reviews/:id/logs` for live tailing
+ *   2. Fetches historical logs for the latest run via REST
+ *   3. Dedupes on `timestamp + content`
+ */
+export function usePrReviewLogs(prReviewId: string) {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [connected, setConnected] = useState(false);
+  const [capped, setCapped] = useState(false);
+  const clientRef = useRef<WsClient | null>(null);
+
+  useEffect(() => {
+    if (!prReviewId) return;
+
+    const pendingLive: LogEntry[] = [];
+    let merged = false;
+
+    const client = createPrReviewLogClient(prReviewId, getWsTokenProvider());
+    clientRef.current = client;
+
+    client.on("pr_review_run:log", (event) => {
+      const entry: LogEntry = {
+        content: event.content,
+        stream: event.stream,
+        timestamp: event.timestamp,
+        logType: event.logType,
+        metadata: event.metadata,
+      };
+      if (!merged) {
+        pendingLive.push(entry);
+      } else {
+        setLogs((prev) => {
+          const last = prev[prev.length - 1];
+          if (
+            last &&
+            last.content === entry.content &&
+            last.logType === entry.logType &&
+            last.timestamp === entry.timestamp
+          ) {
+            return prev;
+          }
+          return [...prev, entry];
+        });
+      }
+    });
+
+    client.connect();
+    setConnected(true);
+
+    api
+      .listPrReviewLogs(prReviewId)
+      .then((res) => {
+        const historical: LogEntry[] = res.logs.map((l: any) => ({
+          content: l.content,
+          stream: l.stream,
+          timestamp: l.timestamp,
+          logType: l.logType ?? undefined,
+          metadata: l.metadata ?? undefined,
+        }));
+        if (historical.length >= HISTORICAL_LIMIT) setCapped(true);
+
+        const historicalKeys = new Set(historical.map((l) => l.timestamp + l.content));
+        const uniqueLive = pendingLive.filter((l) => !historicalKeys.has(l.timestamp + l.content));
+
+        setLogs([...historical, ...uniqueLive]);
+        merged = true;
+      })
+      .catch(() => {
+        setLogs(pendingLive);
+        merged = true;
+      });
+
+    return () => {
+      client.disconnect();
+      setConnected(false);
+    };
+  }, [prReviewId]);
+
+  const clear = useCallback(() => setLogs([]), []);
+
+  return { logs, connected, capped, clear };
+}

--- a/apps/web/src/lib/ws-client.ts
+++ b/apps/web/src/lib/ws-client.ts
@@ -135,3 +135,10 @@ export function createWorkflowRunLogClient(
 ): WsClient {
   return new WsClient(`${getWsBaseUrl()}/ws/workflow-runs/${workflowRunId}/logs`, tokenProvider);
 }
+
+export function createPrReviewLogClient(
+  prReviewId: string,
+  tokenProvider?: TokenProvider,
+): WsClient {
+  return new WsClient(`${getWsBaseUrl()}/ws/pr-reviews/${prReviewId}/logs`, tokenProvider);
+}

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -41,11 +41,15 @@ RUN npm install -g @anthropic-ai/claude-code
 # GitHub Copilot CLI (pinned + best-effort — package may be temporarily unavailable)
 RUN npm install -g @github/copilot@1.0.20 || echo "WARN: @github/copilot install failed; copilot agent will not be available in this image"
 
-# OpenCode CLI (experimental — pinned version for stable JSON output)
+# OpenCode CLI (experimental — pinned version for stable JSON output).
+# Best-effort: opencode.ai is a single point of failure for the install
+# script, so let the build succeed even when the upstream is briefly
+# unavailable (matches the @github/copilot and openclaw fallbacks).
 ARG OPENCODE_VERSION=latest
-RUN curl -fsSL https://opencode.ai/install | bash \
+RUN (curl -fsSL https://opencode.ai/install | bash \
   && mv /root/.opencode/bin/opencode /usr/local/bin/ \
-  && rm -rf /root/.opencode
+  && rm -rf /root/.opencode) \
+  || echo "WARN: opencode install failed; opencode agent will not be available in this image"
 
 # Google Gemini CLI
 RUN npm install -g @google/gemini-cli


### PR DESCRIPTION
## Summary

The two detail pages — `/tasks/[id]` and `/reviews/[id]` — told the same story with different building blocks: bespoke state strip vs. `StateBadge`, inline log `<div>` vs. `LogViewer`, hand-rolled header vs. factored header, separate chat code paths. A user moving between the views had to relearn the location of every familiar control.

This PR extracts shared primitives and adopts them in both pages.

## What changed

**New shared components / hooks**
- `DetailHeader` — title + state badge + subtitle + meta + actions
- `StatePipelineStrip` — compact horizontal pipeline strip (Queued → CI → Reviewing → Ready → Submitted)
- `PrStatusBar` — CI / review / PR-state row with optional right-aligned actions
- `ChatTranscript` + `ChatComposer` — message list and input with optional interrupt button (auto-resize, Enter-to-send, Shift+Enter-for-newline)
- `usePrReviewLogs` — WS-driven log tailing for PR reviews, same `{ logs, connected, capped, clear }` shape as `useLogs` so it plugs straight into `LogViewer`'s `externalLogs` prop

**Extended primitives**
- `StateBadge` gains configs for `waiting_ci`, `reviewing`, `ready`, `stale`, `submitted` so both pages render the same badge component

**Backend (live log streaming for PR reviews)**
- `event-bus.publishEvent` now also publishes to `optio:pr-review:{id}` for any event that carries a `prReviewId` — the existing `pr_review_run:log` and `pr_review_run:state_changed` publishes wire up for free
- New WS endpoint `/ws/pr-reviews/:id/logs` mirroring `/ws/logs/:taskId` (catch-up + live subscription), registered in `server.ts`
- `createPrReviewLogClient` helper in `ws-client.ts`

**Page changes**
- `/reviews/[id]` adopts `DetailHeader`, `StatePipelineStrip`, `PrStatusBar`, `ChatTranscript`/`ChatComposer`, `LogViewer` (with full search / filtering / tool-use grouping), and the existing `classifyError` banner
- `/tasks/[id]` adopts `DetailHeader`, `PrStatusBar`, and `ChatComposer` for the mid-task messaging bar (with Stop=interrupt)

**Stays inline** (these are the actual primitive of "review", not duplication):
- Verdict picker (Approve / Request Changes / Comment)
- Inline file-comment editor (path / line / body)
- Split merge button with strategy dropdown
- Draft `dirty` / Save Draft state machine

## Test plan
- [ ] Visit `/reviews/<id>` for a working review — header renders, state badge matches the rest of the app, pipeline strip shows correct stage
- [ ] Open the runs/logs panel — logs stream in live (via WS) instead of polling; search and filter work
- [ ] Send a chat message — composer behaves the same as the task page's mid-task bar
- [ ] Visit `/tasks/<id>` for a running claude-code task — Stop and Send buttons in the message bar still work
- [ ] CI status row on a PR-opened task still shows CI / review / cost / Request Review action
- [ ] Failed review now renders the classified-error banner with retry button