### PR TITLE
session: agent's last line renders twice (final-output highlight echo)

### DIFF
--- a/apps/api/src/services/agent-event-parser.test.ts
+++ b/apps/api/src/services/agent-event-parser.test.ts
@@ -148,12 +148,32 @@ describe("parseClaudeEvent", () => {
     const result = parseClaudeEvent(line, TASK_ID);
     expect(result.entries).toHaveLength(1);
     expect(result.entries[0].type).toBe("info");
-    expect(result.entries[0].content).toContain("Task completed successfully");
+    // The result event must NOT echo the assistant's final text: the same
+    // text was already streamed via an `assistant` text block, so including
+    // it here would render the agent's final line twice in the chat view
+    // (once plain, once green-tinted from the info-type highlight).
+    expect(result.entries[0].content).not.toContain("Task completed successfully");
     expect(result.entries[0].content).toContain("$0.0534");
     expect(result.entries[0].content).toContain("5 turns");
     expect(result.entries[0].metadata?.cost).toBe(0.0534);
     // The task worker closes stdin on terminal events so claude exits
     // instead of idling in stream-json input mode.
+    expect(result.isTerminal).toBe(true);
+  });
+
+  it("emits result-event metadata even when there is no result text", () => {
+    const line = JSON.stringify({
+      type: "result",
+      total_cost_usd: 0.001,
+      num_turns: 1,
+      duration_ms: 500,
+      session_id: "session-abc",
+    });
+    const result = parseClaudeEvent(line, TASK_ID);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].type).toBe("info");
+    expect(result.entries[0].content).toContain("1 turns");
+    expect(result.entries[0].content).toContain("$0.0010");
     expect(result.isTerminal).toBe(true);
   });
 

--- a/apps/api/src/services/agent-event-parser.ts
+++ b/apps/api/src/services/agent-event-parser.ts
@@ -125,21 +125,25 @@ export function parseClaudeEvent(
   // the turn and, with --input-format stream-json, will sit idle waiting for
   // another user message. The task worker closes stdin when it sees this so
   // claude exits cleanly.
+  //
+  // We deliberately do NOT include `event.result` (the final assistant text)
+  // in the entry content: that same text was already streamed via an
+  // `assistant` text block, so echoing it here would render the agent's last
+  // line twice in chat — once plain, once green-tinted from the info-type
+  // "final answer" highlight.
   if (event.type === "result") {
-    const parts: string[] = [];
-    if (event.result) parts.push(event.result);
     const meta: string[] = [];
     if (event.num_turns) meta.push(`${event.num_turns} turns`);
     if (event.duration_ms) meta.push(`${(event.duration_ms / 1000).toFixed(1)}s`);
     if (event.total_cost_usd) meta.push(`$${event.total_cost_usd.toFixed(4)}`);
-    if (meta.length) parts.push(`(${meta.join(" · ")})`);
+    const content = meta.length ? `(${meta.join(" · ")})` : "";
 
     entries.push({
       taskId,
       timestamp,
       sessionId,
       type: "info",
-      content: parts.join(" "),
+      content,
       metadata: {
         cost: event.total_cost_usd,
         turns: event.num_turns,


### PR DESCRIPTION
Closes #512

## What changed
The Claude Code stream-json `result` event includes the final assistant text in `event.result`, but that same text was already emitted as an `assistant` text block during streaming. `parseClaudeEvent` was including `event.result` in the info-type entry, so it landed in the chat as a duplicate of the agent's last line — once as plain streamed text, once green-tinted from the info "final answer" highlight.

Fix in `apps/api/src/services/agent-event-parser.ts`: drop `event.result` from the info entry's content. Keep the metadata-only summary `(N turns · Xs · $Y)` and the full `metadata` payload (`cost`, `turns`, `durationMs`, `isError`) so cost tracking and the cost footer chip in `LogViewer` are unchanged. Closing stdin on terminal events is unchanged.

This fix flows through every consumer of `parseClaudeEvent` (`session-chat`, `task-worker`, `pr-review-worker`, `persistent-agent-worker`, `workflow-worker`), since the duplication was the same shape everywhere — the streamed text already covers the final answer; the info entry only needs to carry the summary metadata.

## How to test
- Open any session, ask the agent a one-line question (e.g. "what's 2+2"). The reply should now appear once (`4`), not twice with the second one green-tinted. The green chevron line at the end shows just the `(1 turns · Xs)` summary plus the cost chip.
- `cd apps/api && npx vitest run src/services/agent-event-parser.test.ts` — updated existing test to assert the result content does **not** echo the assistant text, and added a new test covering the meta-only path when `event.result` is absent.
- `pnpm turbo typecheck && pnpm turbo test` both pass (2056 tests).