### PR TITLE
feat(reviews): agent-aware review configuration

### DIFF
--- a/apps/api/src/db/migrations/1777186008_review_agent_type.sql
+++ b/apps/api/src/db/migrations/1777186008_review_agent_type.sql
@@ -1,0 +1,22 @@
+-- Agent-aware review configuration.
+--
+-- Adds the ability to pick the review agent independently of the coding agent.
+-- See `apps/api/src/services/review-config.ts` for the resolution order.
+--
+-- New columns:
+--   repos.review_agent_type            -- per-repo override; NULL = inherit
+--   optio_settings.default_review_agent_type
+--   optio_settings.default_review_model
+--
+-- All NULL by default. Existing repos keep their current behaviour: when
+-- review_agent_type is NULL the resolver falls through to repos.default_agent_type
+-- (or claude-code), so reviews continue to run on Claude as they do today.
+
+ALTER TABLE "repos"
+  ADD COLUMN IF NOT EXISTS "review_agent_type" text;
+
+ALTER TABLE "optio_settings"
+  ADD COLUMN IF NOT EXISTS "default_review_agent_type" text;
+
+ALTER TABLE "optio_settings"
+  ADD COLUMN IF NOT EXISTS "default_review_model" text;

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -516,6 +516,13 @@
     {
       "idx": 73,
       "version": "7",
+      "when": 1777186008000,
+      "tag": "1777186008_review_agent_type",
+      "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
       "when": 1777200000000,
       "tag": "1777200000_custom_skills_agent_types_files",
       "breakpoints": true

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -283,6 +283,7 @@ export const repos = pgTable(
     reviewTrigger: text("review_trigger").default("on_ci_pass"), // "manual" | "on_pr" | "on_ci_pass"
     reviewPromptTemplate: text("review_prompt_template"), // null = use default
     testCommand: text("test_command"), // "npm test", "cargo test", etc.
+    reviewAgentType: text("review_agent_type"), // null = inherit (defaultAgentType / global)
     reviewModel: text("review_model").default("sonnet"), // can use cheaper model for reviews
     // External (non-optio-authored) PR auto-review
     externalReviewMode: text("external_review_mode").notNull().default("off"), // "off" | "on_request" | "on_pr_hold" | "on_pr_post"
@@ -868,6 +869,10 @@ export const optioSettings = pgTable(
     enabledTools: jsonb("enabled_tools").$type<string[]>().notNull().default([]), // empty = all enabled
     confirmWrites: boolean("confirm_writes").notNull().default(true),
     maxTurns: integer("max_turns").notNull().default(20),
+    // Review-agent defaults applied when a repo doesn't override them.
+    // NULL means "fall back to repo's defaultAgentType / catalog default".
+    defaultReviewAgentType: text("default_review_agent_type"),
+    defaultReviewModel: text("default_review_model"),
     workspaceId: uuid("workspace_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/apps/api/src/routes/optio-settings.ts
+++ b/apps/api/src/routes/optio-settings.ts
@@ -3,6 +3,8 @@ import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import * as optioSettingsService from "../services/optio-settings-service.js";
 import { logAction } from "../services/optio-action-service.js";
+import { AGENT_TYPES, modelBelongsToAgentCatalog } from "@optio/shared";
+import { ErrorResponseSchema } from "../schemas/common.js";
 
 const updateSettingsSchema = z
   .object({
@@ -18,6 +20,16 @@ const updateSettingsSchema = z
       .describe("Subset of tools the assistant is allowed to use"),
     confirmWrites: z.boolean().optional().describe("If true, prompt before write operations"),
     maxTurns: z.number().int().min(5).max(50).optional(),
+    defaultReviewAgentType: z
+      .enum([...AGENT_TYPES] as [string, ...string[]])
+      .nullable()
+      .optional()
+      .describe("Workspace-level default agent for code reviews; null to clear"),
+    defaultReviewModel: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Workspace-level default review model; null to clear"),
   })
   .describe("Partial update to Optio assistant settings");
 
@@ -55,16 +67,29 @@ export async function optioSettingsRoutes(rawApp: FastifyInstance) {
           "enabled tools, confirm-writes flag, max turns.",
         tags: ["Setup & Settings"],
         body: updateSettingsSchema,
-        response: { 200: SettingsResponseSchema },
+        response: { 200: SettingsResponseSchema, 400: ErrorResponseSchema },
       },
     },
     async (req, reply) => {
+      const body = req.body;
+
+      // Mirror the per-repo validation: a default review model only makes
+      // sense in the context of an explicit agent. If both fields are
+      // provided, the model must belong to that agent's catalog.
+      if (body.defaultReviewAgentType && body.defaultReviewModel) {
+        if (!modelBelongsToAgentCatalog(body.defaultReviewAgentType, body.defaultReviewModel)) {
+          return reply.status(400).send({
+            error: `Default review model "${body.defaultReviewModel}" does not belong to the "${body.defaultReviewAgentType}" catalog.`,
+          });
+        }
+      }
+
       const workspaceId = req.user?.workspaceId ?? null;
-      const settings = await optioSettingsService.upsertSettings(req.body, workspaceId);
+      const settings = await optioSettingsService.upsertSettings(body, workspaceId);
       logAction({
         userId: req.user?.id,
         action: "settings.update",
-        params: { ...req.body },
+        params: { ...body },
         result: {},
         success: true,
       }).catch(() => {});

--- a/apps/api/src/routes/repos.ts
+++ b/apps/api/src/routes/repos.ts
@@ -8,6 +8,8 @@ import {
   validateRequestLimitPair,
   parseCpuMillicores,
   parseMemoryMi,
+  AGENT_TYPES,
+  modelBelongsToAgentCatalog,
 } from "@optio/shared";
 import { requireRole } from "../plugins/auth.js";
 import { getGitHubToken } from "../services/github-token-service.js";
@@ -15,6 +17,8 @@ import { isSsrfSafeUrl } from "../utils/ssrf.js";
 import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import { RepoSchema } from "../schemas/integration.js";
+import { resolveReviewConfig } from "../services/review-config.js";
+import * as optioSettingsService from "../services/optio-settings-service.js";
 
 const createRepoSchema = z
   .object({
@@ -59,6 +63,11 @@ const updateRepoSchema = z
     reviewTrigger: z.string().optional(),
     reviewPromptTemplate: z.string().nullable().optional(),
     testCommand: z.string().optional(),
+    reviewAgentType: z
+      .enum([...AGENT_TYPES] as [string, ...string[]])
+      .nullable()
+      .optional()
+      .describe("Override the agent used for code reviews. Null = inherit."),
     reviewModel: z.string().optional(),
     externalReviewMode: z.enum(["off", "on_request", "on_pr_hold", "on_pr_post"]).optional(),
     externalReviewFilters: z
@@ -141,7 +150,29 @@ export async function repoRoutes(rawApp: FastifyInstance) {
       if (wsId && repo.workspaceId !== wsId) {
         return reply.status(404).send({ error: "Repo not found" });
       }
-      reply.send({ repo });
+
+      // Compute the effective review agent + model so the UI can show
+      // "Inherit from repo default → gemini · gemini-2.5-pro" hints when
+      // the per-repo overrides are unset. Errors here are non-fatal — the
+      // UI can fall back to the raw stored values.
+      const globalSettings = await optioSettingsService
+        .getSettings(repo.workspaceId ?? null)
+        .catch(() => null);
+      const resolved = resolveReviewConfig({
+        repoReviewAgentType: repo.reviewAgentType ?? null,
+        repoDefaultAgentType: repo.defaultAgentType ?? null,
+        repoReviewModel: repo.reviewModel ?? null,
+        globalDefaultReviewAgentType: globalSettings?.defaultReviewAgentType ?? null,
+        globalDefaultReviewModel: globalSettings?.defaultReviewModel ?? null,
+      });
+
+      reply.send({
+        repo: {
+          ...repo,
+          effectiveReviewAgentType: resolved.agentType,
+          effectiveReviewModel: resolved.model,
+        },
+      });
     },
   );
 
@@ -270,6 +301,19 @@ export async function repoRoutes(rawApp: FastifyInstance) {
       if (!memPair.valid) resourceErrors.push(memPair.error!);
       if (resourceErrors.length > 0) {
         return reply.status(400).send({ error: resourceErrors.join(" ") });
+      }
+
+      // Reject reviewAgentType + reviewModel combinations where the model
+      // belongs to a different agent's catalog (e.g. agent=gemini, model=sonnet).
+      // If only the agent changes, the resolver picks the catalog default.
+      const incomingReviewAgent = body.reviewAgentType ?? undefined;
+      const incomingReviewModel = body.reviewModel;
+      if (incomingReviewAgent && incomingReviewModel) {
+        if (!modelBelongsToAgentCatalog(incomingReviewAgent, incomingReviewModel)) {
+          return reply.status(400).send({
+            error: `Review model "${incomingReviewModel}" does not belong to the "${incomingReviewAgent}" catalog.`,
+          });
+        }
       }
 
       const repo = await repoService.updateRepo(id, body);

--- a/apps/api/src/services/optio-settings-service.ts
+++ b/apps/api/src/services/optio-settings-service.ts
@@ -37,6 +37,8 @@ export async function getSettings(workspaceId?: string | null): Promise<OptioSet
     enabledTools: [],
     confirmWrites: true,
     maxTurns: 20,
+    defaultReviewAgentType: null,
+    defaultReviewModel: null,
     workspaceId: workspaceId ?? null,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -68,6 +70,10 @@ export async function upsertSettings(
     if (input.enabledTools !== undefined) updates.enabledTools = input.enabledTools;
     if (input.confirmWrites !== undefined) updates.confirmWrites = input.confirmWrites;
     if (input.maxTurns !== undefined) updates.maxTurns = input.maxTurns;
+    if (input.defaultReviewAgentType !== undefined)
+      updates.defaultReviewAgentType = input.defaultReviewAgentType;
+    if (input.defaultReviewModel !== undefined)
+      updates.defaultReviewModel = input.defaultReviewModel;
 
     const [row] = await db
       .update(optioSettings)
@@ -85,6 +91,8 @@ export async function upsertSettings(
         enabledTools: input.enabledTools ?? [],
         confirmWrites: input.confirmWrites ?? true,
         maxTurns: input.maxTurns ?? 20,
+        defaultReviewAgentType: input.defaultReviewAgentType ?? null,
+        defaultReviewModel: input.defaultReviewModel ?? null,
         workspaceId: workspaceId ?? undefined,
       })
       .returning();
@@ -100,6 +108,8 @@ function mapRow(row: typeof optioSettings.$inferSelect): OptioSettings {
     enabledTools: row.enabledTools,
     confirmWrites: row.confirmWrites,
     maxTurns: row.maxTurns,
+    defaultReviewAgentType: row.defaultReviewAgentType ?? null,
+    defaultReviewModel: row.defaultReviewModel ?? null,
     workspaceId: row.workspaceId,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,

--- a/apps/api/src/services/repo-service.ts
+++ b/apps/api/src/services/repo-service.ts
@@ -43,6 +43,7 @@ export interface RepoRecord {
   reviewTrigger: string | null;
   reviewPromptTemplate: string | null;
   testCommand: string | null;
+  reviewAgentType: string | null;
   reviewModel: string | null;
   maxAutoResumes: number | null;
   externalReviewMode: string;
@@ -210,6 +211,7 @@ export async function updateRepo(
     reviewTrigger?: string;
     reviewPromptTemplate?: string | null;
     testCommand?: string;
+    reviewAgentType?: string | null;
     reviewModel?: string;
     externalReviewMode?: string;
     externalReviewFilters?: {

--- a/apps/api/src/services/review-config.test.ts
+++ b/apps/api/src/services/review-config.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { resolveReviewConfig } from "./review-config.js";
+
+describe("resolveReviewConfig", () => {
+  describe("agent type resolution", () => {
+    it("uses repoReviewAgentType when set (highest priority)", () => {
+      const result = resolveReviewConfig({
+        repoReviewAgentType: "gemini",
+        repoDefaultAgentType: "claude-code",
+        globalDefaultReviewAgentType: "codex",
+      });
+      expect(result.agentType).toBe("gemini");
+    });
+
+    it("falls back to repoDefaultAgentType when reviewAgentType is null", () => {
+      const result = resolveReviewConfig({
+        repoReviewAgentType: null,
+        repoDefaultAgentType: "gemini",
+        globalDefaultReviewAgentType: "codex",
+      });
+      expect(result.agentType).toBe("gemini");
+    });
+
+    it("falls back to globalDefaultReviewAgentType when both repo fields are null", () => {
+      const result = resolveReviewConfig({
+        repoReviewAgentType: null,
+        repoDefaultAgentType: null,
+        globalDefaultReviewAgentType: "gemini",
+      });
+      expect(result.agentType).toBe("gemini");
+    });
+
+    it("falls back to claude-code when nothing is set", () => {
+      const result = resolveReviewConfig({});
+      expect(result.agentType).toBe("claude-code");
+    });
+  });
+
+  describe("model resolution", () => {
+    it("uses repoReviewModel when it belongs to the resolved agent's catalog", () => {
+      const result = resolveReviewConfig({
+        repoReviewAgentType: "gemini",
+        repoReviewModel: "gemini-2.5-pro",
+      });
+      expect(result.model).toBe("gemini-2.5-pro");
+    });
+
+    it("accepts a model alias as the per-repo model", () => {
+      const result = resolveReviewConfig({
+        repoDefaultAgentType: "claude-code",
+        repoReviewModel: "sonnet",
+      });
+      expect(result.model).toBe("sonnet");
+    });
+
+    it("ignores a stored model that doesn't belong to the resolved agent's catalog", () => {
+      const result = resolveReviewConfig({
+        repoReviewAgentType: "gemini",
+        // Legacy "sonnet" carried over from a Claude config — should be dropped.
+        repoReviewModel: "sonnet",
+      });
+      expect(result.agentType).toBe("gemini");
+      // Falls back to the gemini catalog default rather than erroring.
+      expect(result.model).not.toBe("sonnet");
+      expect(result.model).toMatch(/gemini-/);
+    });
+
+    it("falls back to globalDefaultReviewModel when the per-repo model is null", () => {
+      const result = resolveReviewConfig({
+        repoReviewAgentType: "claude-code",
+        repoReviewModel: null,
+        globalDefaultReviewModel: "claude-opus-4-7",
+      });
+      expect(result.model).toBe("claude-opus-4-7");
+    });
+
+    it("falls back to the catalog default when no model is set", () => {
+      const result = resolveReviewConfig({
+        repoDefaultAgentType: "gemini",
+      });
+      expect(result.agentType).toBe("gemini");
+      // The Gemini catalog has a `latest` model; resolveModelId picks it.
+      expect(result.model).toMatch(/gemini-/);
+      expect(result.model.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("design doc scenarios", () => {
+    it("Gemini-only user: defaultAgentType=gemini routes reviews to Gemini", () => {
+      // The user sets repoDefaultAgentType=gemini once and reviews follow,
+      // even when reviewAgentType and reviewModel are unset.
+      const result = resolveReviewConfig({
+        repoReviewAgentType: null,
+        repoDefaultAgentType: "gemini",
+        repoReviewModel: null,
+      });
+      expect(result.agentType).toBe("gemini");
+      expect(result.model).toMatch(/gemini-/);
+    });
+
+    it("Existing Claude user: no change in behavior", () => {
+      // A repo created before this change has defaultAgentType=claude-code
+      // and reviewModel=sonnet but no reviewAgentType.
+      const result = resolveReviewConfig({
+        repoReviewAgentType: null,
+        repoDefaultAgentType: "claude-code",
+        repoReviewModel: "sonnet",
+      });
+      expect(result.agentType).toBe("claude-code");
+      expect(result.model).toBe("sonnet");
+    });
+
+    it("Per-repo override beats workspace default", () => {
+      const result = resolveReviewConfig({
+        repoReviewAgentType: "claude-code",
+        repoDefaultAgentType: "gemini",
+        globalDefaultReviewAgentType: "codex",
+      });
+      expect(result.agentType).toBe("claude-code");
+    });
+  });
+});

--- a/apps/api/src/services/review-config.ts
+++ b/apps/api/src/services/review-config.ts
@@ -1,0 +1,86 @@
+/**
+ * Resolves the review agent type and model for a repo, applying the inheritance
+ * chain described in the agent-aware review configuration design.
+ *
+ * Both `review-service.ts` (subtask reviews on Optio-opened PRs) and
+ * `pr-review-worker.ts` (external PR review runs) call this helper so there
+ * is one source of truth for the resolution order.
+ *
+ * Resolution order (first non-null wins):
+ *   1. repos.reviewAgentType                     (per-repo override)
+ *   2. repos.defaultAgentType                    (the repo's primary agent)
+ *   3. global defaultReviewAgentType             (workspace-level setting)
+ *   4. global defaultAgentType                   (not currently exposed; reserved)
+ *   5. "claude-code"                             (final fallback)
+ *
+ * Model uses the same chain — repos.reviewModel → global defaultReviewModel →
+ * the resolved agent's catalog default. If a stored model doesn't belong to
+ * the resolved agent's catalog (e.g. legacy "sonnet" with a Gemini agent) we
+ * silently drop it and fall back to the catalog default rather than erroring.
+ */
+
+import {
+  PROVIDER_CATALOGS,
+  modelBelongsToAgentCatalog,
+  providerForAgentType,
+  resolveModelId,
+  type AgentType,
+} from "@optio/shared";
+
+export interface ReviewConfigInputs {
+  /** Per-repo review override (column `repos.review_agent_type`). */
+  repoReviewAgentType?: string | null;
+  /** Repo's primary agent (column `repos.default_agent_type`). */
+  repoDefaultAgentType?: string | null;
+  /** Per-repo review model (column `repos.review_model`). */
+  repoReviewModel?: string | null;
+  /** Global default review agent (column `optio_settings.default_review_agent_type`). */
+  globalDefaultReviewAgentType?: string | null;
+  /** Global default review model (column `optio_settings.default_review_model`). */
+  globalDefaultReviewModel?: string | null;
+}
+
+export interface ReviewConfigResolved {
+  agentType: AgentType;
+  model: string;
+}
+
+const FALLBACK_AGENT: AgentType = "claude-code";
+
+function pickAgentType(inputs: ReviewConfigInputs): AgentType {
+  const candidates = [
+    inputs.repoReviewAgentType,
+    inputs.repoDefaultAgentType,
+    inputs.globalDefaultReviewAgentType,
+  ];
+  for (const c of candidates) {
+    if (c && typeof c === "string") return c as AgentType;
+  }
+  return FALLBACK_AGENT;
+}
+
+function defaultModelForAgent(agentType: AgentType): string {
+  const provider = providerForAgentType(agentType);
+  const catalog = PROVIDER_CATALOGS[provider];
+  if (!catalog) return "";
+  // Resolve with empty input so resolveModelId picks the latest-of-family / first.
+  return resolveModelId(provider, undefined) ?? catalog.models[0]?.id ?? "";
+}
+
+export function resolveReviewConfig(inputs: ReviewConfigInputs): ReviewConfigResolved {
+  const agentType = pickAgentType(inputs);
+
+  const candidates = [inputs.repoReviewModel, inputs.globalDefaultReviewModel];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (modelBelongsToAgentCatalog(agentType, candidate)) {
+      return { agentType, model: candidate };
+    }
+    // Stored model belongs to a different agent's catalog — ignore and keep
+    // looking. This is the "legacy reviewModel=sonnet on Gemini repo" path
+    // described in the design doc.
+  }
+
+  return { agentType, model: defaultModelForAgent(agentType) };
+}

--- a/apps/api/src/services/review-service.test.ts
+++ b/apps/api/src/services/review-service.test.ts
@@ -21,6 +21,7 @@ vi.mock("../db/schema.js", () => ({
   tasks: {},
   taskEvents: {},
   taskLogs: {},
+  optioSettings: { workspaceId: "workspaceId" },
 }));
 
 const mockGetTask = vi.fn();
@@ -48,6 +49,15 @@ const mockQueueSubtask = vi.fn();
 vi.mock("./subtask-service.js", () => ({
   createSubtask: (...args: any[]) => mockCreateSubtask(...args),
   queueSubtask: (...args: any[]) => mockQueueSubtask(...args),
+}));
+
+// optioSettingsService is read through the resolver to surface workspace-level
+// defaults. Stub it out so the resolver only sees per-repo data in these tests.
+vi.mock("./optio-settings-service.js", () => ({
+  getSettings: vi.fn().mockResolvedValue({
+    defaultReviewAgentType: null,
+    defaultReviewModel: null,
+  }),
 }));
 
 import { db } from "../db/client.js";
@@ -129,7 +139,8 @@ describe("launchReview", () => {
     // Verify task was transitioned to queued
     expect(mockTransitionTask).toHaveBeenCalledWith("review-1", "queued", "review_requested");
 
-    // Verify job was added to queue with review overrides
+    // Verify job was added to queue with review overrides. Both `model`
+    // (new agent-agnostic field) and `claudeModel` (back-compat) are set.
     expect(mockQueueAdd).toHaveBeenCalledWith(
       "process-task",
       expect.objectContaining({
@@ -137,6 +148,7 @@ describe("launchReview", () => {
         reviewOverride: expect.objectContaining({
           renderedPrompt: expect.any(String),
           taskFileContent: expect.stringContaining("Implement feature X"),
+          model: "haiku",
           claudeModel: "haiku",
         }),
       }),
@@ -167,16 +179,61 @@ describe("launchReview", () => {
 
     await launchReview("task-2");
 
-    // Should use default model "sonnet"
+    // With no repo config and no global override, the resolver picks
+    // claude-code's catalog default (an Anthropic model id).
     expect(mockQueueAdd).toHaveBeenCalledWith(
       "process-task",
       expect.objectContaining({
         reviewOverride: expect.objectContaining({
-          claudeModel: "sonnet",
+          model: expect.stringMatching(/claude-/),
+          claudeModel: expect.stringMatching(/claude-/),
         }),
       }),
       expect.any(Object),
     );
+  });
+
+  it("creates a Gemini review subtask for a Gemini-only repo", async () => {
+    const parentTask = {
+      id: "task-4",
+      title: "Add observability",
+      prompt: "Add metrics",
+      prUrl: "https://github.com/org/repo/pull/77",
+      repoUrl: "https://github.com/org/repo",
+    };
+
+    mockGetTask.mockResolvedValueOnce(parentTask);
+
+    // Repo lookup returns a Gemini-configured repo. Note: legacy reviewModel
+    // value of "sonnet" is intentionally still in the row to verify the
+    // resolver drops mismatched models silently.
+    vi.mocked(db.select().from(undefined as any).where as any)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          defaultAgentType: "gemini",
+          reviewAgentType: null,
+          reviewModel: "sonnet", // wrong-catalog leftover, must be ignored
+        },
+      ]);
+
+    mockCreateSubtask.mockResolvedValueOnce({ id: "review-4" });
+    mockTransitionTask.mockResolvedValueOnce({ id: "review-4", state: "queued" });
+
+    await launchReview("task-4");
+
+    // Subtask should be created with the Gemini agent type, not claude-code.
+    expect(mockCreateSubtask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentTaskId: "task-4",
+        agentType: "gemini",
+      }),
+    );
+
+    // Model should be a Gemini model id, not the bogus "sonnet" leftover.
+    const queueCall = mockQueueAdd.mock.calls[0];
+    expect(queueCall[1].reviewOverride.model).toMatch(/gemini-/);
+    expect(queueCall[1].reviewOverride.model).not.toBe("sonnet");
   });
 
   it("includes review context with PR details", async () => {

--- a/apps/api/src/services/review-service.ts
+++ b/apps/api/src/services/review-service.ts
@@ -10,6 +10,8 @@ import * as taskService from "./task-service.js";
 import { getGitPlatformForRepo } from "./git-token-service.js";
 import { taskQueue } from "../workers/task-worker.js";
 import { logger } from "../logger.js";
+import { resolveReviewConfig } from "./review-config.js";
+import * as optioSettingsService from "./optio-settings-service.js";
 
 /**
  * Fetch PR description, reviews, and comments to give the
@@ -91,6 +93,20 @@ export async function launchReview(parentTaskId: string): Promise<string> {
   const { getRepoByUrl } = await import("./repo-service.js");
   const repoConfig = await getRepoByUrl(parentTask.repoUrl);
 
+  // Resolve which agent + model the review should run with. The same resolver
+  // is used by pr-review-worker so config behaviour stays consistent across
+  // the two review entrypoints.
+  const globalSettings = await optioSettingsService
+    .getSettings(parentTask.workspaceId ?? null)
+    .catch(() => null);
+  const review = resolveReviewConfig({
+    repoReviewAgentType: repoConfig?.reviewAgentType ?? null,
+    repoDefaultAgentType: repoConfig?.defaultAgentType ?? null,
+    repoReviewModel: repoConfig?.reviewModel ?? null,
+    globalDefaultReviewAgentType: globalSettings?.defaultReviewAgentType ?? null,
+    globalDefaultReviewModel: globalSettings?.defaultReviewModel ?? null,
+  });
+
   // Fetch PR context using platform abstraction
   const prContextPromise = fetchPrContext(parentTask.repoUrl, prNumber, parentTask.createdBy);
 
@@ -103,7 +119,7 @@ export async function launchReview(parentTaskId: string): Promise<string> {
     prompt: `Review PR #${prNumber} for: ${parentTask.title}`,
     taskType: "review",
     blocksParent: true,
-    agentType: "claude-code",
+    agentType: review.agentType,
   });
 
   const reviewTask = subtask;
@@ -170,8 +186,11 @@ export async function launchReview(parentTaskId: string): Promise<string> {
         renderedPrompt,
         taskFileContent: reviewContext,
         taskFilePath: REVIEW_TASK_FILE_PATH,
-        // Use review model if configured
-        claudeModel: repoConfig?.reviewModel ?? "sonnet",
+        // Agent-agnostic model field — read by the worker for any review agent.
+        model: review.model,
+        // Back-compat: keep populating claudeModel for one release so
+        // in-flight workers that pre-date the resolver still find a model.
+        claudeModel: review.model,
       },
     },
     {

--- a/apps/api/src/services/slack-service.test.ts
+++ b/apps/api/src/services/slack-service.test.ts
@@ -71,6 +71,7 @@ function makeRepoConfig(overrides: Partial<RepoRecord> = {}): RepoRecord {
     reviewTrigger: "on_ci_pass",
     reviewPromptTemplate: null,
     testCommand: null,
+    reviewAgentType: null,
     reviewModel: "sonnet",
     externalReviewMode: "off",
     externalReviewFilters: null,

--- a/apps/api/src/workers/pr-review-worker.ts
+++ b/apps/api/src/workers/pr-review-worker.ts
@@ -49,6 +49,8 @@ import { instrumentWorkerProcessor } from "../telemetry/instrument-worker.js";
 import { logger } from "../logger.js";
 import * as prReviewService from "../services/pr-review-service.js";
 import { enqueueReconcile } from "../services/reconcile-queue.js";
+import { resolveReviewConfig } from "../services/review-config.js";
+import * as optioSettingsService from "../services/optio-settings-service.js";
 import {
   buildAgentCommand,
   buildInitialClaudeStreamMessage,
@@ -196,19 +198,37 @@ export function startPrReviewWorker() {
           (run.metadata as {
             taskFileContent?: string;
             taskFilePath?: string;
+            // Newer field — agent-agnostic. Supersedes claudeModel.
+            model?: string;
+            // Legacy field — left in place for one release while in-flight
+            // jobs queued before the agent-aware review change drain.
             claudeModel?: string;
           } | null) ?? {};
 
         const renderedPrompt = run.prompt ?? "";
         const taskFileContent = metadata.taskFileContent ?? "";
         const taskFilePath = metadata.taskFilePath ?? ".optio/review-context.md";
-        const claudeModel = metadata.claudeModel ?? repoConfig.reviewModel ?? "sonnet";
-
-        const agentType = repoConfig.defaultAgentType ?? "claude-code";
 
         // ── Secret resolution ──────────────────────────────────────
         const workspaceId = review.workspaceId ?? null;
         const userId = review.createdBy ?? null;
+
+        // Resolve agent + model via the shared resolver so the two review
+        // entrypoints stay in sync. Metadata.model wins over repo defaults
+        // (the queueing service already ran the resolver and stamped its
+        // decision); fall through to live resolution otherwise.
+        const globalSettings = await optioSettingsService
+          .getSettings(workspaceId)
+          .catch(() => null);
+        const resolvedReview = resolveReviewConfig({
+          repoReviewAgentType: repoConfig.reviewAgentType ?? null,
+          repoDefaultAgentType: repoConfig.defaultAgentType ?? null,
+          repoReviewModel: metadata.model ?? metadata.claudeModel ?? repoConfig.reviewModel ?? null,
+          globalDefaultReviewAgentType: globalSettings?.defaultReviewAgentType ?? null,
+          globalDefaultReviewModel: globalSettings?.defaultReviewModel ?? null,
+        });
+        const agentType = resolvedReview.agentType;
+        const resolvedModel = resolvedReview.model;
         const claudeAuthMode: "api-key" | "max-subscription" | "oauth-token" =
           ((await retrieveSecretWithFallback("CLAUDE_AUTH_MODE", "global", workspaceId).catch(
             () => null,
@@ -265,6 +285,22 @@ export function startPrReviewWorker() {
         const parsedRepo = parseRepoUrl(review.repoUrl);
         const _repoName = parsedRepo ? `${parsedRepo.owner}/${parsedRepo.repo}` : review.repoUrl;
 
+        // Inject the resolved review model into the field for the resolved
+        // agent type. The adapter for `agentType` only reads its own field,
+        // but we still pass through the other agents' configured models
+        // unchanged so cross-agent settings (e.g. claudeContextWindow) remain
+        // available when an adapter happens to consume them.
+        const claudeModel =
+          agentType === "claude-code" ? resolvedModel : (repoConfig.claudeModel ?? undefined);
+        const copilotModel =
+          agentType === "copilot" ? resolvedModel : (repoConfig.copilotModel ?? undefined);
+        const opencodeModel =
+          agentType === "opencode"
+            ? resolvedModel
+            : (repoConfig.opencodeModel ?? opencodeDefaultModel);
+        const geminiModel =
+          agentType === "gemini" ? resolvedModel : (repoConfig.geminiModel ?? undefined);
+
         const agentConfig = adapter.buildContainerConfig({
           taskId: run.id,
           prompt: renderedPrompt,
@@ -281,13 +317,13 @@ export function startPrReviewWorker() {
           claudeContextWindow: repoConfig.claudeContextWindow ?? undefined,
           claudeThinking: repoConfig.claudeThinking ?? undefined,
           claudeEffort: repoConfig.claudeEffort ?? undefined,
-          copilotModel: repoConfig.copilotModel ?? undefined,
+          copilotModel,
           copilotEffort: repoConfig.copilotEffort ?? undefined,
-          opencodeModel: repoConfig.opencodeModel ?? opencodeDefaultModel,
+          opencodeModel,
           opencodeAgent: repoConfig.opencodeAgent ?? undefined,
           opencodeBaseUrl: repoConfig.opencodeBaseUrl ?? opencodeDefaultBaseUrl,
           geminiAuthMode,
-          geminiModel: repoConfig.geminiModel ?? undefined,
+          geminiModel,
           geminiApprovalMode:
             (repoConfig.geminiApprovalMode as "default" | "auto_edit" | "yolo") ?? undefined,
           maxTurnsCoding: repoConfig.maxTurnsCoding ?? undefined,

--- a/apps/web/src/app/repos/[id]/page.tsx
+++ b/apps/web/src/app/repos/[id]/page.tsx
@@ -33,7 +33,8 @@ import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { SharedDirectoriesSection } from "@/components/shared-directories-section";
 import { AgentOptionsPicker, type AgentOptionsValues } from "@/components/agent-options-picker";
-import { ANTHROPIC_CATALOG, resolveModelId } from "@optio/shared";
+import type { AgentType } from "@optio/shared";
+import { ReviewAgentPicker } from "@/components/review-agent-picker";
 
 const AGENT_TABS = [
   { value: "claude-code", label: "Claude Code" },
@@ -95,7 +96,11 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
   const [reviewEnabled, setReviewEnabled] = useState(false);
   const [reviewTrigger, setReviewTrigger] = useState("on_ci_pass");
   const [testCommand, setTestCommand] = useState("");
-  const [reviewModel, setReviewModel] = useState("sonnet");
+  // null = inherit from repo's defaultAgentType / global setting.
+  const [reviewAgentType, setReviewAgentType] = useState<AgentType | null>(null);
+  const [reviewModel, setReviewModel] = useState("");
+  const [effectiveReviewAgentType, setEffectiveReviewAgentType] = useState<string | null>(null);
+  const [effectiveReviewModel, setEffectiveReviewModel] = useState<string | null>(null);
   const [reviewPromptTemplate, setReviewPromptTemplate] = useState("");
   const [showReviewPrompt, setShowReviewPrompt] = useState(false);
   // External (non-optio-authored) PR auto-review
@@ -178,7 +183,10 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
         setReviewEnabled(r.reviewEnabled ?? false);
         setReviewTrigger(r.reviewTrigger ?? "on_ci_pass");
         setTestCommand(r.testCommand ?? "");
-        setReviewModel(r.reviewModel ?? "sonnet");
+        setReviewAgentType((r.reviewAgentType as AgentType | null) ?? null);
+        setReviewModel(r.reviewModel ?? "");
+        setEffectiveReviewAgentType(r.effectiveReviewAgentType ?? null);
+        setEffectiveReviewModel(r.effectiveReviewModel ?? null);
         setReviewPromptTemplate(r.reviewPromptTemplate ?? "");
         if (r.reviewPromptTemplate) setShowReviewPrompt(true);
         setExternalReviewMode(r.externalReviewMode ?? "off");
@@ -267,7 +275,8 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
         reviewEnabled,
         reviewTrigger,
         testCommand,
-        reviewModel,
+        reviewAgentType,
+        reviewModel: reviewModel || undefined,
         reviewPromptTemplate: showReviewPrompt ? reviewPromptTemplate : null,
         externalReviewMode,
         externalReviewWaitForCi,
@@ -781,61 +790,31 @@ export default function RepoDetailPage({ params }: { params: Promise<{ id: strin
                 </div>
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-xs text-text-muted mb-1">Review Model</label>
-                  <select
-                    value={reviewModel}
-                    onChange={(e) => setReviewModel(e.target.value)}
-                    className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-                  >
-                    {Object.keys(ANTHROPIC_CATALOG.aliases).map((alias) => {
-                      const id = resolveModelId("anthropic", alias);
-                      const label =
-                        ANTHROPIC_CATALOG.models.find((m) => m.id === id)?.label ?? alias;
-                      return (
-                        <option key={alias} value={alias}>
-                          {label}
-                        </option>
-                      );
-                    })}
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-xs text-text-muted mb-1">Context Window</label>
-                  <select
-                    value={claudeContextWindow}
-                    className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-                  >
-                    <option value="200k">200K tokens</option>
-                    <option value="1m">1M tokens</option>
-                  </select>
-                </div>
-              </div>
+              <ReviewAgentPicker
+                agentType={reviewAgentType}
+                onAgentTypeChange={setReviewAgentType}
+                model={reviewModel}
+                onModelChange={setReviewModel}
+                allowInherit
+                inheritedHint={
+                  effectiveReviewAgentType
+                    ? `Reviews will run with: ${effectiveReviewAgentType}${
+                        effectiveReviewModel ? ` · ${effectiveReviewModel}` : ""
+                      }`
+                    : undefined
+                }
+              />
 
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-xs text-text-muted mb-1">Effort Level</label>
-                  <select
-                    value={claudeEffort}
-                    className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-                  >
-                    <option value="low">Low</option>
-                    <option value="medium">Medium</option>
-                    <option value="high">High</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-xs text-text-muted mb-1">Max Turns</label>
-                  <NumberInput
-                    min={1}
-                    max={100}
-                    value={maxTurnsReview}
-                    onChange={(v) => setMaxTurnsReview(v)}
-                    fallback={10}
-                    placeholder="10"
-                  />
-                </div>
+              <div>
+                <label className="block text-xs text-text-muted mb-1">Max Turns</label>
+                <NumberInput
+                  min={1}
+                  max={100}
+                  value={maxTurnsReview}
+                  onChange={(v) => setMaxTurnsReview(v)}
+                  fallback={10}
+                  placeholder="10"
+                />
               </div>
 
               {/* Collapsible review prompt */}

--- a/apps/web/src/app/repos/new/page.tsx
+++ b/apps/web/src/app/repos/new/page.tsx
@@ -21,7 +21,8 @@ import {
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { AgentOptionsPicker, type AgentOptionsValues } from "@/components/agent-options-picker";
-import { ANTHROPIC_CATALOG, resolveModelId } from "@optio/shared";
+import type { AgentType } from "@optio/shared";
+import { ReviewAgentPicker } from "@/components/review-agent-picker";
 
 const STEPS = [
   { id: "repo", label: "Repository" },
@@ -65,7 +66,9 @@ export default function NewRepoPage() {
   // Step 4: Review
   const [reviewEnabled, setReviewEnabled] = useState(false);
   const [reviewTrigger, setReviewTrigger] = useState("on_ci_pass");
-  const [reviewModel, setReviewModel] = useState("sonnet");
+  // null = inherit from repo's defaultAgentType / global setting.
+  const [reviewAgentType, setReviewAgentType] = useState<AgentType | null>(null);
+  const [reviewModel, setReviewModel] = useState("");
   const [testCommand, setTestCommand] = useState("");
   const [autoResume, setAutoResume] = useState(false);
   const [autoMerge, setAutoMerge] = useState(false);
@@ -133,7 +136,8 @@ export default function NewRepoPage() {
         reviewEnabled,
         reviewTrigger,
         testCommand: testCommand || undefined,
-        reviewModel,
+        reviewAgentType,
+        reviewModel: reviewModel || undefined,
         autoResume,
         autoMerge,
       });
@@ -268,6 +272,8 @@ export default function NewRepoPage() {
             setReviewEnabled={setReviewEnabled}
             reviewTrigger={reviewTrigger}
             setReviewTrigger={setReviewTrigger}
+            reviewAgentType={reviewAgentType}
+            setReviewAgentType={setReviewAgentType}
             reviewModel={reviewModel}
             setReviewModel={setReviewModel}
             testCommand={testCommand}
@@ -610,6 +616,8 @@ function ReviewStep({
   setReviewEnabled,
   reviewTrigger,
   setReviewTrigger,
+  reviewAgentType,
+  setReviewAgentType,
   reviewModel,
   setReviewModel,
   testCommand,
@@ -625,6 +633,8 @@ function ReviewStep({
   setReviewEnabled: (v: boolean) => void;
   reviewTrigger: string;
   setReviewTrigger: (v: string) => void;
+  reviewAgentType: AgentType | null;
+  setReviewAgentType: (v: AgentType | null) => void;
   reviewModel: string;
   setReviewModel: (v: string) => void;
   testCommand: string;
@@ -660,38 +670,29 @@ function ReviewStep({
 
         {reviewEnabled && (
           <div className="space-y-3 ml-6 pl-4 border-l-2 border-primary/20">
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-xs text-text-muted mb-1">Trigger</label>
-                <select
-                  value={reviewTrigger}
-                  onChange={(e) => setReviewTrigger(e.target.value)}
-                  className={selectClass}
-                >
-                  <option value="on_ci_pass">After CI passes</option>
-                  <option value="on_pr">Immediately on PR open</option>
-                  <option value="manual">Manual only</option>
-                </select>
-              </div>
-              <div>
-                <label className="block text-xs text-text-muted mb-1">Review Model</label>
-                <select
-                  value={reviewModel}
-                  onChange={(e) => setReviewModel(e.target.value)}
-                  className={selectClass}
-                >
-                  {Object.keys(ANTHROPIC_CATALOG.aliases).map((alias) => {
-                    const id = resolveModelId("anthropic", alias);
-                    const label = ANTHROPIC_CATALOG.models.find((m) => m.id === id)?.label ?? alias;
-                    return (
-                      <option key={alias} value={alias}>
-                        {label}
-                      </option>
-                    );
-                  })}
-                </select>
-              </div>
+            <div>
+              <label className="block text-xs text-text-muted mb-1">Trigger</label>
+              <select
+                value={reviewTrigger}
+                onChange={(e) => setReviewTrigger(e.target.value)}
+                className={selectClass}
+              >
+                <option value="on_ci_pass">After CI passes</option>
+                <option value="on_pr">Immediately on PR open</option>
+                <option value="manual">Manual only</option>
+              </select>
             </div>
+
+            <ReviewAgentPicker
+              agentType={reviewAgentType}
+              onAgentTypeChange={setReviewAgentType}
+              model={reviewModel}
+              onModelChange={setReviewModel}
+              allowInherit
+              inheritedHint="Reviews will run with the repo's default agent unless overridden."
+              selectClass={selectClass}
+            />
+
             <div>
               <label className="block text-xs text-text-muted mb-1">Test command</label>
               <input

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -30,8 +30,10 @@ import {
   ALL_OPTIO_TOOL_NAMES,
   ANTHROPIC_CATALOG,
   resolveModelId,
+  type AgentType,
 } from "@optio/shared";
 import { NotificationPreferences } from "@/components/notifications/notification-preferences";
+import { ReviewAgentPicker } from "@/components/review-agent-picker";
 
 function PromptTemplateEditor() {
   const [template, setTemplate] = useState("");
@@ -149,7 +151,9 @@ function PromptTemplateEditor() {
 
 function DefaultReviewEditor() {
   const [reviewPrompt, setReviewPrompt] = useState("");
-  const [reviewModel, setReviewModel] = useState("sonnet");
+  // Workspace-level review defaults — saved via PUT /api/optio/settings.
+  const [reviewAgentType, setReviewAgentType] = useState<AgentType>("claude-code");
+  const [reviewModel, setReviewModel] = useState("");
   const [reviewTrigger, setReviewTrigger] = useState("on_ci_pass");
   const [reviewContextWindow, setReviewContextWindow] = useState("200k");
   const [reviewEffort, setReviewEffort] = useState("medium");
@@ -159,13 +163,23 @@ function DefaultReviewEditor() {
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    api
-      .getReviewDefault()
-      .then((res) => setReviewPrompt(res.template))
-      .catch(() => {
-        import("@optio/shared")
-          .then((m) => setReviewPrompt(m.DEFAULT_REVIEW_PROMPT_TEMPLATE))
-          .catch(() => {});
+    Promise.all([
+      api.getReviewDefault().catch(() => null),
+      api.getOptioSettings().catch(() => null),
+    ])
+      .then(([promptRes, settingsRes]) => {
+        if (promptRes?.template) {
+          setReviewPrompt(promptRes.template);
+        } else {
+          import("@optio/shared")
+            .then((m) => setReviewPrompt(m.DEFAULT_REVIEW_PROMPT_TEMPLATE))
+            .catch(() => {});
+        }
+        const s = settingsRes?.settings;
+        if (s) {
+          if (s.defaultReviewAgentType) setReviewAgentType(s.defaultReviewAgentType as AgentType);
+          if (s.defaultReviewModel) setReviewModel(s.defaultReviewModel);
+        }
       })
       .finally(() => setLoading(false));
   }, []);
@@ -184,38 +198,26 @@ function DefaultReviewEditor() {
         Default review settings applied to all repos unless overridden in repo settings.
       </p>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <label className="block text-xs text-text-muted mb-1">Default Trigger</label>
-          <select
-            value={reviewTrigger}
-            onChange={(e) => setReviewTrigger(e.target.value)}
-            className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-          >
-            <option value="on_ci_pass">After CI passes</option>
-            <option value="on_pr">Immediately on PR open</option>
-            <option value="manual">Manual only</option>
-          </select>
-        </div>
-        <div>
-          <label className="block text-xs text-text-muted mb-1">Default Review Model</label>
-          <select
-            value={reviewModel}
-            onChange={(e) => setReviewModel(e.target.value)}
-            className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
-          >
-            {Object.keys(ANTHROPIC_CATALOG.aliases).map((alias) => {
-              const id = resolveModelId("anthropic", alias);
-              const label = ANTHROPIC_CATALOG.models.find((m) => m.id === id)?.label ?? alias;
-              return (
-                <option key={alias} value={alias}>
-                  {label}
-                </option>
-              );
-            })}
-          </select>
-        </div>
+      <div>
+        <label className="block text-xs text-text-muted mb-1">Default Trigger</label>
+        <select
+          value={reviewTrigger}
+          onChange={(e) => setReviewTrigger(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20"
+        >
+          <option value="on_ci_pass">After CI passes</option>
+          <option value="on_pr">Immediately on PR open</option>
+          <option value="manual">Manual only</option>
+        </select>
       </div>
+
+      <ReviewAgentPicker
+        agentType={reviewAgentType}
+        onAgentTypeChange={(next) => setReviewAgentType(next ?? "claude-code")}
+        model={reviewModel}
+        onModelChange={setReviewModel}
+        allowInherit={false}
+      />
 
       <div className="grid grid-cols-3 gap-4">
         <div>
@@ -315,9 +317,13 @@ function DefaultReviewEditor() {
             setSaving(true);
             try {
               await api.saveReviewDefault(reviewPrompt);
+              await api.updateOptioSettings({
+                defaultReviewAgentType: reviewAgentType,
+                defaultReviewModel: reviewModel || null,
+              });
               toast.success("Review defaults saved");
-            } catch {
-              toast.error("Failed to save");
+            } catch (err) {
+              toast.error(err instanceof Error ? err.message : "Failed to save");
             } finally {
               setSaving(false);
             }

--- a/apps/web/src/components/review-agent-picker.tsx
+++ b/apps/web/src/components/review-agent-picker.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+/**
+ * Two-step picker for the code-review agent: agent type → model.
+ *
+ * Used on /repos/new, /repos/[id], and /settings. When `allowInherit` is true
+ * (per-repo pages) an "Inherit from repo default" option appears at the top of
+ * the agent dropdown that sets `agentType = null`. The settings page passes
+ * `allowInherit=false` since the workspace-level default is the bottom of the
+ * inheritance chain — there's nothing above it to inherit from.
+ */
+
+import {
+  AGENT_TYPES,
+  PROVIDER_CATALOGS,
+  providerForAgentType,
+  resolveModelId,
+  type AgentType,
+} from "@optio/shared";
+
+const AGENT_LABELS: Record<AgentType, string> = {
+  "claude-code": "Claude Code",
+  codex: "OpenAI Codex",
+  copilot: "GitHub Copilot",
+  opencode: "OpenCode",
+  gemini: "Google Gemini",
+  openclaw: "OpenClaw",
+};
+
+export interface ReviewAgentPickerProps {
+  /** Currently selected agent type. `null` means "inherit". */
+  agentType: AgentType | null;
+  onAgentTypeChange: (next: AgentType | null) => void;
+  /** Currently selected model (or alias). Empty string means "use catalog default". */
+  model: string;
+  onModelChange: (next: string) => void;
+  /** Show the "Inherit" option in the agent dropdown. */
+  allowInherit?: boolean;
+  /**
+   * When `agentType === null`, render this hint underneath the model dropdown.
+   * Intended to be the resolved effective value, e.g. "Reviews will run with:
+   * gemini · gemini-2.5-pro".
+   */
+  inheritedHint?: string;
+  /** Optional class applied to all select controls. */
+  selectClass?: string;
+}
+
+const DEFAULT_SELECT_CLASS =
+  "w-full px-3 py-2 rounded-lg bg-bg border border-border text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20";
+
+export function ReviewAgentPicker({
+  agentType,
+  onAgentTypeChange,
+  model,
+  onModelChange,
+  allowInherit = false,
+  inheritedHint,
+  selectClass = DEFAULT_SELECT_CLASS,
+}: ReviewAgentPickerProps) {
+  const handleAgentChange = (value: string) => {
+    if (value === "__inherit__") {
+      onAgentTypeChange(null);
+      // Reset the model when switching to inherit so we don't carry stale ids.
+      onModelChange("");
+      return;
+    }
+    const next = value as AgentType;
+    onAgentTypeChange(next);
+    // Reset model to that agent's catalog default whenever the agent changes.
+    const defaultModelId = resolveModelId(providerForAgentType(next), undefined) ?? "";
+    onModelChange(defaultModelId);
+  };
+
+  // When inheriting, the model dropdown is meaningless — the resolver picks it.
+  const inheriting = agentType === null;
+  const catalog = inheriting ? null : PROVIDER_CATALOGS[providerForAgentType(agentType!)];
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-xs text-text-muted mb-1">Review Agent</label>
+          <select
+            value={inheriting ? "__inherit__" : (agentType ?? "")}
+            onChange={(e) => handleAgentChange(e.target.value)}
+            className={selectClass}
+          >
+            {allowInherit && <option value="__inherit__">Inherit from repo default</option>}
+            {AGENT_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {AGENT_LABELS[t]}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-text-muted mb-1">Review Model</label>
+          {inheriting || !catalog ? (
+            <select value="" disabled className={selectClass}>
+              <option value="">—</option>
+            </select>
+          ) : catalog.modelIsFreeText ? (
+            <input
+              value={model}
+              onChange={(e) => onModelChange(e.target.value)}
+              placeholder={catalog.modelPlaceholder ?? ""}
+              className={selectClass}
+            />
+          ) : (
+            <select
+              value={model}
+              onChange={(e) => onModelChange(e.target.value)}
+              className={selectClass}
+            >
+              {!model && <option value="">Default</option>}
+              {catalog.models.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                  {m.latest ? " (latest)" : ""}
+                  {m.preview ? " (Preview)" : ""}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      </div>
+      {inheriting && inheritedHint && (
+        <p className="text-[10px] text-text-muted/70">{inheritedHint}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1035,6 +1035,8 @@ export const api = {
     enabledTools?: string[];
     confirmWrites?: boolean;
     maxTurns?: number;
+    defaultReviewAgentType?: string | null;
+    defaultReviewModel?: string | null;
   }) =>
     request<{ settings: any }>("/api/optio/settings", {
       method: "PUT",

--- a/packages/shared/src/agent-options/index.ts
+++ b/packages/shared/src/agent-options/index.ts
@@ -40,6 +40,58 @@ export const ALL_PROVIDER_IDS: readonly AgentProviderId[] = [
 ];
 
 /**
+ * The set of agent type identifiers persisted in `repos.default_agent_type`,
+ * `repos.review_agent_type`, etc. Each one maps to a provider catalog via
+ * `providerForAgentType()`.
+ */
+export type AgentType = "claude-code" | "codex" | "copilot" | "opencode" | "gemini" | "openclaw";
+
+export const AGENT_TYPES: readonly AgentType[] = [
+  "claude-code",
+  "codex",
+  "copilot",
+  "opencode",
+  "gemini",
+  "openclaw",
+];
+
+/**
+ * Map an agent type (DB value) to the provider catalog id used by
+ * `PROVIDER_CATALOGS`. Each agent type has exactly one matching catalog.
+ */
+export function providerForAgentType(agentType: AgentType | string): AgentProviderId {
+  switch (agentType) {
+    case "claude-code":
+      return "anthropic";
+    case "codex":
+      return "openai";
+    case "gemini":
+      return "gemini";
+    case "copilot":
+      return "copilot";
+    case "opencode":
+      return "opencode";
+    case "openclaw":
+      return "openclaw";
+    default:
+      // Fall back to anthropic — preserves existing behavior for legacy rows.
+      return "anthropic";
+  }
+}
+
+/**
+ * True if the given model id (or alias) belongs to the catalog for `agentType`.
+ * Used by the API layer to reject mismatched (agentType, model) pairs.
+ */
+export function modelBelongsToAgentCatalog(agentType: AgentType | string, model: string): boolean {
+  const catalog = PROVIDER_CATALOGS[providerForAgentType(agentType)];
+  if (!catalog) return false;
+  if (model in catalog.aliases) return true;
+  if (catalog.modelIsFreeText) return true;
+  return catalog.models.some((m) => m.id === model);
+}
+
+/**
  * Resolve a possibly-aliased model string (e.g. `opus`, `sonnet`, a full dated
  * id, or `undefined`) to a concrete model id for the given provider.
  *

--- a/packages/shared/src/types/optio-settings.ts
+++ b/packages/shared/src/types/optio-settings.ts
@@ -5,6 +5,14 @@ export interface OptioSettings {
   enabledTools: string[];
   confirmWrites: boolean;
   maxTurns: number;
+  /**
+   * Workspace-level review-agent fallback. When a repo doesn't set its own
+   * `reviewAgentType` and `defaultAgentType`, the resolver in
+   * `apps/api/src/services/review-config.ts` picks this up. Null = no
+   * preference (resolver continues falling back through its chain).
+   */
+  defaultReviewAgentType: string | null;
+  defaultReviewModel: string | null;
   workspaceId?: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -16,6 +24,8 @@ export interface UpdateOptioSettingsInput {
   enabledTools?: string[];
   confirmWrites?: boolean;
   maxTurns?: number;
+  defaultReviewAgentType?: string | null;
+  defaultReviewModel?: string | null;
 }
 
 /** Tool category for UI grouping */


### PR DESCRIPTION
Closes #500

## What changed

The code-review path was hard-wired to Claude Code in three places, so a user with only Gemini configured couldn't run reviews at all. This PR makes the review agent type and model resolve through an inheritance chain — set `defaultAgentType=gemini` once and reviews follow.

### Resolution order
1. `repos.reviewAgentType` — per-repo override
2. `repos.defaultAgentType` — the repo's primary agent
3. `optio_settings.defaultReviewAgentType` — workspace-level setting
4. `"claude-code"` — final fallback

Model uses the same chain. If a stored model doesn't belong to the resolved agent's catalog (e.g. legacy `reviewModel="sonnet"` on a Gemini repo) it's silently dropped and the catalog default is used.

### Backend
- New `apps/api/src/services/review-config.ts` — single resolver. Both `review-service.ts` (subtask reviews) and `pr-review-worker.ts` (external PR reviews) call it, so behaviour stays in sync.
- Schema: adds `repos.review_agent_type`, `optio_settings.default_review_agent_type`, `optio_settings.default_review_model`, all NULL by default. New unix-timestamp migration.
- `review-service.ts` now writes both `model` (new agent-agnostic field) and `claudeModel` (back-compat) into the queue payload so in-flight workers don't break during the rollout.
- `PATCH /api/repos/:id` rejects mismatched (`reviewAgentType`, `reviewModel`) pairs with a 400. Same validation on the global settings route.
- `GET /api/repos/:id` returns `effectiveReviewAgentType` and `effectiveReviewModel` so the UI can render inheritance hints.

### Web
- New `ReviewAgentPicker` component with a two-step picker: agent → model. Used on `/repos/new`, `/repos/[id]`, and `/settings`.
- Per-repo pages get an "Inherit from repo default" option that sets `reviewAgentType=null` and renders the resolved effective values as a small hint.
- Settings page persists the workspace-level review defaults via `PUT /api/optio/settings`.

### Out of scope
Per-agent prompt templates and per-agent review concurrency — see the design doc on the issue. The plain text `reviewPromptTemplate` continues to work across agents.

## How to test

Acceptance criteria from the design doc:

- [ ] **Gemini-only repo** runs reviews via Gemini end-to-end. Set repo `defaultAgentType=gemini`, `reviewEnabled=true`, leave `reviewAgentType` null. Both subtask reviews and PR-watcher reviews should launch a Gemini agent (`agentType: "gemini"` in the subtask, `claudeModel` no longer used for selection in the worker).
- [ ] **Existing Claude repos** keep working. Repos created before this change have `reviewAgentType=null`, `defaultAgentType="claude-code"`, `reviewModel="sonnet"` — the resolver picks Claude with the sonnet alias.
- [ ] **Per-repo settings page** shows the agent picker, model dropdown adapts when the agent changes.
- [ ] **Inherit option** on per-repo pages renders the resolved fallback as a hint.
- [ ] **Stored `reviewModel`** from before the change does not break loading or saving the repo settings page.
- [ ] **Migration** adds NULL columns and is idempotent (uses `IF NOT EXISTS`).
- [ ] **Mismatched pair** is rejected: `PATCH /api/repos/:id` with `{reviewAgentType:"gemini", reviewModel:"sonnet"}` returns 400.
- [ ] Both review entrypoints (`review-service.ts`, `pr-review-worker.ts`) go through the same resolver.

## Verification

- `pnpm turbo typecheck` clean across all packages
- `pnpm --filter @optio/api test` 2024+ passes (12 new resolver tests, 2 new review-service scenarios)
- `pnpm --filter @optio/shared test` 414 passes
- `cd apps/web && npx next build` clean
- Migration journal consistency test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)