### PR TITLE
Dynamic per-provider model & options picker with refresh button

### DIFF
--- a/apps/api/src/routes/agent-options.test.ts
+++ b/apps/api/src/routes/agent-options.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildRouteTestApp } from "../test-utils/build-route-test-app.js";
+import type { FastifyInstance } from "fastify";
+
+const mockGetProviderOptions = vi.fn();
+const mockInvalidateProviderCache = vi.fn();
+
+vi.mock("../services/agent-options-service.js", () => ({
+  getProviderOptions: (...args: unknown[]) => mockGetProviderOptions(...args),
+  invalidateProviderCache: (...args: unknown[]) => mockInvalidateProviderCache(...args),
+}));
+
+vi.mock("../services/oauth/index.js", () => ({
+  isAuthDisabled: () => false,
+}));
+
+import { agentOptionsRoutes } from "./agent-options.js";
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  return buildRouteTestApp(agentOptionsRoutes);
+}
+
+describe("GET /api/agents/options", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns all provider catalogs", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/agents/options" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body.providers)).toBe(true);
+    const ids = body.providers.map((p: { provider: string }) => p.provider);
+    expect(ids).toEqual(
+      expect.arrayContaining(["anthropic", "openai", "gemini", "copilot", "opencode", "openclaw"]),
+    );
+  });
+});
+
+describe("GET /api/agents/:provider/options", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns the provider options", async () => {
+    mockGetProviderOptions.mockResolvedValue({
+      catalog: {
+        provider: "anthropic",
+        models: [],
+        aliases: {},
+        options: [],
+        liveRefreshSupported: true,
+        label: "Claude Code",
+        modelField: "claudeModel",
+      },
+      source: "baseline",
+      cached: false,
+      refreshedAt: null,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/agents/anthropic/options",
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.provider).toBe("anthropic");
+    expect(body.source).toBe("baseline");
+    expect(body.cached).toBe(false);
+    expect(mockGetProviderOptions).toHaveBeenCalledWith("anthropic", {
+      workspaceId: "ws-1",
+      forceRefresh: false,
+    });
+  });
+
+  it("honours the refresh query param", async () => {
+    mockGetProviderOptions.mockResolvedValue({
+      catalog: {
+        provider: "anthropic",
+        models: [],
+        aliases: {},
+        options: [],
+        liveRefreshSupported: true,
+        label: "Claude Code",
+        modelField: "claudeModel",
+      },
+      source: "live",
+      cached: false,
+      refreshedAt: 1700000000,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/agents/anthropic/options?refresh=true",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockInvalidateProviderCache).toHaveBeenCalledWith("anthropic");
+    expect(mockGetProviderOptions).toHaveBeenCalledWith("anthropic", {
+      workspaceId: "ws-1",
+      forceRefresh: true,
+    });
+  });
+
+  it("rejects an unknown provider id", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/agents/bogus/options",
+    });
+    expect(res.statusCode).toBe(400);
+    expect(mockGetProviderOptions).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the live-probe error when the fallback kicked in", async () => {
+    mockGetProviderOptions.mockResolvedValue({
+      catalog: {
+        provider: "anthropic",
+        models: [],
+        aliases: {},
+        options: [],
+        liveRefreshSupported: true,
+        label: "Claude Code",
+        modelField: "claudeModel",
+      },
+      source: "baseline",
+      cached: false,
+      refreshedAt: null,
+      error: "Anthropic /v1/models returned 401",
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/agents/anthropic/options?refresh=true",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().error).toBe("Anthropic /v1/models returned 401");
+  });
+});
+
+describe("POST /api/agents/:provider/options/refresh", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("invalidates the cache and reprobes", async () => {
+    mockGetProviderOptions.mockResolvedValue({
+      catalog: {
+        provider: "gemini",
+        models: [],
+        aliases: {},
+        options: [],
+        liveRefreshSupported: true,
+        label: "Google Gemini",
+        modelField: "geminiModel",
+      },
+      source: "live",
+      cached: false,
+      refreshedAt: 1700000000,
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/agents/gemini/options/refresh",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockInvalidateProviderCache).toHaveBeenCalledWith("gemini");
+    expect(mockGetProviderOptions).toHaveBeenCalledWith("gemini", {
+      workspaceId: "ws-1",
+      forceRefresh: true,
+    });
+  });
+
+  it("rejects non-admin callers", async () => {
+    const nonAdminApp = await buildRouteTestApp(agentOptionsRoutes, {
+      user: { id: "user-2", workspaceId: "ws-1", workspaceRole: "member" },
+    });
+
+    const res = await nonAdminApp.inject({
+      method: "POST",
+      url: "/api/agents/anthropic/options/refresh",
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/apps/api/src/routes/agent-options.ts
+++ b/apps/api/src/routes/agent-options.ts
@@ -1,0 +1,153 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import type { ZodTypeProvider } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { ALL_PROVIDER_IDS, PROVIDER_CATALOGS, type AgentProviderId } from "@optio/shared";
+import { getProviderOptions, invalidateProviderCache } from "../services/agent-options-service.js";
+import { isAuthDisabled } from "../services/oauth/index.js";
+import { ErrorResponseSchema } from "../schemas/common.js";
+
+const providerParamsSchema = z.object({
+  provider: z.enum(["anthropic", "openai", "gemini", "copilot", "opencode", "openclaw"]),
+});
+
+const refreshQuerySchema = z.object({
+  refresh: z
+    .union([z.literal("true"), z.literal("false"), z.literal("1"), z.literal("0")])
+    .optional(),
+});
+
+const ProviderOptionsResponseSchema = z
+  .object({
+    provider: z.string(),
+    source: z.enum(["baseline", "live"]),
+    cached: z.boolean(),
+    refreshedAt: z.number().nullable(),
+    error: z.string().optional(),
+    catalog: z.unknown(),
+  })
+  .describe("Provider options catalog, optionally augmented by a live probe");
+
+const ProviderListResponseSchema = z
+  .object({
+    providers: z.array(z.unknown()),
+  })
+  .describe("All provider catalogs (hardcoded baseline only)");
+
+const requireAdminWhenAuthenticated = async (req: FastifyRequest, reply: FastifyReply) => {
+  if (isAuthDisabled()) return;
+  if (!req.user) return;
+  if (req.user.workspaceRole !== "admin") {
+    return reply.status(403).send({
+      error: "Admin role required for agent options refresh",
+    });
+  }
+};
+
+export async function agentOptionsRoutes(rawApp: FastifyInstance) {
+  const app = rawApp.withTypeProvider<ZodTypeProvider>();
+
+  app.get(
+    "/api/agents/options",
+    {
+      schema: {
+        operationId: "listAgentOptions",
+        summary: "List hardcoded agent options for every provider",
+        description:
+          "Return the per-provider hardcoded catalog (models, aliases, options) " +
+          "without consulting any upstream list-models API. Used by the UI on " +
+          "first paint before a live refresh kicks in.",
+        tags: ["Setup & Settings"],
+        response: { 200: ProviderListResponseSchema },
+      },
+    },
+    async (_req, reply) => {
+      const providers = ALL_PROVIDER_IDS.map((id) => PROVIDER_CATALOGS[id]);
+      reply.send({ providers });
+    },
+  );
+
+  app.get(
+    "/api/agents/:provider/options",
+    {
+      schema: {
+        operationId: "getAgentProviderOptions",
+        summary: "Get model & options for a specific agent provider",
+        description:
+          "Return the catalog for a single provider. If `refresh=true`, bypass " +
+          "the Redis cache and reprobe the provider's list-models API. " +
+          "Providers without a public list-models endpoint (Copilot, OpenCode, " +
+          "OpenClaw) always return the hardcoded baseline.",
+        tags: ["Setup & Settings"],
+        params: providerParamsSchema,
+        querystring: refreshQuerySchema,
+        response: {
+          200: ProviderOptionsResponseSchema,
+          400: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const provider = req.params.provider as AgentProviderId;
+      const forceRefresh = req.query.refresh === "true" || req.query.refresh === "1";
+
+      if (forceRefresh) {
+        await invalidateProviderCache(provider);
+      }
+
+      const workspaceId = req.user?.workspaceId ?? null;
+      const result = await getProviderOptions(provider, {
+        workspaceId,
+        forceRefresh,
+      });
+
+      reply.send({
+        provider,
+        source: result.source,
+        cached: result.cached,
+        refreshedAt: result.refreshedAt,
+        ...(result.error ? { error: result.error } : {}),
+        catalog: result.catalog,
+      });
+    },
+  );
+
+  app.post(
+    "/api/agents/:provider/options/refresh",
+    {
+      preHandler: [requireAdminWhenAuthenticated],
+      schema: {
+        operationId: "refreshAgentProviderOptions",
+        summary: "Invalidate the cache and reprobe a provider",
+        description:
+          "Admin-only shortcut for explicit refresh from the UI's Refresh " +
+          "button. Equivalent to `GET /api/agents/:provider/options?refresh=true` " +
+          "but always POST so browsers/proxies don't cache it.",
+        tags: ["Setup & Settings"],
+        params: providerParamsSchema,
+        response: {
+          200: ProviderOptionsResponseSchema,
+          403: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const provider = req.params.provider as AgentProviderId;
+      await invalidateProviderCache(provider);
+      const workspaceId = req.user?.workspaceId ?? null;
+      const result = await getProviderOptions(provider, {
+        workspaceId,
+        forceRefresh: true,
+      });
+      reply.send({
+        provider,
+        source: result.source,
+        cached: result.cached,
+        refreshedAt: result.refreshedAt,
+        ...(result.error ? { error: result.error } : {}),
+        catalog: result.catalog,
+      });
+    },
+  );
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -51,6 +51,7 @@ import { sharedDirectoryRoutes } from "./routes/shared-directories.js";
 import { notificationRoutes } from "./routes/notifications.js";
 import { optioRoutes } from "./routes/optio.js";
 import { optioSettingsRoutes } from "./routes/optio-settings.js";
+import { agentOptionsRoutes } from "./routes/agent-options.js";
 import { activityRoutes } from "./routes/activity.js";
 import githubAppRoutes from "./routes/github-app.js";
 import { githubTokenRoutes } from "./routes/github-token.js";
@@ -284,6 +285,7 @@ export async function buildServer() {
   await app.register(notificationRoutes);
   await app.register(optioRoutes);
   await app.register(optioSettingsRoutes);
+  await app.register(agentOptionsRoutes);
   await app.register(activityRoutes);
   await app.register(githubAppRoutes);
   await app.register(githubTokenRoutes);

--- a/apps/api/src/services/agent-options-service.test.ts
+++ b/apps/api/src/services/agent-options-service.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockRetrieveSecret = vi.fn();
+const mockRedisGet = vi.fn();
+const mockRedisSet = vi.fn();
+const mockRedisDel = vi.fn();
+
+vi.mock("./secret-service.js", () => ({
+  retrieveSecret: (...args: unknown[]) => mockRetrieveSecret(...args),
+}));
+
+vi.mock("./event-bus.js", () => ({
+  getRedisClient: () => ({
+    get: (...args: unknown[]) => mockRedisGet(...args),
+    set: (...args: unknown[]) => mockRedisSet(...args),
+    del: (...args: unknown[]) => mockRedisDel(...args),
+    scanStream: () => {
+      return {
+        on(event: string, cb: (arg?: unknown) => void) {
+          if (event === "end") queueMicrotask(() => cb());
+          return this;
+        },
+      };
+    },
+  }),
+}));
+
+import { getProviderOptions } from "./agent-options-service.js";
+
+const originalFetch = globalThis.fetch;
+
+describe("getProviderOptions", () => {
+  beforeEach(() => {
+    mockRetrieveSecret.mockReset();
+    mockRedisGet.mockReset();
+    mockRedisSet.mockReset();
+    mockRedisDel.mockReset();
+    mockRedisGet.mockResolvedValue(null);
+    mockRedisSet.mockResolvedValue("OK");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns the baseline when the provider doesn't support live refresh", async () => {
+    const result = await getProviderOptions("copilot");
+    expect(result.source).toBe("baseline");
+    expect(result.cached).toBe(false);
+    expect(result.catalog.provider).toBe("copilot");
+    expect(mockRetrieveSecret).not.toHaveBeenCalled();
+  });
+
+  it("returns the baseline when no API key is configured", async () => {
+    mockRetrieveSecret.mockRejectedValueOnce(new Error("Secret not found"));
+    const result = await getProviderOptions("anthropic");
+    expect(result.source).toBe("baseline");
+    expect(mockRetrieveSecret).toHaveBeenCalledWith("ANTHROPIC_API_KEY", "global", undefined);
+  });
+
+  it("probes upstream and merges when no cache entry exists", async () => {
+    mockRetrieveSecret.mockResolvedValueOnce("sk-ant-xxx");
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [{ id: "claude-opus-4-7" }, { id: "claude-new-model-id" }],
+        }),
+    }) as unknown as typeof fetch;
+
+    const result = await getProviderOptions("anthropic");
+    expect(result.source).toBe("live");
+    expect(result.cached).toBe(false);
+    expect(result.catalog.models.some((m) => m.id === "claude-new-model-id")).toBe(true);
+    expect(mockRedisSet).toHaveBeenCalled();
+  });
+
+  it("uses the cached list when present (skipping the probe)", async () => {
+    mockRetrieveSecret.mockResolvedValueOnce("sk-ant-xxx");
+    mockRedisGet.mockResolvedValueOnce(
+      JSON.stringify({
+        ids: ["claude-from-cache"],
+        refreshedAt: 1700000000,
+      }),
+    );
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await getProviderOptions("anthropic");
+    expect(result.source).toBe("live");
+    expect(result.cached).toBe(true);
+    expect(result.refreshedAt).toBe(1700000000);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.catalog.models.some((m) => m.id === "claude-from-cache")).toBe(true);
+  });
+
+  it("force-refresh bypasses the cache", async () => {
+    mockRetrieveSecret.mockResolvedValueOnce("sk-ant-xxx");
+    mockRedisGet.mockResolvedValueOnce(
+      JSON.stringify({ ids: ["cached-id"], refreshedAt: 1700000000 }),
+    );
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [{ id: "fresh-id" }] }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await getProviderOptions("anthropic", { forceRefresh: true });
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(result.source).toBe("live");
+    expect(result.cached).toBe(false);
+    expect(result.catalog.models.some((m) => m.id === "fresh-id")).toBe(true);
+    expect(result.catalog.models.some((m) => m.id === "cached-id")).toBe(false);
+  });
+
+  it("falls back to baseline when the upstream probe fails", async () => {
+    mockRetrieveSecret.mockResolvedValueOnce("sk-ant-xxx");
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({}),
+    }) as unknown as typeof fetch;
+
+    const result = await getProviderOptions("anthropic");
+    expect(result.source).toBe("baseline");
+    expect(result.error).toMatch(/401/);
+  });
+
+  it("strips the `models/` prefix from gemini ids", async () => {
+    mockRetrieveSecret.mockResolvedValueOnce("aiza-xxx");
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          models: [{ name: "models/gemini-4-pro" }, { name: "models/gemini-3-pro" }],
+        }),
+    }) as unknown as typeof fetch;
+
+    const result = await getProviderOptions("gemini");
+    expect(result.source).toBe("live");
+    expect(result.catalog.models.some((m) => m.id === "gemini-4-pro")).toBe(true);
+    // already in the baseline — not duplicated
+    const geminiThreeProEntries = result.catalog.models.filter((m) => m.id === "gemini-3-pro");
+    expect(geminiThreeProEntries.length).toBe(1);
+  });
+});

--- a/apps/api/src/services/agent-options-service.ts
+++ b/apps/api/src/services/agent-options-service.ts
@@ -1,0 +1,247 @@
+import { createHash } from "node:crypto";
+import {
+  PROVIDER_CATALOGS,
+  mergeLiveModels,
+  type AgentProviderId,
+  type ProviderCatalog,
+} from "@optio/shared";
+import { getRedisClient } from "./event-bus.js";
+import { retrieveSecret } from "./secret-service.js";
+
+/** Cache TTL for live-probed model lists. ~1h matches the task spec. */
+const CACHE_TTL_SECONDS = 60 * 60;
+
+/** Redis key prefix for cached live model lists. */
+const CACHE_KEY_PREFIX = "optio:agent-options";
+
+type LiveProbe = (apiKey: string) => Promise<string[]>;
+
+/** Anthropic: GET /v1/models → data[].id. */
+async function probeAnthropic(apiKey: string): Promise<string[]> {
+  const res = await fetch("https://api.anthropic.com/v1/models?limit=100", {
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+  });
+  if (!res.ok) throw new Error(`Anthropic /v1/models returned ${res.status}`);
+  const body = (await res.json()) as { data?: Array<{ id?: string }> };
+  return (body.data ?? []).map((m) => m.id ?? "").filter(Boolean);
+}
+
+/** OpenAI: GET /v1/models → data[].id. */
+async function probeOpenAI(apiKey: string): Promise<string[]> {
+  const res = await fetch("https://api.openai.com/v1/models", {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) throw new Error(`OpenAI /v1/models returned ${res.status}`);
+  const body = (await res.json()) as { data?: Array<{ id?: string }> };
+  return (body.data ?? []).map((m) => m.id ?? "").filter(Boolean);
+}
+
+/** Gemini: GET /v1beta/models?key=... → models[].name (strip "models/" prefix). */
+async function probeGemini(apiKey: string): Promise<string[]> {
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(apiKey)}`,
+  );
+  if (!res.ok) throw new Error(`Gemini /v1beta/models returned ${res.status}`);
+  const body = (await res.json()) as { models?: Array<{ name?: string }> };
+  return (body.models ?? [])
+    .map((m) => m.name ?? "")
+    .map((name) => (name.startsWith("models/") ? name.slice("models/".length) : name))
+    .filter(Boolean);
+}
+
+interface ProbeConfig {
+  /** Redis cache key suffix (distinguishes providers sharing a DB column). */
+  probeKey: AgentProviderId;
+  /** Secret name that holds the API key for the upstream probe. */
+  secretName: string;
+  /** Probe function that returns a list of upstream model ids. */
+  probe: LiveProbe;
+}
+
+const PROBE_CONFIG: Partial<Record<AgentProviderId, ProbeConfig>> = {
+  anthropic: { probeKey: "anthropic", secretName: "ANTHROPIC_API_KEY", probe: probeAnthropic },
+  openai: { probeKey: "openai", secretName: "OPENAI_API_KEY", probe: probeOpenAI },
+  gemini: { probeKey: "gemini", secretName: "GEMINI_API_KEY", probe: probeGemini },
+};
+
+/**
+ * Build a short hash of the key used for the probe — lets us invalidate the
+ * cache automatically when the API key is rotated without storing the secret
+ * itself in the Redis key.
+ */
+function hashKey(key: string): string {
+  return createHash("sha256").update(key).digest("hex").slice(0, 16);
+}
+
+function buildCacheKey(provider: AgentProviderId, keyHash: string): string {
+  return `${CACHE_KEY_PREFIX}:${provider}:${keyHash}`;
+}
+
+export interface ProviderOptionsResult {
+  catalog: ProviderCatalog;
+  /** "baseline" = hardcoded only; "live" = merged with upstream list. */
+  source: "baseline" | "live";
+  /** True if the live list came from Redis (not a fresh probe). */
+  cached: boolean;
+  /** Unix seconds when the cache entry was refreshed, or null when baseline-only. */
+  refreshedAt: number | null;
+  /** User-visible error if the live probe failed (cache-miss fallback to baseline). */
+  error?: string;
+}
+
+interface GetOptions {
+  /** Workspace scope for secret resolution. */
+  workspaceId?: string | null;
+  /** If true, skip the Redis cache and always probe upstream. */
+  forceRefresh?: boolean;
+}
+
+async function readLiveIdsFromCache(
+  provider: AgentProviderId,
+  keyHash: string,
+): Promise<{ ids: string[]; refreshedAt: number } | null> {
+  try {
+    const redis = getRedisClient();
+    const raw = await redis.get(buildCacheKey(provider, keyHash));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { ids?: string[]; refreshedAt?: number };
+    if (!Array.isArray(parsed.ids)) return null;
+    return {
+      ids: parsed.ids,
+      refreshedAt: parsed.refreshedAt ?? Math.floor(Date.now() / 1000),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function writeLiveIdsToCache(
+  provider: AgentProviderId,
+  keyHash: string,
+  ids: string[],
+): Promise<number> {
+  const refreshedAt = Math.floor(Date.now() / 1000);
+  try {
+    const redis = getRedisClient();
+    await redis.set(
+      buildCacheKey(provider, keyHash),
+      JSON.stringify({ ids, refreshedAt }),
+      "EX",
+      CACHE_TTL_SECONDS,
+    );
+  } catch {
+    // Cache write failures are non-fatal — the caller still gets the merged result.
+  }
+  return refreshedAt;
+}
+
+/**
+ * Load the options catalog for a provider, optionally merging in a live
+ * list-models probe. For providers without `liveRefreshSupported`, this
+ * just returns the hardcoded baseline.
+ */
+export async function getProviderOptions(
+  provider: AgentProviderId,
+  opts: GetOptions = {},
+): Promise<ProviderOptionsResult> {
+  const baseline = PROVIDER_CATALOGS[provider];
+  if (!baseline) {
+    throw new Error(`Unknown agent provider: ${provider}`);
+  }
+
+  if (!baseline.liveRefreshSupported) {
+    return {
+      catalog: baseline,
+      source: "baseline",
+      cached: false,
+      refreshedAt: null,
+    };
+  }
+
+  const probeConfig = PROBE_CONFIG[provider];
+  if (!probeConfig) {
+    return {
+      catalog: baseline,
+      source: "baseline",
+      cached: false,
+      refreshedAt: null,
+    };
+  }
+
+  // Look up the configured API key for the probe. Missing → baseline only.
+  let apiKey: string | null = null;
+  try {
+    apiKey = await retrieveSecret(probeConfig.secretName, "global", opts.workspaceId ?? undefined);
+  } catch {
+    // No configured key — nothing to probe with.
+  }
+
+  if (!apiKey) {
+    return {
+      catalog: baseline,
+      source: "baseline",
+      cached: false,
+      refreshedAt: null,
+    };
+  }
+
+  const keyHash = hashKey(apiKey);
+
+  if (!opts.forceRefresh) {
+    const cached = await readLiveIdsFromCache(provider, keyHash);
+    if (cached) {
+      return {
+        catalog: mergeLiveModels(baseline, cached.ids),
+        source: "live",
+        cached: true,
+        refreshedAt: cached.refreshedAt,
+      };
+    }
+  }
+
+  try {
+    const ids = await probeConfig.probe(apiKey);
+    const refreshedAt = await writeLiveIdsToCache(provider, keyHash, ids);
+    return {
+      catalog: mergeLiveModels(baseline, ids),
+      source: "live",
+      cached: false,
+      refreshedAt,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return {
+      catalog: baseline,
+      source: "baseline",
+      cached: false,
+      refreshedAt: null,
+      error,
+    };
+  }
+}
+
+/** Invalidate the cached list for a provider across every tracked API-key hash. */
+export async function invalidateProviderCache(provider: AgentProviderId): Promise<void> {
+  const redis = getRedisClient();
+  try {
+    // Small provider count + short hash space → SCAN is overkill.
+    // Using a broad pattern match is fine here.
+    const stream = redis.scanStream({ match: `${CACHE_KEY_PREFIX}:${provider}:*`, count: 50 });
+    const toDelete: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      stream.on("data", (keys: string[]) => {
+        toDelete.push(...keys);
+      });
+      stream.on("end", () => resolve());
+      stream.on("error", reject);
+    });
+    if (toDelete.length > 0) {
+      await redis.del(...toDelete);
+    }
+  } catch {
+    // Cache invalidation failures are non-fatal.
+  }
+}

--- a/apps/api/src/ws/optio-chat.ts
+++ b/apps/api/src/ws/optio-chat.ts
@@ -5,6 +5,7 @@ import { logger } from "../logger.js";
 import {
   OPTIO_TOOL_SCHEMAS,
   OPTIO_TOOL_CATEGORIES,
+  resolveModelId,
   type OptioToolDefinition,
   type OptioToolSchema,
 } from "@optio/shared";
@@ -22,11 +23,11 @@ import {
 
 const ANTHROPIC_API_URL = process.env.ANTHROPIC_API_BASE_URL ?? "https://api.anthropic.com";
 
-const ANTHROPIC_MODEL_MAP: Record<string, string> = {
-  opus: "claude-opus-4-7",
-  sonnet: "claude-sonnet-4-6",
-  haiku: "claude-haiku-4-5-20251001",
-};
+/**
+ * Fallback when the stored model ID is unrecognised (not a known alias, not a
+ * cataloged dated id). Kept as a concrete dated id so an Anthropic API call
+ * never sends a stale alias.
+ */
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 const DEFAULT_MAX_TURNS = 10;
 
@@ -615,7 +616,7 @@ export async function optioChatWs(app: FastifyInstance) {
 
       // Load settings
       const settings = await getSettings(user.workspaceId);
-      const model = ANTHROPIC_MODEL_MAP[settings.model] ?? DEFAULT_MODEL;
+      const model = resolveModelId("anthropic", settings.model) ?? DEFAULT_MODEL;
       const maxTurns = settings.maxTurns || DEFAULT_MAX_TURNS;
 
       // Build system prompt (tool definitions are passed separately to the API)
@@ -666,7 +667,7 @@ export async function optioChatWs(app: FastifyInstance) {
       }
 
       const settings = await getSettings(user.workspaceId);
-      const model = ANTHROPIC_MODEL_MAP[settings.model] ?? DEFAULT_MODEL;
+      const model = resolveModelId("anthropic", settings.model) ?? DEFAULT_MODEL;
       const maxTurns = settings.maxTurns || DEFAULT_MAX_TURNS;
       const systemPrompt = buildSystemPrompt({
         systemPrompt: settings.systemPrompt,

--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -32,6 +32,8 @@ import { formatRelativeTime, formatDuration } from "@/lib/utils";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { SharedDirectoriesSection } from "@/components/shared-directories-section";
+import { AgentOptionsPicker, type AgentOptionsValues } from "@/components/agent-options-picker";
+import { ANTHROPIC_CATALOG, resolveModelId } from "@optio/shared";
 
 const AGENT_TABS = [
   { value: "claude-code", label: "Claude Code" },
@@ -787,9 +789,16 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
                     onChange={(e) => setReviewModel(e.target.value)}
                     className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
                   >
-                    <option value="sonnet">Sonnet 4.6</option>
-                    <option value="opus">Opus 4.7</option>
-                    <option value="haiku">Haiku 4.5</option>
+                    {Object.keys(ANTHROPIC_CATALOG.aliases).map((alias) => {
+                      const id = resolveModelId("anthropic", alias);
+                      const label =
+                        ANTHROPIC_CATALOG.models.find((m) => m.id === id)?.label ?? alias;
+                      return (
+                        <option key={alias} value={alias}>
+                          {label}
+                        </option>
+                      );
+                    })}
                   </select>
                 </div>
                 <div>
@@ -1121,54 +1130,22 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
         {/* Claude Code tab */}
         {activeAgentTab === "claude-code" && (
           <div className="space-y-3">
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-xs text-text-muted mb-1">Model</label>
-                <select
-                  value={claudeModel}
-                  onChange={(e) => setClaudeModel(e.target.value)}
-                  className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-                >
-                  <option value="sonnet">Sonnet 4.6</option>
-                  <option value="opus">Opus 4.7</option>
-                  <option value="haiku">Haiku 4.5</option>
-                </select>
-              </div>
-              <div>
-                <label className="block text-xs text-text-muted mb-1">Context Window</label>
-                <select
-                  value={claudeContextWindow}
-                  onChange={(e) => setClaudeContextWindow(e.target.value)}
-                  className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-                >
-                  <option value="200k">200K tokens</option>
-                  <option value="1m">1M tokens</option>
-                </select>
-              </div>
-              <div>
-                <label className="block text-xs text-text-muted mb-1">Effort Level</label>
-                <select
-                  value={claudeEffort}
-                  onChange={(e) => setClaudeEffort(e.target.value)}
-                  className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-                >
-                  <option value="low">Low</option>
-                  <option value="medium">Medium</option>
-                  <option value="high">High</option>
-                </select>
-              </div>
-              <div className="flex items-end pb-1">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={claudeThinking}
-                    onChange={(e) => setClaudeThinking(e.target.checked)}
-                    className="w-4 h-4 rounded"
-                  />
-                  <span className="text-sm">Extended Thinking</span>
-                </label>
-              </div>
-            </div>
+            <AgentOptionsPicker
+              provider="anthropic"
+              values={{
+                claudeModel,
+                claudeContextWindow,
+                claudeEffort,
+                claudeThinking,
+              }}
+              onChange={(v: AgentOptionsValues) => {
+                if (typeof v.claudeModel === "string") setClaudeModel(v.claudeModel);
+                if (typeof v.claudeContextWindow === "string")
+                  setClaudeContextWindow(v.claudeContextWindow);
+                if (typeof v.claudeEffort === "string") setClaudeEffort(v.claudeEffort);
+                if (typeof v.claudeThinking === "boolean") setClaudeThinking(v.claudeThinking);
+              }}
+            />
             <div>
               <label className="block text-xs text-text-muted mb-1">Max Turns</label>
               <NumberInput
@@ -1193,36 +1170,14 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
 
         {/* Copilot tab */}
         {activeAgentTab === "copilot" && (
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-xs text-text-muted mb-1">Model</label>
-              <select
-                value={copilotModel}
-                onChange={(e) => setCopilotModel(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-              >
-                <option value="">Default</option>
-                <option value="claude-sonnet-4.5">Claude Sonnet 4.5</option>
-                <option value="gpt-5">GPT-5</option>
-                <option value="gpt-5.2">GPT-5.2</option>
-                <option value="gpt-5.4">GPT-5.4</option>
-                <option value="gpt-5.4-mini">GPT-5.4 Mini</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-xs text-text-muted mb-1">Reasoning Effort</label>
-              <select
-                value={copilotEffort}
-                onChange={(e) => setCopilotEffort(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-              >
-                <option value="">Default</option>
-                <option value="low">Low</option>
-                <option value="medium">Medium</option>
-                <option value="high">High</option>
-              </select>
-            </div>
-          </div>
+          <AgentOptionsPicker
+            provider="copilot"
+            values={{ copilotModel, copilotEffort }}
+            onChange={(v: AgentOptionsValues) => {
+              if (typeof v.copilotModel === "string") setCopilotModel(v.copilotModel);
+              if (typeof v.copilotEffort === "string") setCopilotEffort(v.copilotEffort);
+            }}
+          />
         )}
 
         {/* OpenCode tab */}
@@ -1232,90 +1187,40 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
               Use a custom base URL to connect to local or self-hosted OpenAI-compatible inference
               servers (vLLM, lightllm, Ollama, etc.).
             </p>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-xs text-text-muted mb-1">Model</label>
-                <input
-                  value={opencodeModel}
-                  onChange={(e) => setOpencodeModel(e.target.value)}
-                  placeholder="Default (auto-detect)"
-                  className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-                />
-                <p className="text-xs text-text-muted mt-1">
-                  e.g. anthropic/claude-sonnet-4, openai/gpt-4o, meta-llama/Llama-3.1-70B
-                </p>
-              </div>
-              <div>
-                <label className="block text-xs text-text-muted mb-1">Agent</label>
-                <input
-                  value={opencodeAgent}
-                  onChange={(e) => setOpencodeAgent(e.target.value)}
-                  placeholder="Default"
-                  className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-                />
-              </div>
-            </div>
-            <div>
-              <label className="block text-xs text-text-muted mb-1">Custom Base URL</label>
-              <input
-                value={opencodeBaseUrl}
-                onChange={(e) => setOpencodeBaseUrl(e.target.value)}
-                placeholder="https://your-inference-server/v1"
-                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-              />
-              <p className="text-xs text-text-muted mt-1">
-                OpenAI-compatible endpoint URL. When set, API keys are optional — a placeholder key
-                is used if none is configured in Secrets.
-              </p>
-            </div>
+            <AgentOptionsPicker
+              provider="opencode"
+              values={{ opencodeModel, opencodeAgent, opencodeBaseUrl }}
+              onChange={(v: AgentOptionsValues) => {
+                if (typeof v.opencodeModel === "string") setOpencodeModel(v.opencodeModel);
+                if (typeof v.opencodeAgent === "string") setOpencodeAgent(v.opencodeAgent);
+                if (typeof v.opencodeBaseUrl === "string") setOpencodeBaseUrl(v.opencodeBaseUrl);
+              }}
+            />
           </div>
         )}
 
         {/* Gemini tab */}
         {activeAgentTab === "gemini" && (
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-xs text-text-muted mb-1">Model</label>
-              <select
-                value={geminiModel}
-                onChange={(e) => setGeminiModel(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-              >
-                <option value="gemini-2.5-pro">Gemini 2.5 Pro</option>
-                <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
-                <option value="gemini-2.0-flash">Gemini 2.0 Flash</option>
-                <option value="gemini-3-pro">Gemini 3 Pro</option>
-                <option value="gemini-3-flash-preview">Gemini 3 Flash Preview</option>
-                <option value="gemini-3.1-pro-preview">Gemini 3.1 Pro</option>
-                <option value="gemini-3.1-flash-lite-preview">Gemini 3.1 Flash Lite Preview</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-xs text-text-muted mb-1">Approval Mode</label>
-              <select
-                value={geminiApprovalMode}
-                onChange={(e) => setGeminiApprovalMode(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-              >
-                <option value="yolo">Yolo (skip all approvals)</option>
-                <option value="auto_edit">Auto Edit</option>
-                <option value="default">Default</option>
-              </select>
-            </div>
-          </div>
+          <AgentOptionsPicker
+            provider="gemini"
+            values={{ geminiModel, geminiApprovalMode }}
+            onChange={(v: AgentOptionsValues) => {
+              if (typeof v.geminiModel === "string") setGeminiModel(v.geminiModel);
+              if (typeof v.geminiApprovalMode === "string")
+                setGeminiApprovalMode(v.geminiApprovalMode);
+            }}
+          />
         )}
 
         {/* OpenClaw tab */}
         {activeAgentTab === "openclaw" && (
-          <div>
-            <label className="block text-xs text-text-muted mb-1">Model</label>
-            <input
-              value={openclawModel}
-              onChange={(e) => setOpenclawModel(e.target.value)}
-              placeholder="Default (auto-detect)"
-              className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-            />
-          </div>
+          <AgentOptionsPicker
+            provider="openclaw"
+            values={{ openclawModel }}
+            onChange={(v: AgentOptionsValues) => {
+              if (typeof v.openclawModel === "string") setOpenclawModel(v.openclawModel);
+            }}
+          />
         )}
       </section>
 

--- a/apps/web/src/app/repos/new/page.tsx
+++ b/apps/web/src/app/repos/new/page.tsx
@@ -20,6 +20,8 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
+import { AgentOptionsPicker, type AgentOptionsValues } from "@/components/agent-options-picker";
+import { ANTHROPIC_CATALOG, resolveModelId } from "@optio/shared";
 
 const STEPS = [
   { id: "repo", label: "Repository" },
@@ -554,54 +556,23 @@ function AgentStep({
         </p>
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <label className="block text-xs text-text-muted mb-1">Model</label>
-          <select
-            value={claudeModel}
-            onChange={(e) => setClaudeModel(e.target.value)}
-            className={selectClass}
-          >
-            <option value="sonnet">Sonnet 4.6</option>
-            <option value="opus">Opus 4.7</option>
-            <option value="haiku">Haiku 4.5</option>
-          </select>
-        </div>
-        <div>
-          <label className="block text-xs text-text-muted mb-1">Context Window</label>
-          <select
-            value={claudeContextWindow}
-            onChange={(e) => setClaudeContextWindow(e.target.value)}
-            className={selectClass}
-          >
-            <option value="200k">200K tokens</option>
-            <option value="1m">1M tokens</option>
-          </select>
-        </div>
-        <div>
-          <label className="block text-xs text-text-muted mb-1">Effort Level</label>
-          <select
-            value={claudeEffort}
-            onChange={(e) => setClaudeEffort(e.target.value)}
-            className={selectClass}
-          >
-            <option value="low">Low</option>
-            <option value="medium">Medium</option>
-            <option value="high">High</option>
-          </select>
-        </div>
-        <div className="flex items-end pb-1">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={claudeThinking}
-              onChange={(e) => setClaudeThinking(e.target.checked)}
-              className="w-4 h-4 rounded"
-            />
-            <span className="text-sm">Extended Thinking</span>
-          </label>
-        </div>
-      </div>
+      <AgentOptionsPicker
+        provider="anthropic"
+        values={{
+          claudeModel,
+          claudeContextWindow,
+          claudeEffort,
+          claudeThinking,
+        }}
+        onChange={(v: AgentOptionsValues) => {
+          if (typeof v.claudeModel === "string") setClaudeModel(v.claudeModel);
+          if (typeof v.claudeContextWindow === "string")
+            setClaudeContextWindow(v.claudeContextWindow);
+          if (typeof v.claudeEffort === "string") setClaudeEffort(v.claudeEffort);
+          if (typeof v.claudeThinking === "boolean") setClaudeThinking(v.claudeThinking);
+        }}
+        inputClass={selectClass}
+      />
 
       <div className="grid grid-cols-2 gap-4">
         <div>
@@ -709,9 +680,15 @@ function ReviewStep({
                   onChange={(e) => setReviewModel(e.target.value)}
                   className={selectClass}
                 >
-                  <option value="sonnet">Sonnet 4.6</option>
-                  <option value="opus">Opus 4.7</option>
-                  <option value="haiku">Haiku 4.5</option>
+                  {Object.keys(ANTHROPIC_CATALOG.aliases).map((alias) => {
+                    const id = resolveModelId("anthropic", alias);
+                    const label = ANTHROPIC_CATALOG.models.find((m) => m.id === id)?.label ?? alias;
+                    return (
+                      <option key={alias} value={alias}>
+                        {label}
+                      </option>
+                    );
+                  })}
                 </select>
               </div>
             </div>

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -25,7 +25,12 @@ import {
   Github,
   KeyRound,
 } from "lucide-react";
-import { OPTIO_TOOL_CATEGORIES, ALL_OPTIO_TOOL_NAMES } from "@optio/shared";
+import {
+  OPTIO_TOOL_CATEGORIES,
+  ALL_OPTIO_TOOL_NAMES,
+  ANTHROPIC_CATALOG,
+  resolveModelId,
+} from "@optio/shared";
 import { NotificationPreferences } from "@/components/notifications/notification-preferences";
 
 function PromptTemplateEditor() {
@@ -199,9 +204,15 @@ function DefaultReviewEditor() {
             onChange={(e) => setReviewModel(e.target.value)}
             className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
           >
-            <option value="sonnet">Sonnet 4.6</option>
-            <option value="opus">Opus 4.7</option>
-            <option value="haiku">Haiku 4.5</option>
+            {Object.keys(ANTHROPIC_CATALOG.aliases).map((alias) => {
+              const id = resolveModelId("anthropic", alias);
+              const label = ANTHROPIC_CATALOG.models.find((m) => m.id === id)?.label ?? alias;
+              return (
+                <option key={alias} value={alias}>
+                  {label}
+                </option>
+              );
+            })}
           </select>
         </div>
       </div>
@@ -854,9 +865,15 @@ function OptioAgentSettings() {
           onChange={(e) => setModel(e.target.value)}
           className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
         >
-          <option value="opus">Opus — most capable, highest cost</option>
-          <option value="sonnet">Sonnet — balanced capability and cost</option>
-          <option value="haiku">Haiku — fastest, lowest cost</option>
+          {Object.keys(ANTHROPIC_CATALOG.aliases).map((alias) => {
+            const id = resolveModelId("anthropic", alias);
+            const label = ANTHROPIC_CATALOG.models.find((m) => m.id === id)?.label ?? alias;
+            return (
+              <option key={alias} value={alias}>
+                {label}
+              </option>
+            );
+          })}
         </select>
       </div>
 

--- a/apps/web/src/components/agent-options-picker.tsx
+++ b/apps/web/src/components/agent-options-picker.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { RefreshCw, AlertCircle } from "lucide-react";
+import {
+  getProviderCatalog,
+  groupModelsByFamily,
+  type AgentProviderId,
+  type ProviderCatalog,
+} from "@optio/shared";
+import { api } from "@/lib/api-client";
+
+/**
+ * Picker state — one map of field-name → value covering the model plus every
+ * provider-specific option. Keys match `ProviderCatalog.modelField` and
+ * `OptionField.key`, which in turn mirror the DB columns on `repos`.
+ */
+export type AgentOptionsValues = Record<string, string | boolean>;
+
+interface Props {
+  provider: AgentProviderId;
+  values: AgentOptionsValues;
+  onChange: (values: AgentOptionsValues) => void;
+  /** Optional class applied to all select/input controls. */
+  inputClass?: string;
+  /** Hide the Refresh button (e.g. in wizards). */
+  hideRefresh?: boolean;
+}
+
+const DEFAULT_INPUT_CLASS =
+  "w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20";
+
+interface LiveState {
+  catalog: ProviderCatalog;
+  source: "baseline" | "live";
+  cached: boolean;
+  refreshedAt: number | null;
+  error?: string;
+}
+
+function formatRefreshed(unixSeconds: number | null): string {
+  if (!unixSeconds) return "";
+  const ageMs = Date.now() - unixSeconds * 1000;
+  const ageMin = Math.floor(ageMs / 60_000);
+  if (ageMin < 1) return "just now";
+  if (ageMin < 60) return `${ageMin}m ago`;
+  const ageH = Math.floor(ageMin / 60);
+  if (ageH < 24) return `${ageH}h ago`;
+  return new Date(unixSeconds * 1000).toLocaleDateString();
+}
+
+/**
+ * Unified picker for every agent provider. Renders the model dropdown (or
+ * free-text input, for OpenCode/OpenClaw) plus provider-specific options like
+ * context window, effort, approval mode, extended-thinking, etc.
+ *
+ * Loads the hardcoded baseline synchronously on first paint, then fires
+ * `GET /api/agents/:provider/options` in the background to merge in a live
+ * list-models probe. A manual Refresh button invalidates the server cache.
+ */
+export function AgentOptionsPicker({
+  provider,
+  values,
+  onChange,
+  inputClass = DEFAULT_INPUT_CLASS,
+  hideRefresh = false,
+}: Props) {
+  const baseline = getProviderCatalog(provider);
+
+  const [live, setLive] = useState<LiveState | null>(
+    baseline ? { catalog: baseline, source: "baseline", cached: false, refreshedAt: null } : null,
+  );
+  const [refreshing, setRefreshing] = useState(false);
+  const didFetchForProvider = useRef<AgentProviderId | null>(null);
+
+  const fetchOptions = useCallback(
+    async (forceRefresh = false) => {
+      if (!baseline) return;
+      setRefreshing(true);
+      try {
+        const res = await api.getAgentProviderOptions(provider, {
+          refresh: forceRefresh,
+        });
+        setLive({
+          catalog: res.catalog as ProviderCatalog,
+          source: res.source,
+          cached: res.cached,
+          refreshedAt: res.refreshedAt,
+          error: res.error,
+        });
+      } catch (err) {
+        setLive((prev) =>
+          prev ? { ...prev, error: err instanceof Error ? err.message : "Refresh failed" } : null,
+        );
+      } finally {
+        setRefreshing(false);
+      }
+    },
+    [baseline, provider],
+  );
+
+  // Auto-fetch once per provider change. For providers that don't support
+  // live refresh the backend just echoes the baseline, which is cheap.
+  useEffect(() => {
+    if (didFetchForProvider.current === provider) return;
+    didFetchForProvider.current = provider;
+    fetchOptions(false).catch(() => {});
+  }, [provider, fetchOptions]);
+
+  if (!baseline) {
+    return <div className="text-xs text-text-muted italic">Unknown provider: {provider}</div>;
+  }
+
+  const catalog = live?.catalog ?? baseline;
+  const modelValue = String(values[catalog.modelField] ?? "");
+  const canRefresh = catalog.liveRefreshSupported && !hideRefresh;
+
+  const setField = (key: string, value: string | boolean) => {
+    onChange({ ...values, [key]: value });
+  };
+
+  const modelGroups = groupModelsByFamily(catalog);
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label className="block text-xs text-text-muted">Model</label>
+            {canRefresh && (
+              <button
+                type="button"
+                onClick={() => fetchOptions(true)}
+                disabled={refreshing}
+                title={
+                  live?.refreshedAt
+                    ? `Last refreshed ${formatRefreshed(live.refreshedAt)}`
+                    : "Refresh model list"
+                }
+                className="flex items-center gap-1 text-[10px] text-primary hover:underline disabled:opacity-50 disabled:cursor-wait"
+              >
+                <RefreshCw className={`w-3 h-3 ${refreshing ? "animate-spin" : ""}`} />
+                {refreshing ? "Refreshing" : "Refresh"}
+              </button>
+            )}
+          </div>
+          {catalog.modelIsFreeText ? (
+            <>
+              <input
+                value={modelValue}
+                onChange={(e) => setField(catalog.modelField, e.target.value)}
+                placeholder={catalog.modelPlaceholder ?? ""}
+                className={inputClass}
+              />
+              {catalog.modelHelpText && (
+                <p className="text-xs text-text-muted mt-1">{catalog.modelHelpText}</p>
+              )}
+            </>
+          ) : (
+            <select
+              value={modelValue}
+              onChange={(e) => setField(catalog.modelField, e.target.value)}
+              className={inputClass}
+            >
+              {!modelValue && <option value="">Default</option>}
+              {modelGroups.length === 1 && modelGroups[0].family === modelGroups[0].models[0].id
+                ? modelGroups[0].models.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.label}
+                      {m.preview ? " (Preview)" : ""}
+                      {m.source === "live" ? " •" : ""}
+                    </option>
+                  ))
+                : modelGroups.map((group) => (
+                    <optgroup key={group.family} label={group.family}>
+                      {group.models.map((m) => (
+                        <option key={m.id} value={m.id}>
+                          {m.label}
+                          {m.latest ? " (latest)" : ""}
+                          {m.preview ? " (Preview)" : ""}
+                          {m.source === "live" ? " •" : ""}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ))}
+            </select>
+          )}
+        </div>
+
+        {catalog.options
+          .filter((f) => f.kind === "select")
+          .map((field) => {
+            const v = values[field.key];
+            const val = typeof v === "string" ? v : String(field.default ?? "");
+            return (
+              <div key={field.key}>
+                <label className="block text-xs text-text-muted mb-1">{field.label}</label>
+                <select
+                  value={val}
+                  onChange={(e) => setField(field.key, e.target.value)}
+                  className={inputClass}
+                >
+                  {field.choices?.map((c) => (
+                    <option key={c.value} value={c.value}>
+                      {c.label}
+                    </option>
+                  ))}
+                </select>
+                {field.helpText && <p className="text-xs text-text-muted mt-1">{field.helpText}</p>}
+              </div>
+            );
+          })}
+
+        {catalog.options
+          .filter((f) => f.kind === "boolean")
+          .map((field) => {
+            const v = values[field.key];
+            const checked = typeof v === "boolean" ? v : Boolean(field.default);
+            return (
+              <div key={field.key} className="flex items-end pb-1">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(e) => setField(field.key, e.target.checked)}
+                    className="w-4 h-4 rounded"
+                  />
+                  <span className="text-sm">{field.label}</span>
+                </label>
+              </div>
+            );
+          })}
+      </div>
+
+      {catalog.options.some((f) => f.kind === "text") && (
+        <div className="space-y-3">
+          {catalog.options
+            .filter((f) => f.kind === "text")
+            .map((field) => {
+              const v = values[field.key];
+              const val = typeof v === "string" ? v : "";
+              return (
+                <div key={field.key}>
+                  <label className="block text-xs text-text-muted mb-1">{field.label}</label>
+                  <input
+                    value={val}
+                    onChange={(e) => setField(field.key, e.target.value)}
+                    placeholder={field.placeholder ?? ""}
+                    className={inputClass}
+                  />
+                  {field.helpText && (
+                    <p className="text-xs text-text-muted mt-1">{field.helpText}</p>
+                  )}
+                </div>
+              );
+            })}
+        </div>
+      )}
+
+      {live?.error && (
+        <p className="flex items-start gap-1 text-[10px] text-warning">
+          <AlertCircle className="w-3 h-3 mt-0.5 shrink-0" />
+          Live model list unavailable — showing built-in defaults. ({live.error})
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1587,4 +1587,27 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ params }),
     }),
+
+  // Agent Options — per-provider model & runtime-option catalog
+  getAgentProviderOptions: (provider: string, opts?: { refresh?: boolean }) => {
+    const qs = opts?.refresh ? "?refresh=true" : "";
+    return request<{
+      provider: string;
+      source: "baseline" | "live";
+      cached: boolean;
+      refreshedAt: number | null;
+      error?: string;
+      catalog: unknown;
+    }>(`/api/agents/${provider}/options${qs}`);
+  },
+
+  refreshAgentProviderOptions: (provider: string) =>
+    request<{
+      provider: string;
+      source: "baseline" | "live";
+      cached: boolean;
+      refreshedAt: number | null;
+      error?: string;
+      catalog: unknown;
+    }>(`/api/agents/${provider}/options/refresh`, { method: "POST" }),
 };

--- a/packages/shared/src/agent-options/agent-options.test.ts
+++ b/packages/shared/src/agent-options/agent-options.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import {
+  ALL_PROVIDER_IDS,
+  ANTHROPIC_CATALOG,
+  COPILOT_CATALOG,
+  GEMINI_CATALOG,
+  OPENAI_CATALOG,
+  OPENCLAW_CATALOG,
+  OPENCODE_CATALOG,
+  PROVIDER_CATALOGS,
+  getProviderCatalog,
+  groupModelsByFamily,
+  mergeLiveModels,
+  resolveModelId,
+} from "./index.js";
+
+describe("PROVIDER_CATALOGS", () => {
+  it("has a catalog for every provider id", () => {
+    for (const id of ALL_PROVIDER_IDS) {
+      expect(PROVIDER_CATALOGS[id]).toBeDefined();
+      expect(PROVIDER_CATALOGS[id].provider).toBe(id);
+    }
+  });
+
+  it("has exactly one `latest` model per family for auth-gated providers", () => {
+    for (const catalog of [ANTHROPIC_CATALOG, GEMINI_CATALOG]) {
+      const byFamily = new Map<string, number>();
+      for (const model of catalog.models) {
+        if (!model.latest) continue;
+        const key = model.family ?? model.id;
+        byFamily.set(key, (byFamily.get(key) ?? 0) + 1);
+      }
+      for (const count of byFamily.values()) {
+        expect(count).toBe(1);
+      }
+    }
+  });
+
+  it("marks free-text providers with modelIsFreeText", () => {
+    expect(OPENCODE_CATALOG.modelIsFreeText).toBe(true);
+    expect(OPENCLAW_CATALOG.modelIsFreeText).toBe(true);
+    expect(ANTHROPIC_CATALOG.modelIsFreeText).toBeFalsy();
+  });
+
+  it("flags which providers support live refresh", () => {
+    expect(ANTHROPIC_CATALOG.liveRefreshSupported).toBe(true);
+    expect(OPENAI_CATALOG.liveRefreshSupported).toBe(true);
+    expect(GEMINI_CATALOG.liveRefreshSupported).toBe(true);
+    expect(COPILOT_CATALOG.liveRefreshSupported).toBe(false);
+    expect(OPENCODE_CATALOG.liveRefreshSupported).toBe(false);
+    expect(OPENCLAW_CATALOG.liveRefreshSupported).toBe(false);
+  });
+
+  it("points each provider at a stable modelField", () => {
+    expect(ANTHROPIC_CATALOG.modelField).toBe("claudeModel");
+    expect(OPENAI_CATALOG.modelField).toBe("copilotModel");
+    expect(COPILOT_CATALOG.modelField).toBe("copilotModel");
+    expect(GEMINI_CATALOG.modelField).toBe("geminiModel");
+    expect(OPENCODE_CATALOG.modelField).toBe("opencodeModel");
+    expect(OPENCLAW_CATALOG.modelField).toBe("openclawModel");
+  });
+});
+
+describe("resolveModelId", () => {
+  it("resolves the opus alias to the latest dated id", () => {
+    expect(resolveModelId("anthropic", "opus")).toBe("claude-opus-4-7");
+  });
+
+  it("resolves the sonnet alias", () => {
+    expect(resolveModelId("anthropic", "sonnet")).toBe("claude-sonnet-4-6");
+  });
+
+  it("resolves the haiku alias", () => {
+    expect(resolveModelId("anthropic", "haiku")).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("returns an exact-match dated id unchanged", () => {
+    expect(resolveModelId("anthropic", "claude-sonnet-4-5")).toBe("claude-sonnet-4-5");
+  });
+
+  it("passes through unknown strings (future dated ids, free text)", () => {
+    // Simulates a dated id that shipped before we updated the baseline.
+    expect(resolveModelId("anthropic", "claude-opus-4-9-20990101")).toBe(
+      "claude-opus-4-9-20990101",
+    );
+  });
+
+  it("returns the latest-marked model when no input is provided", () => {
+    // Pick a provider with an explicit `latest` flag.
+    expect(resolveModelId("anthropic", undefined)).toBe("claude-opus-4-7");
+  });
+
+  it("returns undefined for free-text providers with no baseline models", () => {
+    expect(resolveModelId("opencode", undefined)).toBeUndefined();
+    expect(resolveModelId("openclaw", undefined)).toBeUndefined();
+  });
+
+  it("returns the input unchanged for free-text providers", () => {
+    expect(resolveModelId("opencode", "anthropic/claude-sonnet-4")).toBe(
+      "anthropic/claude-sonnet-4",
+    );
+  });
+
+  it("treats an empty string like undefined", () => {
+    expect(resolveModelId("anthropic", "")).toBe("claude-opus-4-7");
+  });
+
+  it("resolves gemini-pro alias", () => {
+    expect(resolveModelId("gemini", "gemini-pro")).toBe("gemini-3-pro");
+  });
+});
+
+describe("mergeLiveModels", () => {
+  it("appends new live model ids not in the baseline", () => {
+    const merged = mergeLiveModels(ANTHROPIC_CATALOG, [
+      "claude-opus-4-7",
+      "claude-opus-4-8-future",
+    ]);
+    const ids = merged.models.map((m) => m.id);
+    expect(ids).toContain("claude-opus-4-8-future");
+    // Original id is not duplicated
+    expect(ids.filter((id) => id === "claude-opus-4-7").length).toBe(1);
+  });
+
+  it("preserves baseline metadata when a live id matches", () => {
+    const opus = ANTHROPIC_CATALOG.models.find((m) => m.id === "claude-opus-4-7")!;
+    const merged = mergeLiveModels(ANTHROPIC_CATALOG, ["claude-opus-4-7"]);
+    const mergedOpus = merged.models.find((m) => m.id === "claude-opus-4-7")!;
+    expect(mergedOpus.label).toBe(opus.label);
+    expect(mergedOpus.latest).toBe(true);
+    expect(mergedOpus.source).toBe("baseline");
+  });
+
+  it("tags new live entries with source=live", () => {
+    const merged = mergeLiveModels(ANTHROPIC_CATALOG, ["claude-brand-new-id"]);
+    const added = merged.models.find((m) => m.id === "claude-brand-new-id");
+    expect(added).toBeDefined();
+    expect(added!.source).toBe("live");
+  });
+
+  it("returns the same reference when there are no additions", () => {
+    const merged = mergeLiveModels(ANTHROPIC_CATALOG, ["claude-opus-4-7"]);
+    expect(merged).toBe(ANTHROPIC_CATALOG);
+  });
+
+  it("dedupes within the live list", () => {
+    const merged = mergeLiveModels(ANTHROPIC_CATALOG, ["new-a", "new-a", "new-b"]);
+    const added = merged.models.filter((m) => m.source === "live");
+    expect(added.map((m) => m.id).sort()).toEqual(["new-a", "new-b"]);
+  });
+
+  it("skips empty/null-ish live ids", () => {
+    const merged = mergeLiveModels(ANTHROPIC_CATALOG, ["", "legit-id"]);
+    expect(merged.models.find((m) => m.id === "")).toBeUndefined();
+    expect(merged.models.find((m) => m.id === "legit-id")).toBeDefined();
+  });
+});
+
+describe("groupModelsByFamily", () => {
+  it("groups anthropic models by family", () => {
+    const groups = groupModelsByFamily(ANTHROPIC_CATALOG);
+    const families = groups.map((g) => g.family).sort();
+    expect(families).toEqual(["haiku", "opus", "sonnet"]);
+  });
+
+  it("falls back to the model id when there is no family", () => {
+    const groups = groupModelsByFamily({
+      provider: "anthropic",
+      label: "x",
+      modelField: "claudeModel",
+      models: [{ id: "solo", label: "Solo" }],
+      aliases: {},
+      options: [],
+      liveRefreshSupported: false,
+    });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].family).toBe("solo");
+  });
+});
+
+describe("getProviderCatalog", () => {
+  it("returns the catalog for a known provider", () => {
+    expect(getProviderCatalog("anthropic")).toBe(ANTHROPIC_CATALOG);
+  });
+
+  it("returns undefined for an unknown provider", () => {
+    expect(getProviderCatalog("nonexistent")).toBeUndefined();
+  });
+});

--- a/packages/shared/src/agent-options/anthropic.ts
+++ b/packages/shared/src/agent-options/anthropic.ts
@@ -1,0 +1,82 @@
+import type { ProviderCatalog } from "./types.js";
+
+/**
+ * Hardcoded baseline for Anthropic (Claude Code agent). Kept in sync with
+ * whatever model ids are currently deployed; the `/api/agents/anthropic/options`
+ * endpoint augments this list from Anthropic's `/v1/models` API.
+ */
+export const ANTHROPIC_CATALOG: ProviderCatalog = {
+  provider: "anthropic",
+  label: "Claude Code",
+  modelField: "claudeModel",
+  models: [
+    {
+      id: "claude-opus-4-7",
+      label: "Opus 4.7",
+      family: "opus",
+      latest: true,
+      source: "baseline",
+    },
+    {
+      id: "claude-opus-4-6",
+      label: "Opus 4.6",
+      family: "opus",
+      source: "baseline",
+    },
+    {
+      id: "claude-sonnet-4-6",
+      label: "Sonnet 4.6",
+      family: "sonnet",
+      latest: true,
+      source: "baseline",
+    },
+    {
+      id: "claude-sonnet-4-5",
+      label: "Sonnet 4.5",
+      family: "sonnet",
+      source: "baseline",
+    },
+    {
+      id: "claude-haiku-4-5-20251001",
+      label: "Haiku 4.5",
+      family: "haiku",
+      latest: true,
+      source: "baseline",
+    },
+  ],
+  aliases: {
+    opus: "claude-opus-4-7",
+    sonnet: "claude-sonnet-4-6",
+    haiku: "claude-haiku-4-5-20251001",
+  },
+  options: [
+    {
+      key: "claudeContextWindow",
+      label: "Context Window",
+      kind: "select",
+      default: "1m",
+      choices: [
+        { value: "200k", label: "200K tokens" },
+        { value: "1m", label: "1M tokens" },
+      ],
+    },
+    {
+      key: "claudeEffort",
+      label: "Effort Level",
+      kind: "select",
+      default: "high",
+      choices: [
+        { value: "low", label: "Low" },
+        { value: "medium", label: "Medium" },
+        { value: "high", label: "High" },
+      ],
+    },
+    {
+      key: "claudeThinking",
+      label: "Extended Thinking",
+      kind: "boolean",
+      default: true,
+    },
+  ],
+  liveRefreshSupported: true,
+};

--- a/packages/shared/src/agent-options/copilot.ts
+++ b/packages/shared/src/agent-options/copilot.ts
@@ -1,0 +1,62 @@
+import type { ProviderCatalog } from "./types.js";
+
+/**
+ * Hardcoded baseline for GitHub Copilot. Copilot CLI resolves models locally
+ * with no public list-models API, so this is the final source of truth (no
+ * live refresh to merge in).
+ */
+export const COPILOT_CATALOG: ProviderCatalog = {
+  provider: "copilot",
+  label: "GitHub Copilot",
+  modelField: "copilotModel",
+  models: [
+    {
+      id: "claude-sonnet-4.5",
+      label: "Claude Sonnet 4.5",
+      family: "sonnet",
+      source: "baseline",
+    },
+    {
+      id: "gpt-5",
+      label: "GPT-5",
+      family: "gpt-5",
+      source: "baseline",
+    },
+    {
+      id: "gpt-5.2",
+      label: "GPT-5.2",
+      family: "gpt-5",
+      source: "baseline",
+    },
+    {
+      id: "gpt-5.4",
+      label: "GPT-5.4",
+      family: "gpt-5",
+      latest: true,
+      source: "baseline",
+    },
+    {
+      id: "gpt-5.4-mini",
+      label: "GPT-5.4 Mini",
+      family: "gpt-5-mini",
+      latest: true,
+      source: "baseline",
+    },
+  ],
+  aliases: {},
+  options: [
+    {
+      key: "copilotEffort",
+      label: "Reasoning Effort",
+      kind: "select",
+      default: "",
+      choices: [
+        { value: "", label: "Default" },
+        { value: "low", label: "Low" },
+        { value: "medium", label: "Medium" },
+        { value: "high", label: "High" },
+      ],
+    },
+  ],
+  liveRefreshSupported: false,
+};

--- a/packages/shared/src/agent-options/gemini.ts
+++ b/packages/shared/src/agent-options/gemini.ts
@@ -1,0 +1,74 @@
+import type { ProviderCatalog } from "./types.js";
+
+export const GEMINI_CATALOG: ProviderCatalog = {
+  provider: "gemini",
+  label: "Google Gemini",
+  modelField: "geminiModel",
+  models: [
+    {
+      id: "gemini-2.0-flash",
+      label: "Gemini 2.0 Flash",
+      family: "gemini-flash",
+      source: "baseline",
+    },
+    {
+      id: "gemini-2.5-flash",
+      label: "Gemini 2.5 Flash",
+      family: "gemini-flash",
+      source: "baseline",
+    },
+    {
+      id: "gemini-2.5-pro",
+      label: "Gemini 2.5 Pro",
+      family: "gemini-pro",
+      source: "baseline",
+    },
+    {
+      id: "gemini-3-flash-preview",
+      label: "Gemini 3 Flash (Preview)",
+      family: "gemini-flash",
+      preview: true,
+      source: "baseline",
+    },
+    {
+      id: "gemini-3-pro",
+      label: "Gemini 3 Pro",
+      family: "gemini-pro",
+      latest: true,
+      source: "baseline",
+    },
+    {
+      id: "gemini-3.1-flash-lite-preview",
+      label: "Gemini 3.1 Flash Lite (Preview)",
+      family: "gemini-flash-lite",
+      latest: true,
+      preview: true,
+      source: "baseline",
+    },
+    {
+      id: "gemini-3.1-pro-preview",
+      label: "Gemini 3.1 Pro (Preview)",
+      family: "gemini-pro",
+      preview: true,
+      source: "baseline",
+    },
+  ],
+  aliases: {
+    "gemini-pro": "gemini-3-pro",
+    "gemini-flash": "gemini-2.5-flash",
+  },
+  options: [
+    {
+      key: "geminiApprovalMode",
+      label: "Approval Mode",
+      kind: "select",
+      default: "yolo",
+      choices: [
+        { value: "default", label: "Default" },
+        { value: "auto_edit", label: "Auto Edit" },
+        { value: "yolo", label: "Yolo (skip all approvals)" },
+      ],
+    },
+  ],
+  liveRefreshSupported: true,
+};

--- a/packages/shared/src/agent-options/index.ts
+++ b/packages/shared/src/agent-options/index.ts
@@ -1,0 +1,123 @@
+import { ANTHROPIC_CATALOG } from "./anthropic.js";
+import { OPENAI_CATALOG } from "./openai.js";
+import { GEMINI_CATALOG } from "./gemini.js";
+import { COPILOT_CATALOG } from "./copilot.js";
+import { OPENCODE_CATALOG } from "./opencode.js";
+import { OPENCLAW_CATALOG } from "./openclaw.js";
+import type { AgentProviderId, ModelOption, ProviderCatalog } from "./types.js";
+
+export type {
+  AgentProviderId,
+  ModelOption,
+  OptionChoice,
+  OptionField,
+  ProviderCatalog,
+} from "./types.js";
+export { ANTHROPIC_CATALOG } from "./anthropic.js";
+export { OPENAI_CATALOG } from "./openai.js";
+export { GEMINI_CATALOG } from "./gemini.js";
+export { COPILOT_CATALOG } from "./copilot.js";
+export { OPENCODE_CATALOG } from "./opencode.js";
+export { OPENCLAW_CATALOG } from "./openclaw.js";
+
+/** All providers, keyed by id. */
+export const PROVIDER_CATALOGS: Record<AgentProviderId, ProviderCatalog> = {
+  anthropic: ANTHROPIC_CATALOG,
+  openai: OPENAI_CATALOG,
+  gemini: GEMINI_CATALOG,
+  copilot: COPILOT_CATALOG,
+  opencode: OPENCODE_CATALOG,
+  openclaw: OPENCLAW_CATALOG,
+};
+
+export const ALL_PROVIDER_IDS: readonly AgentProviderId[] = [
+  "anthropic",
+  "openai",
+  "gemini",
+  "copilot",
+  "opencode",
+  "openclaw",
+];
+
+/**
+ * Resolve a possibly-aliased model string (e.g. `opus`, `sonnet`, a full dated
+ * id, or `undefined`) to a concrete model id for the given provider.
+ *
+ * Priority:
+ *   1. The input is a known alias → return the target id.
+ *   2. The input matches an existing model id in the catalog → return as-is.
+ *   3. The input is a non-empty string → return as-is (free-text providers,
+ *      or a dated id we haven't cataloged yet).
+ *   4. Empty/undefined → return the `latest` model of the first family, or
+ *      the first cataloged model, or `undefined` if the provider is free-text
+ *      with no defaults.
+ */
+export function resolveModelId(
+  providerId: AgentProviderId,
+  input: string | null | undefined,
+): string | undefined {
+  const catalog = PROVIDER_CATALOGS[providerId];
+  if (!catalog) return input ?? undefined;
+
+  if (input && catalog.aliases[input]) {
+    return catalog.aliases[input];
+  }
+
+  if (input) {
+    // Exact match against a cataloged model id
+    if (catalog.models.some((m) => m.id === input)) return input;
+    // Unknown string — pass through (covers free-text + uncataloged ids)
+    return input;
+  }
+
+  // No input → pick a sensible default
+  const latest = catalog.models.find((m) => m.latest);
+  if (latest) return latest.id;
+  const first = catalog.models[0];
+  return first?.id;
+}
+
+/**
+ * Merge a list of live model ids (from a provider's list-models API) into the
+ * hardcoded baseline. Live ids not present in the baseline are appended;
+ * existing entries are preserved so we don't lose labels/family metadata.
+ */
+export function mergeLiveModels(catalog: ProviderCatalog, liveIds: string[]): ProviderCatalog {
+  const known = new Set(catalog.models.map((m) => m.id));
+  const additions: ModelOption[] = [];
+  for (const id of liveIds) {
+    if (!id || known.has(id)) continue;
+    known.add(id);
+    additions.push({ id, label: id, source: "live" });
+  }
+  if (additions.length === 0) return catalog;
+  return {
+    ...catalog,
+    models: [...catalog.models, ...additions],
+  };
+}
+
+/**
+ * Group a catalog's models by family. Used by the UI to render grouped
+ * dropdowns (with the latest-of-family marker).
+ */
+export function groupModelsByFamily(
+  catalog: ProviderCatalog,
+): Array<{ family: string; models: ModelOption[] }> {
+  const groups = new Map<string, ModelOption[]>();
+  for (const model of catalog.models) {
+    const family = model.family ?? model.id;
+    const list = groups.get(family);
+    if (list) {
+      list.push(model);
+    } else {
+      groups.set(family, [model]);
+    }
+  }
+  return Array.from(groups.entries()).map(([family, models]) => ({ family, models }));
+}
+
+/** Return the catalog for a provider, or `undefined` for unknown providers. */
+export function getProviderCatalog(provider: string): ProviderCatalog | undefined {
+  return PROVIDER_CATALOGS[provider as AgentProviderId];
+}

--- a/packages/shared/src/agent-options/openai.ts
+++ b/packages/shared/src/agent-options/openai.ts
@@ -1,0 +1,55 @@
+import type { ProviderCatalog } from "./types.js";
+
+/**
+ * Hardcoded baseline for OpenAI (Codex agent). Lives under the `openai`
+ * provider id because the underlying list-models API is OpenAI's.
+ *
+ * NOTE: the DB column for this is `repos.copilotModel` — a historical naming
+ * quirk; see `docs/tasks.md`. We keep `modelField: "copilotModel"` here so
+ * the UI writes to the correct column.
+ */
+export const OPENAI_CATALOG: ProviderCatalog = {
+  provider: "openai",
+  label: "OpenAI Codex",
+  modelField: "copilotModel",
+  models: [
+    {
+      id: "gpt-5",
+      label: "GPT-5",
+      family: "gpt-5",
+      source: "baseline",
+    },
+    {
+      id: "gpt-5.2",
+      label: "GPT-5.2",
+      family: "gpt-5",
+      source: "baseline",
+    },
+    {
+      id: "gpt-5.4",
+      label: "GPT-5.4",
+      family: "gpt-5",
+      latest: true,
+      source: "baseline",
+    },
+    {
+      id: "gpt-5.4-mini",
+      label: "GPT-5.4 Mini",
+      family: "gpt-5-mini",
+      latest: true,
+      source: "baseline",
+    },
+    {
+      id: "claude-sonnet-4.5",
+      label: "Claude Sonnet 4.5",
+      family: "sonnet",
+      source: "baseline",
+    },
+  ],
+  aliases: {
+    "gpt-5": "gpt-5.4",
+    "gpt-5-mini": "gpt-5.4-mini",
+  },
+  options: [],
+  liveRefreshSupported: true,
+};

--- a/packages/shared/src/agent-options/openclaw.ts
+++ b/packages/shared/src/agent-options/openclaw.ts
@@ -1,0 +1,24 @@
+import type { ProviderCatalog } from "./types.js";
+
+/**
+ * OpenClaw wraps a downstream provider and accepts free-text model / agent
+ * identifiers. No public list-models API, so no live refresh.
+ */
+export const OPENCLAW_CATALOG: ProviderCatalog = {
+  provider: "openclaw",
+  label: "OpenClaw",
+  modelField: "openclawModel",
+  modelIsFreeText: true,
+  modelPlaceholder: "Default (auto-detect)",
+  models: [],
+  aliases: {},
+  options: [
+    {
+      key: "openclawAgent",
+      label: "Agent",
+      kind: "text",
+      placeholder: "Default",
+    },
+  ],
+  liveRefreshSupported: false,
+};

--- a/packages/shared/src/agent-options/opencode.ts
+++ b/packages/shared/src/agent-options/opencode.ts
@@ -1,0 +1,34 @@
+import type { ProviderCatalog } from "./types.js";
+
+/**
+ * OpenCode is a pass-through to a downstream provider (Anthropic, OpenAI,
+ * or a self-hosted OpenAI-compatible endpoint). Model selection is free-text
+ * because the full namespace looks like `<provider>/<model>`.
+ */
+export const OPENCODE_CATALOG: ProviderCatalog = {
+  provider: "opencode",
+  label: "OpenCode",
+  modelField: "opencodeModel",
+  modelIsFreeText: true,
+  modelPlaceholder: "Default (auto-detect)",
+  modelHelpText: "e.g. anthropic/claude-sonnet-4, openai/gpt-4o, meta-llama/Llama-3.1-70B",
+  models: [],
+  aliases: {},
+  options: [
+    {
+      key: "opencodeAgent",
+      label: "Agent",
+      kind: "text",
+      placeholder: "Default",
+    },
+    {
+      key: "opencodeBaseUrl",
+      label: "Custom Base URL",
+      kind: "text",
+      placeholder: "https://your-inference-server/v1",
+      helpText:
+        "OpenAI-compatible endpoint URL. When set, API keys are optional — a placeholder key is used if none is configured in Secrets.",
+    },
+  ],
+  liveRefreshSupported: false,
+};

--- a/packages/shared/src/agent-options/types.ts
+++ b/packages/shared/src/agent-options/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared types for per-provider agent options (models + runtime params).
+ *
+ * One `ProviderCatalog` per provider describes the full picker UI:
+ *   - `models` — selectable model IDs grouped by family, with the "latest"
+ *     of each family flagged (used by alias resolution and by the UI to pick
+ *     sensible defaults).
+ *   - `aliases` — short tokens (e.g. "opus", "sonnet") that resolve to the
+ *     latest dated id of a family at request time. Old DB rows continue to
+ *     work even after new dated models ship.
+ *   - `options` — other runtime enums (context window, thinking, effort,
+ *     approval mode, agent preset, etc.).
+ *   - `freeText` — fields that take arbitrary user input (e.g. OpenCode
+ *     model strings like `anthropic/claude-sonnet-4`, OpenCode base URL).
+ *
+ * The shape is stable across providers so the frontend can render any
+ * provider with a single `<AgentOptionsPicker>` component.
+ */
+
+export type AgentProviderId =
+  | "anthropic"
+  | "openai"
+  | "gemini"
+  | "copilot"
+  | "opencode"
+  | "openclaw";
+
+export interface ModelOption {
+  /** The canonical model id passed to the provider (e.g. "claude-opus-4-7"). */
+  id: string;
+  /** Human-readable label for the UI. */
+  label: string;
+  /** Family this model belongs to — aliases resolve to latest-of-family. */
+  family?: string;
+  /** True if this is the latest (preferred) model in its family. */
+  latest?: boolean;
+  /** True if this model is currently in preview. */
+  preview?: boolean;
+  /** Where this option came from — hardcoded baseline or live API probe. */
+  source?: "baseline" | "live";
+}
+
+export interface OptionChoice {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface OptionField {
+  /** Field key matching the DB column/form field (e.g. "claudeEffort"). */
+  key: string;
+  /** Human-readable label. */
+  label: string;
+  /** Control type. `select` = dropdown, `boolean` = checkbox, `text` = input. */
+  kind: "select" | "boolean" | "text";
+  /** Select choices (only for `kind: "select"`). */
+  choices?: OptionChoice[];
+  /** Default value applied when no repo override is set. */
+  default?: string | boolean;
+  /** Free-text placeholder. */
+  placeholder?: string;
+  /** Supplementary help text shown beneath the control. */
+  helpText?: string;
+}
+
+export interface ProviderCatalog {
+  provider: AgentProviderId;
+  /** Human-readable name — "Claude Code", "OpenAI Codex", etc. */
+  label: string;
+  /**
+   * DB column name that stores the selected model id. The `AgentOptionsPicker`
+   * reads/writes this field on the repo record.
+   */
+  modelField: string;
+  /** True if this provider's model field takes a free-text string instead of a select. */
+  modelIsFreeText?: boolean;
+  /** Placeholder for the free-text model field. */
+  modelPlaceholder?: string;
+  /** Help text rendered under the model field. */
+  modelHelpText?: string;
+  /** Alphabetical-ish display name for the model label in UI. */
+  models: ModelOption[];
+  /** Short aliases like `opus` → `claude-opus-4-7`. */
+  aliases: Record<string, string>;
+  /** Additional option fields (context window, effort, etc.). */
+  options: OptionField[];
+  /**
+   * True if the provider has a public list-models API the backend can call
+   * to augment the hardcoded baseline. Copilot/OpenCode/OpenClaw are false.
+   */
+  liveRefreshSupported: boolean;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -31,3 +31,4 @@ export * from "./reconcile/types.js";
 export * from "./reconcile/reconcile-standalone.js";
 export * from "./reconcile/reconcile-repo.js";
 export * from "./reconcile/reconcile-pr-review.js";
+export * from "./agent-options/index.js";


### PR DESCRIPTION
Closes #492

## What changed

Introduces a unified, three-layer provider-options system that replaces the scattered hardcoded model dropdowns across the web UI.

### 1. Hardcoded baselines — `packages/shared/src/agent-options/`

Per-provider catalog for Claude Code (Anthropic), OpenAI Codex, Google Gemini, GitHub Copilot, OpenCode, and OpenClaw. Each catalog declares:

- Models (id, label, family, `latest` flag, `preview` flag, `source`).
- Aliases (e.g. `opus` → `claude-opus-4-7`) resolved at request time.
- Option fields (context window, effort, approval mode, extended thinking, agent preset, custom base URL) as typed select/boolean/text descriptors.
- A `liveRefreshSupported` flag — only Anthropic/OpenAI/Gemini have public list-models APIs; Copilot/OpenCode/OpenClaw are hardcoded-only.

The baseline matches today's UI contents (keeps the Opus 4.7 / Sonnet 4.6 / Haiku 4.5 mapping, the full Gemini 2.x / 3.x / 3.1 preview list, the GPT-5.x family, etc.).

### 2. API — `GET /api/agents/:provider/options`

Returns the catalog, optionally augmented by a live probe of Anthropic `/v1/models`, OpenAI `/v1/models`, or Gemini `/v1beta/models`. Probes are cached in Redis for ~1h, keyed by provider + SHA-256(apiKey) so key rotation auto-invalidates. Failing probes fall back to the baseline and surface the error in the response.

`POST /api/agents/:provider/options/refresh` is an admin-only shortcut for the UI's Refresh button.

### 3. React — `<AgentOptionsPicker provider={...} />`

One component replaces the dropdown blocks in:

- `apps/web/src/app/repos/new/page.tsx` (Step 3 — Agent Settings)
- `apps/web/src/app/repos/[id]/page.tsx` (Claude, Copilot, Gemini, OpenCode, OpenClaw tabs)
- `apps/web/src/app/settings/page.tsx` (OptioAgent model + Default Review Model use the same catalog for label consistency)

The picker auto-fetches once per provider change and exposes a manual Refresh button (hidden for providers without live-refresh support). Models are grouped by family in `<optgroup>`s with `(latest)` / `(Preview)` / `•` (live-discovered) markers. If the live probe fails, a warning banner surfaces the error and the baseline stays visible.

### 4. Alias resolution in `optio-chat.ts`

Replaces the local `ANTHROPIC_MODEL_MAP` with `resolveModelId("anthropic", settings.model)` so old alias values in the DB (`sonnet`, etc.) resolve to the current dated id at request time — no DB rewrite needed.

## Scope boundaries

- DB columns (`repos.claudeModel`, `copilotModel`, `geminiModel`, `opencodeModel`, `openclawModel`, option columns) are unchanged; the picker reads/writes them via existing form state.
- `task-worker.ts` paths that consume resolved model strings are unchanged.
- Per-task override columns and full capability metadata (pricing, token limits) are out of scope per the task spec.

## How to test

- `pnpm turbo typecheck` — 12/12 packages clean.
- `pnpm turbo test` — 1995 tests pass, including 25 new `agent-options` shared tests + 14 new API route/service tests.
- `pnpm format:check` — clean.
- `cd apps/web && npx next build` — clean.
- Manual: open `/repos/new` → Step 3, `/repos/:id` → switch through each agent tab, `/settings` → OptioAgent + Default Review Model. Confirm the Refresh button spins and (with an Anthropic key configured) new live-only models appear with a `•` marker.