### PR TITLE
Copilot/claude fable 5

### DIFF
--- a/packages/shared/src/agent-options/agent-options.test.ts
+++ b/packages/shared/src/agent-options/agent-options.test.ts
@@ -127,9 +127,9 @@ describe("mergeLiveModels", () => {
   });
 
   it("preserves baseline metadata when a live id matches", () => {
-    const opus = ANTHROPIC_CATALOG.models.find((m) => m.id === "claude-opus-4-7")!;
-    const merged = mergeLiveModels(ANTHROPIC_CATALOG, ["claude-opus-4-7"]);
-    const mergedOpus = merged.models.find((m) => m.id === "claude-opus-4-7")!;
+    const opus = ANTHROPIC_CATALOG.models.find((m) => m.id === "claude-opus-4-8")!;
+    const merged = mergeLiveModels(ANTHROPIC_CATALOG, ["claude-opus-4-8"]);
+    const mergedOpus = merged.models.find((m) => m.id === "claude-opus-4-8")!;
     expect(mergedOpus.label).toBe(opus.label);
     expect(mergedOpus.latest).toBe(true);
     expect(mergedOpus.source).toBe("baseline");

--- a/packages/shared/src/agent-options/agent-options.test.ts
+++ b/packages/shared/src/agent-options/agent-options.test.ts
@@ -63,7 +63,7 @@ describe("PROVIDER_CATALOGS", () => {
 
 describe("resolveModelId", () => {
   it("resolves the opus alias to the latest dated id", () => {
-    expect(resolveModelId("anthropic", "opus")).toBe("claude-opus-4-7");
+    expect(resolveModelId("anthropic", "opus")).toBe("claude-opus-4-8");
   });
 
   it("resolves the sonnet alias", () => {
@@ -72,6 +72,10 @@ describe("resolveModelId", () => {
 
   it("resolves the haiku alias", () => {
     expect(resolveModelId("anthropic", "haiku")).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("resolves the fable alias", () => {
+    expect(resolveModelId("anthropic", "fable")).toBe("claude-fable-5");
   });
 
   it("returns an exact-match dated id unchanged", () => {
@@ -87,7 +91,7 @@ describe("resolveModelId", () => {
 
   it("returns the latest-marked model when no input is provided", () => {
     // Pick a provider with an explicit `latest` flag.
-    expect(resolveModelId("anthropic", undefined)).toBe("claude-opus-4-7");
+    expect(resolveModelId("anthropic", undefined)).toBe("claude-opus-4-8");
   });
 
   it("returns undefined for free-text providers with no baseline models", () => {
@@ -102,7 +106,7 @@ describe("resolveModelId", () => {
   });
 
   it("treats an empty string like undefined", () => {
-    expect(resolveModelId("anthropic", "")).toBe("claude-opus-4-7");
+    expect(resolveModelId("anthropic", "")).toBe("claude-opus-4-8");
   });
 
   it("resolves gemini-pro alias", () => {
@@ -160,7 +164,7 @@ describe("groupModelsByFamily", () => {
   it("groups anthropic models by family", () => {
     const groups = groupModelsByFamily(ANTHROPIC_CATALOG);
     const families = groups.map((g) => g.family).sort();
-    expect(families).toEqual(["haiku", "opus", "sonnet"]);
+    expect(families).toEqual(["fable", "haiku", "opus", "sonnet"]);
   });
 
   it("falls back to the model id when there is no family", () => {

--- a/packages/shared/src/agent-options/anthropic.ts
+++ b/packages/shared/src/agent-options/anthropic.ts
@@ -53,7 +53,6 @@ export const ANTHROPIC_CATALOG: ProviderCatalog = {
       id: "claude-fable-5",
       label: "Fable 5",
       family: "fable",
-      latest: true,
       source: "baseline",
     },
   ],

--- a/packages/shared/src/agent-options/anthropic.ts
+++ b/packages/shared/src/agent-options/anthropic.ts
@@ -11,10 +11,16 @@ export const ANTHROPIC_CATALOG: ProviderCatalog = {
   modelField: "claudeModel",
   models: [
     {
+      id: "claude-opus-4-8",
+      label: "Opus 4.8",
+      family: "opus",
+      latest: true,
+      source: "baseline",
+    },
+    {
       id: "claude-opus-4-7",
       label: "Opus 4.7",
       family: "opus",
-      latest: true,
       source: "baseline",
     },
     {
@@ -43,11 +49,19 @@ export const ANTHROPIC_CATALOG: ProviderCatalog = {
       latest: true,
       source: "baseline",
     },
+    {
+      id: "claude-fable-5",
+      label: "Fable 5",
+      family: "fable",
+      latest: true,
+      source: "baseline",
+    },
   ],
   aliases: {
-    opus: "claude-opus-4-7",
+    opus: "claude-opus-4-8",
     sonnet: "claude-sonnet-4-6",
     haiku: "claude-haiku-4-5-20251001",
+    fable: "claude-fable-5",
   },
   options: [
     {


### PR DESCRIPTION
## Summary

Adds `claude-opus-4-8` and `claude-fable-5` to the Anthropic baseline catalog, and updates latest-model metadata so only Opus 4.8 is treated as the latest Anthropic default. This keeps Fable 5 selectable without changing default resolution away from Opus.

## Changes

- **Anthropic catalog**
  - Added baseline entries for `claude-opus-4-8` and `claude-fable-5`
  - Updated the `opus` alias to resolve to `claude-opus-4-8`
  - Kept `fable` as a supported alias for `claude-fable-5`
  - Removed `latest: true` from Fable 5 so only Opus 4.8 remains marked latest

- **Agent option coverage**
  - Updated shared agent-option tests to reflect the new Opus default
  - Added coverage for the `fable` alias and the expanded Anthropic family grouping

```ts
{
  id: "claude-opus-4-8",
  family: "opus",
  latest: true,
}

{
  id: "claude-fable-5",
  family: "fable",
}
```

## Testing

- [x] Tests pass (`pnpm turbo test`)
- [x] Typechecks pass (`pnpm turbo typecheck`)

## Related

Issue: #540 

## Screenshots

<!-- If applicable -->