### PR TITLE
fix(images): install codex CLI in agent images

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -33,6 +33,9 @@ RUN node -e 'const [maj,min] = process.versions.openssl.split(".").map(Number); 
 
 RUN npm install -g @anthropic-ai/claude-code
 
+# OpenAI Codex CLI
+RUN npm install -g @openai/codex
+
 # Allow sudo for extra package installation at runtime
 RUN apt-get update && apt-get install -y sudo \
     && rm -rf /var/lib/apt/lists/*

--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -51,6 +51,9 @@ RUN corepack enable && corepack prepare pnpm@10 --activate
 # Claude Code
 RUN npm install -g @anthropic-ai/claude-code
 
+# OpenAI Codex CLI
+RUN npm install -g @openai/codex
+
 # GitHub Copilot CLI (pinned + best-effort — package may be temporarily unavailable)
 RUN npm install -g @github/copilot@1.0.20 || echo "WARN: @github/copilot install failed; copilot agent will not be available in this image"
 


### PR DESCRIPTION
## Summary

The `codex` agent type is selectable in the app (task-worker invokes `codex exec --full-auto ... --json`), but the agent Docker images never installed the OpenAI Codex CLI, so codex tasks fail with `codex: command not found`.

This adds `npm install -g @openai/codex` to:

- `images/base.Dockerfile` — alongside the other agent CLI installs (Claude Code, Copilot, OpenCode, Gemini). All preset images (`node`, `python`, `go`, `rust`, `full`, etc.) inherit from base, so no other image files need changes.
- `Dockerfile.agent` — the legacy standalone agent image, next to its Claude Code install.

Unpinned to match the neighboring `@anthropic-ai/claude-code` and `@google/gemini-cli` installs.

## Publishing

Merging this auto-triggers the **Build Agent Images** workflow (`.github/workflows/build-images.yml` fires on pushes to `main` touching `images/**`), which rebuilds and republishes the images to GHCR.

Fixes #551