### PR TITLE
feat: add workload identity support and fix repo pod lifecycle issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,7 @@ Key `values.yaml` settings:
 - Image defaults point to GHCR (`ghcr.io/jonwiggins/optio-*`). Set `agent.image.prefix` to `optio-` for local dev
 - `postgresql.enabled` / `redis.enabled` — set to `false` and use `externalDatabase.url` / `externalRedis.url` for managed services
 - `encryption.key` — **required**, generate with `openssl rand -hex 32`
+- `serviceAccount.name` / `serviceAccount.annotations` — used by API/web pods (K8s API access) and agent pods (workload identity). Example for GKE: `iam.gke.io/gcp-service-account: optio@PROJECT_ID.iam.gserviceaccount.com`
 - Local dev overrides in `helm/optio/values.local.yaml` (`setup-local.sh` applies automatically)
 
 ## Troubleshooting

--- a/apps/api/src/services/interactive-session-service.test.ts
+++ b/apps/api/src/services/interactive-session-service.test.ts
@@ -154,6 +154,38 @@ describe("interactive-session-service", () => {
         expect.any(Object),
       );
     });
+
+    it("includes git credential env vars in pod env", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      vi.mocked(getOrCreateRepoPod).mockResolvedValue({
+        id: "pod-1",
+        podName: "pod-1",
+      } as any);
+
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi
+            .fn()
+            .mockResolvedValue([{ id: "session-1", state: "active", podId: "pod-1" }]),
+        }),
+      });
+
+      await createSession({ repoUrl: "https://github.com/o/r" });
+
+      expect(getOrCreateRepoPod).toHaveBeenCalled();
+      const callArgs = vi.mocked(getOrCreateRepoPod).mock.calls[0];
+      const env = callArgs[2];
+
+      // Verify git credential env vars are set
+      expect(env.OPTIO_GIT_CREDENTIAL_URL).toBeDefined();
+      expect(env.OPTIO_GIT_CREDENTIAL_URL).toContain("/api/internal/git-credentials");
+      expect(env.OPTIO_CREDENTIAL_SECRET).toBe("test-secret");
+    });
   });
 
   describe("getSession", () => {

--- a/apps/api/src/services/interactive-session-service.test.ts
+++ b/apps/api/src/services/interactive-session-service.test.ts
@@ -51,6 +51,10 @@ vi.mock("../logger.js", () => ({
   },
 }));
 
+vi.mock("../routes/github-app.js", () => ({
+  getCredentialSecret: vi.fn().mockReturnValue("test-secret"),
+}));
+
 import { db } from "../db/client.js";
 import { publishEvent, publishSessionEvent } from "./event-bus.js";
 import { getOrCreateRepoPod } from "./repo-pool-service.js";

--- a/apps/api/src/services/interactive-session-service.ts
+++ b/apps/api/src/services/interactive-session-service.ts
@@ -24,7 +24,16 @@ export async function createSession(input: {
     OPTIO_REPO_BRANCH: repoBranch,
   };
 
-  // Try to find a GitHub token for the pod
+  // Add git credential helper URLs
+  const apiInternalUrl =
+    process.env.OPTIO_API_INTERNAL_URL ?? `http://localhost:${process.env.API_PORT ?? "4000"}`;
+  env.OPTIO_GIT_CREDENTIAL_URL = `${apiInternalUrl}/api/internal/git-credentials`;
+
+  // Add credential secret for authentication
+  const { getCredentialSecret } = await import("../routes/github-app.js");
+  env.OPTIO_CREDENTIAL_SECRET = getCredentialSecret();
+
+  // Try to find a GitHub token for the pod (fallback for old images without credential helper)
   try {
     const { getGitHubToken } = await import("./github-token-service.js");
     const ghToken = input.userId

--- a/apps/api/src/services/k8s-workload-service.ts
+++ b/apps/api/src/services/k8s-workload-service.ts
@@ -76,25 +76,69 @@ export class K8sWorkloadManager {
   }): Promise<{ name: string; replicas: number }> {
     const { name, spec, homePvcSize, homePvcStorageClass } = opts;
 
+    logger.info({ name, serviceAccountName: spec.serviceAccountName }, "ensureStatefulSet called");
+
     // Ensure the headless Service exists
     await this.ensureHeadlessService(name, spec.labels);
+    logger.info({ name }, "Headless service ensured");
 
     // Check if StatefulSet already exists
+    let existingSts: V1StatefulSet | null = null;
     try {
-      const existing = await this.appsApi.readNamespacedStatefulSet({
+      existingSts = await this.appsApi.readNamespacedStatefulSet({
         name,
         namespace: this.namespace,
       });
+      logger.info({ name, replicas: existingSts.spec?.replicas }, "StatefulSet already exists");
+
+      // Build desired pod template to compare with existing
+      const desiredPodTemplate = this.buildPodTemplate(spec, name, "Always");
+
+      // Check if pod template needs updating (environment variables might have changed)
+      const currentEnv = existingSts.spec?.template?.spec?.containers?.[0]?.env ?? [];
+      const desiredEnv = desiredPodTemplate.spec?.containers?.[0]?.env ?? [];
+      const currentServiceAccount = existingSts.spec?.template?.spec?.serviceAccountName;
+      const desiredServiceAccount = desiredPodTemplate.spec?.serviceAccountName;
+
+      const envChanged = JSON.stringify(currentEnv) !== JSON.stringify(desiredEnv);
+      const serviceAccountChanged = currentServiceAccount !== desiredServiceAccount;
+
+      if (envChanged || serviceAccountChanged) {
+        logger.info(
+          { name, envChanged, serviceAccountChanged },
+          "StatefulSet pod template needs update",
+        );
+
+        // Update the StatefulSet's pod template
+        existingSts.spec!.template = desiredPodTemplate;
+
+        await this.appsApi.replaceNamespacedStatefulSet({
+          name,
+          namespace: this.namespace,
+          body: existingSts,
+        });
+        logger.info({ name }, "StatefulSet pod template updated");
+      }
+
       return {
         name,
-        replicas: existing.spec?.replicas ?? 0,
+        replicas: existingSts.spec?.replicas ?? 0,
       };
     } catch (err: unknown) {
-      if (!this.isNotFoundError(err)) throw err;
+      if (!this.isNotFoundError(err)) {
+        logger.error({ err, name }, "Error checking StatefulSet existence");
+        throw err;
+      }
+      logger.info({ name }, "StatefulSet does not exist, will create");
     }
 
     // Build the StatefulSet
+    logger.info({ name }, "Building pod template");
     const podTemplate = this.buildPodTemplate(spec, name, "Always");
+    logger.info(
+      { name, serviceAccountName: podTemplate.spec?.serviceAccountName },
+      "Pod template built",
+    );
     const matchLabels: Record<string, string> = {
       "app.kubernetes.io/instance": name,
     };
@@ -120,15 +164,25 @@ export class K8sWorkloadManager {
       volumeClaimTemplates: this.buildVolumeClaimTemplates(homePvcSize, homePvcStorageClass),
     };
 
+    logger.info(
+      {
+        name,
+        namespace: this.namespace,
+        serviceAccountName: sts.spec?.template.spec?.serviceAccountName,
+      },
+      "Creating StatefulSet",
+    );
     try {
       await this.appsApi.createNamespacedStatefulSet({
         namespace: this.namespace,
         body: sts,
       });
-      logger.info({ name }, "StatefulSet created");
+      logger.info({ name }, "StatefulSet created successfully");
     } catch (err: unknown) {
+      logger.error({ err, name, namespace: this.namespace }, "Error creating StatefulSet");
       // Another API replica may have created it concurrently (409 Conflict)
       if (this.isConflictError(err)) {
+        logger.info({ name }, "StatefulSet already exists (conflict), reading existing");
         const existing = await this.appsApi.readNamespacedStatefulSet({
           name,
           namespace: this.namespace,
@@ -323,7 +377,9 @@ export class K8sWorkloadManager {
    */
   async waitForPodRunning(podName: string, timeoutMs = POD_READY_TIMEOUT_MS): Promise<void> {
     const deadline = Date.now() + timeoutMs;
+    logger.info({ podName, timeoutMs }, "Waiting for pod to reach Running state");
 
+    let lastPhase: string | undefined;
     while (Date.now() < deadline) {
       try {
         const pod = await this.coreApi.readNamespacedPodStatus({
@@ -331,16 +387,34 @@ export class K8sWorkloadManager {
           namespace: this.namespace,
         });
         const phase = pod.status?.phase;
-        if (phase === "Running") return;
-        if (phase === "Succeeded" || phase === "Failed") return;
+        if (phase !== lastPhase) {
+          logger.info({ podName, phase, conditions: pod.status?.conditions }, "Pod phase changed");
+          lastPhase = phase;
+        }
+        if (phase === "Running") {
+          logger.info({ podName }, "Pod is Running");
+          return;
+        }
+        if (phase === "Succeeded" || phase === "Failed") {
+          logger.info({ podName, phase }, "Pod reached terminal state");
+          return;
+        }
       } catch (err: unknown) {
         // Pod may not exist yet (StatefulSet scaling up)
-        if (!this.isNotFoundError(err)) throw err;
+        if (!this.isNotFoundError(err)) {
+          logger.error({ err, podName }, "Error reading pod status");
+          throw err;
+        }
+        if (lastPhase !== "NotFound") {
+          logger.info({ podName }, "Pod not found yet");
+          lastPhase = "NotFound";
+        }
       }
 
       await this.sleep(POD_READY_POLL_MS);
     }
 
+    logger.error({ podName, timeoutMs }, "Timed out waiting for pod");
     throw new Error(
       `Timed out waiting for pod "${podName}" to reach Running state after ${timeoutMs / 1000}s`,
     );
@@ -525,6 +599,9 @@ export class K8sWorkloadManager {
     }
     if (spec.tolerations && spec.tolerations.length > 0) {
       podSpec.tolerations = spec.tolerations as V1PodSpec["tolerations"];
+    }
+    if (spec.serviceAccountName) {
+      podSpec.serviceAccountName = spec.serviceAccountName;
     }
 
     // Pod-level security context for StatefulSets — ensures PVC mounts are

--- a/apps/api/src/services/repo-pool-service.test.ts
+++ b/apps/api/src/services/repo-pool-service.test.ts
@@ -950,3 +950,211 @@ describe("getOrCreateRepoPod — nodeSelector and tolerations env vars", () => {
     );
   });
 });
+
+describe("getOrCreateRepoPod — stale provisioning pod cleanup", () => {
+  function mockGetOrCreateFlow(opts: {
+    existingPods?: any[];
+    podCount?: number;
+    insertedPod?: any;
+  }) {
+    const dbMock = db as any;
+
+    // Build full chain for existing pods lookup: select().from().where().orderBy()
+    const orderByMock = vi.fn().mockResolvedValue(opts.existingPods ?? []);
+    const whereMockForList = vi.fn().mockReturnValue({
+      orderBy: orderByMock,
+    });
+    const fromMockForList = vi.fn().mockReturnValue({
+      where: whereMockForList,
+    });
+
+    // Build chain for count query: select().from().where()
+    const whereMockForCount = vi.fn().mockResolvedValue([{ count: opts.podCount ?? 0 }]);
+    const fromMockForCount = vi.fn().mockReturnValue({
+      where: whereMockForCount,
+    });
+
+    let selectCallCount = 0;
+    dbMock.select.mockImplementation(() => {
+      selectCallCount++;
+      if (selectCallCount === 1) {
+        // First call: existing pods query
+        return { from: fromMockForList };
+      } else {
+        // Second call: count query
+        return { from: fromMockForCount };
+      }
+    });
+
+    if (opts.insertedPod) {
+      dbMock.returning.mockResolvedValueOnce([opts.insertedPod]);
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (db as any).where.mockReset().mockReturnThis();
+    (db as any).select.mockReset().mockReturnThis();
+  });
+
+  it("deletes provisioning pods older than 10 minutes", async () => {
+    const elevenMinutesAgo = new Date(Date.now() - 11 * 60 * 1000);
+    const stalePod = {
+      id: "stale-pod",
+      repoUrl: "https://github.com/org/repo",
+      state: "provisioning",
+      createdAt: elevenMinutesAgo,
+      podName: "stale-pod-name",
+    };
+
+    mockGetOrCreateFlow({
+      existingPods: [stalePod],
+      podCount: 0,
+      insertedPod: {
+        id: "new-pod",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    mockRuntimeCreate.mockResolvedValueOnce({ id: "k8s-id", name: "optio-repo-new" });
+
+    await getOrCreateRepoPod("https://github.com/org/repo", "main", {});
+
+    // Verify the stale pod was deleted
+    expect((db as any).delete).toHaveBeenCalled();
+  });
+
+  it("does not delete provisioning pods younger than 10 minutes", async () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+    const freshPod = {
+      id: "fresh-pod",
+      repoUrl: "https://github.com/org/repo",
+      state: "ready", // Mark as ready to avoid waitForPodReady loop
+      createdAt: fiveMinutesAgo,
+      podName: "fresh-pod-name",
+      activeTaskCount: 0,
+    };
+
+    mockGetOrCreateFlow({
+      existingPods: [freshPod],
+      podCount: 1,
+    });
+
+    mockRuntimeStatus.mockResolvedValueOnce({ state: "running" });
+
+    const result = await getOrCreateRepoPod("https://github.com/org/repo", "main", {});
+
+    // Verify we didn't delete the fresh pod
+    expect((db as any).delete).not.toHaveBeenCalled();
+    expect(result.id).toBe("fresh-pod");
+  });
+});
+
+describe("getOrCreateRepoPod — service account propagation", () => {
+  function mockGetOrCreateFlow(opts: {
+    existingPods?: any[];
+    podCount?: number;
+    insertedPod?: any;
+  }) {
+    const dbMock = db as any;
+
+    // Build full chain for existing pods lookup: select().from().where().orderBy()
+    const orderByMock = vi.fn().mockResolvedValue(opts.existingPods ?? []);
+    const whereMockForList = vi.fn().mockReturnValue({
+      orderBy: orderByMock,
+    });
+    const fromMockForList = vi.fn().mockReturnValue({
+      where: whereMockForList,
+    });
+
+    // Build chain for count query: select().from().where()
+    const whereMockForCount = vi.fn().mockResolvedValue([{ count: opts.podCount ?? 0 }]);
+    const fromMockForCount = vi.fn().mockReturnValue({
+      where: whereMockForCount,
+    });
+
+    let selectCallCount = 0;
+    dbMock.select.mockImplementation(() => {
+      selectCallCount++;
+      if (selectCallCount === 1) {
+        // First call: existing pods query
+        return { from: fromMockForList };
+      } else {
+        // Second call: count query
+        return { from: fromMockForCount };
+      }
+    });
+
+    if (opts.insertedPod) {
+      dbMock.returning.mockResolvedValueOnce([opts.insertedPod]);
+    }
+  }
+
+  const origServiceAccountName = process.env.OPTIO_SERVICE_ACCOUNT_NAME;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    (db as any).where.mockReset().mockReturnThis();
+    (db as any).select.mockReset().mockReturnThis();
+    if (origServiceAccountName !== undefined) {
+      process.env.OPTIO_SERVICE_ACCOUNT_NAME = origServiceAccountName;
+    } else {
+      delete process.env.OPTIO_SERVICE_ACCOUNT_NAME;
+    }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (db as any).where.mockReset().mockReturnThis();
+    (db as any).select.mockReset().mockReturnThis();
+  });
+
+  it("passes service account name from env to container spec", async () => {
+    process.env.OPTIO_SERVICE_ACCOUNT_NAME = "optio-workload-identity";
+
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    mockRuntimeCreate.mockResolvedValueOnce({ id: "k8s-id", name: "optio-repo-abc" });
+
+    await getOrCreateRepoPod("https://github.com/org/repo", "main", {});
+
+    const spec = mockRuntimeCreate.mock.calls[0][0];
+    expect(spec.serviceAccountName).toBe("optio-workload-identity");
+  });
+
+  it("omits service account name when env var not set", async () => {
+    delete process.env.OPTIO_SERVICE_ACCOUNT_NAME;
+
+    mockGetOrCreateFlow({
+      existingPods: [],
+      podCount: 0,
+      insertedPod: {
+        id: "pod-1",
+        repoUrl: "https://github.com/org/repo",
+        repoBranch: "main",
+        state: "provisioning",
+        instanceIndex: 0,
+      },
+    });
+
+    mockRuntimeCreate.mockResolvedValueOnce({ id: "k8s-id", name: "optio-repo-abc" });
+
+    await getOrCreateRepoPod("https://github.com/org/repo", "main", {});
+
+    const spec = mockRuntimeCreate.mock.calls[0][0];
+    expect(spec.serviceAccountName).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -35,7 +35,10 @@ const REPO_INIT_TIMEOUT_MS = parseIntEnv("OPTIO_REPO_INIT_TIMEOUT_MS", 120000); 
 if (Number.isNaN(REPO_INIT_TIMEOUT_MS) || REPO_INIT_TIMEOUT_MS <= 0) {
   throw new Error("OPTIO_REPO_INIT_TIMEOUT_MS must be a positive integer");
 }
-const SERVICE_ACCOUNT_NAME = process.env.OPTIO_SERVICE_ACCOUNT_NAME; // K8s service account for workload identity
+
+function getServiceAccountName(): string | undefined {
+  return process.env.OPTIO_SERVICE_ACCOUNT_NAME;
+}
 
 /**
  * Parse a JSON-encoded environment variable, returning `undefined` when unset/empty.
@@ -421,7 +424,7 @@ spec:
             ) as unknown[],
           }
         : {}),
-      ...(SERVICE_ACCOUNT_NAME ? { serviceAccountName: SERVICE_ACCOUNT_NAME } : {}),
+      ...(getServiceAccountName() ? { serviceAccountName: getServiceAccountName() } : {}),
     };
 
     // Add Envoy sidecar containers and volumes when secret proxy is enabled
@@ -667,7 +670,7 @@ async function createRepoPodViaStatefulSet(
             ) as unknown[],
           }
         : {}),
-      ...(SERVICE_ACCOUNT_NAME ? { serviceAccountName: SERVICE_ACCOUNT_NAME } : {}),
+      ...(getServiceAccountName() ? { serviceAccountName: getServiceAccountName() } : {}),
     };
 
     // Add Envoy sidecar if secret proxy is enabled
@@ -768,7 +771,7 @@ async function createRepoPodViaStatefulSet(
       {
         stsName,
         serviceAccountName: spec.serviceAccountName,
-        SERVICE_ACCOUNT_NAME_ENV: SERVICE_ACCOUNT_NAME,
+        SERVICE_ACCOUNT_NAME_ENV: getServiceAccountName(),
       },
       "Calling ensureStatefulSet",
     );

--- a/apps/api/src/services/repo-pool-service.ts
+++ b/apps/api/src/services/repo-pool-service.ts
@@ -35,6 +35,7 @@ const REPO_INIT_TIMEOUT_MS = parseIntEnv("OPTIO_REPO_INIT_TIMEOUT_MS", 120000); 
 if (Number.isNaN(REPO_INIT_TIMEOUT_MS) || REPO_INIT_TIMEOUT_MS <= 0) {
   throw new Error("OPTIO_REPO_INIT_TIMEOUT_MS must be a positive integer");
 }
+const SERVICE_ACCOUNT_NAME = process.env.OPTIO_SERVICE_ACCOUNT_NAME; // K8s service account for workload identity
 
 /**
  * Parse a JSON-encoded environment variable, returning `undefined` when unset/empty.
@@ -142,7 +143,20 @@ export async function getOrCreateRepoPod(
         }
         await db.delete(repoPods).where(eq(repoPods.id, pod.id));
       } else if (pod.state === "provisioning") {
-        return waitForPodReady(pod.id);
+        // Check if provisioning pod is stale (>10 min old)
+        const ageMs = Date.now() - new Date(pod.createdAt).getTime();
+        const maxProvisioningMs = 10 * 60 * 1000; // 10 minutes
+        if (ageMs > maxProvisioningMs) {
+          logger.warn(
+            { podId: pod.id, ageMs, maxProvisioningMs },
+            "Deleting stale provisioning pod",
+          );
+          await db.delete(repoPods).where(eq(repoPods.id, pod.id));
+          // Continue to create a new pod
+        } else {
+          logger.info({ podId: pod.id, ageMs }, "Waiting for provisioning pod");
+          return waitForPodReady(pod.id);
+        }
       } else if (pod.state === "error") {
         await db.delete(repoPods).where(eq(repoPods.id, pod.id));
       }
@@ -407,6 +421,7 @@ spec:
             ) as unknown[],
           }
         : {}),
+      ...(SERVICE_ACCOUNT_NAME ? { serviceAccountName: SERVICE_ACCOUNT_NAME } : {}),
     };
 
     // Add Envoy sidecar containers and volumes when secret proxy is enabled
@@ -652,6 +667,7 @@ async function createRepoPodViaStatefulSet(
             ) as unknown[],
           }
         : {}),
+      ...(SERVICE_ACCOUNT_NAME ? { serviceAccountName: SERVICE_ACCOUNT_NAME } : {}),
     };
 
     // Add Envoy sidecar if secret proxy is enabled
@@ -747,6 +763,15 @@ async function createRepoPodViaStatefulSet(
     // Ensure StatefulSet exists and scale to needed replica count
     const homePvcSize = process.env.OPTIO_HOME_PVC_SIZE ?? "10Gi";
     const homePvcStorageClass = process.env.OPTIO_HOME_PVC_STORAGE_CLASS || undefined;
+
+    logger.info(
+      {
+        stsName,
+        serviceAccountName: spec.serviceAccountName,
+        SERVICE_ACCOUNT_NAME_ENV: SERVICE_ACCOUNT_NAME,
+      },
+      "Calling ensureStatefulSet",
+    );
 
     const sts = await manager.ensureStatefulSet({
       name: stsName,

--- a/helm/optio/templates/api-deployment.yaml
+++ b/helm/optio/templates/api-deployment.yaml
@@ -107,6 +107,10 @@ spec:
               value: {{ .Values.agent.statefulSet.enabled | quote }}
             - name: OPTIO_TERMINATION_GRACE_PERIOD_SECONDS
               value: {{ .Values.agent.statefulSet.terminationGracePeriodSeconds | quote }}
+            - name: OPTIO_SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           readinessProbe:

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -478,6 +478,10 @@ rbac:
 serviceAccount:
   create: true
   name: optio
+  # Annotations for the service account (e.g., for GKE Workload Identity).
+  # Used by both API/web pods (for K8s API access) and agent pods (for cloud service auth).
+  # Example for GKE Workload Identity:
+  #   iam.gke.io/gcp-service-account: optio@PROJECT_ID.iam.gserviceaccount.com
   annotations: {}
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/packages/shared/src/types/container.ts
+++ b/packages/shared/src/types/container.ts
@@ -35,6 +35,8 @@ export interface ContainerSpec {
   annotations?: Record<string, string>;
   /** Override the default termination grace period (seconds). */
   terminationGracePeriodSeconds?: number;
+  /** Kubernetes service account name for the pod (for workload identity). */
+  serviceAccountName?: string;
 }
 
 export interface VolumeMount {


### PR DESCRIPTION
Add support for Kubernetes workload identity (e.g., GKE Workload Identity) to enable repo pods to authenticate with cloud services without JSON keys. Also fix several repo pod lifecycle issues that caused provisioning hangs and git clone failures.

## Workload Identity Changes
- Add `serviceAccountName` field to `ContainerSpec` interface  
- Pass service account from API pod to repo pods via Kubernetes Downward API
- Update pod template builder to set `serviceAccountName` on pod spec
- Document workload identity setup in CLAUDE.md and values.yaml

## StatefulSet Lifecycle Fixes
- Fix `ensureStatefulSet` to update pod template when spec changes (env vars, service account)
- Previously, if a StatefulSet was created by one code path (e.g., interactive session), subsequent uses (e.g., tasks) would reuse the old pod template even if env vars had changed
- Add detection for env var and service account changes with automatic update

## Repo Pod Cleanup Fixes
- Add stale provisioning pod detection (>10 min threshold)
- Auto-delete provisioning pods stuck for >10 minutes to prevent indefinite waits

## Git Credential Fixes
- Fix interactive sessions to include git credential env vars (`OPTIO_GIT_CREDENTIAL_URL`, `OPTIO_CREDENTIAL_SECRET`)
- Previously, interactive sessions created StatefulSets without these vars, causing git clone to fail when tasks tried to reuse the same StatefulSet

## Files Changed
- `packages/shared/src/types/container.ts`
- `apps/api/src/services/k8s-workload-service.ts`
- `apps/api/src/services/repo-pool-service.ts`
- `apps/api/src/services/interactive-session-service.ts`
- `helm/optio/templates/api-deployment.yaml`
- `helm/optio/values.yaml`
- `CLAUDE.md`

## Testing
✅ Verified StatefulSet updates when pod template changes  
✅ Verified git clone works after interactive session creates StatefulSet  
✅ Verified stale provisioning pod cleanup  
✅ Verified workload identity service account propagation