### PR TITLE
feat(workspaces): add member management UI with email lookup

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,0 +1,76 @@
+import type { FastifyInstance } from "fastify";
+import type { ZodTypeProvider } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { db } from "../db/client.js";
+import { users } from "../db/schema.js";
+import { eq } from "drizzle-orm";
+import { ErrorResponseSchema } from "../schemas/common.js";
+import { getUserRole } from "../services/workspace-service.js";
+
+const UserLookupResponseSchema = z.object({
+  user: z.object({
+    id: z.string().uuid(),
+    email: z.string(),
+    displayName: z.string(),
+    avatarUrl: z.string().nullable(),
+  }),
+});
+
+export async function userRoutes(rawApp: FastifyInstance) {
+  const app = rawApp.withTypeProvider<ZodTypeProvider>();
+
+  app.get(
+    "/api/users/lookup",
+    {
+      schema: {
+        operationId: "lookupUserByEmail",
+        summary: "Lookup user by email",
+        description: "Find a user by their email address. Restricted to workspace admins.",
+        tags: ["Users"],
+        querystring: z.object({
+          email: z.string().email(),
+        }),
+        response: {
+          200: UserLookupResponseSchema,
+          400: ErrorResponseSchema,
+          401: ErrorResponseSchema,
+          403: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      if (!req.user) {
+        return reply.status(401).send({ error: "Authentication required" });
+      }
+
+      const workspaceId = req.user.workspaceId;
+      if (!workspaceId) {
+        return reply.status(400).send({ error: "No workspace context" });
+      }
+
+      // Check if current user is admin in this workspace
+      const role = await getUserRole(workspaceId, req.user.id);
+      if (role !== "admin") {
+        return reply.status(403).send({ error: "Only admins can look up users by email" });
+      }
+
+      const { email } = req.query;
+      const [user] = await db
+        .select({
+          id: users.id,
+          email: users.email,
+          displayName: users.displayName,
+          avatarUrl: users.avatarUrl,
+        })
+        .from(users)
+        .where(eq(users.email, email));
+
+      if (!user) {
+        return reply.status(404).send({ error: "User not found" });
+      }
+
+      return { user };
+    },
+  );
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -39,6 +39,7 @@ import { messageRoutes } from "./routes/messages.js";
 import { slackRoutes } from "./routes/slack.js";
 
 import { workspaceRoutes } from "./routes/workspaces.js";
+import { userRoutes } from "./routes/users.js";
 import { dependencyRoutes } from "./routes/dependencies.js";
 import { workflowTriggerRoutes } from "./routes/workflow-triggers.js";
 import { mcpServerRoutes } from "./routes/mcp-servers.js";
@@ -273,6 +274,7 @@ export async function buildServer() {
   await app.register(messageRoutes);
   await app.register(slackRoutes);
   await app.register(workspaceRoutes);
+  await app.register(userRoutes);
   await app.register(dependencyRoutes);
   await app.register(workflowTriggerRoutes);
   await app.register(mcpServerRoutes);

--- a/apps/web/src/app/workspace-settings/page.tsx
+++ b/apps/web/src/app/workspace-settings/page.tsx
@@ -155,6 +155,7 @@ function MemberManagement() {
   const [loading, setLoading] = useState(true);
   const [addingEmail, setAddingEmail] = useState("");
   const [addingRole, setAddingRole] = useState("member");
+  const [isAdding, setIsAdding] = useState(false);
 
   useEffect(() => {
     const wsId = localStorage.getItem("optio_workspace_id");
@@ -198,6 +199,38 @@ function MemberManagement() {
       toast.error("Failed to remove member", {
         description: err instanceof Error ? err.message : undefined,
       });
+    }
+  };
+
+  const handleAddMember = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!wsId || !addingEmail || isAdding) return;
+
+    setIsAdding(true);
+    try {
+      // 1. Lookup user by email
+      const { user } = await api.lookupUserByEmail(addingEmail);
+
+      // 2. Check if already a member
+      if (members.some((m) => m.userId === user.id)) {
+        toast.error("User is already a member of this workspace");
+        return;
+      }
+
+      // 3. Add member
+      await api.addWorkspaceMember(wsId, user.id, addingRole);
+
+      // 4. Refresh list
+      const { members: updatedMembers } = await api.listWorkspaceMembers(wsId);
+      setMembers(updatedMembers);
+      setAddingEmail("");
+      toast.success(`${user.displayName} added to workspace`);
+    } catch (err) {
+      toast.error("Failed to add member", {
+        description: err instanceof Error ? err.message : "User not found",
+      });
+    } finally {
+      setIsAdding(false);
     }
   };
 
@@ -270,10 +303,48 @@ function MemberManagement() {
         ))}
       </div>
       {isAdmin && (
-        <p className="text-xs text-text-muted">
-          To add new members, they must first sign in to Optio. You can then add them by their user
-          ID from the API.
-        </p>
+        <div className="pt-4 border-t border-border/50">
+          <p className="text-xs font-medium text-text-muted mb-3 flex items-center gap-1.5">
+            <UserPlus className="w-3.5 h-3.5" /> Add New Member
+          </p>
+          <form onSubmit={handleAddMember} className="flex flex-wrap gap-2">
+            <div className="flex-1 min-w-[200px]">
+              <input
+                type="email"
+                placeholder="user@example.com"
+                value={addingEmail}
+                onChange={(e) => setAddingEmail(e.target.value)}
+                required
+                className="w-full px-3 py-1.5 rounded-lg bg-bg border border-border text-xs focus:outline-none focus:border-primary"
+              />
+            </div>
+            <select
+              value={addingRole}
+              onChange={(e) => setAddingRole(e.target.value)}
+              className="text-xs px-2 py-1.5 rounded border border-border bg-bg focus:outline-none focus:border-primary"
+            >
+              <option value="member">Member</option>
+              <option value="admin">Admin</option>
+              <option value="viewer">Viewer</option>
+            </select>
+            <button
+              type="submit"
+              disabled={isAdding || !addingEmail}
+              className="px-4 py-1.5 rounded-md bg-primary text-white text-xs font-medium hover:bg-primary-hover disabled:opacity-50 flex items-center gap-2"
+            >
+              {isAdding ? (
+                <>
+                  <Loader2 className="w-3 h-3 animate-spin" /> Adding...
+                </>
+              ) : (
+                "Add Member"
+              )}
+            </button>
+          </form>
+          <p className="text-[10px] text-text-muted mt-2">
+            The user must have signed in to Optio at least once to be found.
+          </p>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -728,6 +728,17 @@ export const api = {
 
   logout: () => request<{ ok: boolean }>("/api/auth/logout", { method: "POST" }),
 
+  // Users
+  lookupUserByEmail: (email: string) =>
+    request<{
+      user: {
+        id: string;
+        email: string;
+        displayName: string;
+        avatarUrl: string | null;
+      };
+    }>(`/api/users/lookup?email=${encodeURIComponent(email)}`),
+
   // Interactive Sessions
   listSessions: (params?: {
     repoUrl?: string;


### PR DESCRIPTION
Add a functional member management UI that allows workspace admins to add members by email address. This replaces the previous manual ID-based process with a secure lookup flow.

### Features

**User Lookup API (new)**
- Centralized endpoint to resolve user details (ID, name, avatar) from an email address.
- Restricted to users with the "admin" role in the current workspace.
- Returns 404 with a clear error message if the user has never signed in to Optio.

**Enhanced Member Management UI**
- New "Add Member" form in workspace settings.
- Integrated two-step flow: resolves email to UUID then adds member with selected role.
- Prevents adding users who are already members.
- Responsive design with loading states and toast notifications.

### Changes

**Backend (`apps/api/src`)**
- `routes/users.ts` (NEW): Implements the `GET /api/users/lookup` endpoint with role-based access control.
- `server.ts`: Registers the new user routes.

**Frontend (`apps/web/src`)**
- `lib/api-client.ts`: Added `lookupUserByEmail` to the core API client.
- `app/workspace-settings/page.tsx`: Implemented the member addition form and integrated the lookup logic into the `MemberManagement` component.

### Fixes
- Replaces placeholder text in settings that required users to use the API manually to add members.
- Improves error handling when adding members by providing specific feedback (e.g., "User not found" vs "Already a member").

### Testing
✅ Manual testing: Verified admin can look up and add existing users by email.
✅ Manual testing: Verified non-admins cannot access the lookup endpoint.
✅ Manual testing: Verified error handling for non-existent emails and duplicate members.
✅ Type safety: `pnpm typecheck` passed for all modified files.