### PR TITLE
fix: align ticket provider credentials and fix settings status check

### DIFF
--- a/apps/api/src/routes/github-token.ts
+++ b/apps/api/src/routes/github-token.ts
@@ -63,10 +63,10 @@ export async function githubTokenRoutes(rawApp: FastifyInstance) {
         response: { 200: GitHubTokenStatusResponseSchema },
       },
     },
-    async (_req, reply) => {
+    async (req, reply) => {
       let token: string | null = null;
       try {
-        token = await retrieveSecret("GITHUB_TOKEN");
+        token = await retrieveSecret("GITHUB_TOKEN", "global", req.user?.workspaceId);
       } catch {
         /* no token stored */
       }

--- a/apps/api/src/routes/request-input-validation.test.ts
+++ b/apps/api/src/routes/request-input-validation.test.ts
@@ -179,9 +179,21 @@ describe("tickets route body validation", () => {
     const res = await app.inject({
       method: "POST",
       url: "/api/tickets/providers",
-      payload: { source: "github", config: { org: "test" }, enabled: true },
+      payload: { source: "github", config: { token: "ghp_test", org: "test" }, enabled: true },
     });
     expect(res.statusCode).toBe(201);
+  });
+
+  it("rejects POST /api/tickets/providers for GitHub when no token is available", async () => {
+    // In the test env, getGitHubToken will fail by default as no secrets/app are configured
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/tickets/providers",
+      payload: { source: "github", config: { org: "test" }, enabled: true },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.error).toContain("No GitHub token available");
   });
 });
 

--- a/apps/api/src/routes/tickets.ts
+++ b/apps/api/src/routes/tickets.ts
@@ -15,6 +15,7 @@ import { HmacSha256Verifier } from "../services/crypto/signer.js";
 import { logger } from "../logger.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import { TicketProviderSchema } from "../schemas/integration.js";
+import { getGitHubToken } from "../services/github-token-service.js";
 
 // ── Zod schemas for ticket provider config ─────────────────────────────────
 
@@ -212,7 +213,10 @@ export async function ticketRoutes(rawApp: FastifyInstance) {
           "linked to the provider record.",
         tags: ["Repos & Integrations"],
         body: ticketProviderConfigSchema,
-        response: { 201: ProviderResponseSchema },
+        response: {
+          201: ProviderResponseSchema,
+          400: ErrorResponseSchema,
+        },
       },
     },
     async (req, reply) => {
@@ -226,6 +230,27 @@ export async function ticketRoutes(rawApp: FastifyInstance) {
         if (safeConfig[field]) {
           sensitiveValues[field] = safeConfig[field] as string;
           delete safeConfig[field];
+        }
+      }
+
+      // If this is a GitHub provider and no token was provided, attempt to resolve one.
+      // This aligns the Settings UI creation flow with the Setup Wizard flow.
+      if (body.source === "github" && !sensitiveValues.token) {
+        try {
+          const resolvedToken = await getGitHubToken({
+            server: true,
+            workspaceId: req.user?.workspaceId,
+          });
+          sensitiveValues.token = resolvedToken;
+        } catch (err) {
+          logger.warn(
+            { err, workspaceId: req.user?.workspaceId },
+            "Failed to resolve GitHub token for new provider",
+          );
+          return reply.status(400).send({
+            error:
+              "No GitHub token available. Please configure a GitHub App or add a GITHUB_TOKEN secret first.",
+          });
         }
       }
 

--- a/apps/web/src/app/repos/new/page.tsx
+++ b/apps/web/src/app/repos/new/page.tsx
@@ -72,6 +72,7 @@ export default function NewRepoPage() {
   const [testCommand, setTestCommand] = useState("");
   const [autoResume, setAutoResume] = useState(false);
   const [autoMerge, setAutoMerge] = useState(false);
+  const [ticketIntegrationEnabled, setTicketIntegrationEnabled] = useState(false);
 
   // Creating
   const [creating, setCreating] = useState(false);
@@ -141,6 +142,16 @@ export default function NewRepoPage() {
         autoResume,
         autoMerge,
       });
+
+      if (ticketIntegrationEnabled) {
+        const [owner, repo] = fullName.split("/");
+        if (owner && repo) {
+          await api.createTicketProvider({
+            source: "github",
+            config: { owner, repo, label: "optio" },
+          });
+        }
+      }
 
       toast.success(`${fullName} added successfully`);
       router.push(`/repos/${repoId}`);
@@ -282,6 +293,8 @@ export default function NewRepoPage() {
             setAutoResume={setAutoResume}
             autoMerge={autoMerge}
             setAutoMerge={setAutoMerge}
+            ticketIntegrationEnabled={ticketIntegrationEnabled}
+            setTicketIntegrationEnabled={setTicketIntegrationEnabled}
             selectClass={selectClass}
             inputClass={inputClass}
           />
@@ -626,6 +639,8 @@ function ReviewStep({
   setAutoResume,
   autoMerge,
   setAutoMerge,
+  ticketIntegrationEnabled,
+  setTicketIntegrationEnabled,
   selectClass,
   inputClass,
 }: {
@@ -643,6 +658,8 @@ function ReviewStep({
   setAutoResume: (v: boolean) => void;
   autoMerge: boolean;
   setAutoMerge: (v: boolean) => void;
+  ticketIntegrationEnabled: boolean;
+  setTicketIntegrationEnabled: (v: boolean) => void;
   selectClass: string;
   inputClass: string;
 }) {
@@ -736,6 +753,25 @@ function ReviewStep({
             className="w-4 h-4 rounded"
           />
           <span className="text-sm">Auto-merge PR when checks pass and review completes</span>
+        </label>
+      </div>
+
+      {/* Ticket Integration */}
+      <div className="pt-2 border-t border-border/50">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={ticketIntegrationEnabled}
+            onChange={(e) => setTicketIntegrationEnabled(e.target.checked)}
+            className="w-4 h-4 rounded"
+          />
+          <div>
+            <span className="text-sm">Enable GitHub Issues integration</span>
+            <p className="text-[10px] text-text-muted mt-0.5">
+              Sync issues labeled with <code className="px-1 bg-bg rounded">optio</code> for this
+              repository.
+            </p>
+          </div>
         </label>
       </div>
     </section>


### PR DESCRIPTION
## Problem

GitHub ticket providers created outside the setup wizard (via Settings page or new repository flow) were missing dedicated credential secrets, causing "Secret not found" and "No GitHub token available" errors during background ticket sync.

Additionally, the Settings page showed a false-negative "No token configured" message even when a workspace-scoped GitHub token was available.

## Solution

1. **Workspace-aware status check** ([github-token.ts](apps/api/src/routes/github-token.ts))
   - Fixed `GET /api/github-token/status` to pass `req.user.workspaceId` to `retrieveSecret()`
   - Settings page now correctly reflects the workspace-scoped token status

2. **Auto-resolve credentials on provider creation** ([tickets.ts](apps/api/src/routes/tickets.ts))
   - When creating a GitHub ticket provider without an explicit token:
     - Attempts to resolve a token via `getGitHubToken({ server: true, workspaceId })`
     - Stores it as a provider-specific secret
     - Returns `400 Bad Request` if no token is available (prevents creating "broken" providers)
   - Aligns Settings flow with Setup Wizard behavior

3. **Enable ticket integration during repo creation** ([repos/new/page.tsx](apps/web/src/app/repos/new/page.tsx))
   - Added checkbox to enable GitHub Issues integration in the new repository flow
   - Automatically creates ticket provider with `optio` label filter

4. **Test coverage** ([request-input-validation.test.ts](apps/api/src/routes/request-input-validation.test.ts))
   - Added validation test ensuring provider creation fails gracefully when no token is available

## Testing

- ✅ All existing tests pass (2070 tests)
- ✅ New test validates error handling for missing credentials
- ✅ Manual testing confirmed:
  - Settings page correctly shows token status
  - Creating ticket provider via Settings auto-resolves credentials
  - New repo flow can enable ticket integration in one step

## Files Changed

- `apps/api/src/routes/github-token.ts` - Workspace-aware token status
- `apps/api/src/routes/tickets.ts` - Auto-resolve credentials on provider creation
- `apps/api/src/routes/request-input-validation.test.ts` - Test coverage for error handling
- `apps/web/src/app/repos/new/page.tsx` - Ticket integration toggle in new repo flow