### PR TITLE
fix(auth): resolve workspaceRole in /api/auth/me

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -591,6 +591,13 @@ export async function authRoutes(rawApp: FastifyInstance) {
         });
       }
 
+      // If the auth plugin already resolved the user (with workspace role), use it.
+      if (req.user) {
+        return reply.send({ user: req.user, authDisabled: false });
+      }
+
+      // Fallback for requests that bypass the middleware or when identity is
+      // checked with a raw token (e.g. CLI boot or some tests).
       // Resolve token: Bearer header (BFF proxy) → session cookie (direct)
       const authHeader = req.headers.authorization;
       let token: string | undefined;


### PR DESCRIPTION
## Summary
When authentication is enabled, the `/api/auth/me` endpoint was returning `workspaceRole: null` for authenticated users, even when they held an `admin` role. This occurred because the route handler was manually re-validating the session token via `validateSession` (which lacks workspace context) rather than utilizing the `req.user` object already enriched by the `optio-auth` plugin.

This fix introduces a hybrid approach:
- It **prefers the `req.user` object** if it has already been resolved by the auth plugin, ensuring the `workspaceRole` is included in the response.
- It **retains the manual fallback** for robustness and compatibility with test environments and CLI flows that may not run the full plugin stack.

This ensures the frontend setup page correctly identifies admin users, enabling restricted UI elements like the "Global" agent credential scope.

## Changes
- Modified `apps/api/src/routes/auth.ts`: Updated `getCurrentUser` handler to prefer the existing `req.user` object before falling back to manual token resolution.

## Fixes
- Fixes an issue where "Global" radio buttons on the `/setup` page were incorrectly disabled for administrators when auth is enabled.
- Fixes inconsistent user state between the backend auth middleware and the `/me` identity endpoint.

## Testing
- Verified that all existing unit tests in `auth.test.ts` pass without modification.
- Verified that full integration tests pass with Node v24.15.
- Confirmed the "Global" option on the web setup page is now enabled for admin users.