### PR TITLE
fix: resolve gemini api key duplication and improve error classification

### DIFF
--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -1740,7 +1740,8 @@ export default function SetupPage() {
                                   setGeminiError("");
                                 }}
                                 onPaste={(e) => {
-                                  const pasted = e.clipboardData.getData("text");
+                                  e.preventDefault();
+                                  const pasted = e.clipboardData.getData("text").trim();
                                   if (pasted) {
                                     setGeminiKey(pasted);
                                     setGeminiValidated(false);

--- a/packages/agent-adapters/src/gemini.ts
+++ b/packages/agent-adapters/src/gemini.ts
@@ -64,6 +64,8 @@ export class GeminiAdapter implements AgentAdapter {
       OPTIO_PROMPT: prompt,
       OPTIO_AGENT_TYPE: "gemini",
       OPTIO_BRANCH_NAME: `${TASK_BRANCH_PREFIX}${input.taskId}`,
+      // Ensure the CLI doesn't prompt for trust in isolated ephemeral pods
+      GEMINI_CLI_TRUST_WORKSPACE: "true",
     };
 
     const requiredSecrets: string[] = [];
@@ -163,6 +165,13 @@ export class GeminiAdapter implements AgentAdapter {
     let errorMessage: string | undefined;
     let hasError = false;
     let lastAssistantMessage: string | undefined;
+
+    // Check for JSON error messages embedded in non-JSON output
+    const apiKeyErrorMatch = logs.match(/API key not valid|API_KEY_INVALID/i);
+    if (apiKeyErrorMatch) {
+      errorMessage = "API key not valid. Please pass a valid API key.";
+      hasError = true;
+    }
 
     for (const line of logs.split("\n")) {
       if (!line.trim()) continue;

--- a/packages/agent-adapters/src/gemini.ts
+++ b/packages/agent-adapters/src/gemini.ts
@@ -64,8 +64,6 @@ export class GeminiAdapter implements AgentAdapter {
       OPTIO_PROMPT: prompt,
       OPTIO_AGENT_TYPE: "gemini",
       OPTIO_BRANCH_NAME: `${TASK_BRANCH_PREFIX}${input.taskId}`,
-      // Ensure the CLI doesn't prompt for trust in isolated ephemeral pods
-      GEMINI_CLI_TRUST_WORKSPACE: "true",
     };
 
     const requiredSecrets: string[] = [];

--- a/packages/shared/src/error-classifier.test.ts
+++ b/packages/shared/src/error-classifier.test.ts
@@ -157,4 +157,11 @@ describe("classifyError", () => {
     expect(result.category).toBe("auth");
     expect(result.title).toBe("Authentication token expired");
   });
+
+  it("classifies invalid API key error", () => {
+    const result = classifyError("API_KEY_INVALID error from Gemini API");
+    expect(result.category).toBe("auth");
+    expect(result.title).toBe("Invalid API key");
+    expect(result.retryable).toBe(false);
+  });
 });

--- a/packages/shared/src/error-classifier.ts
+++ b/packages/shared/src/error-classifier.ts
@@ -235,6 +235,18 @@ const ERROR_PATTERNS: Array<{
     }),
   },
   {
+    pattern: /API key not valid|API_KEY_INVALID/i,
+    classify: () => ({
+      category: "auth",
+      title: "Invalid API key",
+      description:
+        "The provided API key is invalid. This can affect Gemini, Anthropic, or OpenAI depending on which agent was running.",
+      remedy:
+        "Go to Secrets and verify your API keys (GEMINI_API_KEY, ANTHROPIC_API_KEY, etc.) are valid and have not been revoked.",
+      retryable: false,
+    }),
+  },
+  {
     pattern: /exit code: (\d+)/i,
     classify: (match) => ({
       category: "agent",


### PR DESCRIPTION
## Summary
This PR fixes a bug where the Gemini API key was being duplicated during paste on the setup page and improves error detection for invalid Gemini API keys during task execution.

## Changes
- **Setup Page**: Added `e.preventDefault()` to the Gemini key `onPaste` handler in `apps/web/src/app/setup/page.tsx` to prevent the browser's default paste action from interfering with React state updates.
- **Gemini Adapter**: Updated `GeminiAdapter` in `packages/agent-adapters/src/gemini.ts` to scan log output for "API key not valid" and "API_KEY_INVALID" patterns.
- **Error Classifier**: Added a specific rule to `packages/shared/src/error-classifier.ts` to catch invalid API key errors and provide actionable remedies.

## Test Validation
- Manually verified that pasting the Gemini API key on the setup page no longer results in a duplicated string.
- Verified that the agent now correctly identifies and reports "Invalid API key" when the Gemini CLI exits with a 400 error due to a bad key, instead of a generic "exit code 1".