### PR TITLE
Follow-ups for member-by-email lookup (#496)

### DIFF
--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildRouteTestApp } from "../test-utils/build-route-test-app.js";
+
+// ─── Mocks ───
+
+const mockGetUserRole = vi.fn();
+
+vi.mock("../services/workspace-service.js", () => ({
+  getUserRole: (...args: unknown[]) => mockGetUserRole(...args),
+}));
+
+const mockDbSelect = vi.fn();
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: (...args: unknown[]) => mockDbSelect(...args),
+      }),
+    }),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  users: {
+    id: "users.id",
+    email: "users.email",
+    displayName: "users.display_name",
+    avatarUrl: "users.avatar_url",
+  },
+}));
+
+import { userRoutes } from "./users.js";
+
+// ─── Helpers ───
+
+async function buildTestApp(
+  user: {
+    id: string;
+    workspaceId: string | null;
+    workspaceRole: "admin" | "member" | "viewer";
+  } | null = {
+    id: "user-1",
+    workspaceId: "ws-1",
+    workspaceRole: "admin",
+  },
+): Promise<FastifyInstance> {
+  return buildRouteTestApp(userRoutes, { user });
+}
+
+describe("GET /api/users/lookup", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns 200 with the user when admin and email matches", async () => {
+    mockGetUserRole.mockResolvedValue("admin");
+    mockDbSelect.mockResolvedValue([
+      {
+        id: "00000000-0000-0000-0000-000000000099",
+        email: "found@example.com",
+        displayName: "Found User",
+        avatarUrl: null,
+      },
+    ]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/users/lookup?email=found@example.com",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().user).toEqual({
+      id: "00000000-0000-0000-0000-000000000099",
+      email: "found@example.com",
+      displayName: "Found User",
+      avatarUrl: null,
+    });
+    expect(mockGetUserRole).toHaveBeenCalledWith("ws-1", "user-1");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const unauthApp = await buildTestApp(null);
+
+    const res = await unauthApp.inject({
+      method: "GET",
+      url: "/api/users/lookup?email=anyone@example.com",
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(mockGetUserRole).not.toHaveBeenCalled();
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the session has no workspaceId", async () => {
+    const noWsApp = await buildTestApp({
+      id: "user-1",
+      workspaceId: null,
+      workspaceRole: "admin",
+    });
+
+    const res = await noWsApp.inject({
+      method: "GET",
+      url: "/api/users/lookup?email=anyone@example.com",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(mockGetUserRole).not.toHaveBeenCalled();
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is a member (not admin)", async () => {
+    mockGetUserRole.mockResolvedValue("member");
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/users/lookup?email=anyone@example.com",
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is a viewer (not admin)", async () => {
+    mockGetUserRole.mockResolvedValue("viewer");
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/users/lookup?email=anyone@example.com",
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is not a member of the workspace at all", async () => {
+    mockGetUserRole.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/users/lookup?email=anyone@example.com",
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when no user has the given email", async () => {
+    mockGetUserRole.mockResolvedValue("admin");
+    mockDbSelect.mockResolvedValue([]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/users/lookup?email=missing@example.com",
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toMatch(/not found/i);
+  });
+
+  it("returns 400 when email querystring is missing", async () => {
+    mockGetUserRole.mockResolvedValue("admin");
+
+    const res = await app.inject({ method: "GET", url: "/api/users/lookup" });
+
+    expect(res.statusCode).toBe(400);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when email querystring is malformed", async () => {
+    mockGetUserRole.mockResolvedValue("admin");
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/users/lookup?email=not-an-email",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -10,7 +10,7 @@ import { getUserRole } from "../services/workspace-service.js";
 const UserLookupResponseSchema = z.object({
   user: z.object({
     id: z.string().uuid(),
-    email: z.string(),
+    email: z.string().email(),
     displayName: z.string(),
     avatarUrl: z.string().nullable(),
   }),

--- a/apps/api/src/routes/workspaces.test.ts
+++ b/apps/api/src/routes/workspaces.test.ts
@@ -272,4 +272,18 @@ describe("workspace members", () => {
 
     expect(res.statusCode).toBe(404);
   });
+
+  it("POST /api/workspaces/:id/members returns 409 when user is already a member", async () => {
+    mockGetUserRole.mockResolvedValue("admin");
+    mockAddMember.mockRejectedValue(new Error("User is already a member of this workspace"));
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/workspaces/ws-1/members",
+      payload: { userId: "00000000-0000-0000-0000-000000000002", role: "member" },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toMatch(/already a member/i);
+  });
 });

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -248,7 +248,9 @@ export async function workspaceRoutes(rawApp: FastifyInstance) {
         summary: "Add a member to a workspace",
         description:
           "Add an existing user to a workspace with the given role. Requires " +
-          "admin role. Returns 404 if the target user does not exist.",
+          "admin role. Returns 404 if the target user does not exist, and 409 " +
+          "if the user is already a member (use the role-update endpoint to " +
+          "change an existing member's role).",
         tags: ["Workspaces"],
         params: IdParamsSchema,
         body: addMemberSchema,
@@ -257,6 +259,7 @@ export async function workspaceRoutes(rawApp: FastifyInstance) {
           401: ErrorResponseSchema,
           403: ErrorResponseSchema,
           404: ErrorResponseSchema,
+          409: ErrorResponseSchema,
         },
       },
     },
@@ -273,6 +276,9 @@ export async function workspaceRoutes(rawApp: FastifyInstance) {
         const msg = err instanceof Error ? err.message : String(err);
         if (msg === "User not found") {
           return reply.status(404).send({ error: "User not found" });
+        }
+        if (msg === "User is already a member of this workspace") {
+          return reply.status(409).send({ error: msg });
         }
         throw err;
       }

--- a/apps/api/src/services/workspace-service.test.ts
+++ b/apps/api/src/services/workspace-service.test.ts
@@ -285,7 +285,9 @@ describe("workspace-service", () => {
 
       (db.insert as any) = vi.fn().mockReturnValue({
         values: vi.fn().mockReturnValue({
-          onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: "m-1" }]),
+          }),
         }),
       });
 
@@ -301,6 +303,27 @@ describe("workspace-service", () => {
       });
 
       await expect(addMember("ws-1", "nonexistent")).rejects.toThrow("User not found");
+    });
+
+    it("throws when membership already exists", async () => {
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "user-1" }]),
+        }),
+      });
+
+      // onConflictDoNothing + returning yields [] when the row already exists
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      await expect(addMember("ws-1", "user-1", "member")).rejects.toThrow(
+        "User is already a member of this workspace",
+      );
     });
   });
 

--- a/apps/api/src/services/workspace-service.ts
+++ b/apps/api/src/services/workspace-service.ts
@@ -123,7 +123,11 @@ export async function listMembers(workspaceId: string): Promise<WorkspaceMemberW
   return rows as WorkspaceMemberWithUser[];
 }
 
-/** Add a user to a workspace. */
+/**
+ * Add a user to a workspace. Throws "User not found" if the target user
+ * does not exist, and "User is already a member" if the membership already
+ * exists. Use {@link updateMemberRole} to change an existing member's role.
+ */
 export async function addMember(
   workspaceId: string,
   userId: string,
@@ -135,13 +139,19 @@ export async function addMember(
     throw new Error("User not found");
   }
 
-  await db
+  // onConflictDoNothing + returning lets us distinguish a fresh insert from
+  // an existing membership without racing against concurrent admins.
+  const inserted = await db
     .insert(workspaceMembers)
     .values({ workspaceId, userId, role })
-    .onConflictDoUpdate({
+    .onConflictDoNothing({
       target: [workspaceMembers.workspaceId, workspaceMembers.userId],
-      set: { role },
-    });
+    })
+    .returning({ id: workspaceMembers.id });
+
+  if (inserted.length === 0) {
+    throw new Error("User is already a member of this workspace");
+  }
 }
 
 /** Update a member's role. Revokes sessions to force re-authentication with updated privileges. */

--- a/apps/web/src/app/workspace-settings/page.tsx
+++ b/apps/web/src/app/workspace-settings/page.tsx
@@ -208,26 +208,19 @@ function MemberManagement() {
 
     setIsAdding(true);
     try {
-      // 1. Lookup user by email
+      // Look the user up by email, then add them. The duplicate-member check
+      // is enforced server-side (409 from POST /members) so a stale local
+      // `members` list can't accidentally re-add someone with a new role.
       const { user } = await api.lookupUserByEmail(addingEmail);
-
-      // 2. Check if already a member
-      if (members.some((m) => m.userId === user.id)) {
-        toast.error("User is already a member of this workspace");
-        return;
-      }
-
-      // 3. Add member
       await api.addWorkspaceMember(wsId, user.id, addingRole);
 
-      // 4. Refresh list
       const { members: updatedMembers } = await api.listWorkspaceMembers(wsId);
       setMembers(updatedMembers);
       setAddingEmail("");
       toast.success(`${user.displayName} added to workspace`);
     } catch (err) {
       toast.error("Failed to add member", {
-        description: err instanceof Error ? err.message : "User not found",
+        description: err instanceof Error ? err.message : undefined,
       });
     } finally {
       setIsAdding(false);


### PR DESCRIPTION
Closes #498

Follow-ups from the review of #496 (member management UI with email lookup). None blocking; addressed in priority order.

## What changed

### 1. Tests for `GET /api/users/lookup` (new `users.test.ts`)
The new route had no test coverage. Added a route test mirroring the
pattern in `workspaces.test.ts` covering:
- 200 — admin in current workspace, user exists
- 401 — unauthenticated
- 400 — no `workspaceId` on the session
- 403 — caller is a member / viewer / non-member (three cases)
- 404 — email doesn't match any user
- 400 — missing or malformed `email` querystring (Zod rejection)

### 2. Server-side duplicate-member 409
`workspaceService.addMember` previously used `onConflictDoUpdate`, which
silently overwrites the role on duplicate. If the client-side `members`
list was stale (race, second tab, refresh-skipped), an admin could
unintentionally promote/demote an existing member without confirmation.

- Switched to `onConflictDoNothing` + `returning()`; zero rows returned
  ⇒ membership already existed ⇒ throw `"User is already a member of
  this workspace"`. This is race-safe across concurrent admin attempts.
- `POST /api/workspaces/:id/members` route now maps that error to **409
  Conflict** (response schema updated). Existing 404 mapping for
  unknown user is preserved.
- `MemberManagement` in the workspace settings page no longer
  pre-checks `members.some(...)` — server is the single source of
  truth. Role changes still go through the dedicated `PATCH
  /members/:userId` endpoint.

### 3. Schema tightening
`UserLookupResponseSchema.email` was `z.string()` while the querystring
input was `z.string().email()`. Bumped the response field to
`z.string().email()` for consistency.

### 4. Toast fallback
The "Failed to add member" toast hardcoded `"User not found"` as the
description for any non-`Error` throw — misleading for 403 / network /
409 failures. Changed to `undefined` so only real `Error.message`
values surface.

## Skipped
- **#3 from the task — workspace-scoping the lookup.** Left as-is per
  the task's recommendation; the current global lookup matches the
  intended UX (an admin doesn't yet know which workspace a target user
  belongs to). Reaffirming this as a conscious choice.

## How to test
- `pnpm turbo typecheck` ✓
- `pnpm turbo test` — 2011 tests pass ✓
- `pnpm format:check` ✓
- Manually: as an admin, try to add an already-existing member by
  email — toast should now say "User is already a member of this
  workspace" (sourced from the 409 response body) instead of the
  client-side message. Role of the existing member is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)