### PR TITLE
fix: stamp workspace_id on webhook/ticket/subtask-created tasks

### DIFF
--- a/apps/api/src/db/migrations/1784588891_backfill_task_workspace_id.sql
+++ b/apps/api/src/db/migrations/1784588891_backfill_task_workspace_id.sql
@@ -1,0 +1,26 @@
+-- Backfill: stamp workspace_id on tasks that were created without one.
+--
+-- Tasks created by non-interactive paths (GitHub webhook / ticket-sync
+-- polling, and review/child subtasks) were inserted with workspace_id =
+-- NULL, so the workspace-scoped UI queries filtered them out even though
+-- they ran fine (issue #544). The application layer now inherits the
+-- workspace from the repo (ticket sync), the parent task (subtasks), or
+-- the task_config; this migration repairs existing rows.
+--
+-- A row is only updated when its repo_url maps to exactly one non-NULL
+-- workspace across the repos table — ambiguous URLs (same repo configured
+-- in multiple workspaces) are left untouched rather than guessed at.
+
+UPDATE tasks t
+   SET workspace_id = r.workspace_id
+  FROM repos r
+ WHERE t.workspace_id IS NULL
+   AND r.repo_url = t.repo_url
+   AND r.workspace_id IS NOT NULL
+   AND NOT EXISTS (
+     SELECT 1
+       FROM repos r2
+      WHERE r2.repo_url = t.repo_url
+        AND r2.workspace_id IS NOT NULL
+        AND r2.workspace_id <> r.workspace_id
+   );

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -547,6 +547,13 @@
       "when": 1777400000000,
       "tag": "1777400000_session_chat_events",
       "breakpoints": true
+    },
+    {
+      "idx": 78,
+      "version": "7",
+      "when": 1784588891000,
+      "tag": "1784588891_backfill_task_workspace_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/services/subtask-service.test.ts
+++ b/apps/api/src/services/subtask-service.test.ts
@@ -130,6 +130,40 @@ describe("subtask-service", () => {
       expect(result.subtaskOrder).toBe(0); // -1 + 1 = 0
     });
 
+    it("inherits the parent task's workspaceId", async () => {
+      const parent = {
+        id: "parent-1",
+        repoUrl: "https://github.com/owner/repo",
+        agentType: "claude-code",
+        priority: 100,
+        workspaceId: "ws-1",
+      };
+      vi.mocked(taskService.getTask).mockResolvedValue(parent as any);
+      vi.mocked(taskService.createTask).mockResolvedValue({ id: "sub-1" } as any);
+
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ max: -1 }]),
+        }),
+      });
+      (db.update as any) = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      await createSubtask({
+        parentTaskId: "parent-1",
+        title: "Review",
+        prompt: "Review the PR",
+        taskType: "review",
+      });
+
+      expect(taskService.createTask).toHaveBeenCalledWith(
+        expect.objectContaining({ workspaceId: "ws-1" }),
+      );
+    });
+
     it("throws when parent task is not found", async () => {
       vi.mocked(taskService.getTask).mockResolvedValue(null as any);
 

--- a/apps/api/src/services/subtask-service.ts
+++ b/apps/api/src/services/subtask-service.ts
@@ -38,6 +38,9 @@ export async function createSubtask(input: SubtaskInput) {
     agentType: input.agentType ?? parent.agentType,
     priority: input.priority ?? Math.max(1, (parent.priority ?? 100) - 1),
     createdBy: parent.createdBy ?? undefined,
+    // Inherit the parent's workspace so subtasks (incl. review subtasks)
+    // stay visible in the workspace-scoped UI.
+    workspaceId: parent.workspaceId ?? null,
   });
 
   // Set subtask fields

--- a/apps/api/src/services/task-config-service.test.ts
+++ b/apps/api/src/services/task-config-service.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../db/schema.js", () => ({
+  taskConfigs: { id: "task_configs.id" },
+  workflowTriggers: {
+    id: "workflow_triggers.id",
+    targetType: "workflow_triggers.target_type",
+    targetId: "workflow_triggers.target_id",
+    type: "workflow_triggers.type",
+    enabled: "workflow_triggers.enabled",
+    createdAt: "workflow_triggers.created_at",
+  },
+}));
+
+vi.mock("./task-service.js", () => ({
+  createTask: vi.fn(),
+  transitionTask: vi.fn(),
+}));
+
+vi.mock("./prompt-template-service.js", () => ({
+  getPromptTemplateById: vi.fn(),
+  renderTemplateString: vi.fn((s: string) => s),
+}));
+
+vi.mock("./repo-service.js", () => ({
+  getRepoByUrl: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../workers/task-worker.js", () => ({
+  taskQueue: { add: vi.fn() },
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { db } from "../db/client.js";
+import * as taskService from "./task-service.js";
+import { getRepoByUrl } from "./repo-service.js";
+import { instantiateTask } from "./task-config-service.js";
+
+function mockGetTaskConfig(config: Record<string, unknown>) {
+  (db.select as any) = vi.fn().mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([config]),
+    }),
+  });
+}
+
+const baseConfig = {
+  id: "cfg-1",
+  name: "Nightly",
+  title: "Nightly task",
+  prompt: "Do the thing",
+  promptTemplateId: null,
+  repoUrl: "https://github.com/o/r",
+  repoBranch: "main",
+  agentType: null,
+  maxRetries: 3,
+  priority: 100,
+  enabled: true,
+  createdBy: null,
+};
+
+describe("task-config-service instantiateTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(taskService.createTask).mockResolvedValue({ id: "task-1", maxRetries: 3 } as any);
+  });
+
+  it("uses the config's own workspaceId when set", async () => {
+    mockGetTaskConfig({ ...baseConfig, workspaceId: "ws-config" });
+
+    await instantiateTask("cfg-1");
+
+    expect(taskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "ws-config" }),
+    );
+    expect(getRepoByUrl).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the repo's workspaceId when the config has none (issue #544)", async () => {
+    mockGetTaskConfig({ ...baseConfig, workspaceId: null });
+    vi.mocked(getRepoByUrl).mockResolvedValueOnce({ id: "repo-1", workspaceId: "ws-repo" } as any);
+
+    await instantiateTask("cfg-1");
+
+    expect(getRepoByUrl).toHaveBeenCalledWith("https://github.com/o/r");
+    expect(taskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "ws-repo" }),
+    );
+  });
+
+  it("passes a NULL workspaceId when neither config nor repo has one", async () => {
+    mockGetTaskConfig({ ...baseConfig, workspaceId: null });
+
+    await instantiateTask("cfg-1");
+
+    expect(taskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: null }),
+    );
+  });
+});

--- a/apps/api/src/services/task-config-service.ts
+++ b/apps/api/src/services/task-config-service.ts
@@ -159,6 +159,17 @@ export async function instantiateTask(
 
   const agentType = effectiveAgentType ?? "claude-code";
 
+  // Resolve the workspace: prefer the config's own workspace, falling back to
+  // the repo's workspace so trigger-spawned tasks from legacy (NULL-workspace)
+  // configs remain visible in the workspace-scoped UI — see issue #544.
+  let workspaceId = config.workspaceId ?? null;
+  if (!workspaceId) {
+    // Dynamic import to avoid a cycle: repo-service → services graph.
+    const { getRepoByUrl } = await import("./repo-service.js");
+    const repo = await getRepoByUrl(config.repoUrl).catch(() => null);
+    workspaceId = repo?.workspaceId ?? null;
+  }
+
   const task = await taskService.createTask({
     title: effectiveTitle,
     prompt: effectivePrompt,
@@ -168,7 +179,7 @@ export async function instantiateTask(
     maxRetries: config.maxRetries,
     priority: config.priority,
     createdBy: config.createdBy ?? undefined,
-    workspaceId: config.workspaceId ?? undefined,
+    workspaceId,
     metadata: {
       taskConfigId: config.id,
       taskConfigName: config.name,

--- a/apps/api/src/services/ticket-sync-service.test.ts
+++ b/apps/api/src/services/ticket-sync-service.test.ts
@@ -65,6 +65,7 @@ import * as taskService from "./task-service.js";
 import { taskQueue } from "../workers/task-worker.js";
 import { retrieveSecret } from "./secret-service.js";
 import { getGitHubToken } from "./github-token-service.js";
+import { getRepoByUrl } from "./repo-service.js";
 import { syncAllTickets } from "./ticket-sync-service.js";
 import { logger } from "../logger.js";
 
@@ -160,6 +161,80 @@ describe("ticket-sync-service", () => {
     expect(taskService.transitionTask).toHaveBeenCalledWith("task-1", "queued", "ticket_sync");
     expect(taskQueue.add).toHaveBeenCalled();
     expect(mockProvider.addComment).toHaveBeenCalled();
+  });
+
+  it("stamps created tasks with the repo's workspaceId (issue #544)", async () => {
+    mockDbSelect([
+      { id: "p1", source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
+    ]);
+
+    // Repo is configured in a workspace — webhook/poll-created tasks must
+    // inherit it or the workspace-scoped UI filters them out.
+    vi.mocked(getRepoByUrl).mockResolvedValueOnce({
+      id: "repo-1",
+      workspaceId: "ws-1",
+      defaultAgentType: null,
+    } as any);
+
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([
+        {
+          title: "Labeled issue",
+          body: "Body",
+          source: "github",
+          externalId: "321",
+          url: "https://github.com/o/r/issues/321",
+          labels: ["optio"],
+          repo: null,
+        },
+      ]),
+      fetchTicketComments: vi.fn().mockResolvedValue([]),
+      addComment: vi.fn().mockResolvedValue(undefined),
+    } as any);
+
+    vi.mocked(taskService.listTasks).mockResolvedValue([] as any);
+    vi.mocked(taskService.createTask).mockResolvedValue({ id: "task-1", maxRetries: 3 } as any);
+
+    await syncAllTickets();
+
+    expect(taskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoUrl: "https://github.com/o/r",
+        workspaceId: "ws-1",
+      }),
+    );
+  });
+
+  it("falls back to a NULL workspaceId when the repo is not configured", async () => {
+    mockDbSelect([
+      { id: "p1", source: "github", config: { repoUrl: "https://github.com/o/r" }, enabled: true },
+    ]);
+
+    // getRepoByUrl default mock resolves null (unknown repo)
+    vi.mocked(getTicketProvider).mockReturnValue({
+      fetchActionableTickets: vi.fn().mockResolvedValue([
+        {
+          title: "Unknown repo issue",
+          body: "",
+          source: "github",
+          externalId: "654",
+          url: "",
+          labels: [],
+          repo: null,
+        },
+      ]),
+      fetchTicketComments: vi.fn().mockResolvedValue([]),
+      addComment: vi.fn().mockResolvedValue(undefined),
+    } as any);
+
+    vi.mocked(taskService.listTasks).mockResolvedValue([] as any);
+    vi.mocked(taskService.createTask).mockResolvedValue({ id: "task-2", maxRetries: 3 } as any);
+
+    await syncAllTickets();
+
+    expect(taskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: null }),
+    );
   });
 
   it("skips tickets that already have tasks", async () => {

--- a/apps/api/src/services/ticket-sync-service.ts
+++ b/apps/api/src/services/ticket-sync-service.ts
@@ -157,6 +157,9 @@ export async function syncAllTickets(): Promise<number> {
           ticketSource: ticket.source,
           ticketExternalId: ticket.externalId,
           metadata: { ticketUrl: ticket.url },
+          // Inherit the repo's workspace so webhook/poll-created tasks are
+          // visible in the (workspace-scoped) UI — see issue #544.
+          workspaceId: repoConfig?.workspaceId ?? null,
         });
 
         await taskService.transitionTask(task.id, TaskState.QUEUED, "ticket_sync");


### PR DESCRIPTION
## Summary

Fixes #544 — a GitHub issue labeled with the trigger label spawns a task via the webhook, the agent runs and opens a PR, but the task never appears in the UI.

### Root cause

The commenter's diagnosis was correct. The webhook path is:

`POST /api/webhooks/github` (`issues.labeled` with the `optio` label) → `syncAllTickets()` → `ticket-sync-service.ts` → `taskService.createTask()` **without a `workspaceId`**. The row lands with `workspace_id = NULL`, and `listTasks({ workspaceId })` (driven by the logged-in user's workspace) filters it out. The task runs fine — it's purely invisible. The same service backs the periodic ticket-sync poller, so label-triggered and polled tasks were both affected.

Two sibling paths shared the bug:
- **Subtasks** (`subtask-service.ts`) — review/child/step subtasks did not inherit the parent's workspace, so review subtasks were also invisible in the Reviews UI.
- **`instantiateTask`** (`task-config-service.ts`) — inherited the config's `workspaceId`, but legacy configs with `NULL` workspace produced invisible tasks with no fallback.

The UI "Assign to Optio" path (`routes/issues.ts`) already stamps `req.user.workspaceId`, which is why that flow worked.

### Changes

- `ticket-sync-service.ts`: pass `workspaceId: repoConfig?.workspaceId ?? null` (the repo config was already being loaded for the agent-type default)
- `subtask-service.ts`: subtasks inherit `parent.workspaceId`
- `task-config-service.ts` `instantiateTask`: falls back to the repo's `workspaceId` when the config has none
- **Backfill migration** `1784588891_backfill_task_workspace_id.sql`: sets `workspace_id` on existing NULL rows from the repo's workspace, but only where the task's `repo_url` maps to exactly one non-NULL workspace across `repos` — ambiguous URLs (same repo configured in multiple workspaces) are deliberately left untouched rather than guessed at

### Tests

- `ticket-sync-service.test.ts`: asserts synced tasks carry the repo's `workspaceId`, and NULL when the repo is unknown
- `subtask-service.test.ts`: asserts subtasks inherit the parent's `workspaceId`
- `task-config-service.test.ts` (new): covers config-workspace, repo-fallback, and NULL cases for `instantiateTask`

`pnpm turbo typecheck`, `pnpm format:check`, and the full API vitest suite (123 files / 2152 tests) pass.

### Follow-up suggestion

Tasks whose `repo_url` is ambiguous across workspaces (or whose repo row was deleted) remain `workspace_id = NULL` after the backfill and stay hidden from workspace-scoped lists. If that matters in practice, a UI/API option to include legacy NULL-workspace rows (e.g. for admins) could be added — left out here since silently attaching them to a guessed workspace seemed riskier.