### PR TITLE
log-viewer: render markdown tables (and other rich blocks) in agent text output

### DIFF
--- a/apps/web/src/components/log-markdown.test.tsx
+++ b/apps/web/src/components/log-markdown.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { LogMarkdown } from "./log-markdown";
+
+afterEach(cleanup);
+
+describe("LogMarkdown", () => {
+  it("renders plain text inside a paragraph", () => {
+    const { container } = render(<LogMarkdown content="hello world" />);
+    expect(screen.getByText("hello world")).toBeInTheDocument();
+    expect(container.querySelector("p")).not.toBeNull();
+  });
+
+  it("renders a GFM table with headers and cells", () => {
+    const md = [
+      "| Col A | Col B |",
+      "| ----- | ----- |",
+      "| a1    | b1    |",
+      "| a2    | b2    |",
+    ].join("\n");
+    const { container } = render(<LogMarkdown content={md} />);
+
+    const table = container.querySelector("table");
+    expect(table).not.toBeNull();
+    const headers = container.querySelectorAll("th");
+    expect(headers).toHaveLength(2);
+    expect(headers[0].textContent).toBe("Col A");
+    expect(headers[1].textContent).toBe("Col B");
+    const cells = container.querySelectorAll("td");
+    expect(cells).toHaveLength(4);
+    expect(cells[0].textContent).toBe("a1");
+    expect(cells[3].textContent).toBe("b2");
+  });
+
+  it("renders a fenced code block inside <pre><code>", () => {
+    const md = ["```ts", "const x: number = 1;", "```"].join("\n");
+    const { container } = render(<LogMarkdown content={md} />);
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    const code = pre!.querySelector("code");
+    expect(code).not.toBeNull();
+    expect(code!.textContent).toContain("const x: number = 1;");
+  });
+
+  it("renders unordered lists with list items", () => {
+    const md = ["- one", "- two", "- three"].join("\n");
+    const { container } = render(<LogMarkdown content={md} />);
+    expect(container.querySelector("ul")).not.toBeNull();
+    expect(container.querySelectorAll("li")).toHaveLength(3);
+    expect(screen.getByText("one")).toBeInTheDocument();
+    expect(screen.getByText("two")).toBeInTheDocument();
+    expect(screen.getByText("three")).toBeInTheDocument();
+  });
+
+  it("renders links with target=_blank and rel attributes", () => {
+    const md = "see [example](https://example.com)";
+    render(<LogMarkdown content={md} />);
+    const link = screen.getByRole("link", { name: "example" });
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel") ?? "").toContain("noopener");
+    expect(link.getAttribute("rel") ?? "").toContain("noreferrer");
+  });
+
+  it("renders inline code wrapped in <code>", () => {
+    render(<LogMarkdown content="use `npm install` to set up" />);
+    const codeEl = document.querySelector("code");
+    expect(codeEl).not.toBeNull();
+    expect(codeEl!.textContent).toBe("npm install");
+  });
+
+  it("does not render markdown image syntax as <img>", () => {
+    const md = "![alt text](https://example.com/foo.png)";
+    const { container } = render(<LogMarkdown content={md} />);
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("does not render raw HTML as DOM (script tag is escaped)", () => {
+    const md = "before <script>window.__pwned = true</script> after";
+    const { container } = render(<LogMarkdown content={md} />);
+    expect(container.querySelector("script")).toBeNull();
+    expect((window as unknown as { __pwned?: boolean }).__pwned).toBeUndefined();
+  });
+
+  it("does not throw on unbalanced / partial markdown (incremental stream)", () => {
+    const partial = "Here is a table:\n\n| Col A | Col B |\n| --- | --- |\n| a1 | b";
+    expect(() => render(<LogMarkdown content={partial} />)).not.toThrow();
+  });
+
+  it("does not throw on an unclosed code fence", () => {
+    const partial = "```ts\nconst x = 1;\n// stream cut off mid-fence";
+    expect(() => render(<LogMarkdown content={partial} />)).not.toThrow();
+  });
+
+  it("renders strikethrough via remark-gfm", () => {
+    const { container } = render(<LogMarkdown content="~~obsolete~~" />);
+    expect(container.querySelector("del")).not.toBeNull();
+  });
+
+  it("forwards className to the wrapping element", () => {
+    const { container } = render(<LogMarkdown content="hi" className="my-test-class" />);
+    expect(container.firstElementChild?.className).toContain("my-test-class");
+  });
+});

--- a/apps/web/src/components/log-markdown.tsx
+++ b/apps/web/src/components/log-markdown.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { memo } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+const components: Components = {
+  p: ({ children }) => (
+    <p className="font-sans text-[13px] leading-relaxed mb-1.5 last:mb-0 break-words">{children}</p>
+  ),
+  strong: ({ children }) => <strong className="font-semibold text-text">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  del: ({ children }) => <del className="line-through text-text-muted">{children}</del>,
+  ul: ({ children }) => (
+    <ul className="font-sans text-[13px] list-disc pl-5 mb-1.5 last:mb-0 space-y-0.5">
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="font-sans text-[13px] list-decimal pl-5 mb-1.5 last:mb-0 space-y-0.5">
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  code: ({ className, children, ...props }) => {
+    const isBlock = typeof className === "string" && className.includes("language-");
+    if (isBlock) {
+      return (
+        <code className={`block ${className ?? ""}`} {...props}>
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code
+        className="px-1 py-0.5 rounded bg-bg-hover text-primary font-mono text-[11px] break-all"
+        {...props}
+      >
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children }) => (
+    <pre className="bg-bg-subtle rounded-md border border-border px-3 py-2 mb-1.5 last:mb-0 overflow-x-auto font-mono text-[11px] leading-relaxed whitespace-pre">
+      {children}
+    </pre>
+  ),
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer nofollow"
+      className="text-primary hover:underline break-all"
+    >
+      {children}
+    </a>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-2 border-primary/30 pl-3 text-text-muted italic font-sans text-[13px] mb-1.5 last:mb-0">
+      {children}
+    </blockquote>
+  ),
+  h1: ({ children }) => (
+    <h1 className="font-sans font-bold text-base text-text-heading mb-1 mt-1 first:mt-0">
+      {children}
+    </h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="font-sans font-bold text-sm text-text-heading mb-1 mt-1 first:mt-0">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="font-sans font-semibold text-sm text-text-heading mb-1 mt-1 first:mt-0">
+      {children}
+    </h3>
+  ),
+  h4: ({ children }) => (
+    <h4 className="font-sans font-semibold text-[13px] text-text-heading mb-1 mt-1 first:mt-0">
+      {children}
+    </h4>
+  ),
+  h5: ({ children }) => (
+    <h5 className="font-sans font-semibold text-[13px] text-text-heading mb-1 mt-1 first:mt-0">
+      {children}
+    </h5>
+  ),
+  h6: ({ children }) => (
+    <h6 className="font-sans font-semibold text-[13px] text-text-heading mb-1 mt-1 first:mt-0">
+      {children}
+    </h6>
+  ),
+  hr: () => <hr className="border-border my-2" />,
+  table: ({ children }) => (
+    <div className="overflow-x-auto mb-1.5 last:mb-0 -mx-1 px-1">
+      <table className="font-sans text-[12px] border-collapse w-full">{children}</table>
+    </div>
+  ),
+  thead: ({ children }) => <thead className="bg-bg-subtle">{children}</thead>,
+  tbody: ({ children }) => <tbody>{children}</tbody>,
+  tr: ({ children }) => <tr className="border-b border-border last:border-b-0">{children}</tr>,
+  th: ({ children, style }) => (
+    <th
+      className="border border-border px-2 py-1 text-left font-semibold text-text-heading"
+      style={style}
+    >
+      {children}
+    </th>
+  ),
+  td: ({ children, style }) => (
+    <td className="border border-border px-2 py-1 align-top" style={style}>
+      {children}
+    </td>
+  ),
+};
+
+// Block-level markdown elements only — no images, iframes, raw HTML, or
+// embedded media. react-markdown ignores raw HTML by default (we don't
+// load `rehype-raw`), and we drop `img` here so markdown image syntax
+// can't trigger external requests from log content.
+const DISALLOWED_ELEMENTS = ["img", "iframe", "script", "style", "video", "audio", "embed"];
+
+interface LogMarkdownProps {
+  content: string;
+  className?: string;
+}
+
+/**
+ * Renders agent-emitted markdown text inside the log viewer. Uses
+ * `remark-gfm` for tables / strikethrough / task lists. Tolerates
+ * partial / unbalanced markdown (the parser is recoverable). Raw HTML
+ * is not rendered — only the safe block-level subset above.
+ */
+export const LogMarkdown = memo(function LogMarkdown({ content, className }: LogMarkdownProps) {
+  return (
+    <div className={className}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={components}
+        disallowedElements={DISALLOWED_ELEMENTS}
+        unwrapDisallowed
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+});

--- a/apps/web/src/components/log-viewer.test.tsx
+++ b/apps/web/src/components/log-viewer.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { LogLine } from "./log-viewer";
+
+afterEach(cleanup);
+
+const tableMarkdown = ["| Col A | Col B |", "| ----- | ----- |", "| a1    | b1    |"].join("\n");
+
+describe("LogLine (text branch)", () => {
+  it("renders text-type content as markdown when no search query is active", () => {
+    const { container } = render(
+      <LogLine log={{ logType: "text", content: tableMarkdown }} searchQuery="" />,
+    );
+    const table = container.querySelector("table");
+    expect(table).not.toBeNull();
+    expect(container.querySelectorAll("th")).toHaveLength(2);
+    expect(container.querySelectorAll("td")).toHaveLength(2);
+  });
+
+  it("falls back to plain-text rendering with highlight when searchQuery is set", () => {
+    const { container } = render(
+      <LogLine log={{ logType: "text", content: tableMarkdown }} searchQuery="Col A" />,
+    );
+    // Markdown table is suppressed so the substring highlighter can wrap matches
+    expect(container.querySelector("table")).toBeNull();
+    const marks = container.querySelectorAll("mark");
+    expect(marks.length).toBeGreaterThan(0);
+    expect(marks[0].textContent).toBe("Col A");
+  });
+
+  it("renders default text (no logType) as markdown", () => {
+    const { container } = render(
+      <LogLine log={{ content: "## A heading\n\nSome **bold** text." }} searchQuery="" />,
+    );
+    expect(container.querySelector("h2")).not.toBeNull();
+    expect(container.querySelector("strong")).not.toBeNull();
+  });
+
+  it("does not invoke markdown rendering for tool_result entries", () => {
+    const { container } = render(
+      <LogLine
+        log={{ logType: "tool_result", content: "| Col A | Col B |\n| --- | --- |\n| a | b |" }}
+        searchQuery=""
+      />,
+    );
+    // tool_result is rendered inside <pre>, never as a real <table>
+    expect(container.querySelector("table")).toBeNull();
+    expect(container.querySelector("pre")).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/log-viewer.tsx
+++ b/apps/web/src/components/log-viewer.tsx
@@ -4,6 +4,7 @@ import { Fragment, useEffect, useRef, useState, useCallback, useMemo } from "rea
 import { useLogs, type LogEntry } from "@/hooks/use-logs";
 import { api } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
+import { LogMarkdown } from "./log-markdown";
 import {
   ArrowDown,
   ArrowUp,
@@ -708,7 +709,7 @@ function ToolCallGroup({
   );
 }
 
-function LogLine({
+export function LogLine({
   log,
   searchQuery,
 }: {
@@ -746,11 +747,15 @@ function LogLine({
           .filter((b: any) => b.type === "text" && b.text)
           .map((b: any) => b.text);
         if (texts.length > 0) {
-          return (
-            <div className="py-0.5 text-text/90 whitespace-pre-wrap break-words">
-              {texts.join("\n")}
-            </div>
-          );
+          const joined = texts.join("\n");
+          if (searchQuery) {
+            return (
+              <div className="py-0.5 text-text/90 whitespace-pre-wrap break-words">
+                <HighlightedText text={joined} search={searchQuery} />
+              </div>
+            );
+          }
+          return <LogMarkdown content={joined} className="py-0.5 text-text/90" />;
         }
         return null;
       }
@@ -858,10 +863,16 @@ function LogLine({
     );
   }
 
-  // Text — default agent output
-  return (
-    <div className="py-0.5 text-text/90 whitespace-pre-wrap break-words">
-      <HighlightedText text={log.content} search={searchQuery} />
-    </div>
-  );
+  // Text — default agent output. Render as markdown so tables / code
+  // fences / lists / links display with proper layout. While a search
+  // query is active, fall back to plain text so the substring-highlight
+  // pass below can wrap matches in <mark>.
+  if (searchQuery) {
+    return (
+      <div className="py-0.5 text-text/90 whitespace-pre-wrap break-words">
+        <HighlightedText text={log.content} search={searchQuery} />
+      </div>
+    );
+  }
+  return <LogMarkdown content={log.content} className="py-0.5 text-text/90" />;
 }


### PR DESCRIPTION
Closes #511

## What changed

- New `LogMarkdown` component (`apps/web/src/components/log-markdown.tsx`)
  wraps `react-markdown` + `remark-gfm`, with a constrained `components`
  map that styles tables, code fences, lists, links, blockquotes,
  headings, and strikethrough using existing Tailwind tokens.
- `LogLine` in `log-viewer.tsx` now routes plain `text`-type entries
  (and the assistant-event branch that decodes streamed JSON) through
  `LogMarkdown` so a 4-column table no longer renders as a wall of
  pipes. Other entry types (`tool_use`, `tool_result`, `thinking`,
  `system`, `error`, `info`) keep their existing structural layouts.
- Search highlighting is preserved by falling back to the existing
  plain-text `HighlightedText` path while the search bar has a query —
  this is the simpler of the two options the issue suggested
  (vs. walking the rendered markdown tree).
- Safety: `LogMarkdown` does not load `rehype-raw`, so raw HTML is
  never rendered as DOM, and `disallowedElements` drops `img`,
  `iframe`, `script`, `style`, `video`, `audio`, `embed` so markdown
  image syntax and similar can't trigger external requests. Links
  open in a new tab with `rel="noopener noreferrer nofollow"`.
- `react-markdown` is built on remark, which is a recoverable parser,
  so partial / unbalanced markdown from incremental streaming
  (unclosed code fence, half-typed table row) renders best-effort
  rather than throwing.

## How to test

1. `pnpm install`
2. `cd apps/web && npx vitest run` — 281 tests pass, including 16 new
   tests in `log-markdown.test.tsx` and `log-viewer.test.tsx`.
3. `pnpm format:check && pnpm turbo typecheck` — both clean.
4. Manual: send any agent (Persistent Agent / Task / Job / Session) a
   prompt like *"give me a 4-column comparison table of X"*. The
   reply now renders as a styled table on `/tasks/[id]`,
   `/jobs/[id]/runs/[runId]`, `/reviews/[id]`, `/agents/[id]`, and
   `/sessions/[id]`. Open the search bar (Ctrl+F) — markdown collapses
   back to plain text so the highlight still works, and dismissing
   search restores the rendered table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)