### PR TITLE
fix: add missing auth.oidc validation in helm chart

### DIFF
--- a/helm/optio/templates/_helpers.tpl
+++ b/helm/optio/templates/_helpers.tpl
@@ -47,9 +47,9 @@ Called from secrets.yaml to fail early on misconfiguration.
   {{- if not .Values.publicUrl -}}
     {{- fail "publicUrl is required when auth is enabled. Set to the externally-reachable URL (e.g. https://optio.example.com)." -}}
   {{- else -}}
-    {{- $hasProvider := or .Values.auth.github.clientId (or .Values.auth.google.clientId .Values.auth.gitlab.clientId) -}}
+    {{- $hasProvider := or .Values.auth.github.clientId (or .Values.auth.google.clientId (or .Values.auth.gitlab.clientId .Values.auth.oidc.clientId)) -}}
     {{- if not $hasProvider -}}
-      {{- fail "At least one OAuth provider must be configured when auth is enabled. Set auth.github.clientId, auth.google.clientId, or auth.gitlab.clientId (with corresponding clientSecret)." -}}
+      {{- fail "At least one OAuth provider must be configured when auth is enabled. Set auth.github.clientId, auth.google.clientId, auth.gitlab.clientId, or auth.oidc.clientId (with corresponding clientSecret/issuerUrl as needed)." -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/helm/optio/templates/_helpers.tpl
+++ b/helm/optio/templates/_helpers.tpl
@@ -49,7 +49,7 @@ Called from secrets.yaml to fail early on misconfiguration.
   {{- else -}}
     {{- $hasProvider := or .Values.auth.github.clientId (or .Values.auth.google.clientId (or .Values.auth.gitlab.clientId .Values.auth.oidc.issuerUrl)) -}}
     {{- if not $hasProvider -}}
-      {{- fail "At least one OAuth provider must be configured when auth is enabled. Set auth.github.clientId, auth.google.clientId, auth.gitlab.clientId, or auth.oidc.issuerUrl (with corresponding clinetId, clientSecret as needed)." -}}
+      {{- fail "At least one OAuth provider must be configured when auth is enabled. Set auth.github.clientId, auth.google.clientId, auth.gitlab.clientId, or auth.oidc.issuerUrl (with corresponding clientId, clientSecret as needed)." -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/helm/optio/templates/_helpers.tpl
+++ b/helm/optio/templates/_helpers.tpl
@@ -47,9 +47,9 @@ Called from secrets.yaml to fail early on misconfiguration.
   {{- if not .Values.publicUrl -}}
     {{- fail "publicUrl is required when auth is enabled. Set to the externally-reachable URL (e.g. https://optio.example.com)." -}}
   {{- else -}}
-    {{- $hasProvider := or .Values.auth.github.clientId (or .Values.auth.google.clientId (or .Values.auth.gitlab.clientId .Values.auth.oidc.clientId)) -}}
+    {{- $hasProvider := or .Values.auth.github.clientId (or .Values.auth.google.clientId (or .Values.auth.gitlab.clientId .Values.auth.oidc.issuerUrl)) -}}
     {{- if not $hasProvider -}}
-      {{- fail "At least one OAuth provider must be configured when auth is enabled. Set auth.github.clientId, auth.google.clientId, auth.gitlab.clientId, or auth.oidc.clientId (with corresponding clientSecret/issuerUrl as needed)." -}}
+      {{- fail "At least one OAuth provider must be configured when auth is enabled. Set auth.github.clientId, auth.google.clientId, auth.gitlab.clientId, or auth.oidc.issuerUrl (with corresponding clinetId, clientSecret as needed)." -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Summary

The Helm chart template is currently missing values validation for OIDC authentication. This MR updates the template helpers to correctly validate and support OIDC configuration.

## Changes

Added an missing conditional check (OR logic) in the Helm template helpers to support and validate `auth.oidc.clientId` configurations.

## Testing

<!-- How was this tested? -->

- [ ] Tests pass (`pnpm turbo test`)
- [ ] Typechecks pass (`pnpm turbo typecheck`)
- [x] Helm validation (`helm lint`)
- [x] Local dry-run installation with OIDC enabled (helm install --dry-run --debug)

## Related

<!-- Issues, PRs, docs, etc. -->

Closes #

## Screenshots

<!-- If applicable -->
