### PR TITLE
chore(models): bump Opus option from 4.6 to 4.7

### DIFF
--- a/apps/api/src/ws/optio-chat.ts
+++ b/apps/api/src/ws/optio-chat.ts
@@ -23,7 +23,7 @@ import {
 const ANTHROPIC_API_URL = process.env.ANTHROPIC_API_BASE_URL ?? "https://api.anthropic.com";
 
 const ANTHROPIC_MODEL_MAP: Record<string, string> = {
-  opus: "claude-opus-4-6",
+  opus: "claude-opus-4-7",
   sonnet: "claude-sonnet-4-6",
   haiku: "claude-haiku-4-5-20251001",
 };

--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -788,7 +788,7 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
                     className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
                   >
                     <option value="sonnet">Sonnet 4.6</option>
-                    <option value="opus">Opus 4.6</option>
+                    <option value="opus">Opus 4.7</option>
                     <option value="haiku">Haiku 4.5</option>
                   </select>
                 </div>
@@ -1130,7 +1130,7 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
                   className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
                 >
                   <option value="sonnet">Sonnet 4.6</option>
-                  <option value="opus">Opus 4.6</option>
+                  <option value="opus">Opus 4.7</option>
                   <option value="haiku">Haiku 4.5</option>
                 </select>
               </div>

--- a/apps/web/src/app/repos/new/page.tsx
+++ b/apps/web/src/app/repos/new/page.tsx
@@ -563,7 +563,7 @@ function AgentStep({
             className={selectClass}
           >
             <option value="sonnet">Sonnet 4.6</option>
-            <option value="opus">Opus 4.6</option>
+            <option value="opus">Opus 4.7</option>
             <option value="haiku">Haiku 4.5</option>
           </select>
         </div>
@@ -710,7 +710,7 @@ function ReviewStep({
                   className={selectClass}
                 >
                   <option value="sonnet">Sonnet 4.6</option>
-                  <option value="opus">Opus 4.6</option>
+                  <option value="opus">Opus 4.7</option>
                   <option value="haiku">Haiku 4.5</option>
                 </select>
               </div>

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -200,7 +200,7 @@ function DefaultReviewEditor() {
             className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
           >
             <option value="sonnet">Sonnet 4.6</option>
-            <option value="opus">Opus 4.6</option>
+            <option value="opus">Opus 4.7</option>
             <option value="haiku">Haiku 4.5</option>
           </select>
         </div>


### PR DESCRIPTION
## Summary

- Claude Opus 4.7 (`claude-opus-4-7`) is the current Opus release; our UI dropdowns and the `optio-chat` alias map were still pointing at 4.6.
- Bumps 5 UI option labels (settings page, new-repo page, repo detail page) and the `ANTHROPIC_MODEL_MAP` entry in `apps/api/src/ws/optio-chat.ts`.
- Sonnet 4.6 and Haiku 4.5 remain current — no changes to those.

## Test plan

- [ ] Visit `/settings` → "Default Review Model" dropdown shows "Opus 4.7".
- [ ] Visit `/repos/new` → Model + Review Model dropdowns show "Opus 4.7".
- [ ] Visit `/repos/:id` → Model + Review Model dropdowns show "Opus 4.7".
- [ ] Open the Optio chat with the `opus` model selected and confirm a request round-trips (backend now sends `claude-opus-4-7` to Anthropic).

Follow-up: we could fetch the model list dynamically from Anthropic's `/v1/models` endpoint with a refresh button, so future bumps don't require a code change. Tracked in a separate issue.