### PR TITLE
session: chat history not preserved when re-opening a session

### DIFF
--- a/apps/api/src/db/migrations/1777400000_session_chat_events.sql
+++ b/apps/api/src/db/migrations/1777400000_session_chat_events.sql
@@ -1,0 +1,20 @@
+-- Persist interactive-session chat events so reconnecting clients can see
+-- the full conversation. Mirrors the persistent_agent_turn_logs / task_logs
+-- shape so the existing log-history UI patterns work without special-casing.
+--
+-- Retention: trimmed by `MAX_SESSION_CHAT_EVENTS` per session at insert time
+-- (oldest events deleted first). No time-based pruning yet — sessions are
+-- already capped at 30-day TTL.
+
+CREATE TABLE "session_chat_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "session_id" uuid NOT NULL REFERENCES "interactive_sessions"("id") ON DELETE CASCADE,
+  "stream" text NOT NULL DEFAULT 'stdout',
+  "content" text NOT NULL,
+  "log_type" text,
+  "metadata" jsonb,
+  "timestamp" timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX "session_chat_events_session_idx"
+  ON "session_chat_events" ("session_id", "timestamp");

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -540,6 +540,13 @@
       "when": 1777300000000,
       "tag": "1777300000_installed_skills",
       "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1777400000000,
+      "tag": "1777400000_session_chat_events",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -475,6 +475,25 @@ export const sessionPrs = pgTable(
   (table) => [index("session_prs_session_id_idx").on(table.sessionId)],
 );
 
+// Persisted chat events for an interactive session. One row per parsed
+// AgentLogEntry the session WebSocket emits. Lets reconnecting clients
+// reload the conversation rather than starting from an empty log.
+export const sessionChatEvents = pgTable(
+  "session_chat_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    sessionId: uuid("session_id")
+      .notNull()
+      .references(() => interactiveSessions.id, { onDelete: "cascade" }),
+    stream: text("stream").notNull().default("stdout"),
+    content: text("content").notNull(),
+    logType: text("log_type"), // "text" | "tool_use" | "tool_result" | "thinking" | "system" | "error" | "info"
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    timestamp: timestamp("timestamp", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("session_chat_events_session_idx").on(table.sessionId, table.timestamp)],
+);
+
 export const taskComments = pgTable(
   "task_comments",
   {

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -12,6 +12,7 @@ const mockEndSession = vi.fn();
 const mockGetSessionPrs = vi.fn();
 const mockAddSessionPr = vi.fn();
 const mockGetActiveSessionCount = vi.fn();
+const mockListSessionChatEvents = vi.fn();
 
 vi.mock("../services/interactive-session-service.js", () => ({
   listSessions: (...args: unknown[]) => mockListSessions(...args),
@@ -21,6 +22,7 @@ vi.mock("../services/interactive-session-service.js", () => ({
   getSessionPrs: (...args: unknown[]) => mockGetSessionPrs(...args),
   addSessionPr: (...args: unknown[]) => mockAddSessionPr(...args),
   getActiveSessionCount: (...args: unknown[]) => mockGetActiveSessionCount(...args),
+  listSessionChatEvents: (...args: unknown[]) => mockListSessionChatEvents(...args),
 }));
 
 const mockDbSelect = vi.fn();
@@ -301,6 +303,69 @@ describe("session PRs", () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.json().error).toBeDefined();
+  });
+});
+
+describe("GET /api/sessions/:id/chat", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns persisted chat events for a session", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockListSessionChatEvents.mockResolvedValue([
+      {
+        id: "ev-1",
+        sessionId: "session-1",
+        stream: "stdout",
+        content: "hello",
+        logType: "text",
+        metadata: null,
+        timestamp: new Date("2026-04-27T00:00:00Z"),
+      },
+    ]);
+
+    const res = await app.inject({ method: "GET", url: "/api/sessions/session-1/chat" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].content).toBe("hello");
+    expect(mockListSessionChatEvents).toHaveBeenCalledWith("session-1", { limit: 1000 });
+  });
+
+  it("respects the limit query param", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockListSessionChatEvents.mockResolvedValue([]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/sessions/session-1/chat?limit=42",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockListSessionChatEvents).toHaveBeenCalledWith("session-1", { limit: 42 });
+  });
+
+  it("returns 404 when session does not exist", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const res = await app.inject({ method: "GET", url: "/api/sessions/nope/chat" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockListSessionChatEvents).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for another user's session", async () => {
+    mockGetSession.mockResolvedValue({ ...mockSession, userId: "other-user" });
+
+    const res = await app.inject({ method: "GET", url: "/api/sessions/session-1/chat" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockListSessionChatEvents).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -9,9 +9,22 @@ import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import {
   InteractiveSessionSchema,
+  SessionChatEventSchema,
   SessionModelConfigSchema,
   SessionPrSchema,
 } from "../schemas/session.js";
+
+const sessionChatQuerySchema = z
+  .object({
+    limit: z.coerce.number().int().min(1).max(5000).default(1000).describe("Max events to return"),
+  })
+  .describe("Query parameters for session chat history");
+
+const SessionChatResponseSchema = z
+  .object({
+    events: z.array(SessionChatEventSchema),
+  })
+  .describe("Persisted chat events for a session, oldest first");
 
 const listSessionsQuerySchema = z
   .object({
@@ -261,6 +274,43 @@ export async function sessionRoutes(rawApp: FastifyInstance) {
       } catch (err) {
         reply.status(400).send({ error: err instanceof Error ? err.message : String(err) });
       }
+    },
+  );
+
+  app.get(
+    "/api/sessions/:id/chat",
+    {
+      schema: {
+        operationId: "getSessionChat",
+        summary: "Get persisted chat history for a session",
+        description:
+          "Returns the persisted chat events for a session in chronological " +
+          "order. Used by the web UI to rehydrate the conversation when the " +
+          "session detail page mounts, so navigating away and back doesn't " +
+          "lose history. The session WebSocket also replays history on " +
+          "connect, but this REST endpoint is the primary loader to mirror " +
+          "how `useLogs` / `useWorkflowRunLogs` work.",
+        tags: ["Sessions"],
+        params: IdParamsSchema,
+        querystring: sessionChatQuerySchema,
+        response: {
+          200: SessionChatResponseSchema,
+          404: ErrorResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const { id } = req.params;
+      const session = await sessionService.getSession(id);
+      if (!session) return reply.status(404).send({ error: "Session not found" });
+
+      if (req.user?.id && session.userId && session.userId !== req.user.id) {
+        return reply.status(404).send({ error: "Session not found" });
+      }
+
+      const { limit } = req.query;
+      const events = await sessionService.listSessionChatEvents(id, { limit });
+      reply.send({ events });
     },
   );
 

--- a/apps/api/src/schemas/registry.ts
+++ b/apps/api/src/schemas/registry.ts
@@ -25,6 +25,7 @@ import {
 } from "./workflow.js";
 import {
   InteractiveSessionSchema,
+  SessionChatEventSchema,
   SessionModelConfigSchema,
   SessionPrSchema,
   ReviewDraftSchema,
@@ -87,6 +88,7 @@ export const namedSchemas = {
   WorkflowRunLogEntry: WorkflowRunLogEntrySchema,
   CronValidationResult: CronValidationResultSchema,
   InteractiveSession: InteractiveSessionSchema,
+  SessionChatEvent: SessionChatEventSchema,
   SessionModelConfig: SessionModelConfigSchema,
   SessionPr: SessionPrSchema,
   ReviewDraft: ReviewDraftSchema,

--- a/apps/api/src/schemas/session.ts
+++ b/apps/api/src/schemas/session.ts
@@ -47,6 +47,24 @@ export const SessionPrSchema = z
   .passthrough()
   .describe("Pull request opened during a session");
 
+export const SessionChatEventSchema = z
+  .object({
+    id: z.string(),
+    sessionId: z.string(),
+    stream: z.string().describe("stdout | stderr | stdin (user message)"),
+    content: z.string(),
+    logType: z
+      .string()
+      .nullable()
+      .describe(
+        "Parsed log category: text | tool_use | tool_result | thinking | system | error | info | user_message",
+      ),
+    metadata: z.record(z.unknown()).nullable(),
+    timestamp: z.union([z.date(), z.string()]),
+  })
+  .passthrough()
+  .describe("A single persisted session-chat event (one parsed agent log entry).");
+
 export const ReviewDraftSchema = z
   .object({
     id: z.string(),

--- a/apps/api/src/services/interactive-session-service.test.ts
+++ b/apps/api/src/services/interactive-session-service.test.ts
@@ -21,6 +21,11 @@ vi.mock("../db/schema.js", () => ({
     sessionId: "session_prs.session_id",
     createdAt: "session_prs.created_at",
   },
+  sessionChatEvents: {
+    id: "session_chat_events.id",
+    sessionId: "session_chat_events.session_id",
+    timestamp: "session_chat_events.timestamp",
+  },
   repos: {
     repoUrl: "repos.repo_url",
   },
@@ -67,6 +72,8 @@ import {
   addSessionPr,
   updateSessionPr,
   getActiveSessionCount,
+  appendSessionChatEvent,
+  listSessionChatEvents,
 } from "./interactive-session-service.js";
 
 describe("interactive-session-service", () => {
@@ -411,6 +418,141 @@ describe("interactive-session-service", () => {
 
       const result = await getActiveSessionCount("https://github.com/o/r");
       expect(result).toBe(2);
+    });
+  });
+
+  describe("appendSessionChatEvent", () => {
+    it("inserts an event with stream/content/logType/metadata", async () => {
+      const insertReturning = vi.fn().mockResolvedValue([
+        {
+          id: "ev-1",
+          sessionId: "s-1",
+          stream: "stdout",
+          content: "hi",
+          logType: "text",
+          metadata: { foo: "bar" },
+          timestamp: new Date("2026-04-27T00:00:00Z"),
+        },
+      ]);
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({ returning: insertReturning }),
+      });
+
+      // Retention prune: empty cutoff lookup
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockResolvedValue([]),
+              }),
+            }),
+          }),
+        }),
+      });
+      (db.delete as any) = vi.fn();
+
+      const result = await appendSessionChatEvent({
+        sessionId: "s-1",
+        content: "hi",
+        logType: "text",
+        metadata: { foo: "bar" },
+      });
+
+      expect(result.id).toBe("ev-1");
+      expect(insertReturning).toHaveBeenCalled();
+    });
+
+    it("prunes old events past the retention cap", async () => {
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            {
+              id: "ev-2",
+              sessionId: "s-1",
+              stream: "stdout",
+              content: "x",
+              timestamp: new Date(),
+            },
+          ]),
+        }),
+      });
+
+      // Retention prune: cutoff lookup returns a timestamp
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockResolvedValue([{ ts: new Date("2026-04-01T00:00:00Z") }]),
+              }),
+            }),
+          }),
+        }),
+      });
+      const deleteWhere = vi.fn().mockResolvedValue(undefined);
+      (db.delete as any) = vi.fn().mockReturnValue({ where: deleteWhere });
+
+      await appendSessionChatEvent({ sessionId: "s-1", content: "x" });
+      expect(deleteWhere).toHaveBeenCalled();
+    });
+
+    it("does not throw if the prune step fails", async () => {
+      (db.insert as any) = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: "ev-3" }]),
+        }),
+      });
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockRejectedValue(new Error("prune blew up")),
+              }),
+            }),
+          }),
+        }),
+      });
+
+      const result = await appendSessionChatEvent({ sessionId: "s-1", content: "x" });
+      expect(result.id).toBe("ev-3");
+    });
+  });
+
+  describe("listSessionChatEvents", () => {
+    it("returns events ordered by timestamp ascending", async () => {
+      const events = [
+        { id: "e-1", content: "first" },
+        { id: "e-2", content: "second" },
+      ];
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue(events),
+            }),
+          }),
+        }),
+      });
+
+      const result = await listSessionChatEvents("s-1");
+      expect(result).toEqual(events);
+    });
+
+    it("respects the requested limit (capped to MAX_SESSION_CHAT_EVENTS)", async () => {
+      const limitFn = vi.fn().mockResolvedValue([]);
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({ limit: limitFn }),
+          }),
+        }),
+      });
+
+      await listSessionChatEvents("s-1", { limit: 1_000_000 });
+      // The clamp should be at MAX_SESSION_CHAT_EVENTS = 5000.
+      expect(limitFn).toHaveBeenCalledWith(5000);
     });
   });
 });

--- a/apps/api/src/services/interactive-session-service.ts
+++ b/apps/api/src/services/interactive-session-service.ts
@@ -1,7 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { eq, and, desc, sql } from "drizzle-orm";
+import { eq, and, desc, asc, sql, lte } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { interactiveSessions, sessionPrs, repos, repoPods } from "../db/schema.js";
+import {
+  interactiveSessions,
+  sessionPrs,
+  sessionChatEvents,
+  repos,
+  repoPods,
+} from "../db/schema.js";
 import { publishEvent, publishSessionEvent } from "./event-bus.js";
 import { InteractiveSessionState, normalizeRepoUrl, type PresetImageId } from "@optio/shared";
 import { getOrCreateRepoPod } from "./repo-pool-service.js";
@@ -215,4 +221,77 @@ export async function getActiveSessionCount(repoUrl?: string) {
     .where(and(...conditions));
 
   return count;
+}
+
+// ── Session Chat Events ─────────────────────────────────────────────────────
+
+/**
+ * Per-session retention cap. Sessions can run for hours/days, and a busy
+ * agent may emit thousands of events per turn. Keeping the most recent N
+ * events keeps the chat usable on reconnect without unbounded table growth.
+ * Older events are pruned synchronously as new ones are inserted.
+ */
+export const MAX_SESSION_CHAT_EVENTS = 5000;
+
+export interface AppendSessionChatEventInput {
+  sessionId: string;
+  content: string;
+  stream?: string;
+  logType?: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: Date;
+}
+
+/**
+ * Persist a single chat event for a session. Trims older events past the
+ * retention cap so a long-running session doesn't grow unboundedly.
+ */
+export async function appendSessionChatEvent(input: AppendSessionChatEventInput) {
+  const [event] = await db
+    .insert(sessionChatEvents)
+    .values({
+      sessionId: input.sessionId,
+      stream: input.stream ?? "stdout",
+      content: input.content,
+      logType: input.logType ?? null,
+      metadata: input.metadata ?? null,
+      timestamp: input.timestamp ?? new Date(),
+    })
+    .returning();
+
+  // Best-effort retention prune. A bulk DELETE keyed on the cutoff timestamp
+  // avoids a per-row lookup on the hot streaming path.
+  try {
+    const [cutoff] = await db
+      .select({ ts: sessionChatEvents.timestamp })
+      .from(sessionChatEvents)
+      .where(eq(sessionChatEvents.sessionId, input.sessionId))
+      .orderBy(desc(sessionChatEvents.timestamp))
+      .limit(1)
+      .offset(MAX_SESSION_CHAT_EVENTS);
+    if (cutoff?.ts) {
+      await db
+        .delete(sessionChatEvents)
+        .where(
+          and(
+            eq(sessionChatEvents.sessionId, input.sessionId),
+            lte(sessionChatEvents.timestamp, cutoff.ts),
+          ),
+        );
+    }
+  } catch (err) {
+    logger.warn({ err, sessionId: input.sessionId }, "Failed to prune session chat events");
+  }
+
+  return event;
+}
+
+export async function listSessionChatEvents(sessionId: string, opts?: { limit?: number }) {
+  const limit = Math.min(opts?.limit ?? 1000, MAX_SESSION_CHAT_EVENTS);
+  return db
+    .select()
+    .from(sessionChatEvents)
+    .where(eq(sessionChatEvents.sessionId, sessionId))
+    .orderBy(asc(sessionChatEvents.timestamp))
+    .limit(limit);
 }

--- a/apps/api/src/ws/session-chat.ts
+++ b/apps/api/src/ws/session-chat.ts
@@ -1,7 +1,11 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { getRuntime } from "../services/container-service.js";
-import { getSession } from "../services/interactive-session-service.js";
+import {
+  appendSessionChatEvent,
+  getSession,
+  listSessionChatEvents,
+} from "../services/interactive-session-service.js";
 import { getSettings } from "../services/optio-settings-service.js";
 import { db } from "../db/client.js";
 import { repoPods, repos, interactiveSessions } from "../db/schema.js";
@@ -144,6 +148,39 @@ export async function sessionChatWs(app: FastifyInstance) {
       },
     });
 
+    // Catch-up: replay persisted chat events so reconnecting clients see
+    // the conversation from before the WebSocket dropped. The REST endpoint
+    // is the primary loader, but this also helps clients that connect via
+    // the WebSocket without first calling the REST endpoint.
+    try {
+      const history = await listSessionChatEvents(sessionId);
+      for (const ev of history) {
+        send({
+          type: "chat_event",
+          event: {
+            taskId: sessionId,
+            timestamp:
+              ev.timestamp instanceof Date
+                ? ev.timestamp.toISOString()
+                : (ev.timestamp as unknown as string),
+            type: (ev.logType ?? "text") as
+              | "text"
+              | "tool_use"
+              | "tool_result"
+              | "thinking"
+              | "system"
+              | "error"
+              | "info",
+            content: ev.content,
+            metadata: ev.metadata ?? undefined,
+          },
+          catchUp: true,
+        });
+      }
+    } catch (err) {
+      log.warn({ err }, "Failed to replay session chat history");
+    }
+
     /**
      * Execute a single claude prompt in the pod worktree.
      * Uses `claude -p` in one-shot mode with stream-json output.
@@ -220,6 +257,7 @@ export async function sessionChatWs(app: FastifyInstance) {
             const { entries } = parseClaudeEvent(line, sessionId);
             for (const entry of entries) {
               send({ type: "chat_event", event: entry });
+              persistChatEvent(sessionId, entry, log);
 
               // Extract cost from result events
               if (entry.metadata?.cost && typeof entry.metadata.cost === "number") {
@@ -238,15 +276,14 @@ export async function sessionChatWs(app: FastifyInstance) {
         execSession.stderr.on("data", (chunk: Buffer) => {
           const text = chunk.toString("utf-8").trim();
           if (text) {
-            send({
-              type: "chat_event",
-              event: {
-                taskId: sessionId,
-                timestamp: new Date().toISOString(),
-                type: "error",
-                content: text,
-              },
-            });
+            const entry = {
+              taskId: sessionId,
+              timestamp: new Date().toISOString(),
+              type: "error" as const,
+              content: text,
+            };
+            send({ type: "chat_event", event: entry });
+            persistChatEvent(sessionId, entry, log);
           }
         });
 
@@ -258,6 +295,7 @@ export async function sessionChatWs(app: FastifyInstance) {
               const { entries } = parseClaudeEvent(outputBuffer, sessionId);
               for (const entry of entries) {
                 send({ type: "chat_event", event: entry });
+                persistChatEvent(sessionId, entry, log);
               }
               outputBuffer = "";
             }
@@ -297,6 +335,15 @@ export async function sessionChatWs(app: FastifyInstance) {
             send({ type: "error", message: "Empty message" });
             return;
           }
+          // Persist the user's prompt so reconnecting clients see their own
+          // side of the conversation, not just the agent's responses. Use
+          // logType=user_message so the UI can render it distinctly.
+          appendSessionChatEvent({
+            sessionId,
+            content: msg.content,
+            stream: "stdin",
+            logType: "user_message",
+          }).catch((err) => log.warn({ err }, "Failed to persist user message"));
           runPrompt(msg.content).catch((err) => {
             log.error({ err }, "Prompt execution failed");
             send({ type: "error", message: "Prompt failed" });
@@ -394,4 +441,23 @@ async function updateSessionCost(sessionId: string, costUsd: number) {
     .update(interactiveSessions)
     .set({ costUsd: costUsd.toFixed(4) })
     .where(eq(interactiveSessions.id, sessionId));
+}
+
+/**
+ * Fire-and-forget persistence for an agent chat event. Failures are logged
+ * but don't break the live stream — the client still gets the event over
+ * the WebSocket; only history-on-reconnect is impacted.
+ */
+function persistChatEvent(
+  sessionId: string,
+  entry: import("@optio/shared").AgentLogEntry,
+  log: { warn: (obj: unknown, msg: string) => void },
+) {
+  appendSessionChatEvent({
+    sessionId,
+    content: entry.content,
+    logType: entry.type,
+    metadata: entry.metadata,
+    timestamp: entry.timestamp ? new Date(entry.timestamp) : undefined,
+  }).catch((err) => log.warn({ err }, "Failed to persist session chat event"));
 }

--- a/apps/web/src/hooks/use-session-logs.test.ts
+++ b/apps/web/src/hooks/use-session-logs.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+const mockGetSessionChat = vi.fn();
+vi.mock("@/lib/api-client", () => ({
+  api: { getSessionChat: (...args: any[]) => mockGetSessionChat(...args) },
+}));
+
+vi.mock("@/lib/ws-client.js", () => ({
+  getWsBaseUrl: () => "ws://localhost",
+}));
+
+// In-test fake WebSocket that lets us drive open/message events directly.
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static OPEN = 1;
+  url: string;
+  readyState = 0;
+  onopen: ((ev?: any) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onerror: ((ev?: any) => void) | null = null;
+  onclose: ((ev?: any) => void) | null = null;
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+
+  // Test helpers ─────────────────────────────────────────────
+  simulateOpen() {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+  simulateMessage(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+}
+
+const originalWebSocket = (globalThis as any).WebSocket;
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  (globalThis as any).WebSocket = FakeWebSocket;
+  vi.clearAllMocks();
+  mockGetSessionChat.mockResolvedValue({ events: [] });
+});
+
+afterEach(() => {
+  (globalThis as any).WebSocket = originalWebSocket;
+});
+
+import { useSessionLogs } from "./use-session-logs";
+
+describe("useSessionLogs", () => {
+  it("opens a session-chat WebSocket on mount", () => {
+    renderHook(() => useSessionLogs("session-1"));
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0].url).toContain("/ws/sessions/session-1/chat");
+  });
+
+  it("loads historical chat events from the REST endpoint", async () => {
+    renderHook(() => useSessionLogs("session-1"));
+    expect(mockGetSessionChat).toHaveBeenCalledWith("session-1", { limit: 5000 });
+  });
+
+  it("renders historical chat events as logs once they resolve", async () => {
+    mockGetSessionChat.mockResolvedValue({
+      events: [
+        {
+          content: "hello from history",
+          stream: "stdout",
+          timestamp: "2026-04-27T00:00:00.000Z",
+          logType: "text",
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useSessionLogs("session-1"));
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(1);
+    });
+    expect(result.current.logs[0].content).toBe("hello from history");
+  });
+
+  it("restores user messages from history into userMessages, not logs", async () => {
+    mockGetSessionChat.mockResolvedValue({
+      events: [
+        {
+          content: "what is 2 + 2?",
+          stream: "stdin",
+          timestamp: "2026-04-27T00:00:00.000Z",
+          logType: "user_message",
+        },
+        {
+          content: "4",
+          stream: "stdout",
+          timestamp: "2026-04-27T00:00:01.000Z",
+          logType: "text",
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useSessionLogs("session-1"));
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(1);
+    });
+    expect(result.current.logs[0].content).toBe("4");
+    expect(result.current.userMessages).toHaveLength(1);
+    expect(result.current.userMessages[0].text).toBe("what is 2 + 2?");
+  });
+
+  it("merges live events with historical (deduplicated)", async () => {
+    // Historical resolves AFTER live arrives, exercising the buffer/dedup path.
+    let resolveHistory: (v: { events: any[] }) => void = () => {};
+    mockGetSessionChat.mockImplementation(
+      () => new Promise((resolve) => (resolveHistory = resolve)),
+    );
+
+    const { result } = renderHook(() => useSessionLogs("session-1"));
+    const ws = FakeWebSocket.instances[0];
+
+    act(() => {
+      // Live event for a frame that ALSO appears in history → must dedup.
+      ws.simulateMessage({
+        type: "chat_event",
+        event: {
+          taskId: "session-1",
+          timestamp: "2026-04-27T00:00:01.000Z",
+          type: "text",
+          content: "duplicate",
+        },
+      });
+      // Live event that history doesn't include → must remain.
+      ws.simulateMessage({
+        type: "chat_event",
+        event: {
+          taskId: "session-1",
+          timestamp: "2026-04-27T00:00:02.000Z",
+          type: "text",
+          content: "live-only",
+        },
+      });
+    });
+
+    act(() => {
+      resolveHistory({
+        events: [
+          {
+            content: "earlier",
+            stream: "stdout",
+            timestamp: "2026-04-27T00:00:00.000Z",
+            logType: "text",
+          },
+          {
+            content: "duplicate",
+            stream: "stdout",
+            timestamp: "2026-04-27T00:00:01.000Z",
+            logType: "text",
+          },
+        ],
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.logs.map((l) => l.content)).toEqual([
+        "earlier",
+        "duplicate",
+        "live-only",
+      ]);
+    });
+  });
+
+  it("ignores catchUp WebSocket frames (REST is the source of truth for history)", async () => {
+    const { result } = renderHook(() => useSessionLogs("session-1"));
+    const ws = FakeWebSocket.instances[0];
+
+    // History resolves empty
+    await waitFor(() => expect(mockGetSessionChat).toHaveBeenCalled());
+
+    act(() => {
+      ws.simulateMessage({
+        type: "chat_event",
+        catchUp: true,
+        event: {
+          taskId: "session-1",
+          timestamp: "2026-04-27T00:00:00.000Z",
+          type: "text",
+          content: "catch-up frame",
+        },
+      });
+      ws.simulateMessage({
+        type: "chat_event",
+        event: {
+          taskId: "session-1",
+          timestamp: "2026-04-27T00:00:01.000Z",
+          type: "text",
+          content: "live frame",
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.logs).toHaveLength(1);
+    });
+    expect(result.current.logs[0].content).toBe("live frame");
+  });
+
+  it("closes the WebSocket on unmount", () => {
+    const { unmount } = renderHook(() => useSessionLogs("session-1"));
+    const ws = FakeWebSocket.instances[0];
+    const closeSpy = vi.spyOn(ws, "close");
+    unmount();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("sets capped=true when historical event count reaches the limit", async () => {
+    const many = Array.from({ length: 5000 }, (_, i) => ({
+      content: `e${i}`,
+      stream: "stdout",
+      timestamp: `2026-04-27T00:00:${String(i % 60).padStart(2, "0")}.000Z`,
+      logType: "text",
+    }));
+    mockGetSessionChat.mockResolvedValue({ events: many });
+
+    const { result } = renderHook(() => useSessionLogs("session-1"));
+
+    await waitFor(() => expect(result.current.capped).toBe(true));
+  });
+
+  it("falls back to live-only logs when history fetch fails", async () => {
+    mockGetSessionChat.mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useSessionLogs("session-1"));
+    const ws = FakeWebSocket.instances[0];
+
+    await waitFor(() => expect(mockGetSessionChat).toHaveBeenCalled());
+
+    act(() => {
+      ws.simulateMessage({
+        type: "chat_event",
+        event: {
+          taskId: "session-1",
+          timestamp: "2026-04-27T00:00:00.000Z",
+          type: "text",
+          content: "live after failure",
+        },
+      });
+    });
+
+    await waitFor(() => expect(result.current.logs).toHaveLength(1));
+    expect(result.current.logs[0].content).toBe("live after failure");
+  });
+});

--- a/apps/web/src/hooks/use-session-logs.ts
+++ b/apps/web/src/hooks/use-session-logs.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { api } from "@/lib/api-client";
 import { getWsBaseUrl } from "@/lib/ws-client.js";
 import type { LogEntry } from "@/hooks/use-logs";
 import type { UserMessage } from "@/components/log-viewer";
@@ -20,12 +21,19 @@ interface UseSessionLogsOpts {
   onCostUpdate?: (costUsd: number) => void;
 }
 
+const HISTORICAL_LIMIT = 5000;
+
 /**
  * Adapter hook: opens the session chat WebSocket, normalizes its events into
  * the same { logs, connected, capped, clear } shape that LogViewer's
  * externalLogs prop expects, plus exposes the session-specific affordances
  * (sendMessage, interrupt, status, model, cost, userMessages) that the
  * surrounding chat shell needs.
+ *
+ * Loads persisted chat history from `GET /api/sessions/:id/chat` first, then
+ * connects the WebSocket for live tail. Live events that arrive before
+ * history resolves are buffered and deduplicated against history on merge —
+ * mirrors the pattern used by `useLogs` and `useWorkflowRunLogs`.
  *
  * One ChatEvent maps to one LogEntry, so LogViewer's full grouping / search /
  * filter / time-gap rendering works for sessions with no special-casing.
@@ -36,6 +44,7 @@ export function useSessionLogs(sessionId: string, opts: UseSessionLogsOpts = {})
   const [status, setStatus] = useState<SessionStatus>("connecting");
   const [model, setModelState] = useState<string>("sonnet");
   const [costUsd, setCostUsd] = useState(0);
+  const [capped, setCapped] = useState(false);
 
   const wsRef = useRef<WebSocket | null>(null);
   const onCostUpdateRef = useRef(opts.onCostUpdate);
@@ -43,8 +52,35 @@ export function useSessionLogs(sessionId: string, opts: UseSessionLogsOpts = {})
 
   useEffect(() => {
     if (!sessionId) return;
+
+    // Buffer live events until historical chat is merged into state. `merged`
+    // flips to true only AFTER setLogs is called with historical data,
+    // closing the race where live events bypass dedup.
+    const pendingLive: LogEntry[] = [];
+    let merged = false;
+
     const ws = new WebSocket(`${getWsBaseUrl()}/ws/sessions/${sessionId}/chat`);
     wsRef.current = ws;
+
+    const appendLive = (entry: LogEntry) => {
+      if (!merged) {
+        pendingLive.push(entry);
+        return;
+      }
+      setLogs((prev) => {
+        // Dedup: skip if the last entry has identical content + type + timestamp
+        const last = prev[prev.length - 1];
+        if (
+          last &&
+          last.content === entry.content &&
+          last.logType === entry.logType &&
+          last.timestamp === entry.timestamp
+        ) {
+          return prev;
+        }
+        return [...prev, entry];
+      });
+    };
 
     ws.onopen = () => setStatus("ready");
     ws.onclose = () => setStatus("disconnected");
@@ -75,7 +111,11 @@ export function useSessionLogs(sessionId: string, opts: UseSessionLogsOpts = {})
             logType: ev.type,
             metadata: ev.metadata,
           };
-          setLogs((prev) => [...prev, entry]);
+          // The WebSocket replays history with `catchUp: true` on connect.
+          // We rely on REST for the canonical history load and ignore the
+          // catch-up frames so they don't double up after dedup.
+          if (msg.catchUp) return;
+          appendLive(entry);
           break;
         }
         case "cost_update":
@@ -85,18 +125,56 @@ export function useSessionLogs(sessionId: string, opts: UseSessionLogsOpts = {})
           }
           break;
         case "error":
-          setLogs((prev) => [
-            ...prev,
-            {
-              content: msg.message ?? "Unknown error",
-              stream: "stderr",
-              timestamp: new Date().toISOString(),
-              logType: "error",
-            },
-          ]);
+          appendLive({
+            content: msg.message ?? "Unknown error",
+            stream: "stderr",
+            timestamp: new Date().toISOString(),
+            logType: "error",
+          });
           break;
       }
     };
+
+    api
+      .getSessionChat(sessionId, { limit: HISTORICAL_LIMIT })
+      .then((res) => {
+        const historical: LogEntry[] = res.events.map((e: any) => ({
+          content: e.content,
+          stream: e.stream ?? "stdout",
+          timestamp:
+            typeof e.timestamp === "string" ? e.timestamp : new Date(e.timestamp).toISOString(),
+          logType: e.logType ?? undefined,
+          metadata: e.metadata ?? undefined,
+        }));
+        // Surface user-typed messages in the dedicated chat input timeline so
+        // the user's side of the conversation re-renders on reconnect.
+        const restoredUserMessages = historical
+          .filter((l) => l.logType === "user_message")
+          .map((l) => ({ text: l.content, timestamp: l.timestamp, status: "sent" as const }));
+        if (restoredUserMessages.length > 0) {
+          setUserMessages((prev) =>
+            prev.length === 0 ? restoredUserMessages : [...restoredUserMessages, ...prev],
+          );
+        }
+        if (historical.length >= HISTORICAL_LIMIT) setCapped(true);
+
+        // Drop user_message rows from the log timeline — they're surfaced
+        // separately above via userMessages, just like a fresh in-tab session.
+        const agentHistorical = historical.filter((l) => l.logType !== "user_message");
+
+        // Deduplicate: drop any live events already in the historical set
+        const historicalKeys = new Set(
+          agentHistorical.map((l: LogEntry) => l.timestamp + l.content),
+        );
+        const uniqueLive = pendingLive.filter((l) => !historicalKeys.has(l.timestamp + l.content));
+
+        setLogs([...agentHistorical, ...uniqueLive]);
+        merged = true;
+      })
+      .catch(() => {
+        setLogs(pendingLive);
+        merged = true;
+      });
 
     return () => {
       ws.close();
@@ -131,7 +209,7 @@ export function useSessionLogs(sessionId: string, opts: UseSessionLogsOpts = {})
   return {
     logs,
     connected: status === "ready" || status === "thinking" || status === "idle",
-    capped: false,
+    capped,
     clear,
     userMessages,
     sendMessage,

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -768,6 +768,13 @@ export const api = {
   endSession: (id: string) =>
     request<{ session: any }>(`/api/sessions/${id}/end`, { method: "POST" }),
 
+  getSessionChat: (sessionId: string, params?: { limit?: number }) => {
+    const qs = new URLSearchParams();
+    if (params?.limit) qs.set("limit", String(params.limit));
+    const query = qs.toString();
+    return request<{ events: any[] }>(`/api/sessions/${sessionId}/chat${query ? `?${query}` : ""}`);
+  },
+
   getSessionPrs: (sessionId: string) => request<{ prs: any[] }>(`/api/sessions/${sessionId}/prs`),
 
   addSessionPr: (sessionId: string, data: { prUrl: string; prNumber: number }) =>


### PR DESCRIPTION
Closes #513

## What changed

Sessions previously emitted chat events live over `/ws/sessions/:id/chat` but never persisted them, so navigating away and back gave you an empty chat with only newly-arriving events. Tasks, workflow runs, and persistent-agent turns all use a *REST history + live WebSocket tail* pattern; sessions were the odd one out. This PR brings sessions in line.

**Persistence**
- New `session_chat_events` table (`apps/api/src/db/migrations/1777400000_session_chat_events.sql`) with `(session_id, timestamp)` index and cascade-delete via `interactive_sessions`.
- `appendSessionChatEvent` / `listSessionChatEvents` in `interactive-session-service.ts`. The insert path prunes per-session events past `MAX_SESSION_CHAT_EVENTS = 5000` so a long-running session doesn't grow unboundedly.

**HTTP / WebSocket**
- New `GET /api/sessions/:id/chat?limit=N` returning persisted events oldest-first, mirroring `/api/tasks/:id/logs` and `/api/workflow-runs/:id/logs`.
- `apps/api/src/ws/session-chat.ts` now persists every parsed agent event, every stderr line, and the user's prompt as it streams them. On WebSocket connect it also replays history with `catchUp: true` (mirrors `persistent-agent-stream` catch-up) for clients that don't call REST first.

**Client**
- `useSessionLogs` now loads history via `api.getSessionChat()` first, then merges live events with the same buffer/dedup pattern as `useLogs` and `useWorkflowRunLogs`. User messages stored in history are restored into `userMessages`. Live `catchUp` frames are ignored — REST is the canonical history loader.

**Tests** (all passing locally)
- `apps/web/src/hooks/use-session-logs.test.ts` — new (9 cases): mount, history fetch, user-message restore, race-safe merge/dedup, catchUp drop, capped, fallback.
- `apps/api/src/services/interactive-session-service.test.ts` — +5 cases: append, prune, prune failure, list-ordered, limit clamp.
- `apps/api/src/routes/sessions.test.ts` — +4 cases: history fetch, limit query, 404 missing, 404 cross-user.

## How to test

1. Apply the migration: `cd apps/api && npx tsx src/db/migrate.ts`
2. Start a session, exchange a few messages with the agent, navigate to `/tasks` or `/repos`, then back to the session — the previous conversation should be visible immediately.
3. Open the same session in a second tab — both tabs should show the same conversation and both should receive new messages live (the bonus the issue calls out).
4. Run the suites: `cd apps/api && pnpm test src/services/interactive-session-service.test.ts src/routes/sessions.test.ts` and `cd apps/web && pnpm test src/hooks/use-session-logs.test.ts`.