### PR TITLE
fix: respect github rate limiting

### DIFF
--- a/apps/api/src/services/git-platform/github.test.ts
+++ b/apps/api/src/services/git-platform/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { GitHubPlatform } from "./github.js";
+import { GitHubPlatform, GitHubApiError, classifyGitHubFailure } from "./github.js";
 import type { RepoIdentifier } from "@optio/shared";
 
 const ri: RepoIdentifier = {
@@ -239,5 +239,82 @@ describe("GitHubPlatform", () => {
 
       await expect(platform.getPullRequest(ri, 999)).rejects.toThrow("GitHub API error 404");
     });
+
+    it("throws a GitHubApiError carrying status, retry-after, and secondary-limit flag", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        headers: new Headers({ "retry-after": "120" }),
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve("You have exceeded a secondary rate limit"),
+      });
+
+      await expect(platform.getPullRequest(ri, 1)).rejects.toMatchObject({
+        name: "GitHubApiError",
+        status: 403,
+        isSecondaryRateLimit: true,
+        retryAfterMs: 120000,
+      });
+    });
+
+    it("flags a primary rate limit from x-ratelimit headers", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        headers: new Headers({ "x-ratelimit-remaining": "0", "x-ratelimit-reset": "1900000000" }),
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve("API rate limit exceeded"),
+      });
+
+      await expect(platform.getPullRequest(ri, 2)).rejects.toMatchObject({
+        name: "GitHubApiError",
+        status: 403,
+        isPrimaryRateLimit: true,
+        isSecondaryRateLimit: false,
+        rateLimitRemaining: 0,
+        rateLimitResetMs: 1900000000000,
+      });
+    });
+  });
+});
+
+describe("classifyGitHubFailure", () => {
+  it("classifies a secondary rate limit (body marker), carrying Retry-After", () => {
+    const f = classifyGitHubFailure(
+      new GitHubApiError(403, "You have exceeded a secondary rate limit", { retryAfterMs: 120000 }),
+    );
+    expect(f).toMatchObject({ kind: "secondary_rate_limit", retryAfterMs: 120000 });
+  });
+
+  it("classifies a primary rate limit (remaining 0) with the reset time", () => {
+    const f = classifyGitHubFailure(
+      new GitHubApiError(403, "API rate limit exceeded", {
+        rateLimitRemaining: 0,
+        rateLimitResetMs: 1_900_000_000_000,
+      }),
+    );
+    expect(f).toMatchObject({ kind: "primary_rate_limit", resetAtMs: 1_900_000_000_000 });
+  });
+
+  it("treats a bare 429 as a secondary rate limit", () => {
+    expect(classifyGitHubFailure(new GitHubApiError(429, "Too Many Requests"))?.kind).toBe(
+      "secondary_rate_limit",
+    );
+  });
+
+  it("classifies 401 as auth and a non-rate-limit 403 as permission", () => {
+    expect(classifyGitHubFailure(new GitHubApiError(401, "Bad credentials"))?.kind).toBe("auth");
+    expect(
+      classifyGitHubFailure(new GitHubApiError(403, "Resource not accessible by integration"))
+        ?.kind,
+    ).toBe("permission");
+  });
+
+  it("returns null for transient 5xx, 4xx logic errors, and non-GitHub errors", () => {
+    expect(classifyGitHubFailure(new GitHubApiError(500, "Server Error"))).toBeNull();
+    expect(classifyGitHubFailure(new GitHubApiError(404, "Not Found"))).toBeNull();
+    expect(classifyGitHubFailure(new GitHubApiError(422, "Unprocessable"))).toBeNull();
+    expect(classifyGitHubFailure(new Error("db hiccup"))).toBeNull();
+    expect(classifyGitHubFailure(undefined)).toBeNull();
   });
 });

--- a/apps/api/src/services/git-platform/github.ts
+++ b/apps/api/src/services/git-platform/github.ts
@@ -11,6 +11,113 @@ import type {
   RepoContent,
 } from "@optio/shared";
 
+/**
+ * Error thrown by GitHubPlatform for any non-2xx GitHub REST response. Carries
+ * the verified response metadata callers need to choose the correct recovery:
+ * HTTP status, `Retry-After`, the `x-ratelimit-*` primary-quota signals, and
+ * whether the body indicates a *secondary* rate limit. The `.message` is kept
+ * identical to the previous `GitHub API error <status>: <body>` string so
+ * existing message-based logging/classification is unaffected.
+ */
+export class GitHubApiError extends Error {
+  readonly status: number;
+  readonly retryAfterMs: number | null;
+  readonly rateLimitRemaining: number | null;
+  readonly rateLimitResetMs: number | null;
+  readonly isSecondaryRateLimit: boolean;
+  readonly isPrimaryRateLimit: boolean;
+
+  constructor(
+    status: number,
+    body: string,
+    meta: {
+      retryAfterMs?: number | null;
+      rateLimitRemaining?: number | null;
+      rateLimitResetMs?: number | null;
+    } = {},
+  ) {
+    super(`GitHub API error ${status}: ${body}`);
+    this.name = "GitHubApiError";
+    this.status = status;
+    this.retryAfterMs = meta.retryAfterMs ?? null;
+    this.rateLimitRemaining = meta.rateLimitRemaining ?? null;
+    this.rateLimitResetMs = meta.rateLimitResetMs ?? null;
+    this.isSecondaryRateLimit =
+      (status === 403 || status === 429) &&
+      /secondary rate limit|exceeded a secondary rate limit|abuse detection/i.test(body);
+    // A primary-quota exhaustion is a 403/429 with the remaining counter at 0
+    // and no secondary marker — it must wait for the reset, not the 60s floor.
+    this.isPrimaryRateLimit =
+      (status === 403 || status === 429) &&
+      this.rateLimitRemaining === 0 &&
+      !this.isSecondaryRateLimit;
+    // Preserve the prototype chain so `instanceof GitHubApiError` holds even
+    // under down-level transpilation targets.
+    Object.setPrototypeOf(this, GitHubApiError.prototype);
+  }
+
+  static fromResponse(res: Response, body: string): GitHubApiError {
+    return new GitHubApiError(res.status, body, {
+      retryAfterMs: parseRetryAfterMs(res.headers),
+      rateLimitRemaining: parseIntHeader(res.headers, "x-ratelimit-remaining"),
+      rateLimitResetMs: parseEpochSecondsToMs(res.headers, "x-ratelimit-reset"),
+    });
+  }
+}
+
+function parseRetryAfterMs(headers: Headers | undefined): number | null {
+  const raw = headers?.get("retry-after");
+  if (!raw) return null;
+  const seconds = Number(raw);
+  return Number.isFinite(seconds) ? Math.max(0, seconds) * 1000 : null;
+}
+
+function parseIntHeader(headers: Headers | undefined, name: string): number | null {
+  const raw = headers?.get(name);
+  if (raw == null || raw === "") return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseEpochSecondsToMs(headers: Headers | undefined, name: string): number | null {
+  const seconds = parseIntHeader(headers, name);
+  return seconds == null ? null : seconds * 1000;
+}
+
+/** Distinct GitHub failure classes, each of which needs a distinct retry policy. */
+export type GitHubFailureKind =
+  | "secondary_rate_limit"
+  | "primary_rate_limit"
+  | "auth"
+  | "permission";
+
+export interface GitHubFailure {
+  kind: GitHubFailureKind;
+  /** Server-directed wait (`Retry-After`), if present. */
+  retryAfterMs: number | null;
+  /** Primary-quota reset time (`x-ratelimit-reset`), if present. */
+  resetAtMs: number | null;
+}
+
+/**
+ * Classify a thrown error into the GitHub failure class that determines retry
+ * policy, or `null` when it is NOT a GitHub block (transient 5xx, 404, 422,
+ * network, or any non-GitHub error) — in which case callers keep their normal
+ * fast-retry behavior. The deadline math (how long to wait) is the caller's
+ * responsibility, since it depends on persisted attempt history.
+ */
+export function classifyGitHubFailure(err: unknown): GitHubFailure | null {
+  if (!(err instanceof GitHubApiError)) return null;
+  const { retryAfterMs, rateLimitResetMs: resetAtMs } = err;
+  if (err.isSecondaryRateLimit) return { kind: "secondary_rate_limit", retryAfterMs, resetAtMs };
+  if (err.isPrimaryRateLimit) return { kind: "primary_rate_limit", retryAfterMs, resetAtMs };
+  // A 429 with no secondary marker / remaining counter is still a rate limit.
+  if (err.status === 429) return { kind: "secondary_rate_limit", retryAfterMs, resetAtMs };
+  if (err.status === 401) return { kind: "auth", retryAfterMs: null, resetAtMs: null };
+  if (err.status === 403) return { kind: "permission", retryAfterMs: null, resetAtMs: null };
+  return null;
+}
+
 export class GitHubPlatform implements GitPlatform {
   readonly type = "github" as const;
   private readonly token: string;
@@ -37,7 +144,7 @@ export class GitHubPlatform implements GitPlatform {
     const res = await fetch(url, init);
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      throw new Error(`GitHub API error ${res.status}: ${body}`);
+      throw GitHubApiError.fromResponse(res, body);
     }
     return (await res.json()) as T;
   }
@@ -196,7 +303,7 @@ export class GitHubPlatform implements GitPlatform {
     });
     if (!res.ok && res.status !== 422) {
       const body = await res.text().catch(() => "");
-      throw new Error(`GitHub API error ${res.status}: ${body}`);
+      throw GitHubApiError.fromResponse(res, body);
     }
   }
 

--- a/apps/api/src/services/reconcile-executor.test.ts
+++ b/apps/api/src/services/reconcile-executor.test.ts
@@ -32,8 +32,21 @@ vi.mock("../db/client.js", () => ({
 }));
 
 vi.mock("../db/schema.js", () => ({
-  tasks: { id: "id", updatedAt: "updated_at" },
+  tasks: {
+    id: "id",
+    updatedAt: "updated_at",
+    reconcileBackoffUntil: "reconcile_backoff_until",
+    reconcileAttempts: "reconcile_attempts",
+    errorMessage: "error_message",
+  },
   workflowRuns: { id: "id", updatedAt: "updated_at", state: "state" },
+  prReviews: {
+    id: "id",
+    updatedAt: "updated_at",
+    reconcileBackoffUntil: "reconcile_backoff_until",
+    reconcileAttempts: "reconcile_attempts",
+    errorMessage: "error_message",
+  },
 }));
 
 vi.mock("./task-service.js", () => ({
@@ -89,6 +102,7 @@ vi.mock("../logger.js", () => ({
 
 // Import AFTER mocks
 import { executeAction } from "./reconcile-executor.js";
+import { GitHubApiError } from "./git-platform/github.js";
 
 // ─── Fixtures ───
 
@@ -536,6 +550,68 @@ describe("reconcile-executor", () => {
       const outcome = await executeAction(action, snap);
       expect(outcome.status).toBe("error");
       expect(mockTransitionTask).not.toHaveBeenCalled();
+    });
+
+    it("persists a cooldown and does not transition on a secondary rate limit", async () => {
+      mockGetPlatform.mockResolvedValue({
+        platform: { mergePullRequest: mockMergePR },
+        ri: { owner: "acme", repo: "repo" },
+      });
+      mockMergePR.mockRejectedValue(
+        new GitHubApiError(403, "You have exceeded a secondary rate limit", {
+          retryAfterMs: 120000,
+        }),
+      );
+      const chain = chainable([{ id: "task-1" }]);
+      mockDbUpdate.mockReturnValue(chain);
+
+      const snap = repoSnapshot();
+      if (snap.run.kind !== "repo") throw new Error("fixture mismatch");
+      snap.run.status.prUrl = "https://github.com/acme/repo/pull/42";
+      snap.run.status.state = TaskState.PR_OPENED;
+
+      const outcome = await executeAction(
+        { kind: "autoMergePr", reason: "auto_merge_ready" },
+        snap,
+      );
+
+      // Applied (not error) so the worker won't fast-retry; run NOT advanced.
+      expect(outcome.status).toBe("applied");
+      expect(outcome.reason).toContain("github_cooldown");
+      expect(mockTransitionTask).not.toHaveBeenCalled();
+      expect(chain.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reconcileBackoffUntil: expect.anything(),
+          errorMessage: expect.stringContaining("secondary rate limit"),
+        }),
+      );
+      // Single delayed wake honoring Retry-After (>=120s).
+      const enqueueArgs = mockEnqueueReconcile.mock.calls.at(-1)?.[1] as { delayMs: number };
+      expect(enqueueArgs.delayMs).toBeGreaterThanOrEqual(120000);
+    });
+
+    it("persists a long cooldown for an auth (bad credentials) failure", async () => {
+      mockGetPlatform.mockResolvedValue({
+        platform: { mergePullRequest: mockMergePR },
+        ri: { owner: "acme", repo: "repo" },
+      });
+      mockMergePR.mockRejectedValue(new GitHubApiError(401, '{"message":"Bad credentials"}'));
+      mockDbUpdate.mockReturnValue(chainable([{ id: "task-1" }]));
+
+      const snap = repoSnapshot();
+      if (snap.run.kind !== "repo") throw new Error("fixture mismatch");
+      snap.run.status.prUrl = "https://github.com/acme/repo/pull/42";
+      snap.run.status.state = TaskState.PR_OPENED;
+
+      const outcome = await executeAction(
+        { kind: "autoMergePr", reason: "auto_merge_ready" },
+        snap,
+      );
+      expect(outcome.status).toBe("applied");
+      expect(outcome.reason).toContain("github_cooldown:auth");
+      expect(mockTransitionTask).not.toHaveBeenCalled();
+      const enqueueArgs = mockEnqueueReconcile.mock.calls.at(-1)?.[1] as { delayMs: number };
+      expect(enqueueArgs.delayMs).toBeGreaterThanOrEqual(60_000);
     });
   });
 

--- a/apps/api/src/services/reconcile-executor.ts
+++ b/apps/api/src/services/reconcile-executor.ts
@@ -15,9 +15,11 @@ import {
   PrReviewState,
   PersistentAgentState,
   parsePrUrl,
+  parseIntEnv,
 } from "@optio/shared";
 import * as taskService from "./task-service.js";
 import { enqueueReconcile } from "./reconcile-queue.js";
+import { classifyGitHubFailure, type GitHubFailure } from "./git-platform/github.js";
 import { logger } from "../logger.js";
 
 /**
@@ -475,6 +477,8 @@ async function applyAutoMergePr(snapshot: WorldSnapshot): Promise<ExecuteOutcome
   try {
     await platform.mergePullRequest(ri, parsed.prNumber, "squash");
   } catch (err) {
+    const cooldown = await handleGithubWriteBlock(snapshot, err);
+    if (cooldown) return cooldown;
     const msg = err instanceof Error ? err.message : String(err);
     logger.warn({ err, taskId, prNumber: parsed.prNumber }, "auto-merge failed");
     return { status: "error", reason: `merge_failed:${msg}`, error: err };
@@ -680,6 +684,123 @@ async function casUpdate(
   return rows.length > 0 ? "applied" : "stale";
 }
 
+// ── GitHub write cooldown ───────────────────────────────────────────────────
+// When a content-creating GitHub write (auto-merge, auto-submit-review) is
+// blocked by a rate limit or an auth/permission failure, we must stop EVERY
+// reconcile producer (event-driven, pr-watcher, resync) from re-issuing that
+// write until a deadline — not just the one delayed retry job. We do that by
+// persisting `reconcileBackoffUntil` on the run: the pure decision functions
+// already short-circuit to a noop while it is in the future, so every producer
+// becomes harmless. A single delayed reconcile is scheduled for the deadline.
+
+const GITHUB_RATE_LIMIT_MIN_BACKOFF_MS = 60_000; // GitHub requires >=60s when no Retry-After
+const GITHUB_RATE_LIMIT_MAX_BACKOFF_MS = 30 * 60_000; // cap exponential growth
+
+function githubCooldownDeadlineMs(
+  failure: GitHubFailure,
+  attempts: number,
+  nowMs: number,
+): { untilMs: number; incrementAttempts: boolean } {
+  switch (failure.kind) {
+    case "primary_rate_limit":
+      // Primary quota: wait until the reset, not the generic 60s floor.
+      return {
+        untilMs: failure.resetAtMs ?? nowMs + GITHUB_RATE_LIMIT_MIN_BACKOFF_MS,
+        incrementAttempts: false,
+      };
+    case "secondary_rate_limit": {
+      if (failure.retryAfterMs != null) {
+        return {
+          untilMs: nowMs + Math.max(failure.retryAfterMs, GITHUB_RATE_LIMIT_MIN_BACKOFF_MS),
+          incrementAttempts: false,
+        };
+      }
+      // No Retry-After: bounded exponential from 60s, escalating with attempts.
+      const backoff = Math.min(
+        GITHUB_RATE_LIMIT_MAX_BACKOFF_MS,
+        GITHUB_RATE_LIMIT_MIN_BACKOFF_MS * 2 ** Math.min(attempts, 6),
+      );
+      return {
+        untilMs: nowMs + backoff + Math.floor(Math.random() * 5_000),
+        incrementAttempts: true,
+      };
+    }
+    case "auth":
+    case "permission":
+      // Retrying the same credential/permission is futile — hold for a long
+      // window rather than looping. The classified errorMessage drives the
+      // GitHub credential/scope recovery UI.
+      return {
+        untilMs: nowMs + parseIntEnv("OPTIO_GITHUB_AUTH_COOLDOWN_MS", 60 * 60_000),
+        incrementAttempts: false,
+      };
+  }
+}
+
+/**
+ * Persist a monotonic (never-shortening) GitHub cooldown on a repo task or
+ * pr-review run, bumping updated_at so any in-flight CAS write becomes stale and
+ * cannot perform a concurrent GitHub write. `GREATEST` guarantees two concurrent
+ * failures keep the later deadline.
+ */
+async function persistGithubCooldown(
+  kind: "repo" | "pr-review",
+  id: string,
+  untilMs: number,
+  opts: { incrementAttempts: boolean; errorMessage: string },
+): Promise<void> {
+  const until = new Date(untilMs);
+  if (kind === "repo") {
+    const set: Record<string, unknown> = {
+      reconcileBackoffUntil: sql`GREATEST(COALESCE(${tasks.reconcileBackoffUntil}, ${until}), ${until})`,
+      errorMessage: opts.errorMessage,
+      updatedAt: new Date(),
+    };
+    if (opts.incrementAttempts) set.reconcileAttempts = sql`${tasks.reconcileAttempts} + 1`;
+    await db.update(tasks).set(set).where(eq(tasks.id, id));
+    return;
+  }
+  const set: Record<string, unknown> = {
+    reconcileBackoffUntil: sql`GREATEST(COALESCE(${prReviews.reconcileBackoffUntil}, ${until}), ${until})`,
+    errorMessage: opts.errorMessage,
+    updatedAt: new Date(),
+  };
+  if (opts.incrementAttempts) set.reconcileAttempts = sql`${prReviews.reconcileAttempts} + 1`;
+  await db.update(prReviews).set(set).where(eq(prReviews.id, id));
+}
+
+/**
+ * If `err` is a GitHub write block (rate limit / auth / permission), persist a
+ * cooldown, schedule a single delayed wake, and return an `applied` outcome so
+ * the worker does NOT additionally fast-retry. Returns null for transient or
+ * non-GitHub errors so the caller falls through to its normal error handling.
+ */
+async function handleGithubWriteBlock(
+  snapshot: WorldSnapshot,
+  err: unknown,
+): Promise<ExecuteOutcome | null> {
+  const failure = classifyGitHubFailure(err);
+  if (!failure) return null;
+  const run = snapshot.run;
+  if (run.kind !== "repo" && run.kind !== "pr-review") return null;
+  const nowMs = Date.now();
+  const attempts = run.status.reconcileAttempts ?? 0;
+  const { untilMs, incrementAttempts } = githubCooldownDeadlineMs(failure, attempts, nowMs);
+  await persistGithubCooldown(run.kind, run.ref.id, untilMs, {
+    incrementAttempts,
+    errorMessage: err instanceof Error ? err.message : String(err),
+  });
+  await enqueueReconcile(run.ref, {
+    reason: `github_cooldown:${failure.kind}`,
+    delayMs: Math.max(0, untilMs - nowMs),
+  });
+  logger.warn(
+    { runId: run.ref.id, kind: failure.kind, untilMs },
+    "GitHub write blocked — persisted reconcile cooldown",
+  );
+  return { status: "applied", reason: `github_cooldown:${failure.kind}` };
+}
+
 // ── PR Review applicators ──────────────────────────────────────────────────
 
 async function applyPrReviewTransition(
@@ -741,6 +862,8 @@ async function applySubmitReview(snapshot: WorldSnapshot): Promise<ExecuteOutcom
     await submitReview(prReviewId);
     return { status: "applied", reason: "auto_submitted" };
   } catch (err) {
+    const cooldown = await handleGithubWriteBlock(snapshot, err);
+    if (cooldown) return cooldown;
     const msg = err instanceof Error ? err.message : String(err);
     return { status: "error", reason: msg, error: err };
   }

--- a/apps/api/src/workers/reconcile-worker.ts
+++ b/apps/api/src/workers/reconcile-worker.ts
@@ -77,7 +77,10 @@ export function startReconcileWorker() {
         });
       }
 
-      // Errors get a longer backoff.
+      // Errors get a longer backoff. GitHub rate-limit / auth / permission
+      // blocks are handled upstream in the executor, which persists a
+      // `reconcileBackoffUntil` cooldown on the run so every reconcile producer
+      // is paused — those do not reach this branch as errors.
       if (outcome.status === "error") {
         await enqueueReconcile(ref, {
           reason: `error_retry:${outcome.reason}`,

--- a/apps/web/src/app/jobs/[id]/runs/[runId]/page.tsx
+++ b/apps/web/src/app/jobs/[id]/runs/[runId]/page.tsx
@@ -5,7 +5,7 @@ import { use, useState, useEffect, useCallback } from "react";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { useWorkflowRunLogs } from "@/hooks/use-workflow-run-logs";
 import { LogViewer } from "@/components/log-viewer";
-import { TokenRefreshBanner } from "@/components/token-refresh-banner";
+import { TokenRefreshBanner, GitHubTokenBanner } from "@/components/token-refresh-banner";
 import { DetailHeader } from "@/components/detail-header";
 import { PrStatusBar } from "@/components/pr-status-bar";
 import { WorkflowRunPipelineTimeline } from "@/components/workflow-run-pipeline-timeline";
@@ -281,8 +281,17 @@ export default function WorkflowRunDetailPage({
         </div>
       </div>
 
-      {/* Auth banner — same recovery surface as task/review pages */}
-      {classifiedError?.category === "auth" && (
+      {/* GitHub credential recovery — distinct from the Claude token banner */}
+      {classifiedError?.recovery === "github-token" && (
+        <div className="shrink-0 border-b border-border bg-bg-card">
+          <div className="max-w-5xl mx-auto px-4 py-3">
+            <GitHubTokenBanner onSaved={refresh} />
+          </div>
+        </div>
+      )}
+
+      {/* Claude auth banner — only for non-GitHub auth (Claude/OpenAI) errors */}
+      {classifiedError?.category === "auth" && !classifiedError.recovery && (
         <div className="shrink-0 border-b border-border bg-bg-card">
           <div className="max-w-5xl mx-auto px-4 py-3">
             <TokenRefreshBanner onSaved={refresh} />
@@ -290,47 +299,50 @@ export default function WorkflowRunDetailPage({
         </div>
       )}
 
-      {/* Classified error banner — matches /tasks/[id] and /reviews/[id] */}
-      {classifiedError && classifiedError.category !== "auth" && (
-        <div className="shrink-0 border-b border-error/20 bg-error/5">
-          <div className="max-w-5xl mx-auto px-4 py-3">
-            <div className="flex items-start gap-3">
-              <AlertCircle className="w-5 h-5 text-error shrink-0 mt-0.5" />
-              <div className="min-w-0 flex-1 space-y-2">
-                <div>
-                  <h3 className="text-sm font-medium text-error">{classifiedError.title}</h3>
-                  <p className="text-xs text-error/70 mt-0.5">{classifiedError.description}</p>
-                </div>
-                {classifiedError.remedy && (
-                  <div className="p-2.5 rounded-md bg-bg/50 border border-border">
-                    <div className="text-[10px] uppercase tracking-wider text-text-muted mb-1">
-                      Suggested fix
-                    </div>
-                    <pre className="text-xs text-text/80 whitespace-pre-wrap font-mono">
-                      {classifiedError.remedy}
-                    </pre>
+      {/* Classified error panel — rate-limit, github-permission, and all
+          non-auth errors (no token form). */}
+      {classifiedError &&
+        classifiedError.recovery !== "github-token" &&
+        !(classifiedError.category === "auth" && !classifiedError.recovery) && (
+          <div className="shrink-0 border-b border-error/20 bg-error/5">
+            <div className="max-w-5xl mx-auto px-4 py-3">
+              <div className="flex items-start gap-3">
+                <AlertCircle className="w-5 h-5 text-error shrink-0 mt-0.5" />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <div>
+                    <h3 className="text-sm font-medium text-error">{classifiedError.title}</h3>
+                    <p className="text-xs text-error/70 mt-0.5">{classifiedError.description}</p>
                   </div>
-                )}
-                <div className="flex items-center gap-2">
-                  {classifiedError.retryable && canRetry && (
-                    <button
-                      onClick={handleRetry}
-                      disabled={actionLoading}
-                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-white text-xs hover:bg-primary-hover disabled:opacity-50 btn-press transition-all"
-                    >
-                      <RotateCcw className="w-3 h-3" />
-                      Retry
-                    </button>
+                  {classifiedError.remedy && (
+                    <div className="p-2.5 rounded-md bg-bg/50 border border-border">
+                      <div className="text-[10px] uppercase tracking-wider text-text-muted mb-1">
+                        Suggested fix
+                      </div>
+                      <pre className="text-xs text-text/80 whitespace-pre-wrap font-mono">
+                        {classifiedError.remedy}
+                      </pre>
+                    </div>
                   )}
-                  <span className="text-[10px] px-2 py-0.5 rounded-full bg-error/10 text-error">
-                    {classifiedError.category}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    {classifiedError.retryable && canRetry && (
+                      <button
+                        onClick={handleRetry}
+                        disabled={actionLoading}
+                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-white text-xs hover:bg-primary-hover disabled:opacity-50 btn-press transition-all"
+                      >
+                        <RotateCcw className="w-3 h-3" />
+                        Retry
+                      </button>
+                    )}
+                    <span className="text-[10px] px-2 py-0.5 rounded-full bg-error/10 text-error">
+                      {classifiedError.category}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
 
       {/* Main content: log column + timeline sidebar — mirrors /tasks/[id] */}
       <div className="flex-1 flex overflow-hidden">

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -12,7 +12,7 @@ import { DetailHeader } from "@/components/detail-header";
 import { PrStatusBar } from "@/components/pr-status-bar";
 import { ChatComposer } from "@/components/chat-box";
 import { StateBadge } from "@/components/state-badge";
-import { TokenRefreshBanner } from "@/components/token-refresh-banner";
+import { TokenRefreshBanner, GitHubTokenBanner } from "@/components/token-refresh-banner";
 import { api } from "@/lib/api-client";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { classifyError } from "@optio/shared";
@@ -502,7 +502,16 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
         (isTerminal || task.state === "needs_attention") &&
         (() => {
           const classified = classifyError(task.errorMessage);
-          if (classified.category === "auth") {
+          if (classified.recovery === "github-token") {
+            return (
+              <div className="shrink-0 border-b border-border bg-bg-card">
+                <div className="max-w-5xl mx-auto px-4 py-3">
+                  <GitHubTokenBanner onSaved={refresh} />
+                </div>
+              </div>
+            );
+          }
+          if (classified.category === "auth" && !classified.recovery) {
             return (
               <div className="shrink-0 border-b border-border bg-bg-card">
                 <div className="max-w-5xl mx-auto px-4 py-3">

--- a/packages/shared/src/agent-options/agent-options.test.ts
+++ b/packages/shared/src/agent-options/agent-options.test.ts
@@ -127,9 +127,9 @@ describe("mergeLiveModels", () => {
   });
 
   it("preserves baseline metadata when a live id matches", () => {
-    const opus = ANTHROPIC_CATALOG.models.find((m) => m.id === "claude-opus-4-7")!;
-    const merged = mergeLiveModels(ANTHROPIC_CATALOG, ["claude-opus-4-7"]);
-    const mergedOpus = merged.models.find((m) => m.id === "claude-opus-4-7")!;
+    const opus = ANTHROPIC_CATALOG.models.find((m) => m.id === "claude-opus-4-8")!;
+    const merged = mergeLiveModels(ANTHROPIC_CATALOG, ["claude-opus-4-8"]);
+    const mergedOpus = merged.models.find((m) => m.id === "claude-opus-4-8")!;
     expect(mergedOpus.label).toBe(opus.label);
     expect(mergedOpus.latest).toBe(true);
     expect(mergedOpus.source).toBe("baseline");

--- a/packages/shared/src/agent-options/agent-options.test.ts
+++ b/packages/shared/src/agent-options/agent-options.test.ts
@@ -63,7 +63,7 @@ describe("PROVIDER_CATALOGS", () => {
 
 describe("resolveModelId", () => {
   it("resolves the opus alias to the latest dated id", () => {
-    expect(resolveModelId("anthropic", "opus")).toBe("claude-opus-4-7");
+    expect(resolveModelId("anthropic", "opus")).toBe("claude-opus-4-8");
   });
 
   it("resolves the sonnet alias", () => {
@@ -72,6 +72,10 @@ describe("resolveModelId", () => {
 
   it("resolves the haiku alias", () => {
     expect(resolveModelId("anthropic", "haiku")).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("resolves the fable alias", () => {
+    expect(resolveModelId("anthropic", "fable")).toBe("claude-fable-5");
   });
 
   it("returns an exact-match dated id unchanged", () => {
@@ -87,7 +91,7 @@ describe("resolveModelId", () => {
 
   it("returns the latest-marked model when no input is provided", () => {
     // Pick a provider with an explicit `latest` flag.
-    expect(resolveModelId("anthropic", undefined)).toBe("claude-opus-4-7");
+    expect(resolveModelId("anthropic", undefined)).toBe("claude-opus-4-8");
   });
 
   it("returns undefined for free-text providers with no baseline models", () => {
@@ -102,7 +106,7 @@ describe("resolveModelId", () => {
   });
 
   it("treats an empty string like undefined", () => {
-    expect(resolveModelId("anthropic", "")).toBe("claude-opus-4-7");
+    expect(resolveModelId("anthropic", "")).toBe("claude-opus-4-8");
   });
 
   it("resolves gemini-pro alias", () => {
@@ -160,7 +164,7 @@ describe("groupModelsByFamily", () => {
   it("groups anthropic models by family", () => {
     const groups = groupModelsByFamily(ANTHROPIC_CATALOG);
     const families = groups.map((g) => g.family).sort();
-    expect(families).toEqual(["haiku", "opus", "sonnet"]);
+    expect(families).toEqual(["fable", "haiku", "opus", "sonnet"]);
   });
 
   it("falls back to the model id when there is no family", () => {

--- a/packages/shared/src/agent-options/anthropic.ts
+++ b/packages/shared/src/agent-options/anthropic.ts
@@ -53,7 +53,6 @@ export const ANTHROPIC_CATALOG: ProviderCatalog = {
       id: "claude-fable-5",
       label: "Fable 5",
       family: "fable",
-      latest: true,
       source: "baseline",
     },
   ],

--- a/packages/shared/src/agent-options/anthropic.ts
+++ b/packages/shared/src/agent-options/anthropic.ts
@@ -11,10 +11,16 @@ export const ANTHROPIC_CATALOG: ProviderCatalog = {
   modelField: "claudeModel",
   models: [
     {
+      id: "claude-opus-4-8",
+      label: "Opus 4.8",
+      family: "opus",
+      latest: true,
+      source: "baseline",
+    },
+    {
       id: "claude-opus-4-7",
       label: "Opus 4.7",
       family: "opus",
-      latest: true,
       source: "baseline",
     },
     {
@@ -43,11 +49,19 @@ export const ANTHROPIC_CATALOG: ProviderCatalog = {
       latest: true,
       source: "baseline",
     },
+    {
+      id: "claude-fable-5",
+      label: "Fable 5",
+      family: "fable",
+      latest: true,
+      source: "baseline",
+    },
   ],
   aliases: {
-    opus: "claude-opus-4-7",
+    opus: "claude-opus-4-8",
     sonnet: "claude-sonnet-4-6",
     haiku: "claude-haiku-4-5-20251001",
+    fable: "claude-fable-5",
   },
   options: [
     {

--- a/packages/shared/src/error-classifier.test.ts
+++ b/packages/shared/src/error-classifier.test.ts
@@ -157,4 +157,51 @@ describe("classifyError", () => {
     expect(result.category).toBe("auth");
     expect(result.title).toBe("Authentication token expired");
   });
+
+  it("classifies GitHub secondary rate limit as non-retryable with rate-limit recovery", () => {
+    const result = classifyError(
+      "GitHub API error 403: You have exceeded a secondary rate limit and have been temporarily blocked from content creation.",
+    );
+    expect(result.category).toBe("auth");
+    expect(result.title).toBe("GitHub secondary rate limit");
+    expect(result.retryable).toBe(false);
+    expect(result.recovery).toBe("rate-limit");
+  });
+
+  it("classifies GitHub bad credentials as non-retryable with github-token recovery", () => {
+    const result = classifyError('GitHub API error 401: {"message":"Bad credentials"}');
+    expect(result.title).toBe("GitHub credentials invalid");
+    expect(result.retryable).toBe(false);
+    expect(result.recovery).toBe("github-token");
+  });
+
+  it("classifies GitHub permission error as non-retryable with github-permission recovery", () => {
+    const result = classifyError(
+      'GitHub API error 403: {"message":"Resource not accessible by integration"}',
+    );
+    expect(result.title).toBe("GitHub permission denied");
+    expect(result.retryable).toBe(false);
+    expect(result.recovery).toBe("github-permission");
+  });
+
+  it("does NOT classify unrelated 'bad credentials' (no GitHub wrapper) as a GitHub error", () => {
+    const result = classifyError("Internal connector rejected the request: bad credentials");
+    expect(result.title).not.toBe("GitHub credentials invalid");
+    expect(result.recovery).toBeUndefined();
+    expect(result.category).toBe("unknown");
+    expect(result.retryable).toBe(true);
+  });
+
+  it("does NOT classify an unrelated 'resource not accessible' string as a GitHub error", () => {
+    const result = classifyError("resource not accessible by integration");
+    expect(result.title).not.toBe("GitHub permission denied");
+    expect(result.recovery).toBeUndefined();
+  });
+
+  it("still treats a non-GitHub provider rate limit as retryable (generic rule)", () => {
+    const result = classifyError("API returned 429 too many requests");
+    expect(result.title).toBe("API rate limit exceeded");
+    expect(result.retryable).toBe(true);
+    expect(result.recovery).toBeUndefined();
+  });
 });

--- a/packages/shared/src/error-classifier.ts
+++ b/packages/shared/src/error-classifier.ts
@@ -4,12 +4,71 @@ export interface ClassifiedError {
   description: string;
   remedy: string;
   retryable: boolean;
+  /**
+   * Stable discriminator for which provider-specific recovery surface the UI
+   * should render. Absent for generic errors. Set explicitly by classifiers so
+   * renderers never have to infer the provider from display-title text.
+   */
+  recovery?: "claude-token" | "github-token" | "github-permission" | "rate-limit";
 }
 
 const ERROR_PATTERNS: Array<{
   pattern: RegExp;
   classify: (match: RegExpMatchArray) => ClassifiedError;
 }> = [
+  // ── GitHub write-path failures ──────────────────────────────────────────
+  // Must precede the generic rate-limit rule and the LLM auth rule. Scoped to
+  // the verified `GitHub API error <status>: <body>` wrapper that GitHubPlatform
+  // produces, so an unrelated provider/service emitting e.g. "bad credentials"
+  // is NOT misclassified as a permanent GitHub failure. `recovery` tells the UI
+  // which provider-specific recovery surface to render.
+  {
+    pattern: /github api error \d+:.*(secondary rate limit|abuse detection)/is,
+    classify: () => ({
+      category: "auth",
+      title: "GitHub secondary rate limit",
+      description:
+        "GitHub temporarily blocked writes (PRs, comments, reviews, merges) because too many " +
+        "content-creating requests were sent too quickly. This is a secondary rate limit, separate " +
+        "from the primary hourly quota.",
+      remedy:
+        "Stop retrying immediately. Wait at least 60 seconds (honor the Retry-After header if present) " +
+        "before further GitHub writes, and reduce concurrent agents/auto-resumes if it recurs.",
+      retryable: false,
+      recovery: "rate-limit",
+    }),
+  },
+  {
+    pattern: /github api error \d+:.*bad credentials/is,
+    classify: () => ({
+      category: "auth",
+      title: "GitHub credentials invalid",
+      description:
+        "GitHub rejected the token (HTTP 401 Bad credentials). The configured GitHub token is missing, " +
+        "expired, or revoked. Retrying with the same token will keep failing.",
+      remedy:
+        "Reconnect the GitHub App or refresh the GITHUB_TOKEN secret. Do not retry until the credential " +
+        "is replaced.",
+      retryable: false,
+      recovery: "github-token",
+    }),
+  },
+  {
+    pattern:
+      /github api error \d+:.*resource not accessible by (integration|personal access token|fine-grained personal access token)/is,
+    classify: () => ({
+      category: "auth",
+      title: "GitHub permission denied",
+      description:
+        "The GitHub token authenticated but lacks permission for this operation (HTTP 403 Resource not " +
+        "accessible). The App installation or token is missing a required scope/permission.",
+      remedy:
+        "Grant the missing permission to the GitHub App installation (or PAT scopes) — e.g. Pull requests: " +
+        "write, Issues: write, Contents: write — then retry.",
+      retryable: false,
+      recovery: "github-permission",
+    }),
+  },
   {
     pattern: /ErrImageNeverPull|InvalidImageName/i,
     classify: (match) => {


### PR DESCRIPTION
**The problem**

On 2026-06-12 a write hit GitHub's secondary rate limit (403, "blocked from content creation"). The reconciler's reaction made it worse: when a content-creating write (auto-merge, auto-submit-review) failed, it was re-issued every ~5–7.5 s with no Retry-After handling and no cap, and the shared error classifier treated GitHub 401/403 as "retryable." So the moment any write started failing, the system hammered the exact endpoints GitHub had just blocked — keeping the limit tripped and risking an integration ban.

**How the fix solves it**

- **Stops the storm at the source.** When a GitHub write is blocked, the executor now persists a cooldown (reconcileBackoffUntil) on the run. Every reconcile producer — event-driven, the 30 s PR watcher, the 5 min resync — already no-ops while that field is in the future, so none of them can re-issue the write until the deadline. (Previously only one retry job was delayed; the others bypassed it.)
- **Right wait for the right failure.** GitHub errors are now typed and classified: secondary limit → honor Retry-After (else ≥60 s, bounded exponential); primary limit → wait for the quota reset; auth/permission → long hold instead of retrying a credential that can't succeed.
- **Correct operator signal.** GitHub failures now surface GitHub-specific recovery (token/permission/rate-limit guidance) instead of the Claude "OAuth token expired" form, and aren't auto-retried as transient.

**Result:** at most one write attempt per server-directed (or ≥60 s) interval instead of a continuous loop — i.e. the client now behaves the way GitHub requires, so a transient secondary limit clears on its own rather than self-perpetuating.