### PR TITLE
feat(tasks): resume stopped agents when a chat message is sent

### DIFF
--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -6,20 +6,31 @@ import { buildRouteTestApp } from "../test-utils/build-route-test-app.js";
 
 const mockGetTask = vi.fn();
 const mockRecordTaskEvent = vi.fn();
+const mockTransitionTask = vi.fn();
 
 vi.mock("../services/task-service.js", () => ({
   getTask: (...args: unknown[]) => mockGetTask(...args),
   recordTaskEvent: (...args: unknown[]) => mockRecordTaskEvent(...args),
+  transitionTask: (...args: unknown[]) => mockTransitionTask(...args),
+}));
+
+const mockQueueAdd = vi.fn();
+vi.mock("../workers/task-worker.js", () => ({
+  taskQueue: {
+    add: (...args: unknown[]) => mockQueueAdd(...args),
+  },
 }));
 
 const mockSendMessage = vi.fn();
 const mockListMessages = vi.fn();
 const mockCanMessageTask = vi.fn();
+const mockMarkDelivered = vi.fn();
 
 vi.mock("../services/task-message-service.js", () => ({
   sendMessage: (...args: unknown[]) => mockSendMessage(...args),
   listMessages: (...args: unknown[]) => mockListMessages(...args),
   canMessageTask: (...args: unknown[]) => mockCanMessageTask(...args),
+  markDelivered: (...args: unknown[]) => mockMarkDelivered(...args),
 }));
 
 const mockPublishTaskMessage = vi.fn();
@@ -71,6 +82,7 @@ describe("POST /api/tasks/:id/message", () => {
       incr: vi.fn().mockResolvedValue(1),
       expire: vi.fn().mockResolvedValue(1),
     });
+    mockMarkDelivered.mockResolvedValue(undefined);
     app = await buildTestApp();
   });
 
@@ -168,7 +180,7 @@ describe("POST /api/tasks/:id/message", () => {
     expect(res.statusCode).toBe(403);
   });
 
-  it("returns 409 when task is not running", async () => {
+  it("returns 409 when task is completed (terminal, not resumable)", async () => {
     mockGetTask.mockResolvedValue({ ...runningClaudeTask, state: "completed" });
     mockCanMessageTask.mockResolvedValue(true);
 
@@ -181,7 +193,20 @@ describe("POST /api/tasks/:id/message", () => {
     expect(res.statusCode).toBe(409);
   });
 
-  it("returns 501 for non-claude-code agent", async () => {
+  it("returns 409 when task is pending (hasn't started, no agent to message)", async () => {
+    mockGetTask.mockResolvedValue({ ...runningClaudeTask, state: "pending" });
+    mockCanMessageTask.mockResolvedValue(true);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/tasks/task-1/message",
+      payload: { content: "hello" },
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("returns 501 for non-claude-code agent in running state", async () => {
     mockGetTask.mockResolvedValue({ ...runningClaudeTask, agentType: "codex" });
     mockCanMessageTask.mockResolvedValue(true);
 
@@ -192,6 +217,98 @@ describe("POST /api/tasks/:id/message", () => {
     });
 
     expect(res.statusCode).toBe(501);
+  });
+
+  it.each(["needs_attention", "failed", "pr_opened", "cancelled"])(
+    "resumes a stopped task when in %s state",
+    async (state) => {
+      mockGetTask.mockResolvedValue({
+        ...runningClaudeTask,
+        state,
+        sessionId: "prior-session-xyz",
+      });
+      mockCanMessageTask.mockResolvedValue(true);
+      const mockMsg = {
+        id: "msg-resume-1",
+        taskId: "task-1",
+        userId: "user-1",
+        content: "please address the review comments",
+        mode: "soft",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        deliveredAt: null,
+        ackedAt: null,
+      };
+      mockSendMessage.mockResolvedValue(mockMsg);
+      mockTransitionTask.mockResolvedValue(undefined);
+      mockQueueAdd.mockResolvedValue({ id: "job-1" });
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/tasks/task-1/message",
+        payload: { content: "please address the review comments" },
+      });
+
+      expect(res.statusCode).toBe(202);
+      // recordTaskEvent fires with the message trigger (non-transitioning),
+      // transitionTask fires with user_message_resume for the actual resume.
+      expect(mockRecordTaskEvent).toHaveBeenCalledWith(
+        "task-1",
+        state,
+        "user_message",
+        expect.stringContaining("please address"),
+        expect.anything(),
+      );
+      expect(mockTransitionTask).toHaveBeenCalledWith(
+        "task-1",
+        "queued",
+        "user_message_resume",
+        expect.stringContaining("please address"),
+      );
+      expect(mockQueueAdd).toHaveBeenCalledWith(
+        "process-task",
+        expect.objectContaining({
+          taskId: "task-1",
+          resumeSessionId: "prior-session-xyz",
+          resumePrompt: "please address the review comments",
+        }),
+        expect.any(Object),
+      );
+      // Running-stream publish path should NOT fire for stopped tasks.
+      expect(mockPublishTaskMessage).not.toHaveBeenCalled();
+      // deliveredAt is stamped immediately for the resume path.
+      expect(res.json().message.deliveredAt).not.toBeNull();
+    },
+  );
+
+  it("resumes a stopped non-claude-code task (agent type is irrelevant for resume)", async () => {
+    mockGetTask.mockResolvedValue({
+      ...runningClaudeTask,
+      state: "needs_attention",
+      agentType: "codex",
+      sessionId: "s1",
+    });
+    mockCanMessageTask.mockResolvedValue(true);
+    mockSendMessage.mockResolvedValue({
+      id: "msg-x",
+      taskId: "task-1",
+      userId: "user-1",
+      content: "retry please",
+      mode: "soft",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      deliveredAt: null,
+      ackedAt: null,
+    });
+    mockTransitionTask.mockResolvedValue(undefined);
+    mockQueueAdd.mockResolvedValue({ id: "job-2" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/tasks/task-1/message",
+      payload: { content: "retry please" },
+    });
+
+    expect(res.statusCode).toBe(202);
+    expect(mockQueueAdd).toHaveBeenCalled();
   });
 
   it("returns 429 when rate limit exceeded", async () => {

--- a/apps/api/src/routes/messages.ts
+++ b/apps/api/src/routes/messages.ts
@@ -1,13 +1,24 @@
 import type { FastifyInstance } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
+import { TaskState } from "@optio/shared";
 import * as taskService from "../services/task-service.js";
 import * as messageService from "../services/task-message-service.js";
 import { publishTaskMessage } from "../services/task-message-bus.js";
 import { publishEvent } from "../services/event-bus.js";
 import { getRedisClient } from "../services/event-bus.js";
+import { taskQueue } from "../workers/task-worker.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import { TaskMessageSchema } from "../schemas/task.js";
+
+// States from which a stopped task can be resumed by sending a chat message.
+// Matches the states accepted by POST /api/tasks/:id/resume and force-restart.
+const RESUMABLE_STATES: readonly string[] = [
+  TaskState.NEEDS_ATTENTION,
+  TaskState.PR_OPENED,
+  TaskState.FAILED,
+  TaskState.CANCELLED,
+];
 
 const sendMessageSchema = z
   .object({
@@ -45,14 +56,19 @@ export async function messageRoutes(rawApp: FastifyInstance) {
     {
       schema: {
         operationId: "sendTaskMessage",
-        summary: "Send a message to a running task",
+        summary: "Send a message to a running or stopped task",
         description:
-          "Deliver a mid-run user message to a running task. The message is " +
-          "inserted in the database, published on the per-task Redis channel " +
-          "so the worker can pick it up, and broadcast via the WebSocket " +
-          "events channel. Rate limited to 10 messages per user per task " +
-          "per minute. Currently only the claude-code agent supports " +
-          "mid-task messaging — other agents return 501.",
+          "Deliver a user message to a task. Behavior depends on state:\n\n" +
+          "- **running**: mid-turn delivery via the Redis channel → task-worker " +
+          "→ stream-json stdin. Claude Code only; other agents return 501.\n" +
+          "- **needs_attention / pr_opened / failed / cancelled**: resumes the " +
+          "agent with the message as the new prompt (re-enqueues the task, " +
+          "reusing the stored session id when available). Works for any agent " +
+          "type.\n" +
+          "- **pending / queued / provisioning / completed**: 409 — no running " +
+          "agent can consume the message and the task isn't in a resumable " +
+          "state.\n\n" +
+          "Rate limited to 10 messages per user per task per minute.",
         tags: ["Tasks"],
         params: IdParamsSchema,
         body: sendMessageSchema,
@@ -85,13 +101,26 @@ export async function messageRoutes(rawApp: FastifyInstance) {
         }
       }
 
-      if (task.state !== "running") {
+      const isRunning = task.state === TaskState.RUNNING;
+      const isResumable = RESUMABLE_STATES.includes(task.state);
+      if (!isRunning && !isResumable) {
+        // pending / waiting_on_deps / queued / provisioning — task hasn't
+        // started yet and has no running agent. completed — terminal, can't
+        // be resumed. In both cases the agent can't consume a message now.
         return reply.status(409).send({
-          error: `Task is in '${task.state}' state. Messages can only be sent to running tasks.`,
+          error:
+            `Task is in '${task.state}' state. ` +
+            `Messages can be sent to running tasks or used to resume stopped tasks ` +
+            `(needs_attention / pr_opened / failed / cancelled). ` +
+            `This task is not in a state where a message can be delivered.`,
         });
       }
 
-      if (task.agentType !== "claude-code") {
+      // Mid-turn messaging (running) requires the claude-code stream-json
+      // stdin bridge. Resume-from-chat re-enqueues the task and doesn't care
+      // about the agent type — any agent can receive the message as a resume
+      // prompt.
+      if (isRunning && task.agentType !== "claude-code") {
         return reply.status(501).send({
           error:
             "Mid-task messaging is currently only supported for Claude Code. Other agents will be supported via tmux wrapping in a follow-up.",
@@ -120,11 +149,14 @@ export async function messageRoutes(rawApp: FastifyInstance) {
         workspaceId: task.workspaceId ?? undefined,
       });
 
-      const trigger = mode === "interrupt" ? "user_interrupt" : "user_message";
+      // Record the message arrival itself (non-transitioning event) so the
+      // task timeline shows user input even for the running-delivery path.
+      // The interrupt subtype is preserved when applicable.
+      const messageTrigger = mode === "interrupt" ? "user_interrupt" : "user_message";
       await taskService.recordTaskEvent(
         id,
         task.state,
-        trigger,
+        messageTrigger,
         content.slice(0, 200),
         req.user?.id,
       );
@@ -141,18 +173,55 @@ export async function messageRoutes(rawApp: FastifyInstance) {
         createdAt: message.createdAt.toISOString(),
       });
 
-      await publishTaskMessage(id, {
-        messageId: message.id,
-        content,
-        mode,
-        userDisplayName,
-      });
+      if (isRunning) {
+        // Deliver mid-turn via the Redis channel → task-worker → stream-json stdin.
+        await publishTaskMessage(id, {
+          messageId: message.id,
+          content,
+          mode,
+          userDisplayName,
+        });
+      } else {
+        // Stopped + resumable: transition to queued and enqueue a resume run
+        // with the user's message as the new prompt. The agent picks up from
+        // the stored session id (if any) so context is preserved.
+        await taskService.transitionTask(
+          id,
+          TaskState.QUEUED,
+          "user_message_resume",
+          content.slice(0, 200),
+        );
+        await taskQueue.add(
+          "process-task",
+          {
+            taskId: id,
+            resumeSessionId: task.sessionId ?? undefined,
+            resumePrompt: content,
+          },
+          {
+            jobId: `${id}-chat-${Date.now()}`,
+            attempts: 1,
+          },
+        );
+        // We'll mark delivery once the worker picks up and writes the first
+        // log; for the chat UX, acking when the resume is queued is accurate
+        // enough — the user's message has been handed off to the agent.
+        await messageService.markDelivered(message.id).catch(() => {});
+        await publishEvent({
+          type: "task:message_delivered",
+          taskId: id,
+          messageId: message.id,
+          timestamp: new Date().toISOString(),
+        });
+      }
 
       app.log.info(
         {
           taskId: id,
           messageId: message.id,
           userId: req.user?.id,
+          fromState: task.state,
+          delivery: isRunning ? "running-stdin" : "resume-queue",
           contentPreview: content.slice(0, 200),
         },
         "Task message sent",
@@ -166,7 +235,7 @@ export async function messageRoutes(rawApp: FastifyInstance) {
           content: message.content,
           mode: message.mode,
           createdAt: message.createdAt.toISOString(),
-          deliveredAt: null,
+          deliveredAt: isRunning ? null : new Date().toISOString(),
           ackedAt: null,
         },
       });

--- a/apps/api/src/services/pr-review-service.ts
+++ b/apps/api/src/services/pr-review-service.ts
@@ -878,8 +878,18 @@ export async function postReviewChat(input: {
     throw new Error("Prior review run has no captured session — chat not available yet");
   }
 
+  // Enqueue first so we fail before committing a user-visible chat message
+  // if the run can't be created (e.g. repo not configured, queue down).
+  // Otherwise the UI shows an orphaned "unanswered" user turn indefinitely.
+  const run = await enqueueReviewRun(review.id, "chat", {
+    prompt: input.message,
+    resumeSessionId: rootRun.sessionId,
+    createdBy: input.userId,
+  });
+
   await db.insert(prReviewChatMessages).values({
     prReviewId: review.id,
+    runId: run.id,
     role: "user",
     content: input.message,
   });
@@ -888,12 +898,6 @@ export async function postReviewChat(input: {
     .update(prReviews)
     .set({ userEngaged: true, updatedAt: new Date() })
     .where(eq(prReviews.id, review.id));
-
-  const run = await enqueueReviewRun(review.id, "chat", {
-    prompt: input.message,
-    resumeSessionId: rootRun.sessionId,
-    createdBy: input.userId,
-  });
 
   return { runId: run.id, prReviewId: review.id };
 }

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -258,7 +258,15 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   const canCancel = ["running", "queued", "provisioning", "needs_attention"].includes(task.state);
   const canRetry = ["failed", "cancelled"].includes(task.state);
   const canResume = ["needs_attention", "failed"].includes(task.state) && !!task.sessionId;
-  const canMessage = task.state === "running" && task.agentType === "claude-code";
+  // Chat composer shows whenever the message endpoint will accept a message:
+  // - running + claude-code (mid-turn delivery via stream-json stdin), or
+  // - stopped-but-resumable (needs_attention / pr_opened / failed / cancelled)
+  //   — the message becomes the resume prompt for any agent type.
+  const canMessageRunning = task.state === "running" && task.agentType === "claude-code";
+  const canMessageStopped = ["needs_attention", "pr_opened", "failed", "cancelled"].includes(
+    task.state,
+  );
+  const canMessage = canMessageRunning || canMessageStopped;
   const canForceRestart = ["needs_attention", "failed", "pr_opened"].includes(task.state);
 
   // Detect plan review state: needs_attention with plan_review trigger
@@ -857,15 +865,22 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
           {/* Message / Resume bar */}
           <div className="shrink-0 border-t border-border bg-bg-card px-4 py-2.5">
             {canMessage ? (
-              /* Mid-task messaging bar (running claude-code tasks) */
+              /* Unified chat bar. For running claude-code tasks the message is
+                 delivered mid-turn via stream-json stdin; for stopped tasks
+                 (needs_attention / pr_opened / failed / cancelled) it resumes
+                 the agent with the message as the new prompt. */
               <ChatComposer
                 value={messageInput}
                 onChange={setMessageInput}
                 onSend={() => handleSendMessage("soft")}
-                onInterrupt={() => handleSendMessage("interrupt")}
+                onInterrupt={canMessageRunning ? () => handleSendMessage("interrupt") : undefined}
                 sending={messageSending}
-                placeholder="Send a message to the running agent..."
-                sendLabel="Send"
+                placeholder={
+                  canMessageRunning
+                    ? "Send a message to the running agent..."
+                    : "Resume the agent with a message..."
+                }
+                sendLabel={canMessageRunning ? "Send" : "Resume"}
                 interruptLabel="Stop"
               />
             ) : isPlanReview && canResume ? (


### PR DESCRIPTION
Previously POST /api/tasks/:id/message returned 409 for any non-running task, so the chat composer was a dead end once an agent stopped. Extend it: when the task is in needs_attention / pr_opened / failed / cancelled, record the message, transition to queued, and enqueue a resume with the message as the new prompt (reusing the stored session id when present). Agent type is only relevant for the running-delivery path; resume works for any agent. UI shows the chat composer in those states with a "Resume" label; onInterrupt stays running-only.

Also fix pr-review chat: enqueueReviewRun ran after the user-message insert, so a failing enqueue (e.g. repo not configured) left an orphaned user turn with no reply ever coming. Enqueue first, then insert the message linked to the new run id.

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- Key changes, organized by area -->

## Testing

<!-- How was this tested? -->

- [ ] Tests pass (`pnpm turbo test`)
- [ ] Typechecks pass (`pnpm turbo typecheck`)

## Related

<!-- Issues, PRs, docs, etc. -->

Closes #

## Screenshots

<!-- If applicable -->
