### PR TITLE
docs: update for v0.4 — Tasks/Jobs/Reviews/Issues split + Persistent Agents tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Persistent Agents** — a third Task tier alongside Repo Tasks and Standalone Tasks. Long-lived, named, message-driven agents that wake on user messages, agent messages, webhooks, cron ticks, or ticket events. Each agent has a stable slug, addressable by other agents in the same workspace via an inter-agent HTTP API. Three configurable pod lifecycle modes: `always-on`, `sticky` (default, with idle warm window), and `on-demand`. Cyclic state machine reconciled by the existing K8s-style control plane. New `/agents` UI with chat, turn history, live activity stream, and pause/resume/restart/archive controls. See [docs/persistent-agents.md](docs/persistent-agents.md) and the four-agent demo in [demos/the-forge](demos/the-forge/README.md).
+- **Persistent Agents** — a third Task tier alongside Repo Tasks and Standalone Tasks. Long-lived, named, message-driven agents that wake on user messages, agent messages, webhooks, cron ticks, or ticket events. Each agent has a stable slug, addressable by other agents in the same workspace via an inter-agent HTTP API. Three configurable pod lifecycle modes: `always-on`, `sticky` (default, with idle warm window), and `on-demand`. Cyclic state machine reconciled by the existing K8s-style control plane (now a fourth `RunKind`: `persistent-agent`). New `/agents` UI with chat, turn history, live activity stream, and pause/resume/restart/archive controls. See [docs/persistent-agents.md](docs/persistent-agents.md) and the four-agent demo in [demos/the-forge](demos/the-forge/README.md).
+- **Issues** as a top-level nav item — the GitHub Issues queue is now its own page at `/issues`, promoted out of the `/tasks` tab strip.
+- **Reviews** as a top-level nav item — code-review subtasks plus external PR reviews now live at `/reviews` (and `/reviews/:id`), with their own reconciler `RunKind` (`pr-review`).
+- **Examples directory** — runnable, self-contained agent configurations under [`examples/`](examples/README.md), starting with two Persistent Agent setups (Forge and Mars Mission Control). Each example is idempotent — re-running `setup.sh` is safe.
+
+### Changed
+
+- **Sidebar nav reorganized.** The hub-and-tabs `/tasks` page is gone. Each tier has its own dedicated route, grouped into **Run** (Tasks · Jobs · Reviews · Issues · Scheduled) and **Live** (Agents · Sessions). The Library group renamed "Templates" to **Prompts** to free that label. Legacy `/tasks?tab=…` URLs redirect to the dedicated pages.
+- **User-facing names finalised.** Repo Tasks → **Tasks**; Standalone Tasks → **Jobs** (matching the existing `/api/jobs` URL); PR Reviews → **Reviews**; Persistent Agents → **Agents**; Templates (in the Library) → **Prompts**. Backend table names (`tasks`, `task_configs`, `workflows`, `prompt_templates`) are unchanged.
+
+### Migration notes
+
+> Upgrading from 0.3.x — there are no required user actions. URL/nav changes:
+>
+> - `/tasks?tab=standalone` → `/jobs` (auto-redirected)
+> - `/tasks?tab=issues` → `/issues` (auto-redirected)
+> - `/tasks?tab=prs` → `/reviews` (auto-redirected)
+> - The "Templates" sidebar item is now labeled **Prompts** but still points to `/templates`.
+> - The new `/agents` route requires the v0.4 schema migration (`1777200001_persistent_agents.sql`) — applied automatically on API startup.
+>
+> No data migration is needed. Existing tasks, workflows, triggers, and templates continue to work unchanged.
 
 ## [0.3.2] - 2026-04-24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,16 @@ Optio is an orchestration system for AI coding agents. Think of it as "CI/CD whe
 
 **Connections** — external service integrations injected into agent pods at runtime via MCP (Model Context Protocol). Built-in providers: Notion, GitHub, Slack, Linear, PostgreSQL, Sentry, Filesystem. Also supports custom MCP servers and HTTP APIs. Fine-grained access control (per-repo, per-agent-type, permission levels).
 
-**Backend-naming note.** For historical reasons the tables are `tasks` (Repo Tasks' one-time runs), `task_configs` (Repo Task blueprints), and `workflows` / `workflow_runs` / `workflow_triggers` (Standalone Tasks and their shared trigger surface). User-facing copy never uses "Workflow" or "Job" — everything is "Task" / "Repo Task" / "Standalone Task" in the UI. The legacy `/api/workflows` path was renamed to `/api/jobs` at the HTTP layer and the `/jobs/*` web routes remain for Standalone detail/runs.
+**Backend-naming note.** For historical reasons the tables are `tasks` (Repo Tasks' one-time runs), `task_configs` (Repo Task blueprints), and `workflows` / `workflow_runs` / `workflow_triggers` (Standalone Tasks and their shared trigger surface). The v0.4 UI settled on these user-facing names:
+
+- **Tasks** — Repo Tasks (formerly "Repo Tasks" in copy; now just "Tasks")
+- **Jobs** — Standalone Tasks (matches the `/api/jobs` URL and `/jobs/*` web routes)
+- **Reviews** — code-review subtasks + external PR reviews (formerly "PR Reviews"; promoted out of `/tasks` into its own top-level slot)
+- **Issues** — GitHub Issues queue (promoted to its own top-level nav item)
+- **Agents** — Persistent Agents (the third tier; long-lived, message-driven)
+- **Prompts** — reusable prompt templates (was "Templates" in the Library)
+
+The sidebar groups these as **Run** (Tasks · Jobs · Reviews · Issues · Scheduled) and **Live** (Agents · Sessions). The `/tasks` hub-with-tabs from earlier versions is gone — each section is its own page now. Legacy `/tasks?tab=...` URLs redirect to the dedicated routes.
 
 For the long-form explanation of how the two flavors map to the three internal types, the polymorphic HTTP layer, and how the UI presents them, see `docs/tasks.md`.
 
@@ -49,23 +58,26 @@ Legacy `/api/jobs/*` and `/api/task-configs/*` endpoints still work as thin alia
 ## Architecture
 
 ```
-┌─────────────┐     ┌──────────────┐     ┌─────────────────────┐
-│   Web UI    │────→│  API Server  │────→│   K8s Pods          │
-│  Next.js    │     │   Fastify    │     │                     │
-│  :30310     │     │   :30400     │     │  ┌─ Repo Pod A ──┐  │
-│             │←ws──│              │     │  │ clone + sleep  │  │
-│             │     │ - BullMQ     │     │  │ ├─ worktree 1  │  │
-│             │     │ - Drizzle    │     │  │ ├─ worktree 2  │  │
-│             │     │ - WebSocket  │     │  │ └─ worktree N  │  │
-│             │     │ - PR Watcher │     │  └────────────────┘  │
-│             │     │ - Workflow Q │     │  ┌─ Workflow Pod ─┐  │
-│             │     │ - Health Mon │     │  │ isolated agent  │  │
-│             │     │ - Connection │     │  └────────────────┘  │
-│             │     │   Service    │     │                       │
-└─────────────┘     └──────┬───────┘     └───────────────────────┘
-                           │
+┌─────────────┐     ┌──────────────┐     ┌─────────────────────────────┐
+│   Web UI    │────→│  API Server  │────→│   K8s Pods                  │
+│  Next.js    │     │   Fastify    │     │                             │
+│  :30310     │     │   :30400     │     │  ┌─ Repo Pod A ──────────┐  │
+│             │←ws──│              │     │  │ clone + sleep          │  │
+│  Run        │     │ - BullMQ     │     │  │ ├─ worktree 1          │  │
+│   Tasks     │     │ - Drizzle    │     │  │ ├─ worktree 2          │  │
+│   Jobs      │     │ - WebSocket  │     │  │ └─ worktree N          │  │
+│   Reviews   │     │ - PR Watcher │     │  └────────────────────────┘  │
+│   Issues    │     │ - Workflow Q │     │  ┌─ Job Pod ─────────────┐  │
+│   Scheduled │     │ - PA Worker  │     │  │ isolated agent         │  │
+│  Live       │     │ - Reconciler │     │  └────────────────────────┘  │
+│   Agents    │     │ - Health Mon │     │  ┌─ Persistent Agent Pod ┐  │
+│   Sessions  │     │ - Connection │     │  │ long-lived; turns      │  │
+│             │     │   Service    │     │  │ wake on messages       │  │
+└─────────────┘     └──────┬───────┘     │  └────────────────────────┘  │
+                           │             └──────────────────────────────┘
                     ┌──────┴───────┐
-                    │  Postgres    │  State, logs, workflows, connections, secrets
+                    │  Postgres    │  State, logs, workflows, persistent agents,
+                    │              │  inboxes, connections, secrets
                     │  Redis       │  Job queue, pub/sub
                     └──────────────┘
 
@@ -138,12 +150,13 @@ These are well-documented in code; read the relevant service files for details:
 - **Shared cache directories**: per-repo persistent PVCs for tool caches (npm, pip, cargo, etc.), managed via `/api/repos/:id/shared-directories`
 - **Interactive sessions**: persistent workspaces with terminal + agent chat, at `/sessions`
 - **Workspaces**: multi-tenancy via `workspaceId` column. Roles (admin/member/viewer) in schema but not fully enforced
-- **Standalone Tasks** (`workflow-service.ts`, `workflow-worker.ts`): reached from the "Standalone" link on `/tasks` (list at `/jobs`, detail at `/jobs/:id`, runs at `/jobs/:id/runs/:runId`). Agent runs with no repo, `{{PARAM}}` prompt templates, four trigger types (manual/schedule/webhook/ticket), pooled pod execution, real-time log streaming, auto-retry with exponential backoff. Pods are **shared across runs within a workflow**, keyed on `(workflow_id, instance_index)`: each workflow has `workflows.maxPodInstances` pod replicas (default 1, max 20) and `workflows.maxAgentsPerPod` concurrent runs per pod (default 2, max 50) — mirrors repo pod scaling. Runs track their assigned pod via `workflow_runs.pod_id` and remember it for retry affinity via `last_pod_id`. Schema: `workflows`, `workflow_triggers`, `workflow_runs`, `workflow_run_logs`, `workflow_pods`
+- **Standalone Tasks / Jobs** (`workflow-service.ts`, `workflow-worker.ts`): top-level **Jobs** nav item under "Run" (list at `/jobs`, detail at `/jobs/:id`, runs at `/jobs/:id/runs/:runId`). Agent runs with no repo, `{{PARAM}}` prompt templates, four trigger types (manual/schedule/webhook/ticket), pooled pod execution, real-time log streaming, auto-retry with exponential backoff. Pods are **shared across runs within a workflow**, keyed on `(workflow_id, instance_index)`: each workflow has `workflows.maxPodInstances` pod replicas (default 1, max 20) and `workflows.maxAgentsPerPod` concurrent runs per pod (default 2, max 50) — mirrors repo pod scaling. Runs track their assigned pod via `workflow_runs.pod_id` and remember it for retry affinity via `last_pod_id`. Schema: `workflows`, `workflow_triggers`, `workflow_runs`, `workflow_run_logs`, `workflow_pods`
 - **Repo Task Configs** (`task-config-service.ts`, routes in `task-configs.ts`): reusable Repo Task blueprints that spawn tasks when triggers fire. `instantiateTask(configId, { triggerId, params })` creates a task with rendered prompt + title, transitions it to QUEUED, and enqueues the BullMQ job. UI at `/tasks/scheduled`. Schema: `task_configs`
 - **Triggers** (`workflow-trigger-service.ts`, `workflow-trigger-worker.ts`): polymorphic trigger table (`workflow_triggers`) keyed by `(target_type, target_id)`. `target_type="job"` dispatches to `createWorkflowRun`; `target_type="task_config"` dispatches to `instantiateTask`. Schedule trigger worker polls every 60s (`OPTIO_WORKFLOW_TRIGGER_INTERVAL`).
-- **Templates** (`prompt-template-service.ts`, routes in `prompt-templates.ts`): reusable prompt templates with `kind` discriminator (`prompt` / `review` / `job` / `task`). `renderTemplateString(template, params)` handles `{{param}}` substitution + `{{#if}}` blocks. UI at `/templates`.
+- **Prompts / Templates** (`prompt-template-service.ts`, routes in `prompt-templates.ts`): reusable prompt templates with `kind` discriminator (`prompt` / `review` / `job` / `task`). `renderTemplateString(template, params)` handles `{{param}}` substitution + `{{#if}}` blocks. UI at `/templates` (labeled **Prompts** in the Library nav as of v0.4 — the "Templates" name was freed for other use).
+- **Persistent Agents** (`persistent-agent-service.ts`, workers `persistent-agent-worker.ts` / `persistent-agent-cleanup-worker.ts`, routes in `persistent-agents.ts` and `internal/persistent-agents.ts`): the third Task tier — long-lived, named, message-driven. Cyclic state machine (`idle → queued → provisioning → running → idle`), per-agent pod lifecycle modes (`always-on` / `sticky` / `on-demand`). Wake sources: user/agent messages, webhook, cron tick, ticket event, system. Inter-agent HTTP API at `/api/internal/persistent-agents/*` (auth via `X-Optio-Agent-Token`). UI at `/agents` (under "Live"). Schema: `persistent_agents`, `persistent_agent_turns`, `persistent_agent_turn_logs`, `persistent_agent_messages`, `persistent_agent_pods`. See `docs/persistent-agents.md` and the demo in `demos/the-forge/`.
 - **Connections** (`connection-service.ts`): external service integrations via MCP. Built-in providers: Notion, GitHub, Slack, Linear, PostgreSQL, Sentry, Filesystem. Also supports custom MCP servers and HTTP APIs. Three-layer model: providers (catalog) → connections (configured instances) → assignments (per-repo/agent-type rules). Injected into agent pods at task runtime via `getConnectionsForTask()` in task-worker
-- **Reconciliation control plane** (`workers/reconcile-worker.ts`, `services/reconcile-{snapshot,executor,queue}.ts`, `packages/shared/src/reconcile/`): K8s-style reconciler for Repo Task runs (`tasks`) and Standalone runs (`workflow_runs`). Pure decision functions consume a frozen `WorldSnapshot` and return a typed `Action`; the executor applies it under CAS so concurrent passes can't trample each other. Producers — `taskService.transitionTask`, `workflow-worker`'s `transitionRun`, `pr-watcher` poll cycle, `repo-cleanup` pod-health detection — wake the reconciler via `enqueueReconcile`. Periodic resync (`OPTIO_RECONCILE_RESYNC_INTERVAL`, 5 min) catches anything missed. The reconciler owns: PR-driven transitions (auto-merge, complete-on-merge, fail-on-close), auto-resume on CI/conflict/review (capped by `OPTIO_MAX_AUTO_RESUMES`), review launch, stall + pod-death detection, control-intent (cancel/retry/resume/restart). Schema: `control_intent`, `reconcile_backoff_until`, `reconcile_attempts` columns on both `tasks` and `workflow_runs`. See `docs/reconciliation.md`
+- **Reconciliation control plane** (`workers/reconcile-worker.ts`, `services/reconcile-{snapshot,executor,queue}.ts`, `packages/shared/src/reconcile/`): K8s-style reconciler with four `RunKind`s — `repo` (Repo Task runs in `tasks`), `standalone` (Job runs in `workflow_runs`), `pr-review` (external PR reviews), and `persistent-agent` (Persistent Agents in `persistent_agents`). Pure decision functions consume a frozen `WorldSnapshot` and return a typed `Action`; the executor applies it under CAS so concurrent passes can't trample each other. Producers — `taskService.transitionTask`, `workflow-worker`'s `transitionRun`, `pr-watcher` poll cycle, `repo-cleanup` pod-health detection, `wakeAgent()` (PA inbox + trigger dispatch) — wake the reconciler via `enqueueReconcile`. Periodic resync (`OPTIO_RECONCILE_RESYNC_INTERVAL`, 5 min) catches anything missed. The reconciler owns: PR-driven transitions (auto-merge, complete-on-merge, fail-on-close), auto-resume on CI/conflict/review (capped by `OPTIO_MAX_AUTO_RESUMES`), review launch, stall + pod-death detection, control-intent (cancel/retry/resume/restart), and the Persistent Agent turn cycle. Schema: `control_intent`, `reconcile_backoff_until`, `reconcile_attempts` columns on `tasks`, `workflow_runs`, and `persistent_agents`. See `docs/reconciliation.md`
 - **Task dependencies**: `task_dependencies` table for multi-step pipelines
 - **Cost tracking**: `GET /api/analytics/costs` with daily/repo/type breakdowns, UI at `/costs`
 - **Error classification**: `packages/shared/src/error-classifier.ts` pattern-matches errors into categories with remedies

--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@
 [![CI](https://github.com/jonwiggins/optio/actions/workflows/ci.yml/badge.svg)](https://github.com/jonwiggins/optio/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
-Optio has one user-facing concept — a **Task** — with one attribute that flips the pipeline behind it: does the task have a repo?
+Optio organizes agent work into three tiers, all driven by the same trigger types, prompt-template engine, log streaming, and `/api/tasks` HTTP surface:
 
-- **Repo Tasks** — turn tickets into merged pull requests. Submit a task (manually, from a GitHub Issue, Linear, Jira, or Notion), and Optio provisions an isolated environment, runs an AI agent, opens a PR, monitors CI, triggers code review, auto-fixes failures, and merges when everything passes.
-- **Standalone Tasks** — run reusable, parameterized agent work with no repo checkout. Generate reports, triage alerts, audit dependencies, query a database, post to Slack — anything that doesn't need to land as a PR.
+- **Tasks** ([Repo Tasks](./docs/tasks.md)) — turn tickets into merged pull requests. Submit a task (manually, from a GitHub Issue, Linear, Jira, or Notion), and Optio provisions an isolated environment, runs an AI agent, opens a PR, monitors CI, triggers code review, auto-fixes failures, and merges when everything passes.
+- **Jobs** ([Standalone Tasks](./docs/tasks.md)) — reusable, parameterized agent runs with no repo checkout. Generate reports, triage alerts, audit dependencies, query a database, post to Slack — anything that doesn't need to land as a PR.
+- **Agents** ([Persistent Agents](./docs/persistent-agents.md)) — long-lived, named, message-driven agent processes. Each has a stable slug, an inbox, and a cyclic state machine. Wake on user messages, agent messages, webhooks, cron ticks, or ticket events. Three pod lifecycle modes (`always-on` / `sticky` / `on-demand`). Address each other via an inter-agent HTTP API. See the four-agent [Forge demo](./examples/persistent-agents/forge/) and the [Mars Mission Control](./examples/persistent-agents/mars-mission-control/) example.
 - **Connections** — give your agents access to external services. Connect Notion, Slack, Linear, GitHub, PostgreSQL, Sentry, or any MCP-compatible server, and Optio injects them into agent pods at runtime.
 
-Both flavors share the same trigger types (manual, schedule, webhook, ticket), the same prompt-template engine, the same real-time log streaming, and the same `/api/tasks` HTTP surface. The difference is whether the agent runs against a worktree or in an empty pod. See [docs/tasks.md](./docs/tasks.md) for the full breakdown.
+Tasks and Jobs are the **job model** — one-shot runs whose identity is the run itself. Persistent Agents are the **service model** — a turn is an input to the long-lived process, not the unit of work. Pick the tier by what shape your work has; see [examples/](./examples/README.md) for runnable starting points and [docs/tasks.md](./docs/tasks.md) for the full breakdown.
 
-The feedback loop is what makes Repo Tasks different. When CI fails, the agent is automatically resumed with the failure context. When a reviewer requests changes, the agent picks up the review comments and pushes a fix. When everything passes, the PR is squash-merged and the issue is closed. You describe the work; Optio drives it to completion.
+The feedback loop is what makes Tasks different. When CI fails, the agent is automatically resumed with the failure context. When a reviewer requests changes, the agent picks up the review comments and pushes a fix. When everything passes, the PR is squash-merged and the issue is closed. You describe the work; Optio drives it to completion.
 
 Under the hood, all task and pod state changes flow through a [Kubernetes-style reconciliation control plane](./docs/reconciliation.md) — a pure-decision-plus-CAS-executor loop with periodic resync that keeps runs from getting stuck on lost events.
 
@@ -29,7 +30,7 @@ Under the hood, all task and pod state changes flow through a [Kubernetes-style 
 
 ## How It Works
 
-### Repo Tasks — ticket to merged PR
+### Tasks — ticket to merged PR
 
 ```
 You create a task          Optio runs the agent           Optio closes the loop
@@ -50,10 +51,10 @@ You create a task          Optio runs the agent           Optio closes the loop
 5. **Feedback loop** — CI failures, merge conflicts, and review feedback automatically resume the agent with context
 6. **Completion** — PR is squash-merged, linked issues are closed, costs are recorded
 
-### Standalone Tasks — reusable agent work without a repo
+### Jobs — reusable agent work without a repo
 
 ```
-You define a task           Optio triggers it              Optio runs & tracks
+You define a job            Optio triggers it              Optio runs & tracks
 ────────────────────        ─────────────────              ───────────────────
 
   Prompt template           Manual (UI / API)              Provision isolated pod
@@ -63,7 +64,21 @@ You define a task           Optio triggers it              Optio runs & tracks
                                                            Auto-retry on failure
 ```
 
-Standalone Tasks run an agent in an isolated pod with no git checkout. Define a prompt template with `{{PARAM}}` placeholders, configure triggers (manual, cron schedule, webhook, or ticket), and let Optio handle execution, retries, and cost tracking. Repo Tasks can also be saved as **blueprints** with the same trigger types — see [docs/tasks.md](./docs/tasks.md).
+Jobs (Standalone Tasks) run an agent in an isolated pod with no git checkout. Define a prompt template with `{{PARAM}}` placeholders, configure triggers (manual, cron schedule, webhook, or ticket), and let Optio handle execution, retries, and cost tracking. Tasks can also be saved as **blueprints** with the same trigger types — see [docs/tasks.md](./docs/tasks.md).
+
+### Agents — long-lived, message-driven
+
+```
+You create an agent         Wake sources                   Per turn
+──────────────────────      ─────────────────              ──────────────────────
+
+  System prompt             User chat message              Drain pending messages
+  agents.md operator   ──→  Inter-agent message    ──→     Render into prompt
+  manual                    Cron tick / webhook            Run one turn → halt
+  Pod lifecycle mode        Ticket event                   Repeat on next wake
+```
+
+Persistent Agents (PAs) are long-lived processes addressable by other agents in the same workspace. Each PA executes one **turn** of work, halts, and waits to be re-woken by a message or trigger event. Pod lifecycle is configurable per agent: `always-on` (lowest latency, highest cost), `sticky` (warm for an idle window after each turn — the default), or `on-demand` (cold-start every turn). PAs reuse the existing trigger system, the reconciler, and the pod-pool primitives. See [docs/persistent-agents.md](./docs/persistent-agents.md) and the [examples/persistent-agents](./examples/persistent-agents/) directory.
 
 ### Connections — extend agent capabilities
 
@@ -74,40 +89,44 @@ Connections give your agents access to external tools and data at runtime. Confi
 ## Key Features
 
 - **Autonomous feedback loop** — auto-resumes the agent on CI failures, merge conflicts, and review feedback; auto-merges when everything passes
-- **Repo Tasks and Standalone Tasks** — one Task concept, two pipelines. Repo Tasks land code via PRs; Standalone Tasks run agents in empty pods for reports, triage, and ops. Both share triggers (manual / schedule / webhook / ticket), templates, and the unified `/api/tasks` HTTP layer
+- **Three Task tiers** — **Tasks** land code via PRs; **Jobs** run agents in empty pods for reports, triage, and ops; **Agents** are long-lived, message-driven services. All three share triggers (manual / schedule / webhook / ticket), prompt templates, the reconciler, and the unified `/api/tasks` HTTP layer
+- **Inter-agent messaging** — Persistent Agents address each other via `/api/internal/persistent-agents/*` for direct messages and broadcasts, enabling multi-agent teams (see the Forge demo)
 - **Connections** — plug external services (Notion, Slack, Linear, GitHub, PostgreSQL, Sentry, custom MCP servers) into agent pods with fine-grained access control per repo and agent type
 - **Pod-per-repo architecture** — one long-lived Kubernetes pod per repo with git worktree isolation, multi-pod scaling, and idle cleanup
 - **Code review agent** — automatically launches a review agent as a subtask, with a separate prompt and model
 - **Multi-agent support** — run Claude Code, OpenAI Codex, GitHub Copilot, Google Gemini, or OpenCode with per-repo model and prompt configuration
 - **GitHub Issues, Linear, Jira, and Notion intake** — assign issues to Optio from the UI or via ticket sync
-- **Reconciliation control plane** — K8s-style pure-decision-plus-CAS-executor loop with periodic resync; keeps tasks and pods from getting stuck on lost events. Ships in shadow mode behind a feature flag
+- **Reconciliation control plane** — K8s-style pure-decision-plus-CAS-executor loop with periodic resync over four `RunKind`s (`repo`, `standalone`, `pr-review`, `persistent-agent`); keeps state from getting stuck on lost events
 - **Real-time dashboard** — live log streaming, pipeline progress, cost analytics, and cluster health
 
 ## Architecture
 
 ```
-┌──────────────┐     ┌────────────────────┐     ┌───────────────────────────┐
-│   Web UI     │────→│    API Server      │────→│      Kubernetes           │
-│   Next.js    │     │    Fastify         │     │                           │
-│   :3100      │     │                    │     │  ┌── Repo Pod A ───────┐  │
-│              │←ws──│  Workers:          │     │  │ clone + sleep       │  │
-│  Dashboard   │     │  ├─ Task Queue     │     │  │ ├─ worktree 1  ⚡    │  │
-│  Tasks       │     │  ├─ PR Watcher     │     │  │ ├─ worktree 2  ⚡    │  │
-│  Repos       │     │  ├─ Workflow Queue │     │  │ └─ worktree N  ⚡    │  │
-│  Standalone  │     │  ├─ Reconciler     │     │  └─────────────────────┘  │
-│  Connections │     │  ├─ Health Mon     │     │  ┌── Standalone Pod ────┐ │
-│  Cluster     │     │  └─ Ticket Sync    │     │  │ isolated agent  ⚡    │ │
-│  Costs       │     │                    │     │  └─────────────────────┘  │
-│              │     │  Services:         │     │                           │
-│              │     │  ├─ Repo Pool      │     │                           │
-│              │     │  ├─ Workflow Pool  │     │  MCP servers injected via │
-│              │     │  ├─ Connections    │     │  Connections at runtime    │
-│              │     │  ├─ Review Agent   │     │                           │
-│              │     │  └─ Auth/Secrets   │     │                           │
-└──────────────┘     └─────────┬──────────┘     └───────────────────────────┘
-                               │                  ⚡ = Claude / Codex / Copilot / Gemini
+┌──────────────┐     ┌────────────────────┐     ┌────────────────────────────┐
+│   Web UI     │────→│    API Server      │────→│      Kubernetes            │
+│   Next.js    │     │    Fastify         │     │                            │
+│   :3100      │     │                    │     │  ┌── Repo Pod A ────────┐  │
+│              │←ws──│  Workers:          │     │  │ clone + sleep        │  │
+│  Run         │     │  ├─ Task Queue     │     │  │ ├─ worktree 1  ⚡     │  │
+│   Tasks      │     │  ├─ PR Watcher     │     │  │ ├─ worktree 2  ⚡     │  │
+│   Jobs       │     │  ├─ Workflow Queue │     │  │ └─ worktree N  ⚡     │  │
+│   Reviews    │     │  ├─ PA Worker      │     │  └──────────────────────┘  │
+│   Issues     │     │  ├─ Reconciler     │     │  ┌── Job Pod ───────────┐  │
+│   Scheduled  │     │  ├─ Health Mon     │     │  │ isolated agent  ⚡    │  │
+│  Live        │     │  └─ Ticket Sync    │     │  └──────────────────────┘  │
+│   Agents     │     │                    │     │  ┌── Persistent Agent ──┐  │
+│   Sessions   │     │  Services:         │     │  │ long-lived; turns   ⚡│  │
+│  Library     │     │  ├─ Repo Pool      │     │  │ wake on messages     │  │
+│   Prompts    │     │  ├─ Workflow Pool  │     │  └──────────────────────┘  │
+│   Repos      │     │  ├─ PA Pool        │     │                            │
+│   Connections│     │  ├─ Connections    │     │  MCP servers injected via  │
+│              │     │  ├─ Review Agent   │     │  Connections at runtime    │
+│              │     │  └─ Auth/Secrets   │     │                            │
+└──────────────┘     └─────────┬──────────┘     └────────────────────────────┘
+                               │                  ⚡ = Claude / Codex / Copilot / Gemini / OpenCode
                         ┌──────┴──────┐
-                        │  Postgres   │  Tasks, workflows, connections, logs, secrets
+                        │  Postgres   │  Tasks, workflows, persistent agents,
+                        │             │  inboxes, connections, logs, secrets
                         │  Redis      │  Job queue, pub/sub, live streaming
                         └─────────────┘
 ```
@@ -207,11 +226,12 @@ helm uninstall optio -n optio
 
 ```
 apps/
-  api/          Fastify API server, BullMQ workers (incl. reconciler),
-                WebSocket endpoints, standalone-task engine, connection service,
-                review service, OAuth
+  api/          Fastify API server, BullMQ workers (incl. reconciler,
+                persistent-agent worker), WebSocket endpoints, standalone-task
+                engine, connection service, review service, OAuth
   web/          Next.js dashboard with real-time streaming, cost analytics,
-                Repo / Standalone Task management, connection catalog
+                Tasks / Jobs / Reviews / Issues / Agents / Sessions surfaces,
+                connection catalog
   site/         Documentation site (GitHub Pages)
   cli/          Terminal client for Optio
 

--- a/docs/persistent-agents.md
+++ b/docs/persistent-agents.md
@@ -142,7 +142,12 @@ A four-agent engineering team:
 - **Sentinel** — reviewer
 - **Chronicler** — scribe (maintains team journal)
 
-See [`demos/the-forge/README.md`](../demos/the-forge/README.md).
+See [`demos/the-forge/README.md`](../demos/the-forge/README.md). A self-contained,
+runnable copy lives at [`examples/persistent-agents/forge/`](../examples/persistent-agents/forge/).
+
+For more runnable examples (including the seven-agent
+[Mars Mission Control](../examples/persistent-agents/mars-mission-control/)
+incident-response scenario), see [`examples/README.md`](../examples/README.md).
 
 ## Reconciliation
 

--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -49,7 +49,7 @@ A snapshot is frozen — once read, the decision function only sees that point-i
 
 ## What it reconciles
 
-Two run kinds, two state machines.
+Four run kinds, four state machines. The `RunKind` discriminator is `"repo" | "standalone" | "pr-review" | "persistent-agent"` (see `packages/shared/src/reconcile/types.ts`).
 
 ### Repo runs (`tasks` table)
 
@@ -72,14 +72,36 @@ The repo decision function evaluates capacity, dependency state, pod health, PR 
 
 States: `queued`, `running`, `completed`, `failed`. Simpler — the decision function reads pod state and decides whether to enqueue the agent, transition, or back off.
 
+### PR-review runs (`pr_reviews` table)
+
+External PR reviews — code-review subtasks for PRs that aren't tied to a Repo Task. The decision function tracks pod state, review-agent completion, and re-runs on push events when configured. Lifted out of the Repo Task pipeline so external PRs can be reviewed without going through the worktree flow.
+
+### Persistent Agent runs (`persistent_agents` table)
+
+The state machine is **cyclic** rather than terminal — agents return to `idle` after each successful turn rather than transitioning to a terminal state.
+
+States: `idle`, `queued`, `provisioning`, `running`, `paused`, `failed`, `archived`.
+
+```
+idle ── pending msg / intent ──▶ queued ──▶ provisioning ──▶ running
+  ▲                                                              │
+  └────────────────── turn halted (success) ─────────────────────┘
+```
+
+The Persistent Agent decision function (`reconcile-persistent-agent.ts`) considers: pending inbox messages, control intent (`pause`, `resume`, `restart`, `archive`), pod lifecycle mode (`always-on` / `sticky` / `on-demand`), pod warm-window (`keep_warm_until`), `consecutive_failures` against `consecutive_failure_limit`, and reconcile backoff. Actions it can return include `enqueueTurn`, `provisionPod`, `markIdle`, `pausePod`, `archive`, `failPermanently`, plus the standard `patchStatus` / `deferWithBackoff` / `noop`.
+
+`paused` and `failed` require a manual `resume` control intent before the agent will act again. `archived` is terminal — the row is kept for history but no further turns are possible.
+
 ## Producers
 
-Three things enqueue a reconcile job:
+Several things enqueue a reconcile job:
 
-1. **State-change events.** `taskService.transitionTask` and `workflow-worker`'s `transitionRun` helper both fire `enqueueReconcile` after every successful transition. Anywhere the codebase changes a run's state, the reconciler is woken within milliseconds.
+1. **State-change events.** `taskService.transitionTask`, `workflow-worker`'s `transitionRun` helper, and the persistent-agent worker's per-turn finalizer all fire `enqueueReconcile` after every successful transition. Anywhere the codebase changes a run's state, the reconciler is woken within milliseconds.
 2. **PR poll updates.** The `pr-watcher-worker` polls open PRs every 30s, writes refreshed `prState` / `prChecksStatus` / `prReviewStatus` / `prReviewComments` to the row, then enqueues a reconcile so the decision function sees the new PR data.
 3. **Pod-health events.** When `repo-cleanup-worker` detects a crashed or OOM-killed pod, it marks worktrees dirty and enqueues a reconcile for each affected task — the reconciler observes `pod.phase=error` from the snapshot and fires the FAILED transition.
-4. **Periodic resync.** Every 5 minutes (configurable) the resync worker scans non-terminal runs in both tables and enqueues each one. Safety net for any signal that's lost.
+4. **Persistent Agent wakes.** `wakeAgent()` (called from the inbox API, the inter-agent HTTP API, the workflow-trigger worker on `target_type='persistent_agent'`, and the cleanup worker on warm-window expiry) enqueues a reconcile so the decision function picks up new messages or intents.
+5. **Control intents.** UI/API actions that set `control_intent` (`cancel`, `retry`, `resume`, `restart`, `pause`, `archive`) enqueue a reconcile so the decision function applies the intent.
+6. **Periodic resync.** Every 5 minutes (configurable) the resync worker scans non-terminal runs across all four tables and enqueues each one. Safety net for any signal that's lost.
 
 The queue dedups by `${kind}__${id}`, so multiple producers do not amplify load.
 
@@ -95,7 +117,7 @@ The queue dedups by `${kind}__${id}`, so multiple producers do not amplify load.
 
 ## Schema
 
-The `tasks` and `workflow_runs` tables each gained three columns (migration `1776686400_reconcile_columns.sql`):
+The `tasks`, `workflow_runs`, `pr_reviews`, and `persistent_agents` tables each carry the same three reconcile columns (`tasks` and `workflow_runs` got them via migration `1776686400_reconcile_columns.sql`; `persistent_agents` includes them in its own migration):
 
 | Column                    | Type          | Purpose                                                     |
 | ------------------------- | ------------- | ----------------------------------------------------------- |
@@ -107,16 +129,18 @@ All three are nullable / default zero, so no backfill was required.
 
 ## Code map
 
-| File                                                          | Role                                            |
-| ------------------------------------------------------------- | ----------------------------------------------- |
-| `packages/shared/src/reconcile/types.ts`                      | `RunRef`, `WorldSnapshot`, `Action` unions      |
-| `packages/shared/src/reconcile/reconcile-repo.ts`             | Pure decision logic for repo runs               |
-| `packages/shared/src/reconcile/reconcile-standalone.ts`       | Pure decision logic for standalone runs         |
-| `apps/api/src/workers/reconcile-worker.ts`                    | BullMQ consumer + resync worker                 |
-| `apps/api/src/services/reconcile-snapshot.ts`                 | Builds the frozen world view                    |
-| `apps/api/src/services/reconcile-executor.ts`                 | CAS-gated mutations; delegates to `taskService` |
-| `apps/api/src/services/reconcile-queue.ts`                    | Queue setup and dedup-aware enqueue helpers     |
-| `apps/api/src/db/migrations/1776686400_reconcile_columns.sql` | Schema columns                                  |
+| File                                                          | Role                                                  |
+| ------------------------------------------------------------- | ----------------------------------------------------- |
+| `packages/shared/src/reconcile/types.ts`                      | `RunKind`, `RunRef`, `WorldSnapshot`, `Action` unions |
+| `packages/shared/src/reconcile/reconcile-repo.ts`             | Pure decision logic for repo runs                     |
+| `packages/shared/src/reconcile/reconcile-standalone.ts`       | Pure decision logic for standalone runs               |
+| `packages/shared/src/reconcile/reconcile-pr-review.ts`        | Pure decision logic for external PR reviews           |
+| `packages/shared/src/reconcile/reconcile-persistent-agent.ts` | Pure decision logic for Persistent Agents             |
+| `apps/api/src/workers/reconcile-worker.ts`                    | BullMQ consumer + resync worker                       |
+| `apps/api/src/services/reconcile-snapshot.ts`                 | Builds the frozen world view                          |
+| `apps/api/src/services/reconcile-executor.ts`                 | CAS-gated mutations; delegates to `taskService`       |
+| `apps/api/src/services/reconcile-queue.ts`                    | Queue setup and dedup-aware enqueue helpers           |
+| `apps/api/src/db/migrations/1776686400_reconcile_columns.sql` | Schema columns for `tasks` + `workflow_runs`          |
 
 Decision logic is exhaustively tested in `packages/shared/src/reconcile/*.test.ts`. Because the decision functions are pure, every state machine edge case is covered without mocking I/O.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -46,7 +46,7 @@ The user-facing flavors are backed by three internal types. The distinction is w
 
 A blueprint plus a fired trigger produces a run. The same trigger types (`manual`, `schedule`, `webhook`, `ticket`) work for both `repo-blueprint` and `standalone` because the trigger table is polymorphic — see [Triggers](#triggers) below.
 
-> **Backend-naming note.** The schema still says `workflows`, `workflow_runs`, and `workflow_triggers` for historical reasons. User-facing copy is always "Task" / "Repo Task" / "Standalone Task". Routes follow the same rule: `/api/tasks` is the canonical surface; `/api/jobs/*` and `/api/task-configs/*` are back-compat aliases.
+> **Backend-naming note.** The schema still says `workflows`, `workflow_runs`, and `workflow_triggers` for historical reasons, and the user-facing label for Standalone Tasks settled on **Jobs** (which matches the existing `/api/jobs` URL and the `/jobs/*` web routes). `/api/tasks` is the canonical polymorphic surface; `/api/jobs/*` and `/api/task-configs/*` are back-compat aliases.
 
 ## The unified `/api/tasks` HTTP layer
 
@@ -66,15 +66,16 @@ Legacy `/api/jobs/*` and `/api/task-configs/*` endpoints still work as thin alia
 
 ## How they appear in the UI
 
-The web UI hides the schema split entirely.
+The web UI hides the schema split entirely. As of v0.4 the old `/tasks`-with-tabs hub is gone — each surface lives at its own top-level route, grouped under **Run** in the sidebar. User-facing names: Standalone Tasks are called **Jobs**, PR reviews are called **Reviews**.
 
-- **`/tasks`** — the main hub.
-  - **Repo Tasks** tab: ad-hoc and blueprint-spawned `tasks` runs. Bulk actions, state filters, real-time WebSocket updates.
-  - **Standalone** tab: `workflows` (blueprints) with their runs and triggers. One-click "Run Now."
-  - **Issues** tab: GitHub Issues across connected repos. "Assign to Optio" creates an ad-hoc Repo Task.
-  - **Pull Requests** tab: PR browser with CI / review / merge tracking.
+- **`/tasks`** — Repo Tasks list. Ad-hoc and blueprint-spawned `tasks` runs, with bulk actions, state filters, and real-time WebSocket updates.
+- **`/jobs`**, **`/jobs/:id`**, **`/jobs/:id/runs/:runId`** — Jobs (Standalone Tasks): blueprint list, detail, and per-run views. One-click "Run Now."
+- **`/reviews`**, **`/reviews/:id`** — Reviews: code-review subtasks plus external PR reviews, with CI / review / merge tracking.
+- **`/issues`** — GitHub Issues across connected repos. "Assign to Optio" creates an ad-hoc Repo Task.
 - **`/tasks/scheduled`** — manage `repo-blueprint` rows: schedule, webhook, ticket, manual triggers; pause/resume; run-now.
-- **`/jobs`**, **`/jobs/:id`**, **`/jobs/:id/runs/:runId`** — Standalone detail and run views (the legacy "jobs" route names live on under the hood).
+- **`/agents`**, **`/agents/:id`** — Persistent Agents (the third tier — see [persistent-agents.md](persistent-agents.md)). Listed under **Live** in the sidebar alongside `/sessions`.
+
+Legacy bookmarks like `/tasks?tab=standalone`, `/tasks?tab=issues`, and `/tasks?tab=prs` are redirected to `/jobs`, `/issues`, and `/reviews` respectively.
 
 ## Triggers
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -68,11 +68,13 @@ OPTIO_API_TOKEN=$(cat ~/.optio-token) \
 
 After provisioning, open the corresponding UI surface:
 
-| Tier              | UI                               |
-| ----------------- | -------------------------------- |
-| Persistent Agents | `/agents` (list) → `/agents/:id` |
-| Repo Tasks        | `/tasks?tab=repo`                |
-| Standalone Tasks  | `/tasks?tab=standalone`          |
+| Tier                       | UI                               |
+| -------------------------- | -------------------------------- |
+| Persistent Agents (Agents) | `/agents` (list) → `/agents/:id` |
+| Repo Tasks (Tasks)         | `/tasks` (list) → `/tasks/:id`   |
+| Standalone Tasks (Jobs)    | `/jobs` (list) → `/jobs/:id`     |
+
+> The v0.4 sidebar split each tier into its own top-level route under **Run** (Tasks · Jobs · Reviews · Issues · Scheduled) and **Live** (Agents · Sessions). The legacy `/tasks?tab=…` URLs redirect to the dedicated pages.
 
 ## Cleanup
 


### PR DESCRIPTION
Closes #514

## What changed

The v0.4 work (PR #510) reshaped both the user-facing terminology and the navigation, but the docs still talked about a tabbed `/tasks` hub, two task flavors, and "Templates" in the Library. This refresh catches them up.

### Naming/nav updates applied across docs

- **Tasks** (was "Repo Tasks") · **Jobs** (was "Standalone Tasks") · **Reviews** (PR Reviews promoted out of `/tasks`) · **Issues** (promoted out of `/tasks`) · **Agents** (Persistent Agents) · **Prompts** (was "Templates" in the Library)
- Sidebar grouping: **Run** (Tasks · Jobs · Reviews · Issues · Scheduled) and **Live** (Agents · Sessions)
- The `/tasks`-with-tabs hub is gone — each section has its own page

### Files updated

| File | Change |
| ---- | ------ |
| `README.md` | Three-tier intro, refreshed architecture diagram + sidebar callout, new Agents section in "How It Works", refreshed Project Structure |
| `CLAUDE.md` | Backend-naming note rewritten with the v0.4 user-facing-name table, architecture diagram updated, Persistent Agents added as a Key Subsystem entry, reconciler entry now lists all four `RunKind`s |
| `docs/tasks.md` | "How they appear in the UI" section replaced with dedicated routes + legacy-redirect note |
| `docs/persistent-agents.md` | Cross-link added from the demo section to `examples/persistent-agents/` |
| `docs/reconciliation.md` | Added `pr-review` and `persistent-agent` `RunKind` sections (state machine, decision-function inputs/outputs); producers list expanded with PA wakes and control intents; code-map and schema sections updated |
| `examples/README.md` | UI table updated to dedicated routes; sidebar nav callout added |
| `CHANGELOG.md` | v0.4.0 entry expanded with Issues/Reviews promotion, the rename summary, and a migration note documenting the legacy `/tasks?tab=...` redirects |

### Migration note

Added inline in `CHANGELOG.md` under the 0.4.0 section. No data migration is required; the legacy `/tasks?tab=standalone|issues|prs` URLs already redirect to `/jobs`, `/issues`, and `/reviews` respectively (see `apps/web/src/app/tasks/page.tsx`). The `/templates` route is unchanged but the sidebar label is now **Prompts**.

## How to test

- [ ] Render `README.md` and `CLAUDE.md` on GitHub and verify the diagrams look reasonable in monospace
- [ ] Check that links in the new "How they appear in the UI" section in `docs/tasks.md` resolve (`persistent-agents.md`, `/jobs`, `/issues`, `/reviews`, `/agents`, `/sessions`, `/tasks/scheduled`)
- [ ] Confirm `pnpm format:check` passes (it does locally)
- [ ] Confirm `pnpm turbo typecheck` still passes (it does — docs-only change, but pre-commit ran it)
- [ ] Spot-check `docs/reconciliation.md` against `packages/shared/src/reconcile/types.ts` — the `RunKind` enumeration matches (`"repo" | "standalone" | "pr-review" | "persistent-agent"`)