### PR TITLE
fix: resolve new repo creation with secrets created as global scope with current workspaceId

### DIFF
--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -96,6 +96,9 @@ const AGENT_KEY_SECRETS = [
   "OPENAI_API_KEY",
   "CLAUDE_CODE_OAUTH_TOKEN",
   "COPILOT_GITHUB_TOKEN",
+  "GEMINI_API_KEY",
+  "GOOGLE_CLOUD_PROJECT",
+  "CLAUDE_VERTEX_PROJECT_ID",
 ];
 
 let _setupCompleteCache: { value: boolean; expires: number } | null = null;

--- a/apps/api/src/routes/github-token.test.ts
+++ b/apps/api/src/routes/github-token.test.ts
@@ -136,7 +136,12 @@ describe("POST /api/github-token/rotate", () => {
     const body = res.json();
     expect(body.success).toBe(true);
     expect(body.user).toEqual({ login: "newuser", name: "New User" });
-    expect(mockStoreSecret).toHaveBeenCalledWith("GITHUB_TOKEN", "ghp_newvalidtoken", "global");
+    expect(mockStoreSecret).toHaveBeenCalledWith(
+      "GITHUB_TOKEN",
+      "ghp_newvalidtoken",
+      "global",
+      undefined,
+    );
   });
 
   it("rejects an invalid token without storing it", async () => {

--- a/apps/api/src/routes/github-token.ts
+++ b/apps/api/src/routes/github-token.ts
@@ -156,7 +156,7 @@ export async function githubTokenRoutes(rawApp: FastifyInstance) {
 
         const user = (await res.json()) as { login: string; name: string };
 
-        await storeSecret("GITHUB_TOKEN", token.trim(), "global");
+        await storeSecret("GITHUB_TOKEN", token.trim(), "global", req.user?.workspaceId);
 
         return reply.send({
           success: true,

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -556,7 +556,11 @@ export async function setupRoutes(rawApp: FastifyInstance) {
         const [, owner, repo] = match;
         const headers: Record<string, string> = { "User-Agent": "Optio" };
         let repoToken: string | null = token ?? null;
-        if (!repoToken) repoToken = await retrieveSecret("GITHUB_TOKEN").catch(() => null);
+        if (!repoToken) {
+          repoToken = await retrieveSecret("GITHUB_TOKEN", "global", req.user?.workspaceId).catch(
+            () => null,
+          );
+        }
         if (!repoToken && isGitHubAppConfigured()) {
           repoToken = await getInstallationToken().catch(() => null);
         }

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -203,13 +203,16 @@ describe("error handler", () => {
 
 describe("Zod error sanitization", () => {
   const originalNodeEnv = process.env.NODE_ENV;
+  const originalAuthDisabled = process.env.OPTIO_AUTH_DISABLED;
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
+    process.env.OPTIO_AUTH_DISABLED = originalAuthDisabled;
   });
 
   it("returns field names only for Zod errors in production", async () => {
     process.env.NODE_ENV = "production";
+    process.env.OPTIO_AUTH_DISABLED = "true";
     const testApp = await buildServer();
 
     // Use /api/setup/ path to bypass auth middleware
@@ -240,6 +243,7 @@ describe("Zod error sanitization", () => {
 
   it("returns full Zod error details in development", async () => {
     process.env.NODE_ENV = "development";
+    process.env.OPTIO_AUTH_DISABLED = "true";
     const testApp = await buildServer();
 
     testApp.post("/api/setup/test-zod-dev", async () => {


### PR DESCRIPTION
## Summary

Fixes new repository creation failures when secrets are created with global scope but include the current workspaceId. This resolves authentication and credential handling issues in multi-workspace environments.

## Changes

### Credential & Workspace Support
- **auth.ts**: Add `GEMINI_API_KEY`, `GOOGLE_CLOUD_PROJECT`, and `CLAUDE_VERTEX_PROJECT_ID` to `AGENT_KEY_SECRETS` for setup completion detection
- **github-token.ts**: Pass `workspaceId` to `storeSecret()` in token rotation endpoint
- **setup.ts**: Pass `workspaceId` to `retrieveSecret()` in repository validation logic

### Test Fixes
- **github-token.test.ts**: Update `storeSecret` expectation to include `workspaceId` parameter (4th argument)
- **server.test.ts**: Set `OPTIO_AUTH_DISABLED=true` in Zod error sanitization tests to bypass authentication checks

## Problem

Secrets are now getting added with global scope and current workspaceId. However, several places in the new repo creation path were not passing current workspaceId. This broke:
1. New repo creation when using global-scope secrets with workspaceId
2. Tests that expected setup routes to remain public during initial setup

## Solution

- Properly thread workspaceId through credential operations
- Isolate error handling tests from authentication by disabling auth in test environment
- Ensure setup completion detection includes all supported agent credential types

## Testing

- ✅ All 2,083 API tests pass
- ✅ All packages typecheck successfully
- ✅ Zod error sanitization tests now pass consistently