### PR TITLE
feat(gemini): update Gemini model options with new preview models

### DIFF
--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -1285,7 +1285,9 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
                 <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
                 <option value="gemini-2.0-flash">Gemini 2.0 Flash</option>
                 <option value="gemini-3-pro">Gemini 3 Pro</option>
-                <option value="gemini-3-flash">Gemini 3 Flash</option>
+                <option value="gemini-3-flash-preview">Gemini 3 Flash Preview</option>
+                <option value="gemini-3.1-pro-preview">Gemini 3.1 Pro</option>
+                <option value="gemini-3.1-flash-lite-preview">Gemini 3.1 Flash Lite Preview</option>
               </select>
             </div>
             <div>


### PR DESCRIPTION
## Summary
- Rename `gemini-3-flash` → `gemini-3-flash-preview` in the per-repo Gemini model dropdown
- Add `gemini-3.1-pro-preview` and `gemini-3.1-flash-lite-preview` options

## Context
Replaces #484, which conflicted against the tabified agent settings layout shipped in #487 and wasn't being rebased. Original change by @nethi; preserved via `Co-authored-by` on the commit.

## Test plan
- [ ] Open a repo settings page, pick the Gemini tab, confirm the three new option labels render and persist on save