### PR TITLE
Overview: show active Persistent Agents and Sessions as pipeline stats bars

### DIFF
--- a/apps/api/src/routes/persistent-agents.test.ts
+++ b/apps/api/src/routes/persistent-agents.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildRouteTestApp } from "../test-utils/build-route-test-app.js";
+
+// ─── Mocks ───
+
+const mockListPersistentAgents = vi.fn();
+const mockGetPersistentAgent = vi.fn();
+const mockListInboxSummary = vi.fn();
+const mockGetPersistentAgentStats = vi.fn();
+
+vi.mock("../services/persistent-agent-service.js", () => ({
+  listPersistentAgents: (...args: unknown[]) => mockListPersistentAgents(...args),
+  getPersistentAgent: (...args: unknown[]) => mockGetPersistentAgent(...args),
+  listInboxSummary: (...args: unknown[]) => mockListInboxSummary(...args),
+  getPersistentAgentStats: (...args: unknown[]) => mockGetPersistentAgentStats(...args),
+  // Stubs for the rest of the namespace import surface
+  createPersistentAgent: vi.fn(),
+  updatePersistentAgent: vi.fn(),
+  deletePersistentAgent: vi.fn(),
+  setControlIntent: vi.fn(),
+  wakeAgent: vi.fn(),
+  listRecentMessages: vi.fn(),
+  listPersistentAgentTurns: vi.fn(),
+  getPersistentAgentTurn: vi.fn(),
+  listTurnLogs: vi.fn(),
+}));
+
+vi.mock("../services/optio-action-service.js", () => ({
+  logAction: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { persistentAgentRoutes } from "./persistent-agents.js";
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  return buildRouteTestApp(persistentAgentRoutes);
+}
+
+describe("GET /api/persistent-agents/stats", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns aggregated agent stats and forwards the workspace ID", async () => {
+    mockGetPersistentAgentStats.mockResolvedValue({
+      total: 8,
+      idle: 4,
+      queued: 1,
+      running: 2,
+      paused: 0,
+      failed: 1,
+      archived: 3,
+    });
+
+    const res = await app.inject({ method: "GET", url: "/api/persistent-agents/stats" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.stats).toEqual({
+      total: 8,
+      idle: 4,
+      queued: 1,
+      running: 2,
+      paused: 0,
+      failed: 1,
+      archived: 3,
+    });
+    expect(mockGetPersistentAgentStats).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("matches the literal `/stats` segment, not the `/:id` route", async () => {
+    // Regression: a GET /api/persistent-agents/stats request must hit the
+    // stats handler, not the detail handler — the detail handler validates
+    // `:id` as a UUID and would 400.
+    mockGetPersistentAgentStats.mockResolvedValue({
+      total: 0,
+      idle: 0,
+      queued: 0,
+      running: 0,
+      paused: 0,
+      failed: 0,
+      archived: 0,
+    });
+
+    const res = await app.inject({ method: "GET", url: "/api/persistent-agents/stats" });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockGetPersistentAgentStats).toHaveBeenCalledTimes(1);
+    expect(mockGetPersistentAgent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/persistent-agents.ts
+++ b/apps/api/src/routes/persistent-agents.ts
@@ -97,6 +97,27 @@ export async function persistentAgentRoutes(rawApp: FastifyInstance) {
     },
   );
 
+  // Aggregated stats — must precede `/:id` so the literal segment wins
+  app.get(
+    "/api/persistent-agents/stats",
+    {
+      schema: {
+        operationId: "getPersistentAgentStats",
+        summary: "Get aggregated persistent agent stats",
+        description:
+          "Returns counts of `persistent_agents` grouped by state for the " +
+          "current workspace. Mirrors `/api/tasks/stats` so dashboards can " +
+          "render an agents stats bar symmetrically with tasks. Archived " +
+          "agents are excluded from `total` because they are terminal.",
+        tags: ["Persistent Agents"],
+      },
+    },
+    async (req, reply) => {
+      const stats = await paService.getPersistentAgentStats(req.user?.workspaceId ?? null);
+      reply.send({ stats });
+    },
+  );
+
   // Detail
   app.get(
     "/api/persistent-agents/:id",

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -13,6 +13,7 @@ const mockGetSessionPrs = vi.fn();
 const mockAddSessionPr = vi.fn();
 const mockGetActiveSessionCount = vi.fn();
 const mockListSessionChatEvents = vi.fn();
+const mockGetSessionStats = vi.fn();
 
 vi.mock("../services/interactive-session-service.js", () => ({
   listSessions: (...args: unknown[]) => mockListSessions(...args),
@@ -23,6 +24,7 @@ vi.mock("../services/interactive-session-service.js", () => ({
   addSessionPr: (...args: unknown[]) => mockAddSessionPr(...args),
   getActiveSessionCount: (...args: unknown[]) => mockGetActiveSessionCount(...args),
   listSessionChatEvents: (...args: unknown[]) => mockListSessionChatEvents(...args),
+  getSessionStats: (...args: unknown[]) => mockGetSessionStats(...args),
 }));
 
 const mockDbSelect = vi.fn();
@@ -384,5 +386,42 @@ describe("GET /api/sessions/active-count", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().count).toBe(3);
+  });
+});
+
+describe("GET /api/sessions/stats", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildTestApp();
+  });
+
+  it("returns aggregated session stats and forwards the workspace ID", async () => {
+    mockGetSessionStats.mockResolvedValue({
+      total: 5,
+      active: 3,
+      ended: 2,
+    });
+
+    const res = await app.inject({ method: "GET", url: "/api/sessions/stats" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.stats).toEqual({ total: 5, active: 3, ended: 2 });
+    expect(mockGetSessionStats).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("matches the literal `/stats` segment, not the `/:id` route", async () => {
+    // Regression: if Fastify routed `/api/sessions/stats` to `/api/sessions/:id`
+    // the request would either return 404 (session id "stats" not found) or
+    // hit getSession instead of getSessionStats.
+    mockGetSessionStats.mockResolvedValue({ total: 0, active: 0, ended: 0 });
+
+    const res = await app.inject({ method: "GET", url: "/api/sessions/stats" });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockGetSessionStats).toHaveBeenCalledTimes(1);
+    expect(mockGetSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -92,6 +92,23 @@ const ActiveCountResponseSchema = z
   })
   .describe("Active session count");
 
+const SessionStatsSchema = z
+  .object({
+    total: z.number().int(),
+    active: z.number().int(),
+    ended: z.number().int(),
+  })
+  .describe(
+    "Counts of interactive sessions grouped by state. `ended` is windowed " +
+      "to the last 24 hours.",
+  );
+
+const SessionStatsResponseSchema = z
+  .object({
+    stats: SessionStatsSchema,
+  })
+  .describe("Aggregated session counts for the current workspace");
+
 export async function sessionRoutes(rawApp: FastifyInstance) {
   const app = rawApp.withTypeProvider<ZodTypeProvider>();
 
@@ -125,6 +142,30 @@ export async function sessionRoutes(rawApp: FastifyInstance) {
       });
       const activeCount = await sessionService.getActiveSessionCount(repoUrl);
       reply.send({ sessions, activeCount });
+    },
+  );
+
+  app.get(
+    "/api/sessions/stats",
+    {
+      schema: {
+        operationId: "getSessionStats",
+        summary: "Get aggregated interactive session stats",
+        description:
+          "Returns counts of `interactive_sessions` grouped by state for the " +
+          "current workspace. Mirrors `/api/tasks/stats` so dashboards can " +
+          "render a Sessions stats bar symmetrically with tasks. The `ended` " +
+          "bucket is windowed to the last 24 hours so the bar reflects " +
+          "recent activity rather than lifetime totals.",
+        tags: ["Sessions"],
+        response: {
+          200: SessionStatsResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const stats = await sessionService.getSessionStats(req.user?.workspaceId ?? null);
+      reply.send({ stats });
     },
   );
 

--- a/apps/api/src/services/interactive-session-service.ts
+++ b/apps/api/src/services/interactive-session-service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eq, and, desc, asc, sql, lte } from "drizzle-orm";
+import { eq, and, desc, asc, gte, isNull, lte, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import {
   interactiveSessions,
@@ -294,4 +294,58 @@ export async function listSessionChatEvents(sessionId: string, opts?: { limit?: 
     .where(eq(sessionChatEvents.sessionId, sessionId))
     .orderBy(asc(sessionChatEvents.timestamp))
     .limit(limit);
+}
+
+/**
+ * How recent an `ended` session is allowed to be to count toward the
+ * Sessions stats bar. Past this window the session disappears from the
+ * "what's been live recently" picture so the Done bucket reflects today's
+ * activity, not historical noise.
+ */
+export const SESSION_RECENT_ENDED_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Per-state counts of interactive sessions in a workspace. Drives the
+ * Sessions stats bar on the overview dashboard — shape mirrors
+ * `getTaskStats()` / `getWorkflowRunStats()` so the frontend can treat all
+ * four execution surfaces symmetrically.
+ *
+ * `ended` is windowed (last 24h) to keep the bar focused on recent
+ * activity. `total` is the sum of `active` + `ended` (within the window),
+ * not a lifetime count.
+ */
+export async function getSessionStats(workspaceId?: string | null) {
+  const wsFilter =
+    workspaceId === undefined
+      ? undefined
+      : workspaceId === null
+        ? isNull(interactiveSessions.workspaceId)
+        : eq(interactiveSessions.workspaceId, workspaceId);
+
+  const recentSince = new Date(Date.now() - SESSION_RECENT_ENDED_WINDOW_MS);
+
+  const [activeRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(interactiveSessions)
+    .where(
+      wsFilter
+        ? and(eq(interactiveSessions.state, "active"), wsFilter)
+        : eq(interactiveSessions.state, "active"),
+    );
+
+  const [endedRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(interactiveSessions)
+    .where(
+      and(
+        eq(interactiveSessions.state, "ended"),
+        gte(interactiveSessions.endedAt, recentSince),
+        ...(wsFilter ? [wsFilter] : []),
+      ),
+    );
+
+  const active = activeRow?.count ?? 0;
+  const ended = endedRow?.count ?? 0;
+
+  return { total: active + ended, active, ended };
 }

--- a/apps/api/src/services/persistent-agent-service.ts
+++ b/apps/api/src/services/persistent-agent-service.ts
@@ -621,4 +621,77 @@ export async function purgeAllForAgent(agentId: string) {
   await db.delete(persistentAgents).where(eq(persistentAgents.id, agentId));
 }
 
+// ── Aggregate stats ─────────────────────────────────────────────────────────
+
+/**
+ * Per-state counts across persistent agents in a workspace. Drives the
+ * Persistent Agents stats bar on the overview dashboard — shape mirrors
+ * `getTaskStats()` / `getWorkflowRunStats()` so the frontend can treat all
+ * four execution surfaces symmetrically.
+ *
+ * `total` excludes archived agents because they are terminal and are not
+ * listed by default in the agents UI; surfacing them as part of the live
+ * count would inflate the at-a-glance picture.
+ */
+export async function getPersistentAgentStats(workspaceId?: string | null) {
+  const wsFilter =
+    workspaceId === undefined
+      ? undefined
+      : workspaceId === null
+        ? isNull(persistentAgents.workspaceId)
+        : eq(persistentAgents.workspaceId, workspaceId);
+
+  const baseQuery = db
+    .select({
+      state: persistentAgents.state,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(persistentAgents);
+
+  const rows = await (wsFilter ? baseQuery.where(wsFilter) : baseQuery).groupBy(
+    persistentAgents.state,
+  );
+
+  let total = 0;
+  let idle = 0;
+  let queued = 0;
+  let running = 0;
+  let paused = 0;
+  let failed = 0;
+  let archived = 0;
+
+  for (const row of rows) {
+    const c = row.count;
+    switch (row.state) {
+      case PersistentAgentState.IDLE:
+        idle += c;
+        total += c;
+        break;
+      case PersistentAgentState.QUEUED:
+      case PersistentAgentState.PROVISIONING:
+        queued += c;
+        total += c;
+        break;
+      case PersistentAgentState.RUNNING:
+        running += c;
+        total += c;
+        break;
+      case PersistentAgentState.PAUSED:
+        paused += c;
+        total += c;
+        break;
+      case PersistentAgentState.FAILED:
+        failed += c;
+        total += c;
+        break;
+      case PersistentAgentState.ARCHIVED:
+        // Terminal — excluded from `total` so the bar reflects live agents only.
+        archived += c;
+        break;
+    }
+  }
+
+  return { total, idle, queued, running, paused, failed, archived };
+}
+
 export { PersistentAgentState, PersistentAgentPodLifecycle, buildSenderId };

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -115,3 +115,45 @@ describe("OverviewPage — section ordering", () => {
     expect(recentTasks.compareDocumentPosition(recentActivity) & FOLLOWING).toBeTruthy();
   });
 });
+
+describe("OverviewPage — Persistent Agents and Sessions stats bars", () => {
+  afterEach(() => cleanup());
+
+  it("hides the Persistent Agents and Sessions section labels when totals are zero", () => {
+    vi.mocked(useDashboardData).mockReturnValue(
+      makeDashboardData({
+        agentStats: { total: 0, idle: 0, queued: 0, running: 0, paused: 0, failed: 0, archived: 0 },
+        sessionStats: { total: 0, active: 0, ended: 0 },
+      }) as any,
+    );
+
+    render(<OverviewPage />);
+
+    expect(screen.queryByText("Persistent Agents")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sessions")).not.toBeInTheDocument();
+  });
+
+  it("renders the Persistent Agents section when total > 0", () => {
+    vi.mocked(useDashboardData).mockReturnValue(
+      makeDashboardData({
+        agentStats: { total: 3, idle: 2, queued: 0, running: 1, paused: 0, failed: 0, archived: 0 },
+      }) as any,
+    );
+
+    render(<OverviewPage />);
+
+    expect(screen.getByText("Persistent Agents")).toBeInTheDocument();
+  });
+
+  it("renders the Sessions section when total > 0", () => {
+    vi.mocked(useDashboardData).mockReturnValue(
+      makeDashboardData({
+        sessionStats: { total: 2, active: 2, ended: 0 },
+      }) as any,
+    );
+
+    render(<OverviewPage />);
+
+    expect(screen.getByText("Sessions")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { usePageTitle } from "@/hooks/use-page-title";
 import { useDashboardData } from "@/hooks/use-dashboard-data";
-import { RefreshCw, GitPullRequest, Terminal } from "lucide-react";
+import { RefreshCw, GitPullRequest, Terminal, Bot, MessageSquare } from "lucide-react";
 import {
   PipelineStatsBar,
   UsagePanel,
@@ -21,6 +21,8 @@ export default function OverviewPage() {
   const {
     taskStats,
     standaloneStats,
+    agentStats,
+    sessionStats,
     recentTasks,
     repoCount,
     cluster,
@@ -130,6 +132,30 @@ export default function OverviewPage() {
             </span>
           </div>
           <PipelineStatsBar variant="standalone" standaloneStats={standaloneStats} />
+        </div>
+      )}
+
+      {(agentStats?.total ?? 0) > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5 px-1">
+            <Bot className="w-3 h-3 text-text-muted/60" />
+            <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted/60">
+              Persistent Agents
+            </span>
+          </div>
+          <PipelineStatsBar variant="agents" agentStats={agentStats} />
+        </div>
+      )}
+
+      {(sessionStats?.total ?? 0) > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5 px-1">
+            <MessageSquare className="w-3 h-3 text-text-muted/60" />
+            <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-muted/60">
+              Sessions
+            </span>
+          </div>
+          <PipelineStatsBar variant="sessions" sessionStats={sessionStats} />
         </div>
       )}
 

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -8,4 +8,11 @@ export { WelcomeHero } from "./welcome-hero.js";
 export { EmptyState } from "./empty-state.js";
 export { AgentComparison } from "./agent-comparison.js";
 export { RecentActivity } from "./recent-activity.js";
-export type { TaskStats, StandaloneStats, UsageData, MetricsHistoryPoint } from "./types.js";
+export type {
+  TaskStats,
+  StandaloneStats,
+  PersistentAgentStats,
+  SessionStats,
+  UsageData,
+  MetricsHistoryPoint,
+} from "./types.js";

--- a/apps/web/src/components/dashboard/pipeline-stats-bar.test.tsx
+++ b/apps/web/src/components/dashboard/pipeline-stats-bar.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { PipelineStatsBar } from "./pipeline-stats-bar";
+
+describe("PipelineStatsBar — agents variant", () => {
+  afterEach(() => cleanup());
+
+  it("renders the agent stage labels and counts", () => {
+    render(
+      <PipelineStatsBar
+        variant="agents"
+        agentStats={{
+          total: 9,
+          idle: 3,
+          queued: 1,
+          running: 2,
+          paused: 1,
+          failed: 1,
+          archived: 1,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+    expect(screen.getByText("Queue")).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("Archived")).toBeInTheDocument();
+
+    const idleLink = screen.getByText("Idle").closest("a");
+    expect(idleLink?.getAttribute("href")).toBe("/agents");
+  });
+
+  it("renders zeroes when agentStats is null", () => {
+    render(<PipelineStatsBar variant="agents" agentStats={null} />);
+    // Six stages — all should render even if all-zero
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+    expect(screen.getByText("Archived")).toBeInTheDocument();
+  });
+});
+
+describe("PipelineStatsBar — sessions variant", () => {
+  afterEach(() => cleanup());
+
+  it("renders Active and Ended (24h) stages", () => {
+    render(
+      <PipelineStatsBar variant="sessions" sessionStats={{ total: 4, active: 3, ended: 1 }} />,
+    );
+
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Ended (24h)")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+
+    const activeLink = screen.getByText("Active").closest("a");
+    expect(activeLink?.getAttribute("href")).toBe("/sessions");
+  });
+
+  it("renders zeroes when sessionStats is null", () => {
+    render(<PipelineStatsBar variant="sessions" sessionStats={null} />);
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Ended (24h)")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/pipeline-stats-bar.tsx
+++ b/apps/web/src/components/dashboard/pipeline-stats-bar.tsx
@@ -1,7 +1,18 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { Activity, CheckCircle, AlertTriangle, GitMerge, Eye, ListChecks } from "lucide-react";
-import type { TaskStats, StandaloneStats } from "./types.js";
+import {
+  Activity,
+  CheckCircle,
+  AlertTriangle,
+  GitMerge,
+  Eye,
+  ListChecks,
+  Pause,
+  Moon,
+  Archive,
+  XCircle,
+} from "lucide-react";
+import type { TaskStats, StandaloneStats, PersistentAgentStats, SessionStats } from "./types.js";
 
 type Stage = {
   key: string;
@@ -111,15 +122,103 @@ function standaloneStages(stats: StandaloneStats | null): Stage[] {
   ];
 }
 
+function agentStages(stats: PersistentAgentStats | null): Stage[] {
+  const href = "/agents";
+  return [
+    {
+      key: "idle",
+      label: "Idle",
+      value: stats?.idle ?? 0,
+      icon: Moon,
+      color: "var(--color-text-muted)",
+      href,
+    },
+    {
+      key: "queue",
+      label: "Queue",
+      value: stats?.queued ?? 0,
+      icon: ListChecks,
+      color: "var(--color-text-muted)",
+      href,
+    },
+    {
+      key: "running",
+      label: "Running",
+      value: stats?.running ?? 0,
+      icon: Activity,
+      color: "var(--color-primary)",
+      href,
+    },
+    {
+      key: "paused",
+      label: "Paused",
+      value: stats?.paused ?? 0,
+      icon: Pause,
+      color: "var(--color-warning)",
+      href,
+    },
+    {
+      key: "failed",
+      label: "Failed",
+      value: stats?.failed ?? 0,
+      icon: AlertTriangle,
+      color: "var(--color-error)",
+      href,
+    },
+    {
+      key: "archived",
+      label: "Archived",
+      value: stats?.archived ?? 0,
+      icon: Archive,
+      color: "var(--color-text-muted)",
+      href,
+    },
+  ];
+}
+
+function sessionStages(stats: SessionStats | null): Stage[] {
+  const href = "/sessions";
+  return [
+    {
+      key: "active",
+      label: "Active",
+      value: stats?.active ?? 0,
+      icon: Activity,
+      color: "var(--color-primary)",
+      href,
+    },
+    {
+      key: "ended",
+      label: "Ended (24h)",
+      value: stats?.ended ?? 0,
+      icon: XCircle,
+      color: "var(--color-text-muted)",
+      href,
+    },
+  ];
+}
+
 type PipelineStatsBarProps =
   | { variant?: "tasks"; taskStats: TaskStats | null }
-  | { variant: "standalone"; standaloneStats: StandaloneStats | null };
+  | { variant: "standalone"; standaloneStats: StandaloneStats | null }
+  | { variant: "agents"; agentStats: PersistentAgentStats | null }
+  | { variant: "sessions"; sessionStats: SessionStats | null };
 
 export function PipelineStatsBar(props: PipelineStatsBarProps) {
-  const stages =
-    props.variant === "standalone"
-      ? standaloneStages(props.standaloneStats)
-      : taskStages(props.taskStats);
+  let stages: Stage[];
+  switch (props.variant) {
+    case "standalone":
+      stages = standaloneStages(props.standaloneStats);
+      break;
+    case "agents":
+      stages = agentStages(props.agentStats);
+      break;
+    case "sessions":
+      stages = sessionStages(props.sessionStats);
+      break;
+    default:
+      stages = taskStages(props.taskStats);
+  }
 
   return (
     <div className="rounded-xl border border-border/50 bg-bg-card overflow-hidden">

--- a/apps/web/src/components/dashboard/types.ts
+++ b/apps/web/src/components/dashboard/types.ts
@@ -17,6 +17,22 @@ export interface StandaloneStats {
   completed: number;
 }
 
+export interface PersistentAgentStats {
+  total: number;
+  idle: number;
+  queued: number;
+  running: number;
+  paused: number;
+  failed: number;
+  archived: number;
+}
+
+export interface SessionStats {
+  total: number;
+  active: number;
+  ended: number;
+}
+
 export interface UsageData {
   available: boolean;
   error?: string;

--- a/apps/web/src/hooks/use-dashboard-data.ts
+++ b/apps/web/src/hooks/use-dashboard-data.ts
@@ -5,6 +5,8 @@ import { api } from "@/lib/api-client";
 import type {
   TaskStats,
   StandaloneStats,
+  PersistentAgentStats,
+  SessionStats,
   UsageData,
   MetricsHistoryPoint,
 } from "@/components/dashboard/types.js";
@@ -14,6 +16,8 @@ const MAX_HISTORY = 60; // 10 minutes at 10s intervals
 export function useDashboardData() {
   const [taskStats, setTaskStats] = useState<TaskStats | null>(null);
   const [standaloneStats, setStandaloneStats] = useState<StandaloneStats | null>(null);
+  const [agentStats, setAgentStats] = useState<PersistentAgentStats | null>(null);
+  const [sessionStats, setSessionStats] = useState<SessionStats | null>(null);
   const [recentTasks, setRecentTasks] = useState<any[]>([]);
   const [repoCount, setRepoCount] = useState<number | null>(null);
   const [cluster, setCluster] = useState<any>(null);
@@ -34,39 +38,56 @@ export function useDashboardData() {
         .listSessions({ state: "active", limit: 5 })
         .catch(() => ({ sessions: [], activeCount: 0 })),
       api.getJobStats().catch(() => null),
+      api.getPersistentAgentStats().catch(() => null),
+      api.getSessionStats().catch(() => null),
     ])
-      .then(([statsRes, tasksRes, clusterRes, reposRes, sessionsRes, jobStatsRes]) => {
-        setActiveSessions(sessionsRes.sessions);
-        setActiveSessionCount(sessionsRes.activeCount);
-        setTaskStats(statsRes.stats);
-        setStandaloneStats(jobStatsRes?.stats ?? null);
-        setRecentTasks(tasksRes.tasks);
-        setRepoCount(reposRes.repos.length);
-        if (clusterRes) {
-          setCluster(clusterRes);
-          setMetricsAvailable(clusterRes.metricsAvailable ?? null);
-          const node = clusterRes.nodes?.[0];
-          if (node) {
-            const memPercent =
-              node.memoryUsedGi != null && node.memoryTotalGi
-                ? Math.round((parseFloat(node.memoryUsedGi) / parseFloat(node.memoryTotalGi)) * 100)
-                : null;
-            setMetricsHistory((prev) => {
-              const next = [
-                ...prev,
-                {
-                  time: Date.now(),
-                  cpuPercent: node.cpuPercent ?? null,
-                  memoryPercent: memPercent,
-                  pods: clusterRes.summary?.totalPods ?? 0,
-                  agents: clusterRes.summary?.agentPods ?? 0,
-                },
-              ];
-              return next.slice(-MAX_HISTORY);
-            });
+      .then(
+        ([
+          statsRes,
+          tasksRes,
+          clusterRes,
+          reposRes,
+          sessionsRes,
+          jobStatsRes,
+          agentStatsRes,
+          sessionStatsRes,
+        ]) => {
+          setActiveSessions(sessionsRes.sessions);
+          setActiveSessionCount(sessionsRes.activeCount);
+          setTaskStats(statsRes.stats);
+          setStandaloneStats(jobStatsRes?.stats ?? null);
+          setAgentStats(agentStatsRes?.stats ?? null);
+          setSessionStats(sessionStatsRes?.stats ?? null);
+          setRecentTasks(tasksRes.tasks);
+          setRepoCount(reposRes.repos.length);
+          if (clusterRes) {
+            setCluster(clusterRes);
+            setMetricsAvailable(clusterRes.metricsAvailable ?? null);
+            const node = clusterRes.nodes?.[0];
+            if (node) {
+              const memPercent =
+                node.memoryUsedGi != null && node.memoryTotalGi
+                  ? Math.round(
+                      (parseFloat(node.memoryUsedGi) / parseFloat(node.memoryTotalGi)) * 100,
+                    )
+                  : null;
+              setMetricsHistory((prev) => {
+                const next = [
+                  ...prev,
+                  {
+                    time: Date.now(),
+                    cpuPercent: node.cpuPercent ?? null,
+                    memoryPercent: memPercent,
+                    pods: clusterRes.summary?.totalPods ?? 0,
+                    agents: clusterRes.summary?.agentPods ?? 0,
+                  },
+                ];
+                return next.slice(-MAX_HISTORY);
+              });
+            }
           }
-        }
-      })
+        },
+      )
       .finally(() => setLoading(false));
   }, []);
 
@@ -124,6 +145,8 @@ export function useDashboardData() {
   return {
     taskStats,
     standaloneStats,
+    agentStats,
+    sessionStats,
     recentTasks,
     repoCount,
     cluster,

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1194,6 +1194,28 @@ export const api = {
       };
     }>("/api/jobs/stats"),
 
+  getPersistentAgentStats: () =>
+    request<{
+      stats: {
+        total: number;
+        idle: number;
+        queued: number;
+        running: number;
+        paused: number;
+        failed: number;
+        archived: number;
+      };
+    }>("/api/persistent-agents/stats"),
+
+  getSessionStats: () =>
+    request<{
+      stats: {
+        total: number;
+        active: number;
+        ended: number;
+      };
+    }>("/api/sessions/stats"),
+
   getWorkflow: (id: string) => request<{ workflow: any }>(`/api/jobs/${id}`),
 
   createWorkflow: (data: {


### PR DESCRIPTION
Closes #515

## What changed

Persistent Agents and Sessions are first-class concepts in the same workspace as Repo Tasks and Standalone Tasks, but they got inferior treatment on the Overview: agents weren't shown at all, and sessions only appeared further down as a list. This PR makes the at-a-glance "what's live right now" picture symmetric across all four execution surfaces by adding two more `PipelineStatsBar`s.

### Backend

Two new stats endpoints, mirroring `/api/tasks/stats` so the frontend can consume them the same way:

- `GET /api/persistent-agents/stats` → `{ total, idle, queued, running, paused, failed, archived }`. `queued` collapses the `queued` + `provisioning` agent states (as `getTaskStats` does for Repo Tasks). Archived agents are excluded from `total` because they're terminal — surfacing them in a "live" count would inflate it.
- `GET /api/sessions/stats` → `{ total, active, ended }`. `ended` is windowed to the last 24h (constant `SESSION_RECENT_ENDED_WINDOW_MS`) so the bar reflects today's activity instead of lifetime totals.

Both endpoints scope by `req.user?.workspaceId ?? null` and live alongside the existing routes — `/api/persistent-agents/stats` is registered before `/:id` so the literal segment wins (regression-tested).

### Frontend

- `PipelineStatsBar` gains `agents` and `sessions` variants alongside the existing `tasks` and `standalone` ones, using the same shell, colors, and hover behavior.
- New `PersistentAgentStats` and `SessionStats` interfaces in `dashboard/types.ts`; new `getPersistentAgentStats()` / `getSessionStats()` methods in `api-client.ts`.
- `useDashboardData` fetches both endpoints alongside the existing `Promise.all` and exposes `agentStats` / `sessionStats`.
- The Overview page renders the new bars between Standalone Tasks and AgentComparison, with section labels `Persistent Agents` (Bot icon) and `Sessions` (MessageSquare icon). Each bar is conditional on `total > 0`, matching the Standalone Tasks pattern, so empty workspaces stay clean.
- Click-through: agents bar links to `/agents`, sessions bar links to `/sessions`.

### Out of scope

- No changes to the agents/sessions detail pages.
- No changes to the existing `ActiveSessions` list view (it still renders below).

## How to test

- `pnpm turbo typecheck` and `pnpm turbo test` both clean.
- `pnpm format:check` clean.
- `cd apps/web && npx next build` clean.
- New tests:
  - `apps/api/src/routes/persistent-agents.test.ts` — covers the new `/stats` route and verifies it isn't shadowed by `/:id`.
  - `apps/api/src/routes/sessions.test.ts` — adds `GET /api/sessions/stats` coverage with the same `/:id` regression check.
  - `apps/web/src/components/dashboard/pipeline-stats-bar.test.tsx` — renders the new variants and checks the click-through hrefs.
  - `apps/web/src/app/page.test.tsx` — verifies the new sections are hidden when totals are zero and shown otherwise.
- Manual: open `/`, confirm new bars appear with non-zero counts, click through to the right pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)