### PR TITLE
fix(reconciler): ms-truncate standalone CAS guard; stop auto-retrying cancelled runs

### DIFF
--- a/apps/api/src/services/reconcile-executor.int.test.ts
+++ b/apps/api/src/services/reconcile-executor.int.test.ts
@@ -10,16 +10,14 @@
  *
  * so reconcileOnce() below composes those same three calls.
  *
- * Precision note (discovered against the real DB): applyStandaloneTransition
- * CAS-guards with a plain `eq(workflowRuns.updatedAt, version)` — unlike
- * casUpdate(), which truncates both sides to milliseconds. A row whose
- * updated_at was last written by PG `now()` (microsecond precision) therefore
- * NEVER matches the ms-precision snapshot version, and every standalone
- * transition from it returns "stale". In production runs reach FAILED via
- * worker/service writes that stamp a JS Date (ms precision), so the guard
- * works there; these tests seed `updatedAt: new Date()` to mirror that, and
- * pin the µs-precision behavior (both the stale transition and the µs-safe
- * casUpdate path) in dedicated tests at the bottom.
+ * Precision note (discovered against the real DB): Postgres `timestamptz`
+ * columns store microseconds while JS Dates carry milliseconds, so every CAS
+ * guard in the executor — including applyStandaloneTransition's — compares
+ * updated_at truncated to milliseconds (see updatedAtMatches). A plain eq()
+ * would silently never match a row whose updated_at was last written by PG
+ * `now()`/`defaultNow()`, leaving every standalone transition from it
+ * permanently "stale". Dedicated tests at the bottom pin the µs-safe behavior
+ * on both the transition and casUpdate paths.
  *
  * Covers:
  *  - QUEUED run → enqueueAgent → the BullMQ "workflow-runs" queue receives
@@ -33,9 +31,11 @@
  *    snapshot is rejected ("cas_failed_standalone_transition") instead of
  *    double-applying.
  *  - FAILED run with retries exhausted stays FAILED, with no write at all.
- *  - control_intent="cancel" on a QUEUED run → FAILED, intent cleared, no
- *    agent job enqueued.
- *  - The µs/ms CAS seam, both ways (see precision note above).
+ *  - control_intent="cancel" on a QUEUED run → FAILED with the retry budget
+ *    exhausted, intent cleared, no agent job enqueued — and the next pass
+ *    leaves the cancelled run alone instead of auto-retrying it.
+ *  - The µs/ms CAS seam: transitions and casUpdate both apply from
+ *    µs-stamped rows (see precision note above).
  */
 import { afterAll, describe, expect, it } from "vitest";
 import { Queue } from "bullmq";
@@ -255,28 +255,30 @@ describe("reconcile standalone: snapshot → decide → execute", () => {
     expect(row.controlIntent).toBeNull();
     expect(row.errorMessage).toBe("Cancelled by user");
     expect(row.finishedAt).not.toBeNull();
+    // Cancellation exhausts the retry budget (insertWorkflow's maxRetries
+    // defaults to 1) so decideFailed cannot auto-retry the cancelled run.
+    expect(row.retryCount).toBe(1);
 
     // The intent short-circuits before decideQueued — no agent job enqueued.
     expect(await agentJobsFor(run.id)).toHaveLength(0);
 
-    // Actual (surprising) follow-up behavior, decision-only so the cancelled
-    // state above stays put: the run is now FAILED with retryCount 0 <
-    // maxRetries and no intent, and decideFailed does not distinguish user
-    // cancellation from agent failure — the next pass would auto-retry the
-    // cancelled run back to QUEUED. (Production cancels via
-    // workflowService.cancelWorkflowRun land in the same failed shape.)
-    const followUpSnapshot = (await buildWorldSnapshot({ kind: "standalone", id: run.id }))!;
-    const followUpAction = reconcileStandalone(followUpSnapshot);
-    expect(followUpAction).toMatchObject({
-      kind: "transition",
-      to: WorkflowRunState.QUEUED,
-      trigger: "auto_retry",
-    });
+    // Follow-up pass: decideFailed sees no retry budget left and leaves the
+    // cancelled run alone. (Before the retry-budget stamp, it treated the
+    // cancellation like any failure and flipped it back to QUEUED — a
+    // user-cancelled run silently reran.)
+    const followUp = await reconcileOnce(run.id);
+    expect(followUp.action).toEqual({ kind: "noop", reason: "failed_no_retry_intent" });
+    expect(followUp.outcome).toEqual({ status: "skipped", reason: "failed_no_retry_intent" });
+    const rowAfter = await getRun(run.id);
+    expect(rowAfter.state).toBe("failed");
+    expect(rowAfter.errorMessage).toBe("Cancelled by user");
+    expect(rowAfter.updatedAt.getTime()).toBe(row.updatedAt.getTime());
+    expect(await agentJobsFor(run.id)).toHaveLength(0);
   });
 });
 
 describe("reconcile standalone: µs/ms updated_at precision seam", () => {
-  it("standalone transition goes permanently stale when updated_at carries microseconds", async () => {
+  it("standalone transition applies when updated_at carries microseconds", async () => {
     const workflow = await insertWorkflow();
     const run = await insertWorkflowRun(workflow.id, {
       state: "failed",
@@ -293,22 +295,26 @@ describe("reconcile standalone: µs/ms updated_at precision seam", () => {
     `);
 
     // The decision is a normal auto-retry transition...
-    const { action, outcome } = await reconcileOnce(run.id);
+    const { snapshot, action, outcome } = await reconcileOnce(run.id);
     expect(action).toMatchObject({ kind: "transition", to: WorkflowRunState.QUEUED });
 
-    // ...but applyStandaloneTransition guards with a plain eq(updatedAt,
-    // version) — no date_trunc, unlike casUpdate — so the ms-truncated
-    // snapshot version never matches the µs-precision stored value and the
-    // write is refused. Re-running the pass yields the same stale outcome:
-    // the auto-retry can never apply until some other writer stamps a
-    // ms-precision updated_at.
-    expect(outcome).toEqual({ status: "stale", reason: "cas_failed_standalone_transition" });
-    const again = await reconcileOnce(run.id);
-    expect(again.outcome).toEqual({ status: "stale", reason: "cas_failed_standalone_transition" });
+    // ...and applyStandaloneTransition now guards with the same ms-truncating
+    // updated_at comparison as casUpdate, so the ms-precision snapshot version
+    // matches the µs-precision stored value and the write applies. (It used
+    // to be a plain eq(updatedAt, version), which NEVER matched a µs-stamped
+    // row — every transition from it was permanently stale.)
+    expect(outcome).toEqual({ status: "applied", reason: "standalone_transition:queued" });
 
     const row = await getRun(run.id);
-    expect(row.state).toBe("failed");
-    expect(row.retryCount).toBe(0);
+    expect(row.state).toBe("queued");
+    expect(row.retryCount).toBe(1);
+    expect(row.errorMessage).toBeNull();
+
+    // CAS integrity is intact: replaying the same action from the now-stale
+    // snapshot is still refused (updated_at and state have both moved on).
+    const replay = await executeAction(action, snapshot);
+    expect(replay).toEqual({ status: "stale", reason: "cas_failed_standalone_transition" });
+    expect((await getRun(run.id)).retryCount).toBe(1);
   });
 
   it("clearControlIntent uses the date_trunc CAS and applies despite microsecond precision", async () => {

--- a/apps/api/src/services/reconcile-executor.ts
+++ b/apps/api/src/services/reconcile-executor.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, sql, type SQL, type SQLWrapper } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { tasks, workflowRuns, prReviews, persistentAgents } from "../db/schema.js";
 import type {
@@ -235,7 +235,11 @@ async function applyStandaloneTransition(
     .where(
       and(
         eq(workflowRuns.id, id),
-        eq(workflowRuns.updatedAt, version),
+        // Ms-truncating comparison, NOT a plain eq — see updatedAtMatches. A
+        // raw eq() silently never matches rows whose updated_at carries
+        // microseconds (e.g. stamped by PG's now()/defaultNow()), which made
+        // every standalone transition from such rows permanently stale.
+        updatedAtMatches(workflowRuns.updatedAt, version),
         eq(workflowRuns.state, fromState),
       ),
     )
@@ -614,6 +618,22 @@ async function publishStandaloneStateChange(
 
 // ── CAS helpers ─────────────────────────────────────────────────────────────
 
+/**
+ * Millisecond-precision `updated_at` comparison — the ONE way every CAS guard
+ * in this file must compare versions. Postgres `timestamptz` columns store
+ * microseconds, but JavaScript's Date type only carries milliseconds — so a
+ * JS-side `eq(updated_at, version)` against a row whose updated_at was set by
+ * PG's `now()`/`defaultNow()` (microsecond precision) will silently never
+ * match, leaving the row permanently "stale" to the executor. We truncate
+ * both sides to milliseconds so the round-trip is symmetric. JS-originated
+ * writes are already ms-precision so this is exactly the comparison we want
+ * everywhere.
+ */
+function updatedAtMatches(column: SQLWrapper, version: Date): SQL {
+  return sql`date_trunc('milliseconds', ${column})
+      = date_trunc('milliseconds', ${version.toISOString()}::timestamptz)`;
+}
+
 async function casUpdate(
   table: "tasks" | "workflow_runs" | "pr_reviews" | "persistent_agents",
   id: string,
@@ -621,24 +641,11 @@ async function casUpdate(
   patch: Record<string, unknown>,
 ): Promise<"applied" | "stale"> {
   const payload = { ...patch, updatedAt: new Date() };
-  // Compare timestamps at millisecond precision. Postgres `timestamptz`
-  // columns store microseconds, but JavaScript's Date type only carries
-  // milliseconds — so a JS-side `eq(updated_at, version)` against a row
-  // whose updated_at was set by PG's `now()` (microsecond precision) will
-  // silently never match. We truncate both sides to milliseconds so the
-  // round-trip is symmetric. JS-originated writes are already ms-precision
-  // so this is exactly the comparison we want everywhere.
   if (table === "tasks") {
     const rows = await db
       .update(tasks)
       .set(payload)
-      .where(
-        and(
-          eq(tasks.id, id),
-          sql`date_trunc('milliseconds', ${tasks.updatedAt})
-              = date_trunc('milliseconds', ${version.toISOString()}::timestamptz)`,
-        ),
-      )
+      .where(and(eq(tasks.id, id), updatedAtMatches(tasks.updatedAt, version)))
       .returning({ id: tasks.id });
     return rows.length > 0 ? "applied" : "stale";
   }
@@ -646,13 +653,7 @@ async function casUpdate(
     const rows = await db
       .update(prReviews)
       .set(payload)
-      .where(
-        and(
-          eq(prReviews.id, id),
-          sql`date_trunc('milliseconds', ${prReviews.updatedAt})
-              = date_trunc('milliseconds', ${version.toISOString()}::timestamptz)`,
-        ),
-      )
+      .where(and(eq(prReviews.id, id), updatedAtMatches(prReviews.updatedAt, version)))
       .returning({ id: prReviews.id });
     return rows.length > 0 ? "applied" : "stale";
   }
@@ -661,11 +662,7 @@ async function casUpdate(
       .update(persistentAgents)
       .set(payload)
       .where(
-        and(
-          eq(persistentAgents.id, id),
-          sql`date_trunc('milliseconds', ${persistentAgents.updatedAt})
-              = date_trunc('milliseconds', ${version.toISOString()}::timestamptz)`,
-        ),
+        and(eq(persistentAgents.id, id), updatedAtMatches(persistentAgents.updatedAt, version)),
       )
       .returning({ id: persistentAgents.id });
     return rows.length > 0 ? "applied" : "stale";
@@ -673,13 +670,7 @@ async function casUpdate(
   const rows = await db
     .update(workflowRuns)
     .set(payload)
-    .where(
-      and(
-        eq(workflowRuns.id, id),
-        sql`date_trunc('milliseconds', ${workflowRuns.updatedAt})
-            = date_trunc('milliseconds', ${version.toISOString()}::timestamptz)`,
-      ),
-    )
+    .where(and(eq(workflowRuns.id, id), updatedAtMatches(workflowRuns.updatedAt, version)))
     .returning({ id: workflowRuns.id });
   return rows.length > 0 ? "applied" : "stale";
 }

--- a/apps/api/src/services/workflow-service.int.test.ts
+++ b/apps/api/src/services/workflow-service.int.test.ts
@@ -8,16 +8,19 @@
  *   - createWorkflowRun: queued row insert + BullMQ enqueue on "workflow-runs"
  *   - transitionWorkflowRunState state-machine enforcement
  *   - appendWorkflowRunLog / getWorkflowRunLogs roundtrip incl. logType filter
- *   - retryWorkflowRun / cancelWorkflowRun state rules
+ *   - retryWorkflowRun / cancelWorkflowRun state rules, incl. cancel
+ *     exhausting the retry budget so the reconciler cannot auto-retry
+ *     a user-cancelled run
  */
 import { randomUUID } from "node:crypto";
 import { afterAll, describe, expect, it } from "vitest";
 import { Queue } from "bullmq";
 import { eq } from "drizzle-orm";
-import { WorkflowRunState } from "@optio/shared";
+import { WorkflowRunState, reconcileStandalone } from "@optio/shared";
 import { db } from "../db/client.js";
 import { workflowRuns } from "../db/schema.js";
 import * as workflowService from "./workflow-service.js";
+import { buildWorldSnapshot } from "./reconcile-snapshot.js";
 import { getBullMQConnectionOptions } from "./redis-config.js";
 import {
   insertWorkflow,
@@ -352,14 +355,36 @@ describe("retryWorkflowRun / cancelWorkflowRun", () => {
     );
   });
 
-  it("cancel fails a queued run with a cancellation message", async () => {
-    const wf = await insertWorkflow();
+  it("cancel fails a queued run with a cancellation message and exhausts the retry budget", async () => {
+    const wf = await insertWorkflow({ maxRetries: 3 });
     const run = await insertWorkflowRun(wf.id); // queued
 
     const cancelled = await workflowService.cancelWorkflowRun(run.id);
     expect(cancelled.state).toBe(WorkflowRunState.FAILED);
     expect(cancelled.errorMessage).toBe("Cancelled by user");
     expect(cancelled.finishedAt).toBeInstanceOf(Date);
+    // retryCount is stamped to the workflow's maxRetries so the reconciler's
+    // decideFailed — which auto-retries any FAILED run with budget left and
+    // cannot tell a user cancel from an agent failure — leaves it alone.
+    expect(cancelled.retryCount).toBe(3);
+
+    // Prove it end-to-end against the reconciler's decision function: the
+    // cancelled run's snapshot decides noop, not auto_retry back to QUEUED.
+    const snapshot = await buildWorldSnapshot({ kind: "standalone", id: run.id });
+    expect(snapshot).not.toBeNull();
+    expect(reconcileStandalone(snapshot!)).toEqual({
+      kind: "noop",
+      reason: "failed_no_retry_intent",
+    });
+  });
+
+  it("cancel never lowers a retryCount already above the workflow's maxRetries", async () => {
+    const wf = await insertWorkflow({ maxRetries: 1 });
+    const run = await insertWorkflowRun(wf.id, { state: "running", retryCount: 4 });
+
+    const cancelled = await workflowService.cancelWorkflowRun(run.id);
+    expect(cancelled.state).toBe(WorkflowRunState.FAILED);
+    expect(cancelled.retryCount).toBe(4);
   });
 
   it("cancel rejects runs already in a state that cannot fail", async () => {

--- a/apps/api/src/services/workflow-service.ts
+++ b/apps/api/src/services/workflow-service.ts
@@ -455,6 +455,13 @@ export async function retryWorkflowRun(id: string) {
 
 /**
  * Cancel a running workflow run by transitioning it to failed.
+ *
+ * Also exhausts the run's retry budget (retryCount = workflow.maxRetries):
+ * the reconciler's decideFailed auto-retries any FAILED run with budget left
+ * and cannot tell a user cancellation from an agent failure — without this a
+ * cancelled run silently reruns. An explicit user retry via retryWorkflowRun
+ * still works (it does not consult maxRetries). The reconciler's
+ * control_intent=cancel path stamps the same shape.
  */
 export async function cancelWorkflowRun(id: string) {
   const run = await getWorkflowRun(id);
@@ -467,12 +474,15 @@ export async function cancelWorkflowRun(id: string) {
 
   transitionWorkflowRun(currentState, WorkflowRunState.FAILED);
 
+  const workflow = await getWorkflow(run.workflowId);
+
   const [updated] = await db
     .update(workflowRuns)
     .set({
       state: WorkflowRunState.FAILED,
       errorMessage: "Cancelled by user",
       finishedAt: new Date(),
+      retryCount: Math.max(run.retryCount ?? 0, workflow?.maxRetries ?? 0),
       updatedAt: new Date(),
     })
     .where(eq(workflowRuns.id, id))

--- a/packages/shared/src/reconcile/reconcile-standalone.test.ts
+++ b/packages/shared/src/reconcile/reconcile-standalone.test.ts
@@ -133,14 +133,20 @@ describe("reconcileStandalone — world-read failures", () => {
 // ── Intent ──────────────────────────────────────────────────────────────────
 
 describe("reconcileStandalone — control intent", () => {
-  it("cancel from QUEUED transitions to FAILED", () => {
-    const s = snapshot({}, { state: WorkflowRunState.QUEUED, controlIntent: "cancel" });
+  it("cancel from QUEUED transitions to FAILED with the retry budget exhausted", () => {
+    const s = snapshot(
+      { maxRetries: 3 },
+      { state: WorkflowRunState.QUEUED, controlIntent: "cancel" },
+    );
     const action = reconcileStandalone(s);
     expect(action.kind).toBe("transition");
     if (action.kind === "transition") {
       expect(action.to).toBe(WorkflowRunState.FAILED);
       expect(action.clearControlIntent).toBe(true);
       expect(action.statusPatch?.errorMessage).toBe("Cancelled by user");
+      // Exhausted budget is what keeps decideFailed from auto-retrying the
+      // cancelled run back to QUEUED on the next pass.
+      expect(action.statusPatch?.retryCount).toBe(3);
     }
   });
 
@@ -150,7 +156,36 @@ describe("reconcileStandalone — control intent", () => {
     expect(action.kind).toBe("transition");
     if (action.kind === "transition") {
       expect(action.to).toBe(WorkflowRunState.FAILED);
+      expect(action.statusPatch?.retryCount).toBe(3);
     }
+  });
+
+  it("cancel never lowers a retryCount already above maxRetries", () => {
+    const s = snapshot(
+      { maxRetries: 1 },
+      { state: WorkflowRunState.RUNNING, controlIntent: "cancel", retryCount: 4 },
+    );
+    const action = reconcileStandalone(s);
+    expect(action.kind).toBe("transition");
+    if (action.kind === "transition") {
+      expect(action.statusPatch?.retryCount).toBe(4);
+    }
+  });
+
+  it("a cancelled run (FAILED, budget exhausted, no intent) is left alone", () => {
+    // The post-cancel shape both cancel paths write: FAILED + "Cancelled by
+    // user" + retryCount == maxRetries. decideFailed must NOT auto-retry it.
+    const s = snapshot(
+      { maxRetries: 3 },
+      {
+        state: WorkflowRunState.FAILED,
+        errorMessage: "Cancelled by user",
+        retryCount: 3,
+        finishedAt: NOW,
+      },
+    );
+    const action = reconcileStandalone(s);
+    expect(action).toEqual({ kind: "noop", reason: "failed_no_retry_intent" });
   });
 
   it("cancel on terminal COMPLETED clears intent without transitioning", () => {

--- a/packages/shared/src/reconcile/reconcile-standalone.ts
+++ b/packages/shared/src/reconcile/reconcile-standalone.ts
@@ -112,6 +112,12 @@ function interpretIntent(
         statusPatch: {
           errorMessage: "Cancelled by user",
           finishedAt: new Date(status.reconcileBackoffUntil ?? Date.now()),
+          // Exhaust the retry budget so decideFailed never auto-retries a
+          // user-cancelled run back to QUEUED (it cannot otherwise tell a
+          // cancellation apart from an agent failure). An explicit user retry
+          // via workflowService.retryWorkflowRun still works — it does not
+          // consult maxRetries. Mirrors workflowService.cancelWorkflowRun.
+          retryCount: Math.max(status.retryCount, spec.maxRetries),
         },
         clearControlIntent: true,
         trigger: "user_cancel",


### PR DESCRIPTION
Fixes two confirmed reconciler bugs in the standalone (`workflow_runs`) path.

## Bug 1 — standalone CAS comparison was microsecond-fragile

`applyStandaloneTransition` in `apps/api/src/services/reconcile-executor.ts` guarded its write with a plain `eq(workflowRuns.updatedAt, version)`, while the file's `casUpdate` helper compares with millisecond truncation (`date_trunc('milliseconds', ...)`).

**Failure scenario:** Postgres `timestamptz` stores microseconds; JS `Date` versions carry only milliseconds. Any run whose `updated_at` was last stamped by PG's `now()` / `defaultNow()` (rather than a JS-originated write) could **never** match the snapshot version — every executor transition from that row returned `stale`, permanently. Auto-retries, cancel transitions, and finish transitions from such rows silently never applied until some other writer happened to stamp a ms-precision `updated_at`.

**Fix:** extracted the ms-truncating comparison into one `updatedAtMatches()` helper and made it the single comparison used by every CAS guard — `casUpdate` (tasks / pr_reviews / persistent_agents / workflow_runs) and `applyStandaloneTransition`. The sibling repo / pr-review / persistent-agent transition applicators already went through `casUpdate` and were audited to confirm no other raw-eq guard exists.

## Bug 2 — the reconciler auto-retried user-cancelled runs

`workflowService.cancelWorkflowRun` (and the reconciler's own `control_intent=cancel` path in `reconcile-standalone.ts`) transitions a run to `FAILED` with "Cancelled by user". `decideFailed` cannot distinguish a user cancellation from an agent failure, so while `retryCount < maxRetries` the next reconcile pass flipped the cancelled run back to `QUEUED` — **a cancelled run silently reran**.

**Fix:** both cancel paths now structurally exhaust the retry budget at cancel time — `retryCount = max(retryCount, workflow.maxRetries)` — so `decideFailed` sees no budget and leaves the run alone. No DB migration, no fragile error-message matching. An explicit user retry via `retryWorkflowRun` still works, since it does not consult `maxRetries`.

## How the tests prove it

- `apps/api/src/services/reconcile-executor.int.test.ts` (real Postgres + Redis):
  - The pinned µs-seam test that previously asserted the **stale** behavior (row stamped `date_trunc('milliseconds', now()) + interval '456 microseconds'`) is flipped: the auto-retry transition now **applies** from the µs-stamped row, and replaying the same action from the stale snapshot is still refused — CAS integrity preserved.
  - The control-intent cancel test now executes a full follow-up reconcile pass and asserts the cancelled run **stays** `FAILED` (`noop failed_no_retry_intent`, no write, no agent job) — previously it pinned the surprising `auto_retry` decision.
- `apps/api/src/services/workflow-service.int.test.ts`: service-level `cancelWorkflowRun` stamps `retryCount = maxRetries`, and feeding the cancelled run's real snapshot into `reconcileStandalone` decides `noop`, not `auto_retry`; plus a test that cancel never lowers a `retryCount` already above `maxRetries`.
- `packages/shared/src/reconcile/reconcile-standalone.test.ts`: cancel action's `statusPatch` carries the exhausted `retryCount`; the post-cancel row shape is left alone by `decideFailed`.

## Verification

- `cd apps/api && npx tsc --noEmit` — clean
- Unit tests: `apps/api` 123 files / 2167 passed; `packages/shared` 19 files / 442 passed
- Both touched integration files run twice (flake check): 24/24 passed both runs
- `pnpm format:check` — clean