### PR TITLE
fix: fail runs on terminal Claude API errors instead of marking them Done

### DIFF
--- a/apps/api/src/workers/task-worker.test.ts
+++ b/apps/api/src/workers/task-worker.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   buildAgentCommand,
   buildInitialClaudeStreamMessage,
+  classifyRunOutcome,
   inferExitCode,
   shouldEscalateNoPr,
 } from "./task-worker.js";
+import { ClaudeCodeAdapter } from "@optio/agent-adapters";
 
 describe("buildAgentCommand", () => {
   describe("claude-code agent", () => {
@@ -438,5 +440,90 @@ describe("shouldEscalateNoPr", () => {
         detectedPrUrl: "https://github.com/org/repo/pull/1",
       }),
     ).toBe(false);
+  });
+});
+
+describe("classifyRunOutcome", () => {
+  const defaults = {
+    success: true,
+    isReviewTask: false,
+    sessionId: "sess-1" as string | undefined,
+    detectedPrUrl: undefined as string | undefined | null,
+  };
+
+  it("returns no_output when a non-review run produced no session", () => {
+    expect(classifyRunOutcome({ ...defaults, sessionId: undefined })).toBe("no_output");
+  });
+
+  it("returns pr_opened when a PR was detected on a non-review run", () => {
+    expect(
+      classifyRunOutcome({ ...defaults, detectedPrUrl: "https://github.com/org/repo/pull/42" }),
+    ).toBe("pr_opened");
+  });
+
+  it("never returns pr_opened for review tasks", () => {
+    expect(
+      classifyRunOutcome({
+        ...defaults,
+        isReviewTask: true,
+        detectedPrUrl: "https://github.com/org/repo/pull/42",
+      }),
+    ).toBe("success");
+  });
+
+  it("returns success for a successful run", () => {
+    expect(classifyRunOutcome(defaults)).toBe("success");
+  });
+
+  it("returns failure for a failed non-review run", () => {
+    expect(classifyRunOutcome({ ...defaults, success: false })).toBe("failure");
+  });
+
+  it("returns failure for a failed review run (issue #552 regression)", () => {
+    // Previously review tasks were unconditionally routed to the success
+    // branch, marking API-error review runs as completed.
+    expect(classifyRunOutcome({ ...defaults, success: false, isReviewTask: true })).toBe("failure");
+  });
+
+  it("returns success for a successful review run", () => {
+    expect(classifyRunOutcome({ ...defaults, isReviewTask: true })).toBe("success");
+  });
+
+  it("fails the reporter's exact scenario: review run, API error result event, exit 0", () => {
+    // Issue #552: Claude Code hit "API Error: Usage credits required for 1M
+    // context", emitted an is_error result event, and exited 0. The task was
+    // wrongly marked Done (agent success) with the error in the message.
+    const apiError =
+      "API Error: Usage credits required for 1M context · turn on usage credits at claude.ai/settings/usage, or use --model to switch to standard context";
+    const logs = [
+      '{"type":"system","subtype":"init","session_id":"s-1","model":"claude-sonnet-4-6[1m]","tools":[]}',
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s-1",
+        message: { content: [{ type: "text", text: apiError }] },
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        result: apiError,
+        num_turns: 1,
+        duration_ms: 500,
+        session_id: "s-1",
+      }),
+    ].join("\n");
+
+    const exitCode = inferExitCode("claude-code", logs);
+    const result = new ClaudeCodeAdapter().parseResult(exitCode, logs);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Usage credits required for 1M context");
+
+    const outcome = classifyRunOutcome({
+      success: result.success,
+      isReviewTask: true,
+      sessionId: "s-1",
+      detectedPrUrl: undefined,
+    });
+    expect(outcome).toBe("failure");
   });
 });

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -1147,7 +1147,14 @@ export function startTaskWorker() {
         }
         const detectedPrUrl = capturedPrUrl || taskAfterExec?.prUrl || fallbackPrUrl;
 
-        if (!sessionId && !isReviewTask) {
+        const outcome = classifyRunOutcome({
+          success: result.success,
+          isReviewTask,
+          sessionId,
+          detectedPrUrl,
+        });
+
+        if (outcome === "no_output") {
           // Agent never started — no session ID means no agent output was produced.
           await repoPool.updateWorktreeState(taskId, "dirty");
           await taskService.transitionTask(
@@ -1157,7 +1164,7 @@ export function startTaskWorker() {
             "Agent process exited without producing any output",
           );
           log.warn("Agent exited without output — no session ID captured");
-        } else if (detectedPrUrl && !isReviewTask) {
+        } else if (outcome === "pr_opened" && detectedPrUrl) {
           // PR exists — go to pr_opened regardless of exit code.
           if (detectedPrUrl !== taskAfterExec?.prUrl) {
             await taskService.updateTaskPr(taskId, detectedPrUrl);
@@ -1171,11 +1178,15 @@ export function startTaskWorker() {
             detectedPrUrl,
           );
           log.info({ prUrl: detectedPrUrl }, "PR opened");
-        } else if (result.success || isReviewTask) {
+        } else if (outcome === "success") {
           // External PR reviews no longer run here — they execute under
           // pr_review_runs via pr-review-worker.ts. Subtask reviews
           // (`taskType === "review"`) still flow through this path and
           // their result lands in the parent coding task's comments.
+          // Failed review runs (e.g. terminal API errors, issue #552) take the
+          // failure branch below like any other run — they must not be marked
+          // completed, which would both show a false green state and count as
+          // an approval for auto-merge in subtask-service.
 
           // Planning mode: agent finished planning — wait for human approval
           if (isPlanningRun && !isReviewTask) {
@@ -1798,6 +1809,29 @@ export function buildAgentCommand(
  * opening one, the work didn't ship — the user should be notified so they can
  * resume or restart the agent.
  */
+/**
+ * Classify how a finished agent run should be handled.
+ *
+ * - "no_output"  — agent produced no session/output at all (non-review only)
+ * - "pr_opened"  — a PR was detected (non-review only; reviews never own a PR)
+ * - "success"    — agent finished successfully
+ * - "failure"    — agent failed; applies to review subtasks too. A review run
+ *   that ends in a terminal agent error (e.g. "API Error: Usage credits
+ *   required", issue #552) must be failed — previously reviews unconditionally
+ *   completed, hiding the error behind a green state and counting as an
+ *   approval for auto-merge.
+ */
+export function classifyRunOutcome(opts: {
+  success: boolean;
+  isReviewTask: boolean;
+  sessionId: string | undefined;
+  detectedPrUrl: string | undefined | null;
+}): "no_output" | "pr_opened" | "success" | "failure" {
+  if (!opts.sessionId && !opts.isReviewTask) return "no_output";
+  if (opts.detectedPrUrl && !opts.isReviewTask) return "pr_opened";
+  return opts.success ? "success" : "failure";
+}
+
 export function shouldEscalateNoPr(opts: {
   success: boolean;
   isReviewTask: boolean;

--- a/packages/agent-adapters/src/claude-code.test.ts
+++ b/packages/agent-adapters/src/claude-code.test.ts
@@ -322,14 +322,94 @@ describe("ClaudeCodeAdapter", () => {
     it("extracts error from result event with is_error=true when exitCode is non-zero", () => {
       const logs = '{"type":"result","is_error":true,"result":"API rate limit exceeded"}';
       const result = adapter.parseResult(1, logs);
+      expect(result.success).toBe(false);
       expect(result.error).toBe("API rate limit exceeded");
     });
 
-    it("does NOT extract error from is_error result when exitCode is 0", () => {
+    it("fails on an is_error result event even when exitCode is 0 (issue #552)", () => {
+      // Claude Code in stream-json mode exits 0 after stdin closes, so the
+      // process exit code cannot be trusted — the result event is authoritative.
       const logs = '{"type":"result","is_error":true,"result":"API rate limit exceeded"}';
+      const result = adapter.parseResult(0, logs);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("API rate limit exceeded");
+      expect(result.summary).toBe("Agent error: API rate limit exceeded");
+    });
+
+    it("reproduces issue #552: usage-credit API error with exit 0 and no real result", () => {
+      const apiError =
+        "API Error: Usage credits required for 1M context · turn on usage credits at claude.ai/settings/usage, or use --model to switch to standard context";
+      const logs = [
+        '{"type":"system","subtype":"init","model":"claude-sonnet-4-6[1m]","tools":[]}',
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: apiError }] },
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          result: apiError,
+          num_turns: 1,
+          duration_ms: 500,
+        }),
+      ].join("\n");
+      const result = adapter.parseResult(0, logs);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Usage credits required for 1M context");
+      expect(result.summary).toMatch(/^Agent error: API Error: Usage credits required/);
+    });
+
+    it("fails on an is_error result event with no result text, using subtype", () => {
+      const logs = '{"type":"result","subtype":"error_during_execution","is_error":true}';
+      const result = adapter.parseResult(0, logs);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Agent reported an error result (error_during_execution)");
+    });
+
+    it("fails when an API error is emitted and no result event follows (crash)", () => {
+      const logs = [
+        '{"type":"system","subtype":"init","model":"claude-sonnet-4-6","tools":[]}',
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "API Error: 500 Internal Server Error" }] },
+        }),
+      ].join("\n");
+      const result = adapter.parseResult(0, logs);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("API Error: 500 Internal Server Error");
+    });
+
+    it("still succeeds when a transient API error is recovered and a real result follows", () => {
+      const logs = [
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "API Error: 529 Overloaded (retrying)" }] },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Finished the review." }] },
+        }),
+        '{"type":"result","is_error":false,"result":"Review complete: LGTM"}',
+      ].join("\n");
       const result = adapter.parseResult(0, logs);
       expect(result.success).toBe(true);
       expect(result.error).toBeUndefined();
+      expect(result.summary).toBe("Review complete: LGTM");
+    });
+
+    it("does not treat ordinary assistant text mentioning errors as failure", () => {
+      const logs = [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "The API Error handling in foo.ts looks fine." }],
+          },
+        }),
+        '{"type":"result","is_error":false,"result":"All good"}',
+      ].join("\n");
+      const result = adapter.parseResult(0, logs);
+      expect(result.success).toBe(true);
     });
 
     it("falls back to Exit code: N when no structured error", () => {

--- a/packages/agent-adapters/src/claude-code.ts
+++ b/packages/agent-adapters/src/claude-code.ts
@@ -116,11 +116,22 @@ export class ClaudeCodeAdapter implements AgentAdapter {
     const costMatch = logs.match(/"total_cost_usd":\s*([\d.]+)/);
 
     // Extract error, token usage, model, and result text from Claude's NDJSON events
-    let error: string | undefined;
-    let resultText: string | undefined;
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let model: string | undefined;
+
+    // Track the final result event — the authoritative signal for how the run
+    // ended. With --input-format stream-json each turn emits a result event and
+    // the CLI then exits 0 once stdin closes, so the process exit code alone
+    // cannot be trusted (see issue #552: an API-error run exited 0).
+    let sawResultEvent = false;
+    let lastResultIsError = false;
+    let lastResultText: string | undefined;
+    let lastResultSubtype: string | undefined;
+    // Synthetic assistant text Claude Code emits when an API call fails
+    // ("API Error: ..."). Only used as a failure signal when the run never
+    // produced a result event (i.e. the error was terminal, not recovered).
+    let lastApiErrorText: string | undefined;
 
     for (const line of logs.split("\n")) {
       try {
@@ -144,32 +155,70 @@ export class ClaudeCodeAdapter implements AgentAdapter {
           }
         }
 
-        // Extract result text from the final result event
-        if (event.type === "result" && event.result) {
-          if (event.is_error && exitCode !== 0) {
-            error = event.result;
-          } else if (!event.is_error) {
-            resultText = event.result;
+        // Track API-error text blocks emitted as synthetic assistant messages
+        if (event.type === "assistant" && Array.isArray(event.message?.content)) {
+          for (const block of event.message.content) {
+            if (
+              block?.type === "text" &&
+              typeof block.text === "string" &&
+              /^API Error[:\s]/.test(block.text.trim())
+            ) {
+              lastApiErrorText = block.text.trim();
+            }
           }
+        }
+
+        // Track the final result event (last one wins across multiple turns)
+        if (event.type === "result") {
+          sawResultEvent = true;
+          lastResultIsError = event.is_error === true;
+          lastResultSubtype = typeof event.subtype === "string" ? event.subtype : undefined;
+          lastResultText =
+            typeof event.result === "string" && event.result ? event.result : undefined;
         }
       } catch {
         // Not JSON, skip
       }
     }
 
+    let error: string | undefined;
+    let resultText: string | undefined;
+    // Did the agent itself report a terminal, unrecovered error?
+    let agentReportedError = false;
+
+    if (sawResultEvent && lastResultIsError) {
+      // Terminal error result (e.g. "API Error: Usage credits required") —
+      // authoritative failure even when the CLI process exits 0.
+      agentReportedError = true;
+      error =
+        lastResultText ??
+        lastApiErrorText ??
+        `Agent reported an error result${lastResultSubtype ? ` (${lastResultSubtype})` : ""}`;
+    } else if (sawResultEvent) {
+      // A successful final result event supersedes any transient API errors
+      // the agent recovered from mid-run.
+      resultText = lastResultText;
+    } else if (lastApiErrorText) {
+      // API error with no result event at all — the run died on the error.
+      agentReportedError = true;
+      error = lastApiErrorText;
+    }
+
     if (exitCode !== 0 && !error) {
       error = `Exit code: ${exitCode}`;
     }
+
+    const success = exitCode === 0 && !agentReportedError;
 
     // Use the agent's actual result text as the summary when available.
     // When the agent reports an explicit error, surface it in the summary
     // so users see what went wrong without digging into raw logs.
     let summary: string;
-    const hasStructuredError = exitCode !== 0 && error && error !== `Exit code: ${exitCode}`;
+    const hasStructuredError = !success && error && error !== `Exit code: ${exitCode}`;
     if (hasStructuredError) {
       const preview = error!.length > 500 ? error!.slice(0, 500) + "…" : error!;
       summary = `Agent error: ${preview}`;
-    } else if (exitCode !== 0) {
+    } else if (!success) {
       summary = `Agent exited with code ${exitCode}`;
     } else if (resultText) {
       // Truncate very long result texts for the summary field
@@ -179,7 +228,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
     }
 
     return {
-      success: exitCode === 0,
+      success,
       prUrl: prMatch?.[0],
       costUsd: costMatch ? parseFloat(costMatch[1]) : undefined,
       inputTokens: totalInputTokens > 0 ? totalInputTokens : undefined,


### PR DESCRIPTION
## Root cause

Issue #552: a Claude Code review run hit `API Error: Usage credits required for 1M context`, exited 0 after one turn, and was marked **Done** with the activity line `Running → Done, agent success — Agent error: API Error: ...`. Two bugs combined:

1. **`ClaudeCodeAdapter.parseResult` trusted the process exit code alone** (`success: exitCode === 0`). In `--input-format stream-json` mode the CLI exits 0 once stdin closes, so the exit code says nothing about how the run ended — the terminal `{"type":"result","is_error":true,...}` event is the authoritative signal, and it was ignored for classification. Error text was also only extracted when `exitCode !== 0`, so `workflow-worker` and `persistent-agent-worker` (which call `parseResult(0, logs)`) both classified API-error runs as successful with no error message.

2. **`task-worker` unconditionally routed review subtasks to the completed branch**: `else if (result.success || isReviewTask)`. Even when `inferExitCode` correctly turned the `is_error` result event into a failure (which is why the error text appeared in the transition message), the review was still transitioned to `COMPLETED` with reason `agent_success`. Worse, a failed-but-"completed" review counted as `state === "completed"` in `subtask-service.onSubtaskComplete`'s `anyApproved` check — an errored review could trigger **auto-merge**.

## Changes

- `packages/agent-adapters/src/claude-code.ts` — `parseResult` now tracks the final result event: an `is_error` result fails the run regardless of exit code and its text (or subtype) becomes `error`; an `API Error: ...` synthetic assistant message with **no** result event at all (agent died on the error) also fails. A transient API error the agent recovers from is unaffected — a later successful result event supersedes it. This fixes the same false-success in standalone Jobs and Persistent Agent turns, which parse with a hardcoded exit code 0.
- `apps/api/src/workers/task-worker.ts` — removed the `|| isReviewTask` bypass via a pure, exported `classifyRunOutcome()` helper. Failed review runs now take the normal failure path: `FAILED` with `errorMessage` surfaced on the row. The reconciler excludes `FAILED` review subtasks from `hasReviewSubtask`, so a fresh review can be relaunched on the next CI-pass/PR edge, and force-redo still works.
- External PR reviews (`pr-review-worker`) already checked `result.success`; they now additionally benefit from the hardened adapter classification.

## Tests

- `claude-code.test.ts`: reproduces the reporter's scenario (API error result event, exit 0, no real result → `success: false`, error surfaced); error result with no result text; API error + crash with no result event; recovered transient API error still succeeds; prose mentioning "API Error" not misclassified.
- `task-worker.test.ts`: `classifyRunOutcome` matrix including the #552 regression (failed review → `"failure"`), plus an end-to-end `inferExitCode` → `parseResult` → `classifyRunOutcome` reproduction of the reporter's log.

`pnpm turbo typecheck`, `pnpm turbo test` (2154 API + 45 adapter tests), and `pnpm format:check` all pass.

Fixes #552