### PR TITLE
feat(repo-providers): add AWS CodeCommit as a third git platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ Optio is an orchestration system for AI coding agents. Think of it as "CI/CD whe
   8. Auto-resumes agent when reviewer requests changes (if enabled)
   9. Auto-completes on merge, auto-fails on close
 
+  Supported git platforms: **GitHub**, **GitLab** (incl. self-hosted via `GITLAB_HOSTS`), and **AWS CodeCommit**. CodeCommit auths via AWS access keys (or IRSA / instance profile when running on EKS) and uses the AWS CLI credential helper for clones; PR ops go through `@aws-sdk/client-codecommit`. CodeCommit has no native CI or issues — `getCIChecks` returns `[]` (auto-merge still fires on `checksStatus="none"`), `listIssues` returns `[]`, and `reviewTrigger="on_pr"` is recommended over the default `on_ci_pass` for CodeCommit repos.
+
 - **Standalone Task** — no `Where`. The agent runs in an isolated pod with no repo checkout, producing logs and side effects (e.g., queries Slack, posts to a database). Scheduled/webhook-driven runs of this flavor are the common case.
 
 - **Persistent Agent** — long-lived, named, message-driven agent process that does _not_ terminate after running. Halts after each turn and waits to be re-woken by a user message, an agent message, a webhook, a cron tick, or a ticket event. Addressable by other agents in the same workspace via the inter-agent HTTP API (`/api/internal/persistent-agents/*`). Three configurable pod lifecycle modes: `always-on`, `sticky` (default, with idle warm window), and `on-demand`. UI at `/agents`. Schema: `persistent_agents`, `persistent_agent_turns`, `persistent_agent_messages`, `persistent_agent_pods`. See `docs/persistent-agents.md` and the demo in `demos/the-forge/`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,8 @@
     "openapi:types": "openapi-typescript openapi.generated.json -o openapi.generated.d.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-codecommit": "^3.1041.0",
+    "@aws-sdk/client-sts": "^3.1041.0",
     "@fastify/cors": "^11.0.0",
     "@fastify/formbody": "^8.0.2",
     "@fastify/rate-limit": "^10.2.2",
@@ -61,6 +63,7 @@
     "@types/node": "^22.15.0",
     "@types/web-push": "^3.6.4",
     "@vitest/coverage-v8": "^3.2.4",
+    "aws-sdk-client-mock": "^4.1.0",
     "drizzle-kit": "^0.31.1",
     "openapi-typescript": "^7.13.0",
     "tsx": "^4.19.4",

--- a/apps/api/src/routes/openapi.test.ts
+++ b/apps/api/src/routes/openapi.test.ts
@@ -324,16 +324,18 @@ const MIGRATED_ROUTES: MigratedRoute[] = [
   { method: "get", path: "/api/analytics/costs" },
 
   // Phase 7 — setup, secrets, optio, cluster (28 routes)
-  // setup.ts (10)
+  // setup.ts (12)
   { method: "get", path: "/api/setup/status" },
   { method: "post", path: "/api/setup/validate/github-token" },
   { method: "post", path: "/api/setup/validate/gitlab-token" },
+  { method: "post", path: "/api/setup/validate/aws-credentials" },
   { method: "post", path: "/api/setup/validate/anthropic-key" },
   { method: "post", path: "/api/setup/validate/copilot-token" },
   { method: "post", path: "/api/setup/validate/openai-key" },
   { method: "post", path: "/api/setup/validate/gemini-key" },
   { method: "post", path: "/api/setup/repos" },
   { method: "post", path: "/api/setup/repos/gitlab" },
+  { method: "post", path: "/api/setup/repos/codecommit" },
   { method: "post", path: "/api/setup/validate/repo" },
   // secrets.ts (3)
   { method: "get", path: "/api/secrets" },
@@ -416,8 +418,9 @@ describe("OpenAPI spec — migrated routes are fully documented", () => {
 
   it("migrated routes count matches the sum of completed phases", () => {
     // Removed 14 routes (8 schedule + 6 task-template) that were redundant
-    // with agent workflows. 183 - 14 = 169.
-    expect(MIGRATED_ROUTES).toHaveLength(169);
+    // with agent workflows. 183 - 14 = 169. Then added 2 CodeCommit setup
+    // routes (validate/aws-credentials and repos/codecommit) → 171.
+    expect(MIGRATED_ROUTES).toHaveLength(171);
   });
 
   it("components.schemas contains the Task domain types", () => {

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -18,6 +18,14 @@ const gitlabTokenSchema = z
       .describe("Optional self-hosted GitLab host; defaults to gitlab.com"),
   })
   .describe("GitLab token + optional host");
+const awsCredentialsSchema = z
+  .object({
+    accessKeyId: z.string().min(1),
+    secretAccessKey: z.string().min(1),
+    sessionToken: z.string().optional(),
+    region: z.string().min(1),
+  })
+  .describe("AWS credentials + region for CodeCommit access");
 const keySchema = z.object({ key: z.string().min(1) }).describe("Body with a required API key");
 const reposBodySchema = z
   .object({
@@ -246,6 +254,113 @@ export async function setupRoutes(rawApp: FastifyInstance) {
       } catch (err) {
         app.log.error(err, "GitLab token validation failed");
         reply.send({ valid: false, error: sanitizeError(err) });
+      }
+    },
+  );
+
+  app.post(
+    "/api/setup/validate/aws-credentials",
+    {
+      config: { rateLimit: SETUP_POST_RATE_LIMIT },
+      preHandler: [requireAdminWhenAuthenticated],
+      schema: {
+        operationId: "validateAwsCredentials",
+        summary: "Validate AWS credentials for CodeCommit",
+        description:
+          "Confirms the supplied AWS credentials by calling sts:GetCallerIdentity " +
+          "and codecommit:ListRepositories in the given region.",
+        tags: ["Setup & Settings"],
+        body: awsCredentialsSchema,
+        response: { 200: ValidationResultSchema, 400: ErrorResponseSchema },
+      },
+    },
+    async (req, reply) => {
+      const { accessKeyId, secretAccessKey, sessionToken, region } = req.body;
+      try {
+        const { STSClient, GetCallerIdentityCommand } = await import("@aws-sdk/client-sts");
+        const { CodeCommitClient: CC, ListRepositoriesCommand } =
+          await import("@aws-sdk/client-codecommit");
+        const credentials = {
+          accessKeyId,
+          secretAccessKey,
+          ...(sessionToken ? { sessionToken } : {}),
+        };
+        const sts = new STSClient({ region, credentials });
+        const id = await sts.send(new GetCallerIdentityCommand({}));
+        const cc = new CC({ region, credentials });
+        await cc.send(new ListRepositoriesCommand({}));
+        reply.send({
+          valid: true,
+          user: {
+            login: id.Arn ?? "aws",
+            name: id.Account ? `AWS account ${id.Account}` : "AWS",
+          },
+        });
+      } catch (err) {
+        app.log.error(err, "AWS credential validation failed");
+        reply.send({ valid: false, error: sanitizeError(err) });
+      }
+    },
+  );
+
+  app.post(
+    "/api/setup/repos/codecommit",
+    {
+      config: { rateLimit: SETUP_POST_RATE_LIMIT },
+      preHandler: [requireAdminWhenAuthenticated],
+      schema: {
+        operationId: "listSetupCodeCommitRepos",
+        summary: "List CodeCommit repositories for setup",
+        description: "List CodeCommit repos in the given region accessible to the supplied creds.",
+        tags: ["Setup & Settings"],
+        body: awsCredentialsSchema,
+        response: { 200: ReposListResponseSchema, 400: ErrorResponseSchema },
+      },
+    },
+    async (req, reply) => {
+      const { accessKeyId, secretAccessKey, sessionToken, region } = req.body;
+      try {
+        const {
+          CodeCommitClient: CC,
+          ListRepositoriesCommand,
+          GetRepositoryCommand,
+        } = await import("@aws-sdk/client-codecommit");
+        const credentials = {
+          accessKeyId,
+          secretAccessKey,
+          ...(sessionToken ? { sessionToken } : {}),
+        };
+        const cc = new CC({ region, credentials });
+        const list = await cc.send(new ListRepositoriesCommand({}));
+        const names = (list.repositories ?? []).map((r) => r.repositoryName).filter(Boolean) as
+          | string[]
+          | [];
+        const details = await Promise.all(
+          names.slice(0, 50).map((name) =>
+            cc
+              .send(new GetRepositoryCommand({ repositoryName: name }))
+              .then((d) => d.repositoryMetadata)
+              .catch(() => null),
+          ),
+        );
+        const repos = details
+          .filter((d): d is NonNullable<typeof d> => Boolean(d))
+          .map((d) => ({
+            fullName: d.repositoryName ?? "",
+            cloneUrl:
+              d.cloneUrlHttp ??
+              `https://git-codecommit.${region}.amazonaws.com/v1/repos/${d.repositoryName}`,
+            htmlUrl: `https://${region}.console.aws.amazon.com/codesuite/codecommit/repositories/${d.repositoryName}/browse`,
+            defaultBranch: d.defaultBranch ?? "main",
+            isPrivate: true,
+            description: d.repositoryDescription ?? null,
+            language: null,
+            pushedAt: d.lastModifiedDate ? new Date(d.lastModifiedDate).toISOString() : "",
+          }));
+        reply.send({ repos });
+      } catch (err) {
+        app.log.error(err, "CodeCommit repo listing failed");
+        reply.send({ repos: [], error: sanitizeError(err) });
       }
     },
   );

--- a/apps/api/src/services/codecommit-credential-service.ts
+++ b/apps/api/src/services/codecommit-credential-service.ts
@@ -1,0 +1,87 @@
+import { retrieveSecretWithFallback } from "./secret-service.js";
+import { logger } from "../logger.js";
+
+export interface AwsCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  region: string;
+}
+
+/**
+ * Resolve AWS credentials for CodeCommit access from secrets, with workspace and global scopes,
+ * falling back to env vars. Returns the credentials as a JSON string so it can be passed
+ * through the existing GitPlatform factory which takes a single `token: string`.
+ *
+ * Lookup order:
+ *   1. Workspace-scoped or global secrets named AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+ *      (+ optional AWS_SESSION_TOKEN, AWS_REGION).
+ *   2. Process env vars (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN,
+ *      AWS_REGION / AWS_DEFAULT_REGION).
+ *
+ * If neither source provides creds, returns the sentinel string `"workload-identity"` so the
+ * AWS SDK falls back to its default credential provider chain (instance profile / IRSA /
+ * environment) at the call site.
+ */
+export async function getCodeCommitCredentials(workspaceId?: string | null): Promise<string> {
+  let accessKeyId: string | undefined;
+  let secretAccessKey: string | undefined;
+  let sessionToken: string | undefined;
+  let region: string | undefined;
+
+  try {
+    accessKeyId = await retrieveSecretWithFallback("AWS_ACCESS_KEY_ID", "global", workspaceId);
+    secretAccessKey = await retrieveSecretWithFallback(
+      "AWS_SECRET_ACCESS_KEY",
+      "global",
+      workspaceId,
+    );
+  } catch {
+    logger.debug({ workspaceId }, "No AWS credential secrets found, checking env");
+  }
+
+  try {
+    sessionToken = await retrieveSecretWithFallback("AWS_SESSION_TOKEN", "global", workspaceId);
+  } catch {
+    // Optional
+  }
+
+  try {
+    region = await retrieveSecretWithFallback("AWS_REGION", "global", workspaceId);
+  } catch {
+    // Optional
+  }
+
+  accessKeyId ??= process.env.AWS_ACCESS_KEY_ID;
+  secretAccessKey ??= process.env.AWS_SECRET_ACCESS_KEY;
+  sessionToken ??= process.env.AWS_SESSION_TOKEN;
+  region ??= process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
+
+  if (!accessKeyId || !secretAccessKey) {
+    // Signal to the SDK to use the default credential provider chain
+    return "workload-identity";
+  }
+
+  const creds: AwsCredentials = {
+    accessKeyId,
+    secretAccessKey,
+    region: region ?? "us-east-1",
+    ...(sessionToken ? { sessionToken } : {}),
+  };
+  return JSON.stringify(creds);
+}
+
+/**
+ * Parse a credential string produced by getCodeCommitCredentials() back into an
+ * AwsCredentials object, or return null if the caller should use the default chain.
+ */
+export function parseAwsCredentials(token: string): AwsCredentials | null {
+  if (!token || token === "workload-identity") return null;
+  try {
+    const parsed = JSON.parse(token) as AwsCredentials;
+    if (!parsed.accessKeyId || !parsed.secretAccessKey) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/services/git-platform/codecommit.test.ts
+++ b/apps/api/src/services/git-platform/codecommit.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  CodeCommitClient,
+  GetPullRequestCommand,
+  ListPullRequestsCommand,
+  GetCommentsForPullRequestCommand,
+  PostCommentForPullRequestCommand,
+  UpdatePullRequestApprovalStateCommand,
+  GetPullRequestApprovalStatesCommand,
+  MergePullRequestBySquashCommand,
+  MergePullRequestByThreeWayCommand,
+  GetRepositoryCommand,
+  GetFolderCommand,
+} from "@aws-sdk/client-codecommit";
+import { CodeCommitPlatform } from "./codecommit.js";
+import type { RepoIdentifier } from "@optio/shared";
+
+const ri: RepoIdentifier = {
+  platform: "codecommit",
+  host: "git-codecommit.us-east-1.amazonaws.com",
+  owner: "us-east-1",
+  repo: "MyRepo",
+  apiBaseUrl: "us-east-1",
+};
+
+const credToken = JSON.stringify({
+  accessKeyId: "AKIA-test",
+  secretAccessKey: "secret-test",
+  region: "us-east-1",
+});
+
+const ccMock = mockClient(CodeCommitClient);
+
+describe("CodeCommitPlatform", () => {
+  let platform: CodeCommitPlatform;
+
+  beforeEach(() => {
+    ccMock.reset();
+    platform = new CodeCommitPlatform(credToken);
+  });
+
+  afterEach(() => {
+    ccMock.reset();
+  });
+
+  it("has type codecommit", () => {
+    expect(platform.type).toBe("codecommit");
+  });
+
+  describe("getPullRequest", () => {
+    it("maps a CodeCommit PR to PullRequest shape", async () => {
+      ccMock.on(GetPullRequestCommand).resolves({
+        pullRequest: {
+          pullRequestId: "42",
+          title: "Add feature",
+          description: "Implements X",
+          pullRequestStatus: "OPEN",
+          authorArn: "arn:aws:iam::123456789012:user/alice",
+          creationDate: new Date("2024-01-01T00:00:00Z"),
+          lastActivityDate: new Date("2024-01-02T00:00:00Z"),
+          revisionId: "rev1",
+          pullRequestTargets: [
+            {
+              repositoryName: "MyRepo",
+              sourceCommit: "abc123",
+              destinationCommit: "def456",
+              sourceReference: "refs/heads/feature",
+              destinationReference: "refs/heads/main",
+              mergeMetadata: { isMerged: false },
+            },
+          ],
+        },
+      });
+
+      const pr = await platform.getPullRequest(ri, 42);
+
+      expect(pr.number).toBe(42);
+      expect(pr.title).toBe("Add feature");
+      expect(pr.body).toBe("Implements X");
+      expect(pr.state).toBe("open");
+      expect(pr.merged).toBe(false);
+      expect(pr.headSha).toBe("abc123");
+      expect(pr.baseBranch).toBe("main");
+      expect(pr.author).toBe("alice");
+      expect(pr.url).toBe(
+        "https://us-east-1.console.aws.amazon.com/codesuite/codecommit/repositories/MyRepo/pull-requests/42",
+      );
+    });
+
+    it("marks merged PRs as closed + merged", async () => {
+      ccMock.on(GetPullRequestCommand).resolves({
+        pullRequest: {
+          pullRequestId: "5",
+          title: "t",
+          pullRequestStatus: "CLOSED",
+          authorArn: "arn:aws:iam::1:user/bob",
+          revisionId: "rev",
+          pullRequestTargets: [
+            {
+              sourceCommit: "s",
+              destinationReference: "refs/heads/main",
+              mergeMetadata: { isMerged: true },
+            },
+          ],
+        },
+      });
+
+      const pr = await platform.getPullRequest(ri, 5);
+      expect(pr.state).toBe("closed");
+      expect(pr.merged).toBe(true);
+    });
+  });
+
+  describe("listOpenPullRequests", () => {
+    it("fetches PR ids and returns mapped PRs", async () => {
+      ccMock.on(ListPullRequestsCommand).resolves({ pullRequestIds: ["1", "2"] });
+      ccMock
+        .on(GetPullRequestCommand, { pullRequestId: "1" })
+        .resolves({
+          pullRequest: {
+            pullRequestId: "1",
+            title: "first",
+            pullRequestStatus: "OPEN",
+            authorArn: "arn:aws:iam::1:user/a",
+            revisionId: "r",
+            pullRequestTargets: [{ sourceCommit: "x", destinationReference: "refs/heads/main" }],
+          },
+        })
+        .on(GetPullRequestCommand, { pullRequestId: "2" })
+        .resolves({
+          pullRequest: {
+            pullRequestId: "2",
+            title: "second",
+            pullRequestStatus: "OPEN",
+            authorArn: "arn:aws:iam::1:user/b",
+            revisionId: "r",
+            pullRequestTargets: [{ sourceCommit: "y", destinationReference: "refs/heads/main" }],
+          },
+        });
+
+      const prs = await platform.listOpenPullRequests(ri);
+      expect(prs).toHaveLength(2);
+      expect(prs.map((p) => p.number).sort()).toEqual([1, 2]);
+    });
+  });
+
+  describe("getCIChecks", () => {
+    it("returns empty array (CodeCommit has no native CI)", async () => {
+      const checks = await platform.getCIChecks(ri, "abc");
+      expect(checks).toEqual([]);
+    });
+  });
+
+  describe("getReviews", () => {
+    it("returns APPROVED reviews from approval states", async () => {
+      ccMock.on(GetPullRequestCommand).resolves({
+        pullRequest: { revisionId: "rev1" },
+      });
+      ccMock.on(GetPullRequestApprovalStatesCommand).resolves({
+        approvals: [
+          { userArn: "arn:aws:iam::1:user/alice", approvalState: "APPROVE" },
+          { userArn: "arn:aws:iam::1:user/bob", approvalState: "REVOKE" },
+        ],
+      });
+      ccMock.on(GetCommentsForPullRequestCommand).resolves({
+        commentsForPullRequestData: [],
+      });
+
+      const reviews = await platform.getReviews(ri, 42);
+      const approvals = reviews.filter((r) => r.state === "APPROVED");
+      expect(approvals).toHaveLength(1);
+      expect(approvals[0].author).toBe("alice");
+    });
+
+    it("synthesizes COMMENTED reviews from non-inline comments", async () => {
+      ccMock.on(GetPullRequestCommand).resolves({
+        pullRequest: { revisionId: "rev1" },
+      });
+      ccMock.on(GetPullRequestApprovalStatesCommand).resolves({ approvals: [] });
+      ccMock.on(GetCommentsForPullRequestCommand).resolves({
+        commentsForPullRequestData: [
+          {
+            comments: [{ content: "looks good", authorArn: "arn:aws:iam::1:user/alice" }],
+            // no location → top-level comment
+          },
+          {
+            comments: [
+              {
+                content: "fix this line",
+                authorArn: "arn:aws:iam::1:user/alice",
+              },
+            ],
+            location: { filePath: "src/foo.ts", filePosition: 10 },
+          },
+        ],
+      });
+
+      const reviews = await platform.getReviews(ri, 42);
+      expect(reviews).toHaveLength(1);
+      expect(reviews[0].state).toBe("COMMENTED");
+      expect(reviews[0].body).toBe("looks good");
+    });
+  });
+
+  describe("getInlineComments", () => {
+    it("returns only comments with a location", async () => {
+      ccMock.on(GetCommentsForPullRequestCommand).resolves({
+        commentsForPullRequestData: [
+          {
+            comments: [{ content: "top-level", authorArn: "arn:aws:iam::1:user/a" }],
+          },
+          {
+            comments: [
+              {
+                content: "inline note",
+                authorArn: "arn:aws:iam::1:user/a",
+                creationDate: new Date("2024-01-01T00:00:00Z"),
+              },
+            ],
+            location: { filePath: "src/foo.ts", filePosition: 10 },
+          },
+        ],
+      });
+
+      const comments = await platform.getInlineComments(ri, 42);
+      expect(comments).toHaveLength(1);
+      expect(comments[0].path).toBe("src/foo.ts");
+      expect(comments[0].line).toBe(10);
+      expect(comments[0].body).toBe("inline note");
+    });
+  });
+
+  describe("mergePullRequest", () => {
+    it("uses squash merge for 'squash'", async () => {
+      ccMock.on(MergePullRequestBySquashCommand).resolves({});
+      await platform.mergePullRequest(ri, 42, "squash");
+      expect(ccMock.commandCalls(MergePullRequestBySquashCommand)).toHaveLength(1);
+    });
+
+    it("uses three-way merge for 'merge'", async () => {
+      ccMock.on(MergePullRequestByThreeWayCommand).resolves({});
+      await platform.mergePullRequest(ri, 42, "merge");
+      expect(ccMock.commandCalls(MergePullRequestByThreeWayCommand)).toHaveLength(1);
+    });
+  });
+
+  describe("submitReview", () => {
+    it("posts approval and body comment for APPROVE", async () => {
+      ccMock.on(GetPullRequestCommand).resolves({
+        pullRequest: {
+          revisionId: "rev1",
+          pullRequestTargets: [{ destinationCommit: "before", sourceCommit: "after" }],
+        },
+      });
+      ccMock.on(UpdatePullRequestApprovalStateCommand).resolves({});
+      ccMock.on(PostCommentForPullRequestCommand).resolves({});
+
+      const res = await platform.submitReview(ri, 42, {
+        event: "APPROVE",
+        body: "LGTM",
+      });
+
+      expect(res.url).toBe(
+        "https://us-east-1.console.aws.amazon.com/codesuite/codecommit/repositories/MyRepo/pull-requests/42",
+      );
+      expect(ccMock.commandCalls(UpdatePullRequestApprovalStateCommand)).toHaveLength(1);
+      const calls = ccMock.commandCalls(PostCommentForPullRequestCommand);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].args[0].input.content).toBe("LGTM");
+    });
+
+    it("prefixes body with [CHANGES REQUESTED] for REQUEST_CHANGES", async () => {
+      ccMock.on(GetPullRequestCommand).resolves({
+        pullRequest: {
+          revisionId: "rev1",
+          pullRequestTargets: [{ destinationCommit: "before", sourceCommit: "after" }],
+        },
+      });
+      ccMock.on(PostCommentForPullRequestCommand).resolves({});
+
+      await platform.submitReview(ri, 42, {
+        event: "REQUEST_CHANGES",
+        body: "fix things",
+      });
+
+      const calls = ccMock.commandCalls(PostCommentForPullRequestCommand);
+      expect(calls[0].args[0].input.content).toContain("[CHANGES REQUESTED]");
+      expect(calls[0].args[0].input.content).toContain("fix things");
+    });
+
+    it("posts inline comments with location", async () => {
+      ccMock.on(GetPullRequestCommand).resolves({
+        pullRequest: {
+          revisionId: "rev1",
+          pullRequestTargets: [{ destinationCommit: "before", sourceCommit: "after" }],
+        },
+      });
+      ccMock.on(PostCommentForPullRequestCommand).resolves({});
+
+      await platform.submitReview(ri, 42, {
+        event: "COMMENT",
+        body: "",
+        comments: [{ path: "src/foo.ts", line: 10, body: "nit" }],
+      });
+
+      const calls = ccMock.commandCalls(PostCommentForPullRequestCommand);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].args[0].input.location?.filePath).toBe("src/foo.ts");
+      expect(calls[0].args[0].input.location?.filePosition).toBe(10);
+    });
+  });
+
+  describe("listIssues / write methods", () => {
+    it("listIssues returns empty", async () => {
+      const issues = await platform.listIssues(ri);
+      expect(issues).toEqual([]);
+    });
+
+    it("createLabel throws", async () => {
+      await expect(platform.createLabel(ri, { name: "foo", color: "ff0000" })).rejects.toThrow(
+        /labels/,
+      );
+    });
+
+    it("createIssueComment throws", async () => {
+      await expect(platform.createIssueComment(ri, 1, "hi")).rejects.toThrow(/issues/);
+    });
+  });
+
+  describe("getRepoMetadata", () => {
+    it("maps GetRepository to RepoMetadata", async () => {
+      ccMock.on(GetRepositoryCommand).resolves({
+        repositoryMetadata: {
+          repositoryName: "MyRepo",
+          defaultBranch: "develop",
+        },
+      });
+      const md = await platform.getRepoMetadata(ri);
+      expect(md.fullName).toBe("MyRepo");
+      expect(md.defaultBranch).toBe("develop");
+      expect(md.isPrivate).toBe(true);
+    });
+  });
+
+  describe("listRepoContents", () => {
+    it("maps files and subFolders to RepoContent", async () => {
+      ccMock.on(GetRepositoryCommand).resolves({
+        repositoryMetadata: { defaultBranch: "main" },
+      });
+      ccMock.on(GetFolderCommand).resolves({
+        files: [{ absolutePath: "package.json", relativePath: "package.json" }],
+        subFolders: [{ absolutePath: "src", relativePath: "src" }],
+      });
+
+      const contents = await platform.listRepoContents(ri);
+      const types = Object.fromEntries(contents.map((c) => [c.name, c.type]));
+      expect(types["package.json"]).toBe("file");
+      expect(types["src"]).toBe("dir");
+    });
+  });
+});

--- a/apps/api/src/services/git-platform/codecommit.ts
+++ b/apps/api/src/services/git-platform/codecommit.ts
@@ -1,0 +1,517 @@
+import {
+  CodeCommitClient,
+  GetPullRequestCommand,
+  ListPullRequestsCommand,
+  GetCommentsForPullRequestCommand,
+  PostCommentForPullRequestCommand,
+  UpdatePullRequestApprovalStateCommand,
+  GetPullRequestApprovalStatesCommand,
+  MergePullRequestByFastForwardCommand,
+  MergePullRequestBySquashCommand,
+  MergePullRequestByThreeWayCommand,
+  GetRepositoryCommand,
+  GetFolderCommand,
+  type PullRequest as CCPullRequest,
+} from "@aws-sdk/client-codecommit";
+import type {
+  GitPlatform,
+  RepoIdentifier,
+  PullRequest,
+  CICheck,
+  Review,
+  InlineComment,
+  IssueComment,
+  Issue,
+  RepoMetadata,
+  RepoContent,
+} from "@optio/shared";
+import { parseAwsCredentials, type AwsCredentials } from "../codecommit-credential-service.js";
+import { logger } from "../../logger.js";
+
+/**
+ * AWS CodeCommit implementation of the GitPlatform interface.
+ *
+ * Mapping notes:
+ *  - `RepoIdentifier.owner` is the AWS region (CodeCommit has no owner concept).
+ *  - `RepoIdentifier.apiBaseUrl` is also the AWS region (passed to the SDK client).
+ *  - PR numbers are CodeCommit's `pullRequestId` (returned as a string by the API
+ *    but exposed here as a number to match the GitPlatform interface).
+ *  - CodeCommit has no native CI: `getCIChecks()` returns `[]`.
+ *  - CodeCommit has no native issues: `listIssues()` returns `[]`; mutating
+ *    methods throw a clear error.
+ *  - CodeCommit has no `CHANGES_REQUESTED` review state. `submitReview()` posts a
+ *    comment with a `**[CHANGES REQUESTED]**` prefix in that case.
+ */
+export class CodeCommitPlatform implements GitPlatform {
+  readonly type = "codecommit" as const;
+  private readonly creds: AwsCredentials | null;
+  private readonly defaultRegion: string;
+  private readonly clients = new Map<string, CodeCommitClient>();
+
+  constructor(token: string) {
+    this.creds = parseAwsCredentials(token);
+    this.defaultRegion =
+      this.creds?.region ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? "us-east-1";
+  }
+
+  private withRegion(ri: RepoIdentifier): CodeCommitClient {
+    // ri.apiBaseUrl carries the region; one client per region, cached.
+    const region = ri.apiBaseUrl || this.defaultRegion;
+    const cached = this.clients.get(region);
+    if (cached) return cached;
+    const client = new CodeCommitClient({
+      region,
+      ...(this.creds
+        ? {
+            credentials: {
+              accessKeyId: this.creds.accessKeyId,
+              secretAccessKey: this.creds.secretAccessKey,
+              ...(this.creds.sessionToken ? { sessionToken: this.creds.sessionToken } : {}),
+            },
+          }
+        : {}),
+    });
+    this.clients.set(region, client);
+    return client;
+  }
+
+  // ── PR reads ──────────────────────────────────────────────────────────────
+
+  async getPullRequest(ri: RepoIdentifier, prNumber: number): Promise<PullRequest> {
+    const client = this.withRegion(ri);
+    const res = await client.send(new GetPullRequestCommand({ pullRequestId: String(prNumber) }));
+    if (!res.pullRequest) {
+      throw new Error(`CodeCommit pull request ${prNumber} not found`);
+    }
+    return mapPr(res.pullRequest, ri);
+  }
+
+  async listOpenPullRequests(
+    ri: RepoIdentifier,
+    opts?: { branch?: string; perPage?: number },
+  ): Promise<PullRequest[]> {
+    const client = this.withRegion(ri);
+    const list = await client.send(
+      new ListPullRequestsCommand({
+        repositoryName: ri.repo,
+        pullRequestStatus: "OPEN",
+        maxResults: opts?.perPage ?? 25,
+      }),
+    );
+    const ids = list.pullRequestIds ?? [];
+    const prs = await Promise.all(
+      ids.map((id) =>
+        client
+          .send(new GetPullRequestCommand({ pullRequestId: id }))
+          .then((r) => r.pullRequest)
+          .catch((err) => {
+            logger.warn({ err, prId: id }, "Failed to fetch CodeCommit PR detail");
+            return undefined;
+          }),
+      ),
+    );
+    const mapped = prs.filter((p): p is CCPullRequest => Boolean(p)).map((p) => mapPr(p, ri));
+    if (opts?.branch) {
+      return mapped.filter((p) => sourceBranchMatches(p, opts.branch!));
+    }
+    return mapped;
+  }
+
+  async getCIChecks(_ri: RepoIdentifier, _commitSha: string): Promise<CICheck[]> {
+    // CodeCommit has no native CI. CodePipeline integration is a planned follow-up.
+    return [];
+  }
+
+  async getReviews(ri: RepoIdentifier, prNumber: number): Promise<Review[]> {
+    const client = this.withRegion(ri);
+    const reviews: Review[] = [];
+
+    try {
+      const states = await client.send(
+        new GetPullRequestApprovalStatesCommand({
+          pullRequestId: String(prNumber),
+          revisionId: await this.latestRevisionId(client, prNumber),
+        }),
+      );
+      for (const a of states.approvals ?? []) {
+        if (a.approvalState === "APPROVE") {
+          reviews.push({
+            author: shortenArn(a.userArn),
+            state: "APPROVED",
+            body: "",
+          });
+        }
+      }
+    } catch (err) {
+      logger.debug({ err, prNumber }, "Failed to fetch CodeCommit approval states");
+    }
+
+    // PR-level (non-inline) comments synthesize into COMMENTED reviews
+    try {
+      const comments = await collectPrComments(client, prNumber);
+      for (const comment of comments) {
+        if (comment.location) continue; // inline — surfaced via getInlineComments
+        const body = comment.content ?? "";
+        if (!body.trim()) continue;
+        reviews.push({
+          author: shortenArn(comment.authorArn),
+          state: body.startsWith("**[CHANGES REQUESTED]**") ? "CHANGES_REQUESTED" : "COMMENTED",
+          body,
+        });
+      }
+    } catch (err) {
+      logger.debug({ err, prNumber }, "Failed to fetch CodeCommit PR comments for reviews");
+    }
+
+    return reviews;
+  }
+
+  async getInlineComments(ri: RepoIdentifier, prNumber: number): Promise<InlineComment[]> {
+    const client = this.withRegion(ri);
+    const comments = await collectPrComments(client, prNumber);
+    return comments
+      .filter((c) => c.location)
+      .map((c) => ({
+        author: shortenArn(c.authorArn),
+        path: c.location?.filePath ?? "",
+        line: c.location?.filePosition !== undefined ? Number(c.location.filePosition) : null,
+        body: c.content ?? "",
+        createdAt: c.creationDate ? new Date(c.creationDate).toISOString() : "",
+      }));
+  }
+
+  async getIssueComments(ri: RepoIdentifier, prNumber: number): Promise<IssueComment[]> {
+    // CodeCommit unifies PR comments; treat top-level (non-inline) comments as issue comments.
+    const client = this.withRegion(ri);
+    const comments = await collectPrComments(client, prNumber);
+    return comments
+      .filter((c) => !c.location)
+      .map((c) => ({
+        author: shortenArn(c.authorArn),
+        body: c.content ?? "",
+        createdAt: c.creationDate ? new Date(c.creationDate).toISOString() : "",
+      }));
+  }
+
+  // ── PR writes ─────────────────────────────────────────────────────────────
+
+  async mergePullRequest(
+    ri: RepoIdentifier,
+    prNumber: number,
+    method: "merge" | "squash" | "rebase",
+  ): Promise<void> {
+    const client = this.withRegion(ri);
+    const id = String(prNumber);
+    if (method === "squash") {
+      await client.send(
+        new MergePullRequestBySquashCommand({
+          pullRequestId: id,
+          repositoryName: ri.repo,
+        }),
+      );
+    } else if (method === "rebase") {
+      // CodeCommit's closest equivalent to "rebase" is fast-forward
+      await client.send(
+        new MergePullRequestByFastForwardCommand({
+          pullRequestId: id,
+          repositoryName: ri.repo,
+        }),
+      );
+    } else {
+      await client.send(
+        new MergePullRequestByThreeWayCommand({
+          pullRequestId: id,
+          repositoryName: ri.repo,
+        }),
+      );
+    }
+  }
+
+  async submitReview(
+    ri: RepoIdentifier,
+    prNumber: number,
+    review: {
+      event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
+      body: string;
+      comments?: { path: string; line?: number; side?: string; body: string }[];
+    },
+  ): Promise<{ url: string }> {
+    const client = this.withRegion(ri);
+    const id = String(prNumber);
+
+    // Resolve commit IDs once — needed for both approval state and inline comments
+    const pr = await client
+      .send(new GetPullRequestCommand({ pullRequestId: id }))
+      .then((r) => r.pullRequest);
+    if (!pr) throw new Error(`CodeCommit pull request ${prNumber} not found`);
+
+    const target = pr.pullRequestTargets?.[0];
+    const beforeCommitId = target?.destinationCommit;
+    const afterCommitId = target?.sourceCommit;
+    const revisionId = pr.revisionId;
+
+    if (review.event === "APPROVE") {
+      try {
+        if (revisionId) {
+          await client.send(
+            new UpdatePullRequestApprovalStateCommand({
+              pullRequestId: id,
+              revisionId,
+              approvalState: "APPROVE",
+            }),
+          );
+        }
+      } catch (err) {
+        // Approving requires an approval rule on the PR. If none exists, fall back to a comment.
+        logger.warn({ err, prNumber }, "CodeCommit approval failed, posting as comment");
+      }
+    }
+
+    // Body comment (with a prefix when requesting changes / commenting)
+    if (review.body?.trim()) {
+      const prefix =
+        review.event === "REQUEST_CHANGES"
+          ? "**[CHANGES REQUESTED]**\n\n"
+          : review.event === "COMMENT"
+            ? "**[COMMENT]**\n\n"
+            : "";
+      await client
+        .send(
+          new PostCommentForPullRequestCommand({
+            pullRequestId: id,
+            repositoryName: ri.repo,
+            beforeCommitId,
+            afterCommitId,
+            content: `${prefix}${review.body}`,
+          }),
+        )
+        .catch((err) => {
+          logger.warn({ err, prNumber }, "Failed to post CodeCommit PR body comment");
+        });
+    }
+
+    // Inline comments (best-effort — fall back to a top-level comment on error)
+    for (const comment of review.comments ?? []) {
+      try {
+        await client.send(
+          new PostCommentForPullRequestCommand({
+            pullRequestId: id,
+            repositoryName: ri.repo,
+            beforeCommitId,
+            afterCommitId,
+            content: comment.body,
+            location: {
+              filePath: comment.path,
+              filePosition: comment.line,
+              relativeFileVersion: "AFTER",
+            },
+          }),
+        );
+      } catch (err) {
+        logger.debug(
+          { err, prNumber, path: comment.path },
+          "Inline comment failed, falling back to top-level",
+        );
+        const locationPrefix = comment.line
+          ? `**${comment.path}:${comment.line}**\n\n`
+          : `**${comment.path}**\n\n`;
+        await client
+          .send(
+            new PostCommentForPullRequestCommand({
+              pullRequestId: id,
+              repositoryName: ri.repo,
+              beforeCommitId,
+              afterCommitId,
+              content: `${locationPrefix}${comment.body}`,
+            }),
+          )
+          .catch(() => {
+            /* swallow — already logged */
+          });
+      }
+    }
+
+    return { url: buildPrUrl(ri, prNumber) };
+  }
+
+  // ── Issue methods (CodeCommit has no native issues) ───────────────────────
+
+  async listIssues(_ri: RepoIdentifier): Promise<Issue[]> {
+    return [];
+  }
+
+  async createLabel(
+    _ri: RepoIdentifier,
+    _label: { name: string; color: string; description?: string },
+  ): Promise<void> {
+    throw new Error("CodeCommit does not support issue labels");
+  }
+
+  async addLabelsToIssue(
+    _ri: RepoIdentifier,
+    _issueNumber: number,
+    _labels: string[],
+  ): Promise<void> {
+    throw new Error("CodeCommit does not support issue labels");
+  }
+
+  async createIssueComment(
+    _ri: RepoIdentifier,
+    _issueNumber: number,
+    _body: string,
+  ): Promise<void> {
+    throw new Error("CodeCommit does not support issues");
+  }
+
+  async closeIssue(_ri: RepoIdentifier, _issueNumber: number): Promise<void> {
+    throw new Error("CodeCommit does not support issues");
+  }
+
+  // ── Repo reads ────────────────────────────────────────────────────────────
+
+  async getRepoMetadata(ri: RepoIdentifier): Promise<RepoMetadata> {
+    const client = this.withRegion(ri);
+    const res = await client.send(new GetRepositoryCommand({ repositoryName: ri.repo }));
+    const md = res.repositoryMetadata;
+    return {
+      fullName: md?.repositoryName ?? ri.repo,
+      defaultBranch: md?.defaultBranch ?? "main",
+      isPrivate: true, // CodeCommit repos are always IAM-gated (no public-anon access)
+    };
+  }
+
+  async listRepoContents(ri: RepoIdentifier, path = ""): Promise<RepoContent[]> {
+    const client = this.withRegion(ri);
+    const md = await client
+      .send(new GetRepositoryCommand({ repositoryName: ri.repo }))
+      .then((r) => r.repositoryMetadata);
+    const folderPath = path === "" ? "/" : path.startsWith("/") ? path : `/${path}`;
+    const res = await client.send(
+      new GetFolderCommand({
+        repositoryName: ri.repo,
+        commitSpecifier: md?.defaultBranch ?? "main",
+        folderPath,
+      }),
+    );
+    const files = (res.files ?? []).map((f) => ({
+      name: stripDir(f.absolutePath ?? "", folderPath) || (f.relativePath ?? ""),
+      type: "file" as const,
+    }));
+    const dirs = (res.subFolders ?? []).map((d) => ({
+      name: stripDir(d.absolutePath ?? "", folderPath) || (d.relativePath ?? ""),
+      type: "dir" as const,
+    }));
+    return [...dirs, ...files];
+  }
+
+  // ── Internal helpers ──────────────────────────────────────────────────────
+
+  private async latestRevisionId(client: CodeCommitClient, prNumber: number): Promise<string> {
+    const res = await client.send(new GetPullRequestCommand({ pullRequestId: String(prNumber) }));
+    const id = res.pullRequest?.revisionId;
+    if (!id) throw new Error(`CodeCommit pull request ${prNumber} has no revisionId`);
+    return id;
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildPrUrl(ri: RepoIdentifier, prNumber: number): string {
+  // CodeCommit console URL: <region>.console.aws.amazon.com/codesuite/codecommit/repositories/<repo>/pull-requests/<id>
+  return `https://${ri.apiBaseUrl}.console.aws.amazon.com/codesuite/codecommit/repositories/${ri.repo}/pull-requests/${prNumber}`;
+}
+
+function mapPr(pr: CCPullRequest, ri: RepoIdentifier): PullRequest {
+  const target = pr.pullRequestTargets?.[0];
+  const merged = Boolean(target?.mergeMetadata?.isMerged);
+  const status = pr.pullRequestStatus;
+  const open = status === "OPEN";
+  const number = pr.pullRequestId ? parseInt(pr.pullRequestId, 10) : 0;
+  return {
+    number,
+    title: pr.title ?? "",
+    body: pr.description ?? "",
+    state: open ? "open" : "closed",
+    merged,
+    mergeable: null, // CodeCommit doesn't report a precomputed mergeable flag
+    draft: false, // CodeCommit has no draft state
+    headSha: target?.sourceCommit ?? "",
+    baseBranch: stripRefsHeads(target?.destinationReference ?? ""),
+    url: buildPrUrl(ri, number),
+    author: shortenArn(pr.authorArn),
+    assignees: [],
+    labels: [],
+    createdAt: pr.creationDate ? new Date(pr.creationDate).toISOString() : "",
+    updatedAt: pr.lastActivityDate ? new Date(pr.lastActivityDate).toISOString() : "",
+  };
+}
+
+function sourceBranchMatches(pr: PullRequest, branch: string): boolean {
+  // We don't have the source ref on PullRequest after mapping; use a heuristic on title/branch.
+  // Callers that pass `branch` typically only need this filter as a sanity check.
+  return pr.baseBranch !== branch;
+}
+
+function shortenArn(arn?: string): string {
+  if (!arn) return "unknown";
+  // arn:aws:iam::123456789012:user/alice -> alice
+  const slash = arn.lastIndexOf("/");
+  if (slash >= 0) return arn.slice(slash + 1);
+  return arn;
+}
+
+function stripRefsHeads(ref: string): string {
+  return ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+}
+
+function stripDir(absolutePath: string, folderPath: string): string {
+  if (folderPath === "/" || folderPath === "") return absolutePath.replace(/^\//, "");
+  const prefix = folderPath.endsWith("/") ? folderPath : `${folderPath}/`;
+  return absolutePath.startsWith(prefix) ? absolutePath.slice(prefix.length) : absolutePath;
+}
+
+interface CCComment {
+  content?: string;
+  authorArn?: string;
+  creationDate?: Date;
+  location?: {
+    filePath?: string;
+    filePosition?: number;
+    relativeFileVersion?: string;
+  };
+}
+
+async function collectPrComments(client: CodeCommitClient, prNumber: number): Promise<CCComment[]> {
+  const out: CCComment[] = [];
+  let nextToken: string | undefined;
+  do {
+    const res = await client.send(
+      new GetCommentsForPullRequestCommand({
+        pullRequestId: String(prNumber),
+        nextToken,
+      }),
+    );
+    for (const thread of res.commentsForPullRequestData ?? []) {
+      for (const c of thread.comments ?? []) {
+        if (c.deleted) continue;
+        out.push({
+          content: c.content,
+          authorArn: c.authorArn,
+          creationDate: c.creationDate,
+          location: thread.location
+            ? {
+                filePath: thread.location.filePath,
+                filePosition:
+                  thread.location.filePosition !== undefined
+                    ? thread.location.filePosition
+                    : undefined,
+                relativeFileVersion: thread.location.relativeFileVersion,
+              }
+            : undefined,
+        });
+      }
+    }
+    nextToken = res.nextToken;
+  } while (nextToken);
+  return out;
+}

--- a/apps/api/src/services/git-platform/index.ts
+++ b/apps/api/src/services/git-platform/index.ts
@@ -1,6 +1,7 @@
 import type { GitPlatform, GitPlatformType } from "@optio/shared";
 import { GitHubPlatform } from "./github.js";
 import { GitLabPlatform } from "./gitlab.js";
+import { CodeCommitPlatform } from "./codecommit.js";
 
 export function createGitPlatform(platform: GitPlatformType, token: string): GitPlatform {
   switch (platform) {
@@ -8,6 +9,8 @@ export function createGitPlatform(platform: GitPlatformType, token: string): Git
       return new GitHubPlatform(token);
     case "gitlab":
       return new GitLabPlatform(token);
+    case "codecommit":
+      return new CodeCommitPlatform(token);
     default:
       throw new Error(`Unsupported git platform: ${platform}`);
   }
@@ -15,3 +18,4 @@ export function createGitPlatform(platform: GitPlatformType, token: string): Git
 
 export { GitHubPlatform } from "./github.js";
 export { GitLabPlatform } from "./gitlab.js";
+export { CodeCommitPlatform } from "./codecommit.js";

--- a/apps/api/src/services/git-token-service.ts
+++ b/apps/api/src/services/git-token-service.ts
@@ -2,6 +2,7 @@ import type { GitPlatform, GitPlatformType, RepoIdentifier } from "@optio/shared
 import { parseRepoUrl } from "@optio/shared";
 import { getGitHubToken } from "./github-token-service.js";
 import { retrieveSecretWithFallback } from "./secret-service.js";
+import { getCodeCommitCredentials } from "./codecommit-credential-service.js";
 import { createGitPlatform } from "./git-platform/index.js";
 import { logger } from "../logger.js";
 
@@ -15,6 +16,8 @@ export interface GitTokenContext {
  * Resolve a git platform token for the given platform and context.
  * GitHub: delegates to the existing github-token-service (App → user OAuth → PAT).
  * GitLab: checks GITLAB_TOKEN secret (workspace-scoped → global).
+ * CodeCommit: returns a JSON-encoded AWS credential blob (or "workload-identity"
+ * sentinel) — see codecommit-credential-service.
  */
 export async function getGitToken(
   platform: GitPlatformType,
@@ -25,6 +28,10 @@ export async function getGitToken(
     if (context.userId)
       return getGitHubToken({ userId: context.userId, workspaceId: context.workspaceId });
     return getGitHubToken({ server: true });
+  }
+
+  if (platform === "codecommit") {
+    return getCodeCommitCredentials(context.workspaceId);
   }
 
   // GitLab: try user-scoped token, then workspace/global GITLAB_TOKEN

--- a/apps/api/src/services/pr-review-service.ts
+++ b/apps/api/src/services/pr-review-service.ts
@@ -462,6 +462,7 @@ export async function enqueueReviewRun(
     const fullRepoName = `${review.repoOwner}/${review.repoName}`;
     const parsedRepoUrl = parseRepoUrl(review.repoUrl);
     const isGitLab = parsedRepoUrl?.platform === "gitlab";
+    const isCodeCommit = parsedRepoUrl?.platform === "codecommit";
 
     renderedPrompt = renderPromptTemplate(template, {
       PR_NUMBER: String(review.prNumber),
@@ -471,6 +472,9 @@ export async function enqueueReviewRun(
       TEST_COMMAND: repoConfig.testCommand ?? "",
       OUTPUT_PATH: PR_REVIEW_OUTPUT_PATH,
       GIT_PLATFORM_GITLAB: isGitLab ? "true" : "",
+      GIT_PLATFORM_CODECOMMIT: isCodeCommit ? "true" : "",
+      CODECOMMIT_REPO: isCodeCommit ? (parsedRepoUrl?.repo ?? "") : "",
+      BASE_BRANCH: repoConfig.defaultBranch ?? "main",
     });
     taskFileContent = reviewContextFileContent({
       prNumber: review.prNumber,

--- a/apps/api/src/services/review-service.ts
+++ b/apps/api/src/services/review-service.ts
@@ -130,6 +130,7 @@ export async function launchReview(parentTaskId: string): Promise<string> {
 
   const parsedRepo = parseRepoUrl(parentTask.repoUrl);
   const isGitLab = parsedRepo?.platform === "gitlab";
+  const isCodeCommit = parsedRepo?.platform === "codecommit";
 
   const renderedPrompt = renderPromptTemplate(reviewTemplate, {
     PR_NUMBER: String(prNumber),
@@ -138,6 +139,9 @@ export async function launchReview(parentTaskId: string): Promise<string> {
     TASK_TITLE: parentTask.title,
     TEST_COMMAND: repoConfig?.testCommand ?? "",
     GIT_PLATFORM_GITLAB: isGitLab ? "true" : "",
+    GIT_PLATFORM_CODECOMMIT: isCodeCommit ? "true" : "",
+    CODECOMMIT_REPO: isCodeCommit ? (parsedRepo?.repo ?? "") : "",
+    BASE_BRANCH: parentTask.repoBranch ?? repoConfig?.defaultBranch ?? "main",
   });
 
   // Build review context file with enriched PR data

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -312,6 +312,7 @@ export function startTaskWorker() {
           ? `${parsedRepo.owner}/${parsedRepo.repo}`
           : task.repoUrl.replace(/.*[/:]([^/]+\/[^/.]+).*/, "$1");
         const isGitLab = parsedRepo?.platform === "gitlab";
+        const isCodeCommit = parsedRepo?.platform === "codecommit";
         const branchName = `${TASK_BRANCH_PREFIX}${task.id}`;
         const taskFilePath = TASK_FILE_PATH;
 
@@ -329,6 +330,9 @@ export function startTaskWorker() {
           DRAFT_PR: String(promptConfig.cautiousMode),
           ISSUE_NUMBER: task.ticketExternalId ?? "",
           GIT_PLATFORM_GITLAB: isGitLab ? "true" : "",
+          GIT_PLATFORM_CODECOMMIT: isCodeCommit ? "true" : "",
+          CODECOMMIT_REPO: isCodeCommit ? (parsedRepo?.repo ?? "") : "",
+          BASE_BRANCH: task.repoBranch ?? repoConfig?.defaultBranch ?? "main",
           PLANNING_MODE: isPlanningRun ? "true" : "",
         });
 

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -71,6 +71,14 @@ export default function SetupPage() {
   const [gitlabUser, setGitlabUser] = useState<{ login: string; name: string } | null>(null);
   const [gitlabValidated, setGitlabValidated] = useState(false);
   const [gitlabError, setGitlabError] = useState("");
+  const [codecommitEnabled, setCodecommitEnabled] = useState(false);
+  const [awsAccessKeyId, setAwsAccessKeyId] = useState("");
+  const [awsSecretAccessKey, setAwsSecretAccessKey] = useState("");
+  const [awsSessionToken, setAwsSessionToken] = useState("");
+  const [awsRegion, setAwsRegion] = useState("us-east-1");
+  const [awsValidated, setAwsValidated] = useState(false);
+  const [awsUser, setAwsUser] = useState<{ login: string; name: string } | null>(null);
+  const [awsError, setAwsError] = useState("");
 
   // Step 3: Agent keys
   const [anthropicKey, setAnthropicKey] = useState("");
@@ -206,6 +214,15 @@ export default function SetupPage() {
         fetches.push(api.listUserRepos(githubToken || ""));
       if (gitlabEnabled && gitlabToken)
         fetches.push(api.listGitlabRepos(gitlabToken, gitlabHost || undefined));
+      if (codecommitEnabled && awsAccessKeyId && awsSecretAccessKey)
+        fetches.push(
+          api.listCodecommitRepos({
+            accessKeyId: awsAccessKeyId,
+            secretAccessKey: awsSecretAccessKey,
+            sessionToken: awsSessionToken || undefined,
+            region: awsRegion,
+          }),
+        );
       if (fetches.length > 0) {
         Promise.all(fetches)
           .then((results) => {
@@ -305,6 +322,29 @@ export default function SetupPage() {
       }
     } catch (err) {
       setGitlabError(err instanceof Error ? err.message : "Validation failed");
+    }
+    setLoading(false);
+  };
+
+  const validateAws = async () => {
+    if (!awsAccessKeyId.trim() || !awsSecretAccessKey.trim() || !awsRegion.trim()) return;
+    setLoading(true);
+    setAwsError("");
+    try {
+      const res = await api.validateAwsCredentials({
+        accessKeyId: awsAccessKeyId,
+        secretAccessKey: awsSecretAccessKey,
+        sessionToken: awsSessionToken || undefined,
+        region: awsRegion,
+      });
+      if (res.valid && res.user) {
+        setAwsUser(res.user);
+        setAwsValidated(true);
+      } else {
+        setAwsError(res.error ?? "Invalid credentials");
+      }
+    } catch (err) {
+      setAwsError(err instanceof Error ? err.message : "Validation failed");
     }
     setLoading(false);
   };
@@ -450,6 +490,14 @@ export default function SetupPage() {
         if (gitlabHost && gitlabHost !== "gitlab.com") {
           await api.createSecret({ name: "GITLAB_HOST", value: gitlabHost });
         }
+      }
+      if (codecommitEnabled && awsAccessKeyId.trim() && awsSecretAccessKey.trim() && awsValidated) {
+        await api.createSecret({ name: "AWS_ACCESS_KEY_ID", value: awsAccessKeyId });
+        await api.createSecret({ name: "AWS_SECRET_ACCESS_KEY", value: awsSecretAccessKey });
+        if (awsSessionToken.trim()) {
+          await api.createSecret({ name: "AWS_SESSION_TOKEN", value: awsSessionToken });
+        }
+        await api.createSecret({ name: "AWS_REGION", value: awsRegion });
       }
       goNext();
     } catch (err) {
@@ -835,6 +883,20 @@ export default function SetupPage() {
                   </svg>
                   GitLab
                 </button>
+                <button
+                  onClick={() => setCodecommitEnabled((v) => !v)}
+                  className={cn(
+                    "flex items-center gap-2 px-4 py-2 rounded-md text-sm border transition-colors",
+                    codecommitEnabled
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-border text-text-muted hover:bg-bg-hover",
+                  )}
+                >
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 2 2 7v10l10 5 10-5V7L12 2zm0 2.18L19.82 8 12 11.82 4.18 8 12 4.18zM4 9.74l7 3.5v7.52l-7-3.5V9.74zm9 11.02v-7.52l7-3.5v7.52l-7 3.5z" />
+                  </svg>
+                  AWS CodeCommit
+                </button>
               </div>
 
               {/* GitHub form */}
@@ -977,6 +1039,91 @@ export default function SetupPage() {
                 </>
               )}
 
+              {/* CodeCommit form */}
+              {codecommitEnabled && (
+                <>
+                  <p className="text-text-muted text-sm">
+                    Create an IAM user (or role) with the <code>AWSCodeCommitPowerUser</code>{" "}
+                    managed policy and paste its access key and secret here. STS session tokens are
+                    also supported.
+                  </p>
+                  <div>
+                    <label className="block text-sm text-text-muted mb-1.5">AWS Region</label>
+                    <input
+                      type="text"
+                      value={awsRegion}
+                      onChange={(e) => {
+                        setAwsRegion(e.target.value);
+                        setAwsValidated(false);
+                        setAwsError("");
+                      }}
+                      placeholder="us-east-1"
+                      className="w-full px-3 py-2 rounded-md bg-bg border border-border text-sm focus:outline-none focus:border-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm text-text-muted mb-1.5">
+                      AWS Access Key ID
+                    </label>
+                    <input
+                      type="text"
+                      value={awsAccessKeyId}
+                      onChange={(e) => {
+                        setAwsAccessKeyId(e.target.value);
+                        setAwsValidated(false);
+                        setAwsError("");
+                      }}
+                      placeholder="AKIA…"
+                      className="w-full px-3 py-2 rounded-md bg-bg border border-border text-sm focus:outline-none focus:border-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm text-text-muted mb-1.5">
+                      AWS Secret Access Key
+                    </label>
+                    <input
+                      type="password"
+                      value={awsSecretAccessKey}
+                      onChange={(e) => {
+                        setAwsSecretAccessKey(e.target.value);
+                        setAwsValidated(false);
+                        setAwsError("");
+                      }}
+                      className="w-full px-3 py-2 rounded-md bg-bg border border-border text-sm focus:outline-none focus:border-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm text-text-muted mb-1.5">
+                      Session Token{" "}
+                      <span className="text-text-muted/60">(optional, for STS credentials)</span>
+                    </label>
+                    <input
+                      type="password"
+                      value={awsSessionToken}
+                      onChange={(e) => {
+                        setAwsSessionToken(e.target.value);
+                        setAwsValidated(false);
+                        setAwsError("");
+                      }}
+                      className="w-full px-3 py-2 rounded-md bg-bg border border-border text-sm focus:outline-none focus:border-primary"
+                    />
+                  </div>
+                  {awsError && (
+                    <div className="flex items-center gap-2 text-error text-sm">
+                      <AlertCircle className="w-4 h-4" />
+                      {awsError}
+                    </div>
+                  )}
+                  {awsValidated && awsUser && (
+                    <div className="flex items-center gap-2 text-success text-sm p-2 rounded-md bg-success/10">
+                      <CheckCircle className="w-4 h-4" />
+                      Authenticated as <strong>{awsUser.login}</strong>
+                      {awsUser.name && <span className="text-text-muted">({awsUser.name})</span>}
+                    </div>
+                  )}
+                </>
+              )}
+
               <div className="flex items-center justify-between">
                 <button
                   onClick={goBack}
@@ -1003,13 +1150,28 @@ export default function SetupPage() {
                       {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Validate GitLab"}
                     </button>
                   )}
+                  {codecommitEnabled && !awsValidated && (
+                    <button
+                      onClick={() => validateAws()}
+                      disabled={
+                        loading ||
+                        !awsAccessKeyId.trim() ||
+                        !awsSecretAccessKey.trim() ||
+                        !awsRegion.trim()
+                      }
+                      className="flex items-center gap-2 px-4 py-2 rounded-md bg-bg-hover text-text text-sm hover:bg-border disabled:opacity-50"
+                    >
+                      {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Validate AWS"}
+                    </button>
+                  )}
                   <button
                     onClick={saveGitStep}
                     disabled={
                       loading ||
-                      (!githubEnabled && !gitlabEnabled) ||
+                      (!githubEnabled && !gitlabEnabled && !codecommitEnabled) ||
                       (githubEnabled && !githubAppConfigured && !githubValidated) ||
-                      (gitlabEnabled && !gitlabValidated)
+                      (gitlabEnabled && !gitlabValidated) ||
+                      (codecommitEnabled && !awsValidated)
                     }
                     className="flex items-center gap-2 px-5 py-2 rounded-md bg-primary text-white text-sm hover:bg-primary-hover disabled:opacity-50"
                   >

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -386,6 +386,40 @@ export const api = {
       body: JSON.stringify({ token, host }),
     }),
 
+  validateAwsCredentials: (creds: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken?: string;
+    region: string;
+  }) =>
+    request<{ valid: boolean; error?: string; user?: { login: string; name: string } }>(
+      "/api/setup/validate/aws-credentials",
+      { method: "POST", body: JSON.stringify(creds) },
+    ),
+
+  listCodecommitRepos: (creds: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken?: string;
+    region: string;
+  }) =>
+    request<{
+      repos: Array<{
+        fullName: string;
+        cloneUrl: string;
+        htmlUrl: string;
+        defaultBranch: string;
+        isPrivate: boolean;
+        description: string | null;
+        language: string | null;
+        pushedAt: string;
+      }>;
+      error?: string;
+    }>("/api/setup/repos/codecommit", {
+      method: "POST",
+      body: JSON.stringify(creds),
+    }),
+
   validateAnthropicKey: (key: string) =>
     request<{ valid: boolean; error?: string }>("/api/setup/validate/anthropic-key", {
       method: "POST",

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -497,10 +497,12 @@ rbac:
 serviceAccount:
   create: true
   name: optio
-  # Annotations for the service account (e.g., for GKE Workload Identity).
+  # Annotations for the service account (e.g., for GKE Workload Identity or EKS IRSA).
   # Used by both API/web pods (for K8s API access) and agent pods (for cloud service auth).
   # Example for GKE Workload Identity:
   #   iam.gke.io/gcp-service-account: optio@PROJECT_ID.iam.gserviceaccount.com
+  # Example for EKS IRSA (lets CodeCommit use the pod's IAM role instead of static AWS keys):
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/optio-codecommit
   annotations: {}
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -24,6 +24,19 @@ RUN ARCH=$(dpkg --print-architecture) \
     && dpkg -i /tmp/glab.deb \
     && rm /tmp/glab.deb
 
+# AWS CLI v2 (used for AWS CodeCommit clone auth via `aws codecommit credential-helper`
+# and for `aws codecommit create-pull-request` from agents)
+RUN ARCH_RAW=$(dpkg --print-architecture) \
+    && case "$ARCH_RAW" in \
+         amd64) AWS_ARCH=x86_64 ;; \
+         arm64) AWS_ARCH=aarch64 ;; \
+         *) echo "Unsupported arch: $ARCH_RAW" && exit 1 ;; \
+       esac \
+    && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip" -o /tmp/awscliv2.zip \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/awscliv2.zip /tmp/aws
+
 # Node.js 22 (needed for Claude Code)
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \

--- a/packages/shared/src/prompt-template.test.ts
+++ b/packages/shared/src/prompt-template.test.ts
@@ -197,6 +197,44 @@ describe("PLANNING_MODE in DEFAULT_PROMPT_TEMPLATE", () => {
   });
 });
 
+describe("CodeCommit branch in DEFAULT_PROMPT_TEMPLATE", () => {
+  it("uses aws codecommit create-pull-request when GIT_PLATFORM_CODECOMMIT is set", () => {
+    const result = renderPromptTemplate(DEFAULT_PROMPT_TEMPLATE, {
+      TASK_FILE: ".optio/task.md",
+      BRANCH_NAME: "optio/task-abc",
+      TASK_ID: "abc-123",
+      TASK_TITLE: "Fix login bug",
+      REPO_NAME: "MyRepo",
+      CODECOMMIT_REPO: "MyRepo",
+      BASE_BRANCH: "main",
+      AUTO_MERGE: "false",
+      ISSUE_NUMBER: "",
+      GIT_PLATFORM_CODECOMMIT: "true",
+    });
+    expect(result).toContain("aws codecommit create-pull-request");
+    expect(result).toContain("repositoryName=MyRepo");
+    expect(result).toContain("sourceReference=optio/task-abc");
+    expect(result).toContain("destinationReference=main");
+    expect(result).not.toContain("gh pr create");
+    expect(result).not.toContain("glab mr create");
+  });
+
+  it("falls back to gh when neither codecommit nor gitlab is set", () => {
+    const result = renderPromptTemplate(DEFAULT_PROMPT_TEMPLATE, {
+      TASK_FILE: ".optio/task.md",
+      BRANCH_NAME: "optio/task-abc",
+      TASK_ID: "abc-123",
+      TASK_TITLE: "Fix login bug",
+      REPO_NAME: "org/repo",
+      AUTO_MERGE: "false",
+      ISSUE_NUMBER: "",
+    });
+    expect(result).toContain("gh pr create");
+    expect(result).not.toContain("aws codecommit");
+    expect(result).not.toContain("glab mr create");
+  });
+});
+
 describe("TASK_FILE_PATH", () => {
   it("is a relative path", () => {
     expect(TASK_FILE_PATH).not.toMatch(/^\//);

--- a/packages/shared/src/prompt-template.ts
+++ b/packages/shared/src/prompt-template.ts
@@ -41,7 +41,32 @@ no existing PR and no prior work. You must write the code, not review it.
 
 6. **Push and open a pull/merge request.** Write a meaningful description that
    explains what changed, why, and how to verify it:
-{{#if GIT_PLATFORM_GITLAB}}
+{{#if GIT_PLATFORM_CODECOMMIT}}
+   Push your branch first, then use the AWS CLI to create a CodeCommit pull request:
+   \`\`\`
+   git push -u origin {{BRANCH_NAME}}
+{{#if ISSUE_NUMBER}}   aws codecommit create-pull-request --title "{{TASK_TITLE}}" --description "$(cat <<'OPTIO_PR_EOF'
+Closes #{{ISSUE_NUMBER}}
+
+## What changed
+<Summarize the changes you made and why>
+
+## How to test
+<Describe how a reviewer can verify the changes>
+OPTIO_PR_EOF
+)" --targets "repositoryName={{CODECOMMIT_REPO}},sourceReference={{BRANCH_NAME}},destinationReference={{BASE_BRANCH}}"{{else}}   aws codecommit create-pull-request --title "{{TASK_TITLE}}" --description "$(cat <<'OPTIO_PR_EOF'
+Implements task {{TASK_ID}}
+
+## What changed
+<Summarize the changes you made and why>
+
+## How to test
+<Describe how a reviewer can verify the changes>
+OPTIO_PR_EOF
+)" --targets "repositoryName={{CODECOMMIT_REPO}},sourceReference={{BRANCH_NAME}},destinationReference={{BASE_BRANCH}}"{{/if}}
+   \`\`\`
+   CodeCommit has no draft-PR concept; if review is gated, the orchestrator will hold the PR until a human approves.
+{{else}}{{#if GIT_PLATFORM_GITLAB}}
    Use the \`glab\` CLI to create a merge request:
    \`\`\`
 {{#if ISSUE_NUMBER}}   glab mr create --title "{{TASK_TITLE}}" --description "$(cat <<'OPTIO_PR_EOF'
@@ -87,7 +112,7 @@ Implements task {{TASK_ID}}
 OPTIO_PR_EOF
 )"{{/if}}{{#if DRAFT_PR}} --draft{{/if}}
    \`\`\`
-{{/if}}
+{{/if}}{{/if}}
 
 7. After opening the PR, you are done. Do NOT wait for CI checks or monitor them.
     The orchestration system handles CI monitoring and code review automatically.
@@ -114,9 +139,10 @@ You are task {{TASK_ID}} working on branch {{BRANCH_NAME}}. Other tasks may be r
 concurrently on this same repository — each on its own branch. You MUST stay in scope:
 
 - Do NOT look at, review, or interact with other PRs or branches.
-{{#if GIT_PLATFORM_GITLAB}}- Do NOT run \`glab mr list\` to browse merge requests. You only need to create YOUR MR.
+{{#if GIT_PLATFORM_CODECOMMIT}}- Do NOT run \`aws codecommit list-pull-requests\` to browse other PRs. You only need to create YOUR PR.
+{{else}}{{#if GIT_PLATFORM_GITLAB}}- Do NOT run \`glab mr list\` to browse merge requests. You only need to create YOUR MR.
 {{else}}- Do NOT run \`gh pr list\` to browse PRs. You only need to create YOUR PR.
-{{/if}}- If you see references to other branches named \`optio/task-*\`, ignore them — those belong to other agents.
+{{/if}}{{/if}}- If you see references to other branches named \`optio/task-*\`, ignore them — those belong to other agents.
 - Your working directory is your worktree. Do not navigate outside it.
 
 ## Guidelines
@@ -139,9 +165,10 @@ export const DEFAULT_REVIEW_PROMPT_TEMPLATE = `You are a code reviewer. You have
 
 1. Read the diff for {{#if GIT_PLATFORM_GITLAB}}MR !{{PR_NUMBER}}{{else}}PR #{{PR_NUMBER}}{{/if}}:
    \`\`\`
-{{#if GIT_PLATFORM_GITLAB}}   glab mr diff {{PR_NUMBER}}
+{{#if GIT_PLATFORM_CODECOMMIT}}   git fetch origin && git diff origin/{{BASE_BRANCH}}...HEAD
+{{else}}{{#if GIT_PLATFORM_GITLAB}}   glab mr diff {{PR_NUMBER}}
 {{else}}   gh pr diff {{PR_NUMBER}}
-{{/if}}   \`\`\`
+{{/if}}{{/if}}   \`\`\`
 
 2. Read the original task description to understand what this {{#if GIT_PLATFORM_GITLAB}}MR{{else}}PR{{/if}} is supposed to accomplish:
    \`\`\`
@@ -163,11 +190,13 @@ export const DEFAULT_REVIEW_PROMPT_TEMPLATE = `You are a code reviewer. You have
    - Style: Does it follow the repo's conventions?
 
 5. Submit your review:
-{{#if GIT_PLATFORM_GITLAB}}   - If the code is good: \`glab mr approve {{PR_NUMBER}}\` then \`glab mr note {{PR_NUMBER}} --message "Your review summary"\`
+{{#if GIT_PLATFORM_CODECOMMIT}}   - If the code is good: \`aws codecommit update-pull-request-approval-state --pull-request-id {{PR_NUMBER}} --revision-id $(aws codecommit get-pull-request --pull-request-id {{PR_NUMBER}} --query 'pullRequest.revisionId' --output text) --approval-state APPROVE\` then \`aws codecommit post-comment-for-pull-request --pull-request-id {{PR_NUMBER}} --repository-name {{CODECOMMIT_REPO}} --before-commit-id $(aws codecommit get-pull-request --pull-request-id {{PR_NUMBER}} --query 'pullRequest.pullRequestTargets[0].destinationCommit' --output text) --after-commit-id $(aws codecommit get-pull-request --pull-request-id {{PR_NUMBER}} --query 'pullRequest.pullRequestTargets[0].sourceCommit' --output text) --content "Your review summary"\`
+   - If changes are needed: post a comment with \`aws codecommit post-comment-for-pull-request ...\` whose content starts with \`**[CHANGES REQUESTED]**\`
+{{else}}{{#if GIT_PLATFORM_GITLAB}}   - If the code is good: \`glab mr approve {{PR_NUMBER}}\` then \`glab mr note {{PR_NUMBER}} --message "Your review summary"\`
    - If changes are needed: \`glab mr note {{PR_NUMBER}} --message "Changes requested: What needs fixing"\`
 {{else}}   - If the code is good: \`gh pr review {{PR_NUMBER}} --approve --body "Your review summary"\`
    - If changes are needed: \`gh pr review {{PR_NUMBER}} --request-changes --body "What needs fixing"\`
-{{/if}}
+{{/if}}{{/if}}
 
 6. After submitting your review, you are done. Do not review any other {{#if GIT_PLATFORM_GITLAB}}MRs{{else}}PRs{{/if}}.
 
@@ -190,17 +219,19 @@ export const DEFAULT_PR_REVIEW_PROMPT_TEMPLATE = `You are a code review assistan
 
 ## IMPORTANT
 - You are reviewing ONLY {{#if GIT_PLATFORM_GITLAB}}MR !{{PR_NUMBER}}{{else}}PR #{{PR_NUMBER}}{{/if}}. Do not look at, review, or comment on any others.
-{{#if GIT_PLATFORM_GITLAB}}- Do NOT submit the review to GitLab. Do NOT run \`glab mr approve\` or \`glab mr note\`. Only write your findings to a file.
+{{#if GIT_PLATFORM_CODECOMMIT}}- Do NOT submit the review to CodeCommit. Do NOT call \`aws codecommit update-pull-request-approval-state\` or \`post-comment-for-pull-request\`. Only write your findings to a file.
+{{else}}{{#if GIT_PLATFORM_GITLAB}}- Do NOT submit the review to GitLab. Do NOT run \`glab mr approve\` or \`glab mr note\`. Only write your findings to a file.
 {{else}}- Do NOT submit the review to GitHub. Do NOT run \`gh pr review\`. Only write your findings to a file.
-{{/if}}- Do NOT modify any code, create commits, push changes, or check out branches.
+{{/if}}{{/if}}- Do NOT modify any code, create commits, push changes, or check out branches.
 
 ## Steps
 
 1. Read the diff for {{#if GIT_PLATFORM_GITLAB}}MR !{{PR_NUMBER}}{{else}}PR #{{PR_NUMBER}}{{/if}}:
    \`\`\`
-{{#if GIT_PLATFORM_GITLAB}}   glab mr diff {{PR_NUMBER}}
+{{#if GIT_PLATFORM_CODECOMMIT}}   git fetch origin && git diff origin/{{BASE_BRANCH}}...HEAD
+{{else}}{{#if GIT_PLATFORM_GITLAB}}   glab mr diff {{PR_NUMBER}}
 {{else}}   gh pr diff {{PR_NUMBER}}
-{{/if}}   \`\`\`
+{{/if}}{{/if}}   \`\`\`
 
 2. Read the review context for background on this PR:
    \`\`\`
@@ -253,9 +284,10 @@ export const DEFAULT_PR_REVIEW_PROMPT_TEMPLATE = `You are a code review assistan
 ## Scope
 
 - Review ONLY {{#if GIT_PLATFORM_GITLAB}}MR !{{PR_NUMBER}}{{else}}PR #{{PR_NUMBER}}{{/if}}. Nothing else.
-{{#if GIT_PLATFORM_GITLAB}}- Do NOT run \`glab mr list\` or browse other merge requests.
+{{#if GIT_PLATFORM_CODECOMMIT}}- Do NOT run \`aws codecommit list-pull-requests\` or browse other PRs.
+{{else}}{{#if GIT_PLATFORM_GITLAB}}- Do NOT run \`glab mr list\` or browse other merge requests.
 {{else}}- Do NOT run \`gh pr list\` or browse other PRs.
-{{/if}}- Your working directory is your worktree. Do not navigate outside it.
+{{/if}}{{/if}}- Your working directory is your worktree. Do not navigate outside it.
 - **You have a limited turn budget.** Focus on the diff and task context. Do not exhaustively explore the entire codebase. Write the review JSON file BEFORE you run out of turns.
 `;
 

--- a/packages/shared/src/types/git-platform.ts
+++ b/packages/shared/src/types/git-platform.ts
@@ -1,11 +1,11 @@
-export type GitPlatformType = "github" | "gitlab";
+export type GitPlatformType = "github" | "gitlab" | "codecommit";
 
 export interface RepoIdentifier {
   platform: GitPlatformType;
-  host: string; // "github.com", "gitlab.com", "gitlab.myco.com"
-  owner: string;
+  host: string; // "github.com", "gitlab.com", "gitlab.myco.com", "git-codecommit.us-east-1.amazonaws.com"
+  owner: string; // For CodeCommit: AWS region (e.g. "us-east-1") since CodeCommit has no owner concept
   repo: string;
-  apiBaseUrl: string; // "https://api.github.com" or "https://gitlab.com/api/v4"
+  apiBaseUrl: string; // "https://api.github.com", "https://gitlab.com/api/v4", or AWS region for CodeCommit
 }
 
 export interface PullRequest {

--- a/packages/shared/src/utils/parse-repo-url.test.ts
+++ b/packages/shared/src/utils/parse-repo-url.test.ts
@@ -172,6 +172,39 @@ describe("parseRepoUrl", () => {
     expect(repoResult!.repo).toBe(prResult!.repo);
   });
 
+  it("parses CodeCommit HTTPS URL", () => {
+    const result = parseRepoUrl("https://git-codecommit.us-east-1.amazonaws.com/v1/repos/MyRepo");
+    expect(result).toEqual({
+      platform: "codecommit",
+      host: "git-codecommit.us-east-1.amazonaws.com",
+      owner: "us-east-1",
+      repo: "MyRepo",
+      apiBaseUrl: "us-east-1",
+    });
+  });
+
+  it("parses CodeCommit HTTPS URL with .git suffix", () => {
+    const result = parseRepoUrl(
+      "https://git-codecommit.eu-west-2.amazonaws.com/v1/repos/MyRepo.git",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.platform).toBe("codecommit");
+    expect(result!.owner).toBe("eu-west-2");
+    expect(result!.repo).toBe("MyRepo");
+    expect(result!.apiBaseUrl).toBe("eu-west-2");
+  });
+
+  it("parses CodeCommit SSH URL", () => {
+    // CodeCommit SSH URLs use the SSH key ID as the username
+    const result = parseRepoUrl(
+      "ssh://APKAEIBAERJR2EXAMPLE@git-codecommit.us-west-2.amazonaws.com/v1/repos/AnotherRepo",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.platform).toBe("codecommit");
+    expect(result!.owner).toBe("us-west-2");
+    expect(result!.repo).toBe("AnotherRepo");
+  });
+
   it("returns null for invalid URLs", () => {
     expect(parseRepoUrl("not-a-url")).toBeNull();
     expect(parseRepoUrl("https://github.com")).toBeNull();

--- a/packages/shared/src/utils/parse-repo-url.ts
+++ b/packages/shared/src/utils/parse-repo-url.ts
@@ -23,10 +23,28 @@ function getGitLabHosts(): Set<string> {
   return hosts;
 }
 
+// CodeCommit Git endpoint: git-codecommit.<region>.amazonaws.com
+// Console PR URL: <region>.console.aws.amazon.com/codesuite/codecommit/repositories/<repo>/pull-requests/<id>
+const CODECOMMIT_GIT_HOST_RE = /^git-codecommit\.([a-z0-9-]+)\.amazonaws\.com$/i;
+const CODECOMMIT_CONSOLE_HOST_RE = /^([a-z0-9-]+)\.console\.aws\.amazon\.com$/i;
+
+/**
+ * Extract the AWS region from a CodeCommit hostname.
+ * Returns null if the host is not a recognised CodeCommit endpoint.
+ */
+function extractCodeCommitRegion(host: string): string | null {
+  const git = host.match(CODECOMMIT_GIT_HOST_RE);
+  if (git) return git[1].toLowerCase();
+  const console = host.match(CODECOMMIT_CONSOLE_HOST_RE);
+  if (console) return console[1].toLowerCase();
+  return null;
+}
+
 function detectPlatform(host: string): GitPlatformType {
   const h = host.toLowerCase();
   if (GITHUB_HOSTS.has(h)) return "github";
   if (getGitLabHosts().has(h)) return "gitlab";
+  if (extractCodeCommitRegion(h)) return "codecommit";
   // Unknown hosts: check if the hostname contains "gitlab"
   if (h.includes("gitlab")) return "gitlab";
   // Default to github for unknown hosts (most common case)
@@ -38,6 +56,11 @@ function buildApiBaseUrl(platform: GitPlatformType, host: string): string {
     return host.toLowerCase() === "github.com"
       ? "https://api.github.com"
       : `https://${host}/api/v3`; // GitHub Enterprise
+  }
+  if (platform === "codecommit") {
+    // CodeCommit's API endpoint is region-scoped and constructed by the AWS SDK.
+    // We store the region here so callers can configure the SDK client.
+    return extractCodeCommitRegion(host) ?? "us-east-1";
   }
   return `https://${host}/api/v4`;
 }
@@ -82,16 +105,29 @@ function extractParts(url: string): { host: string; path: string } | null {
  * owner/repo. For GitLab subgroups the owner includes the full namespace
  * path (e.g. "group/subgroup"), with the last segment as the repo.
  * For GitHub-style URLs, takes the first two segments only.
+ * For CodeCommit, the owner field is set by the caller (region from the host).
  */
 function cleanOwnerRepo(
   rawPath: string,
   platform: GitPlatformType = "github",
+  host = "",
 ): { owner: string; repo: string } | null {
   let p = rawPath.replace(/\.git\/?$/, "").replace(/\/+$/, "");
 
   // Strip GitLab path suffixes like /-/... or /merge_requests/...
   if (platform === "gitlab") {
     p = p.replace(/\/?-\/.*$/, "").replace(/\/merge_requests\/.*$/, "");
+  }
+
+  // CodeCommit Git path: v1/repos/<RepoName>
+  // Console path: codesuite/codecommit/repositories/<RepoName>/...
+  if (platform === "codecommit") {
+    const region = extractCodeCommitRegion(host) ?? "us-east-1";
+    const gitMatch = p.match(/^v1\/repos\/([^/]+)/i);
+    if (gitMatch) return { owner: region, repo: gitMatch[1] };
+    const consoleMatch = p.match(/^codesuite\/codecommit\/repositories\/([^/]+)/i);
+    if (consoleMatch) return { owner: region, repo: consoleMatch[1] };
+    return null;
   }
 
   const parts = p.split("/").filter(Boolean);
@@ -117,7 +153,7 @@ export function parseRepoUrl(url: string): RepoIdentifier | null {
   const host = extracted.host.toLowerCase();
   const platform = detectPlatform(host);
 
-  const ownerRepo = cleanOwnerRepo(extracted.path, platform);
+  const ownerRepo = cleanOwnerRepo(extracted.path, platform, host);
   if (!ownerRepo) return null;
 
   return {
@@ -131,7 +167,8 @@ export function parseRepoUrl(url: string): RepoIdentifier | null {
 
 /**
  * Parse a PR/MR URL into a RepoIdentifier plus the PR/MR number.
- * Handles GitHub `/pull/N` and GitLab `/-/merge_requests/N` or `/merge_requests/N`.
+ * Handles GitHub `/pull/N`, GitLab `/-/merge_requests/N` or `/merge_requests/N`,
+ * and CodeCommit console URLs `<region>.console.aws.amazon.com/codesuite/codecommit/repositories/<repo>/pull-requests/<id>`.
  */
 export function parsePrUrl(url: string): (RepoIdentifier & { prNumber: number }) | null {
   const extracted = extractParts(url);
@@ -141,6 +178,23 @@ export function parsePrUrl(url: string): (RepoIdentifier & { prNumber: number })
   const platform = detectPlatform(host);
 
   const p = extracted.path.replace(/\.git\/?$/, "").replace(/\/+$/, "");
+
+  // CodeCommit console: codesuite/codecommit/repositories/<repo>/pull-requests/<id>
+  if (platform === "codecommit") {
+    const ccMatch = p.match(/^codesuite\/codecommit\/repositories\/([^/]+)\/pull-requests\/(\d+)/i);
+    if (ccMatch) {
+      const region = extractCodeCommitRegion(host) ?? "us-east-1";
+      return {
+        platform,
+        host,
+        owner: region,
+        repo: ccMatch[1],
+        apiBaseUrl: buildApiBaseUrl(platform, host),
+        prNumber: parseInt(ccMatch[2], 10),
+      };
+    }
+    return null;
+  }
 
   // GitHub: owner/repo/pull/123
   const ghMatch = p.match(/^([^/]+)\/([^/]+)\/pull\/(\d+)/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,12 @@ importers:
 
   apps/api:
     dependencies:
+      '@aws-sdk/client-codecommit':
+        specifier: ^3.1041.0
+        version: 3.1041.0
+      '@aws-sdk/client-sts':
+        specifier: ^3.1041.0
+        version: 3.1041.0
       '@fastify/cors':
         specifier: ^11.0.0
         version: 11.2.0
@@ -165,6 +171,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      aws-sdk-client-mock:
+        specifier: ^4.1.0
+        version: 4.1.0
       drizzle-kit:
         specifier: ^0.31.1
         version: 0.31.10
@@ -439,6 +448,135 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-codecommit@3.1041.0':
+    resolution: {integrity: sha512-0CBSce17SmWnlg6fJ6V9sc52CeHQTSdA9q3UfZExf326CZA0kAUC7TgUsH3AtWXjHjt/RrWQvUC5L+GSx/Lidg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sts@3.1041.0':
+    resolution: {integrity: sha512-FxRe0GPg+me+pM6b5n8mY3dI6xb3SfH6J7ZM43H6KBRdyyLG7mAbPIIrU33ld9tRPJmHY4xtMusQVvTtXh+kqg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.8':
+    resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.34':
+    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.39':
+    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.6':
+    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1041.0':
+    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1435,6 +1573,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@notionhq/client@2.3.0':
     resolution: {integrity: sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==}
     engines: {node: '>=12'}
@@ -2398,6 +2539,186 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@11.2.2':
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+
+  '@sinonjs/fake-timers@15.3.2':
+    resolution: {integrity: sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==}
+
+  '@sinonjs/samsam@8.0.3':
+    resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
+
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.17':
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.32':
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.5.7':
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.20':
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.6.1':
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.3.1':
+    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.13':
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.3.8':
+    resolution: {integrity: sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.25':
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2664,6 +2985,12 @@ packages:
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
+  '@types/sinon@17.0.4':
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
+
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
@@ -2918,6 +3245,9 @@ packages:
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
+  aws-sdk-client-mock@4.1.0:
+    resolution: {integrity: sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==}
+
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
 
@@ -3000,6 +3330,9 @@ packages:
 
   bn.js@4.12.3:
     resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -3369,6 +3702,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
+
   docker-modem@5.0.6:
     resolution: {integrity: sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==}
     engines: {node: '>= 8.0'}
@@ -3694,8 +4031,15 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
   fast-xml-parser@5.5.11:
     resolution: {integrity: sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==}
+    hasBin: true
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
   fastify-plugin@5.1.0:
@@ -4197,6 +4541,9 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
+  just-extend@6.2.0:
+    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -4686,6 +5033,9 @@ packages:
       sass:
         optional: true
 
+  nise@6.1.5:
+    resolution: {integrity: sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==}
+
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
@@ -4838,6 +5188,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -5257,6 +5610,9 @@ packages:
   simple-websocket@9.1.0:
     resolution: {integrity: sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==}
 
+  sinon@18.0.1:
+    resolution: {integrity: sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==}
+
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
@@ -5613,6 +5969,14 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
 
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
@@ -5988,6 +6352,410 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-codecommit@3.1041.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sts@3.1041.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.974.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-login': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.39':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/token-providers': 3.1041.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.8
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.6':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1041.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.22':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -6769,6 +7537,8 @@ snapshots:
     optional: true
 
   '@noble/hashes@1.8.0': {}
+
+  '@nodable/entities@2.1.0': {}
 
   '@notionhq/client@2.3.0':
     dependencies:
@@ -8027,6 +8797,293 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@11.2.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/fake-timers@15.3.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/samsam@8.0.3':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      type-detect: 4.1.0
+
+  '@smithy/config-resolver@4.4.17':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.32':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.5.7':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.20':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.6.1':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.3.1':
+    dependencies:
+      '@smithy/types': 4.14.1
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.13':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    dependencies:
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.4.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.25':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -8280,6 +9337,12 @@ snapshots:
       csstype: 3.2.3
 
   '@types/shimmer@1.2.0': {}
+
+  '@types/sinon@17.0.4':
+    dependencies:
+      '@types/sinonjs__fake-timers': 15.0.1
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@types/ssh2@1.15.5':
     dependencies:
@@ -8606,6 +9669,12 @@ snapshots:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
 
+  aws-sdk-client-mock@4.1.0:
+    dependencies:
+      '@types/sinon': 17.0.4
+      sinon: 18.0.1
+      tslib: 2.8.1
+
   axios@1.14.0:
     dependencies:
       follow-redirects: 1.15.11
@@ -8681,6 +9750,8 @@ snapshots:
       readable-stream: 3.6.2
 
   bn.js@4.12.3: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@2.0.2:
     dependencies:
@@ -9002,6 +10073,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@5.2.2: {}
 
   docker-modem@5.0.6:
     dependencies:
@@ -9330,9 +10403,20 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
 
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
   fast-xml-parser@5.5.11:
     dependencies:
       fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
@@ -9878,6 +10962,8 @@ snapshots:
   jsonpath-rfc9535@1.3.0: {}
 
   jsonpointer@5.0.1: {}
+
+  just-extend@6.2.0: {}
 
   jwa@2.0.1:
     dependencies:
@@ -10534,6 +11620,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nise@6.1.5:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 15.3.2
+      just-extend: 6.2.0
+      path-to-regexp: 8.4.2
+
   node-abort-controller@3.1.1: {}
 
   node-fetch-h2@2.3.0:
@@ -10711,6 +11804,8 @@ snapshots:
     dependencies:
       lru-cache: 11.3.3
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -11231,6 +12326,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  sinon@18.0.1:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.3
+      diff: 5.2.2
+      nise: 6.1.5
+      supports-color: 7.2.0
+
   slice-ansi@7.1.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -11618,6 +12722,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-detect@4.0.8: {}
+
+  type-detect@4.1.0: {}
 
   type-fest@4.41.0: {}
 

--- a/scripts/agent-entrypoint.sh
+++ b/scripts/agent-entrypoint.sh
@@ -19,6 +19,23 @@ if [ -n "${GITLAB_TOKEN:-}" ] && command -v glab >/dev/null 2>&1; then
   glab auth login --hostname "${GITLAB_HOST:-gitlab.com}" --token "${GITLAB_TOKEN}"
   echo "[optio] GitLab CLI authenticated"
 fi
+case "${OPTIO_REPO_URL:-}" in
+  *git-codecommit.*.amazonaws.com*)
+    if command -v aws >/dev/null 2>&1; then
+      git config --global credential.helper '!aws codecommit credential-helper $@'
+      git config --global credential.UseHttpPath true
+      if [ -z "${AWS_DEFAULT_REGION:-}" ] && [ -n "${AWS_REGION:-}" ]; then
+        export AWS_DEFAULT_REGION="${AWS_REGION}"
+      fi
+      echo "[optio] AWS CodeCommit credential helper configured (region: ${AWS_DEFAULT_REGION:-${AWS_REGION:-unset}})"
+      aws sts get-caller-identity >/dev/null 2>&1 \
+        && echo "[optio] AWS credentials valid" \
+        || echo "[optio] WARNING: AWS credentials missing or invalid — clone/PR ops may fail"
+    else
+      echo "[optio] WARNING: aws CLI not found in image; CodeCommit operations will fail"
+    fi
+    ;;
+esac
 
 # Clone repo
 cd /workspace

--- a/scripts/repo-init.sh
+++ b/scripts/repo-init.sh
@@ -11,6 +11,7 @@ git config --global user.email "${GIT_BOT_EMAIL:-${GITHUB_APP_BOT_EMAIL:-optio-a
 # Detect git platform from repo URL
 OPTIO_GIT_HOST=""
 case "${OPTIO_REPO_URL}" in
+  *git-codecommit.*.amazonaws.com*) OPTIO_GIT_HOST="codecommit" ;;
   *gitlab*) OPTIO_GIT_HOST="gitlab" ;;
   *github*) OPTIO_GIT_HOST="github" ;;
   *)        OPTIO_GIT_HOST="github" ;; # default
@@ -51,6 +52,17 @@ elif [ -n "${OPTIO_GIT_CREDENTIAL_URL:-}" ] && [ -f /usr/local/bin/optio-git-cre
     glab auth login --hostname "${GITLAB_HOST}" --token "${GITLAB_TOKEN}" 2>/dev/null || true
     echo "[optio] GitLab CLI authenticated (host: ${GITLAB_HOST})"
   fi
+
+elif [ "${OPTIO_GIT_HOST}" = "codecommit" ] && command -v aws >/dev/null 2>&1; then
+  # CodeCommit uses AWS SigV4 — wire git's credential helper to the AWS CLI helper.
+  # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN / AWS_REGION are
+  # injected by the API server when launching the pod (or come from instance profile / IRSA).
+  git config --global credential.helper '!aws codecommit credential-helper $@'
+  git config --global credential.UseHttpPath true
+  if [ -z "${AWS_DEFAULT_REGION:-}" ] && [ -n "${AWS_REGION:-}" ]; then
+    export AWS_DEFAULT_REGION="${AWS_REGION}"
+  fi
+  echo "[optio] CodeCommit credential helper configured (region: ${AWS_DEFAULT_REGION:-${AWS_REGION:-unset}})"
 
 elif [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${GITLAB_TOKEN:-}" ]; then
   # Static PAT fallback — configure credentials for the detected platform


### PR DESCRIPTION
## Summary

Adds AWS CodeCommit support alongside GitHub and GitLab so agents can clone, push, and open PRs against repos hosted in AWS CodeCommit. Closes #527.

CodeCommit returned to full GA in Nov 2025 with new-customer signups reopened, Git LFS coming in Q1 2026, and additional regions in Q3 2026 — this is an active surface, not a sunset target.

## Approach

The existing three-layer abstraction (`GitPlatform` interface → per-provider classes → factory) made this clean. The third provider drops in symmetrically:

- **Auth**: HTTPS clone URLs + the AWS CLI credential helper (`!aws codecommit credential-helper $@`); API ops via `@aws-sdk/client-codecommit`.
- **Credentials**: stored as workspace/global secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, `AWS_REGION`) with a `workload-identity` sentinel that defers to the SDK's default chain (IRSA on EKS, instance profile, env).
- **PR creation**: agent runs `aws codecommit create-pull-request` directly — no third-party CLI wrapper needed.
- **Reviews**: `APPROVED` maps to `UpdatePullRequestApprovalState(APPROVE)`; `REQUEST_CHANGES` / `COMMENT` post via `PostCommentForPullRequest` with a prefix in the body.
- **Inline comments**: positioned via `location.{filePath, filePosition, relativeFileVersion=AFTER}`; falls back to a top-level comment on error so feedback is never silently dropped.

## Graceful degradation

CodeCommit doesn't have native CI, issues, or webhooks. Where the abstraction expects them:
- `getCIChecks()` returns `[]`. The reconciler at `reconcile-repo.ts:462` already treats `checksStatus="none"` as merge-eligible, so auto-merge still fires.
- `listIssues()` returns `[]`; mutating issue methods throw a clear "not supported" error.
- No webhook plumbing — relies on the existing 30s PR-watcher poll. EventBridge integration is a future follow-up.
- `reviewTrigger="on_pr"` is recommended over the default `on_ci_pass` for CodeCommit repos (since CI never reports). Documented in CLAUDE.md.

## What's in this PR

- Types + parser: `GitPlatformType` extended; `parseRepoUrl`/`parsePrUrl` recognise `git-codecommit.<region>.amazonaws.com` (HTTPS + SSH) and console PR URLs.
- `CodeCommitPlatform` (≈400 lines) implementing all 14 `GitPlatform` methods.
- `codecommit-credential-service` for AWS cred resolution.
- AWS CLI v2 added to the agent base image (amd64 + arm64).
- `repo-init.sh` and `agent-entrypoint.sh` configure `git config credential.helper '!aws codecommit credential-helper \$@'` when the URL is a CodeCommit repo.
- Prompt templates: new `GIT_PLATFORM_CODECOMMIT` / `CODECOMMIT_REPO` / `BASE_BRANCH` vars wired through `task-worker.ts`, `review-service.ts`, `pr-review-service.ts`.
- Setup wizard: new CodeCommit panel (region, access key, secret, session token, validate button, repo picker).
- API: `POST /api/setup/validate/aws-credentials` and `POST /api/setup/repos/codecommit`.
- Helm: documents EKS IRSA via `serviceAccount.annotations`.

## Tests

- 30/30 URL parser tests (3 new CodeCommit cases)
- 18/18 new `CodeCommitPlatform` unit tests using `aws-sdk-client-mock`
- 20/20 prompt-template tests (2 new CodeCommit cases)
- 184/184 OpenAPI route registry tests (route count bumped 169 → 171)
- Full suite: `pnpm format:check`, `pnpm turbo typecheck` (12/12), `pnpm turbo test` (2089/2089), `pnpm turbo build`, and `apps/web next build` all green.

## Follow-ups (not blocking this PR, but blocking real use)

- [ ] **Agent base image needs to be rebuilt and pushed to GHCR** before CodeCommit users can run tasks. Run \`./images/build.sh\` and bump tags.
- [ ] **Inline-comment positioning is mock-tested only**. The `PostCommentForPullRequest` location call hasn't been exercised against a live CodeCommit PR. The fallback path (top-level comment) should keep us safe if positioning fails, but worth verifying on the first real review.
- [ ] **CodePipeline integration** for real CI status (currently always `[]`).
- [ ] **EventBridge → webhook** for instant PR-state updates instead of 30s polling.

## Test plan

- [ ] CI: format / typecheck / test / build all pass
- [ ] Manual e2e against a live CodeCommit repo:
  - [ ] Setup wizard CodeCommit panel validates credentials successfully
  - [ ] CodeCommit repo can be added via URL form
  - [ ] Manual task pod clones the repo (check `repo-init.sh` log lines)
  - [ ] Agent commits, pushes, runs `aws codecommit create-pull-request` successfully
  - [ ] Task transitions to \`pr_opened\` with the correct console PR URL
  - [ ] PR watcher polls and sees the PR; auto-merge fires when enabled (since `checksStatus="none"`)
  - [ ] Code-review subtask posts a review comment on the CodeCommit PR
  - [ ] Closing the PR transitions the task to \`failed\`