### PR TITLE
fix: stop rotating the encryption key on setup re-runs; make decrypt failures actionable

### DIFF
--- a/apps/api/src/services/repo-service.ts
+++ b/apps/api/src/services/repo-service.ts
@@ -87,6 +87,7 @@ function decryptRepoRow(row: typeof repos.$inferSelect): RepoRecord {
         authTag: row.slackWebhookUrlAuthTag,
       },
       aad,
+      `repo ${row.id} slackWebhookUrl`,
     );
   }
   const {

--- a/apps/api/src/services/secret-service.test.ts
+++ b/apps/api/src/services/secret-service.test.ts
@@ -363,6 +363,78 @@ describe("secret-service", () => {
     });
   });
 
+  describe("decrypt error wrapping (issue #553)", () => {
+    /** Encrypt with a DIFFERENT key than the service's — simulates key rotation. */
+    function encryptWithRotatedKey(plaintext: string) {
+      const rotatedKey = Buffer.from("b".repeat(64), "hex");
+      const iv = randomBytes(12);
+      const cipher = createCipheriv("aes-256-gcm", rotatedKey, iv);
+      const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+      return { alg: ALG_AES_256_GCM_V1, iv, ciphertext, authTag: cipher.getAuthTag() };
+    }
+
+    it("wraps the raw GCM auth failure in an actionable message", () => {
+      const blob = encryptWithRotatedKey("some-value");
+      expect(() => decrypt(blob)).toThrow(/Failed to decrypt stored secret/);
+      expect(() => decrypt(blob)).toThrow(/encryption key \(OPTIO_ENCRYPTION_KEY\)/);
+    });
+
+    it("preserves the original error message for debugging", () => {
+      const blob = encryptWithRotatedKey("some-value");
+      expect(() => decrypt(blob)).toThrow(/Unsupported state or unable to authenticate data/);
+    });
+
+    it("includes the secret name when provided, but never the value", () => {
+      const blob = encryptWithRotatedKey("super-sensitive-value");
+      let message = "";
+      try {
+        decrypt(blob, undefined, "MY_API_KEY");
+      } catch (err) {
+        message = (err as Error).message;
+      }
+      expect(message).toContain('"MY_API_KEY"');
+      expect(message).not.toContain("super-sensitive-value");
+    });
+
+    it("omits the name label when no secret name is provided", () => {
+      const blob = encryptWithRotatedKey("v");
+      expect(() => decrypt(blob)).toThrow(/^Failed to decrypt stored secret — /);
+    });
+
+    it("wraps AAD-mismatch failures the same way", () => {
+      const blob = encrypt("secret-value", Buffer.from("API_KEY|global|ws-1"));
+      expect(() => decrypt(blob, Buffer.from("API_KEY|global|ws-2"), "API_KEY")).toThrow(
+        /Failed to decrypt stored secret "API_KEY"/,
+      );
+    });
+
+    it("does not wrap unsupported-algorithm errors", () => {
+      const blob = encrypt("test");
+      blob.alg = 0x10;
+      expect(() => decrypt(blob)).toThrow(/^Unsupported encryption algorithm: 0x10$/);
+    });
+
+    it("retrieveSecret surfaces the wrapped error with the secret name", async () => {
+      const blob = encryptWithRotatedKey("stored-under-old-key");
+      (db.select as any) = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              encryptedValue: blob.ciphertext,
+              iv: blob.iv,
+              authTag: blob.authTag,
+              alg: blob.alg,
+            },
+          ]),
+        }),
+      });
+
+      await expect(retrieveSecret("ROTATED_KEY_SECRET")).rejects.toThrow(
+        /Failed to decrypt stored secret "ROTATED_KEY_SECRET"/,
+      );
+    });
+  });
+
   describe("buildSecretAAD", () => {
     it("builds AAD from name, scope, and workspaceId", () => {
       const aad = buildSecretAAD("API_KEY", "global", "ws-123");

--- a/apps/api/src/services/secret-service.ts
+++ b/apps/api/src/services/secret-service.ts
@@ -92,13 +92,31 @@ export function encrypt(plaintext: string, aad?: Buffer): EncryptedBlob {
   return { alg: ALG_AES_256_GCM_V1, iv, ciphertext, authTag: cipher.getAuthTag() };
 }
 
-export function decrypt(blob: EncryptedBlob, aad?: Buffer): string {
+/**
+ * Decrypt an EncryptedBlob. `secretName` (optional) is included in error
+ * messages for diagnosability — never the value.
+ *
+ * A failed GCM auth check surfaces from Node as the cryptic "Unsupported state
+ * or unable to authenticate data"; in practice this almost always means the
+ * encryption key changed after the secret was stored (see issue #553), so we
+ * wrap it with an actionable message. The original error text is preserved.
+ */
+export function decrypt(blob: EncryptedBlob, aad?: Buffer, secretName?: string): string {
   if (!Number.isInteger(blob.alg) || blob.alg < 1 || blob.alg > 255) {
     throw new Error(`Invalid algorithm id: ${blob.alg}`);
   }
   switch (blob.alg) {
     case ALG_AES_256_GCM_V1:
-      return decryptAesGcmV1(blob, aad);
+      try {
+        return decryptAesGcmV1(blob, aad);
+      } catch (err) {
+        const label = secretName ? ` "${secretName}"` : "";
+        throw new Error(
+          `Failed to decrypt stored secret${label} — the encryption key (OPTIO_ENCRYPTION_KEY) ` +
+            `has likely changed since it was saved. Re-enter the credential, or restore the ` +
+            `original encryption key. (${err instanceof Error ? err.message : String(err)})`,
+        );
+      }
     default:
       throw new Error(`Unsupported encryption algorithm: 0x${blob.alg.toString(16)}`);
   }
@@ -222,6 +240,7 @@ export async function retrieveSecret(
       authTag: secret.authTag,
     },
     aad,
+    name,
   );
 }
 
@@ -315,6 +334,7 @@ export async function healContradictoryGlobalSecrets(): Promise<number> {
             authTag: row.authTag,
           },
           oldAad,
+          row.name,
         );
 
         const [shadow] = await db

--- a/apps/api/src/services/webhook-service.ts
+++ b/apps/api/src/services/webhook-service.ts
@@ -61,6 +61,7 @@ function decryptWebhookRow(row: typeof webhooks.$inferSelect): WebhookRecord {
         authTag: row.secretAuthTag,
       },
       aad,
+      `webhook ${row.id} secret`,
     );
   }
   return {

--- a/packages/shared/src/error-classifier.test.ts
+++ b/packages/shared/src/error-classifier.test.ts
@@ -29,6 +29,43 @@ describe("classifyError", () => {
     expect(result.title).toContain("ANTHROPIC_API_KEY");
   });
 
+  it("classifies wrapped decrypt failure with secret name", () => {
+    const result = classifyError(
+      'Failed to decrypt stored secret "SLACK_TOKEN" — the encryption key (OPTIO_ENCRYPTION_KEY) ' +
+        "has likely changed since it was saved. Re-enter the credential, or restore the original " +
+        "encryption key. (Unsupported state or unable to authenticate data)",
+    );
+    expect(result.category).toBe("auth");
+    expect(result.title).toBe("Cannot decrypt secret: SLACK_TOKEN");
+    expect(result.remedy).toContain("encryption key");
+    expect(result.retryable).toBe(false);
+  });
+
+  it("classifies wrapped decrypt failure without secret name", () => {
+    const result = classifyError("Failed to decrypt stored secret — the encryption key changed");
+    expect(result.category).toBe("auth");
+    expect(result.title).toBe("Cannot decrypt stored secret");
+    expect(result.retryable).toBe(false);
+  });
+
+  it("classifies raw GCM auth failure (unwrapped)", () => {
+    const result = classifyError("Error: Unsupported state or unable to authenticate data");
+    expect(result.category).toBe("auth");
+    expect(result.title).toBe("Cannot decrypt stored secret");
+    expect(result.retryable).toBe(false);
+  });
+
+  it("prefers decrypt classification over credential-name patterns", () => {
+    // The message mentions ANTHROPIC_API_KEY, but the root cause is a decrypt
+    // failure — must not be classified as "Anthropic API key missing".
+    const result = classifyError(
+      'Failed to decrypt stored secret "ANTHROPIC_API_KEY" — the encryption key ' +
+        "(OPTIO_ENCRYPTION_KEY) has likely changed since it was saved.",
+    );
+    expect(result.title).toBe("Cannot decrypt secret: ANTHROPIC_API_KEY");
+    expect(result.retryable).toBe(false);
+  });
+
   it("classifies invalid state transition", () => {
     const result = classifyError(
       "InvalidTransitionError: Invalid state transition: failed -> provisioning",

--- a/packages/shared/src/error-classifier.ts
+++ b/packages/shared/src/error-classifier.ts
@@ -116,6 +116,31 @@ const ERROR_PATTERNS: Array<{
       retryable: true,
     }),
   },
+  // Must precede the credential-name patterns (ANTHROPIC_API_KEY, OPENAI_API_KEY, …)
+  // so a decrypt failure mentioning a secret's name isn't misclassified as a
+  // missing key. Matches both the wrapped message from secret-service.decrypt()
+  // and Node's raw AES-GCM auth failure in case it surfaces unwrapped.
+  {
+    pattern:
+      /failed to decrypt stored secret(?: "([^"]+)")?|unsupported state or unable to authenticate data/i,
+    classify: (match) => {
+      const name = match[1];
+      return {
+        category: "auth",
+        title: name ? `Cannot decrypt secret: ${name}` : "Cannot decrypt stored secret",
+        description:
+          `A stored secret${name ? ` ("${name}")` : ""} could not be decrypted. This almost always ` +
+          "means the encryption key (OPTIO_ENCRYPTION_KEY) changed after the secret was saved — " +
+          "for example, a redeploy generated a fresh key — so decryption fails for every " +
+          "previously stored credential.",
+        remedy:
+          "Re-enter the affected credentials under Secrets (or re-run the setup wizard), or " +
+          "restore the original encryption key (Helm value encryption.key) and redeploy. " +
+          "Retrying without doing one of these will keep failing.",
+        retryable: false,
+      };
+    },
+  },
   {
     pattern:
       /OAuth token has expired|authentication_failed|token.*expired|401.*authentication|pre-flight validation/i,

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -76,7 +76,17 @@ else
 fi
 
 echo "[5/6] Deploying Optio to Kubernetes via Helm..."
-ENCRYPTION_KEY=$(openssl rand -hex 32)
+# Reuse the existing encryption key if the release already has one. Rotating the
+# key invalidates every secret stored in Postgres (AES-256-GCM decryption fails
+# with "Unsupported state or unable to authenticate data") — see issue #553.
+ENCRYPTION_KEY=$(kubectl get secret optio-config -n optio \
+  -o jsonpath='{.data.OPTIO_ENCRYPTION_KEY}' 2>/dev/null | base64 -d || true)
+if [ -n "$ENCRYPTION_KEY" ]; then
+  echo "   Reusing existing encryption key from optio-config secret."
+else
+  echo "   Generating new encryption key..."
+  ENCRYPTION_KEY=$(openssl rand -hex 32)
+fi
 
 if helm status optio -n optio &>/dev/null; then
   echo "   Existing release found, upgrading..."

--- a/scripts/update-local.sh
+++ b/scripts/update-local.sh
@@ -86,6 +86,9 @@ echo "   Images built."
 
 # Rolling restart
 echo "[4/4] Restarting deployments..."
+# NOTE: --reset-then-reuse-values carries forward the release's existing values,
+# including encryption.key. Never pass a freshly generated encryption key here —
+# rotating it invalidates all stored secrets (see issue #553 and setup-local.sh).
 helm upgrade optio helm/optio -n optio -f helm/optio/values.local.yaml --reset-then-reuse-values
 
 DEPLOYMENTS="deployment/optio-api deployment/optio-web"


### PR DESCRIPTION
Related to #553

The "Unsupported state or unable to authenticate data" failure reported there is what AES-256-GCM decryption throws when the encryption key no longer matches the one the secret was stored under. Two fixes:

## 1. `setup-local.sh` no longer rotates the encryption key on re-runs

`ENCRYPTION_KEY=$(openssl rand -hex 32)` ran unconditionally — including on the `helm upgrade` path — so every re-run of `setup-local.sh` silently rotated the key and invalidated **all** stored secrets. The script now reads the existing key from the release's `optio-config` k8s secret (`OPTIO_ENCRYPTION_KEY`) and reuses it, generating a fresh key only on first install.

`update-local.sh` already preserves the key via `--reset-then-reuse-values`; added a comment documenting that invariant so it isn't broken later.

## 2. Decrypt failures now carry context and a remedy

- `decrypt()` in `secret-service.ts` wraps GCM auth failures: `Failed to decrypt stored secret "NAME" — the encryption key (OPTIO_ENCRYPTION_KEY) has likely changed since it was saved. Re-enter the credential, or restore the original encryption key. (<original error>)`. The secret name/id is included where call sites have it (`retrieveSecret`, heal loop, repo Slack webhook URL, webhook secret) — never the value. Original error text is preserved for debugging.
- New `error-classifier.ts` pattern (matches both the wrapped message and the raw Node error) classifies it as `auth`, non-retryable, with a remedy shown in the UI. Ordered before the credential-name patterns so a decrypt failure for e.g. `ANTHROPIC_API_KEY` isn't misclassified as a missing key.

## Testing

- `pnpm turbo typecheck` — clean
- `secret-service.test.ts` (63 tests) — new coverage: wrapped message on key rotation, original error preserved, name included / value never included, AAD-mismatch wrapping, unsupported-alg errors not wrapped, `retrieveSecret` propagating the name
- `error-classifier.test.ts` (33 tests) — new coverage: wrapped with/without name, raw GCM error, precedence over credential-name patterns
- `repo-service.test.ts` / `webhook-service.test.ts` — pass
- `bash -n` on both scripts

### Manual verification of the script change

1. `./scripts/setup-local.sh` on a cluster with an existing release → logs "Reusing existing encryption key from optio-config secret"; `kubectl get secret optio-config -n optio -o jsonpath='{.data.OPTIO_ENCRYPTION_KEY}'` is unchanged before/after, and previously stored secrets still decrypt.
2. `helm uninstall optio -n optio` then `./scripts/setup-local.sh` → logs "Generating new encryption key..." (fresh install path).
3. `./scripts/update-local.sh` → key unchanged.

Not auto-closing #553 — the reporter's instance already has secrets encrypted under a lost key, so they need to re-enter their credentials (or restore the original key) to recover; the new error/classifier will now say exactly that.
