### PR TITLE
fix(triggers): compute nextFireAt in workflow-trigger-service so schedule triggers fire

### DIFF
--- a/apps/api/e2e/scheduled-trigger.e2e.test.ts
+++ b/apps/api/e2e/scheduled-trigger.e2e.test.ts
@@ -8,7 +8,9 @@
  * markTriggerFired advances nextFireAt + stamps lastFiredAt. Also: disabled
  * triggers are skipped by the due-query, webhook ingress via
  * POST /api/hooks/:path (including HMAC secret enforcement), and the legacy
- * /api/jobs/:id/triggers route's nextFireAt behavior.
+ * /api/jobs/:id/triggers route computing nextFireAt for schedule triggers
+ * just like the unified route (it used to leave it null — such triggers
+ * never fired).
  *
  * cron-parser supports 6-field (seconds) expressions, so schedule triggers
  * here use every-2-seconds crons to become due within ~2s instead of waiting
@@ -195,16 +197,35 @@ describe("scheduled trigger e2e", () => {
       WHERE id = ${disabledTrigger.id}
     `;
 
-    // Legacy /api/jobs/:id/triggers route: its createTrigger never computes
-    // nextFireAt, so an enabled schedule trigger created there is never due.
+    // Legacy /api/jobs/:id/triggers route: its createTrigger computes
+    // nextFireAt exactly like the unified route (regression: it used to leave
+    // it null, so schedule triggers created there never fired). A daily cron
+    // anchored ~12h out keeps the computed nextFireAt far from due, so the
+    // poller can't fire it before we null the value below.
+    const cronAnchor = new Date(Date.now() + 12 * 60 * 60 * 1000);
     const legacyWorkflowId = await createJob("e2e legacy trigger job", "Should never run either");
     const legacyRes = await api<{ trigger: Trigger }>(`/api/jobs/${legacyWorkflowId}/triggers`, {
       method: "POST",
-      body: JSON.stringify({ type: "schedule", config: { cronExpression: "* * * * * *" } }),
+      body: JSON.stringify({
+        type: "schedule",
+        config: {
+          cronExpression: `${cronAnchor.getUTCMinutes()} ${cronAnchor.getUTCHours()} * * *`,
+        },
+      }),
     });
     expect(legacyRes.status).toBe(201);
     expect(legacyRes.body.trigger.enabled).toBe(true);
-    expect(legacyRes.body.trigger.nextFireAt).toBeNull();
+    expect(legacyRes.body.trigger.nextFireAt).not.toBeNull();
+    const legacyNextFireAt = new Date(legacyRes.body.trigger.nextFireAt!).getTime();
+    expect(legacyNextFireAt).toBeGreaterThan(Date.now());
+    expect(legacyNextFireAt).toBeLessThanOrEqual(cronAnchor.getTime() + 24 * 60 * 60 * 1000);
+
+    // The API can no longer produce a nextFireAt-less enabled schedule
+    // trigger — null it directly to pin the due-query's NULL handling.
+    await sql`
+      UPDATE workflow_triggers SET next_fire_at = NULL
+      WHERE id = ${legacyRes.body.trigger.id}
+    `;
 
     // Canary: an enabled, due schedule trigger created AFTER both of the
     // above. When it fires and its run completes, the poller has demonstrably

--- a/apps/api/src/services/task-config-service.ts
+++ b/apps/api/src/services/task-config-service.ts
@@ -217,11 +217,7 @@ export async function setEnabled(id: string, enabled: boolean) {
 
 // ── Trigger CRUD for task_config targets ─────────────────────────────────────
 
-import { CronExpressionParser } from "cron-parser";
-
-function computeNextFire(cronExpression: string): Date {
-  return CronExpressionParser.parse(cronExpression).next().toDate();
-}
+import { computeNextFire } from "../utils/cron.js";
 
 export async function listTaskConfigTriggers(taskConfigId: string) {
   return db

--- a/apps/api/src/services/workflow-service.ts
+++ b/apps/api/src/services/workflow-service.ts
@@ -1,5 +1,4 @@
 import { eq, desc, sql, and, lte } from "drizzle-orm";
-import { CronExpressionParser } from "cron-parser";
 import { db } from "../db/client.js";
 import {
   workflows,
@@ -11,6 +10,7 @@ import {
 import { WorkflowRunState, canTransitionWorkflowRun, transitionWorkflowRun } from "@optio/shared";
 import { publishWorkflowRunEvent } from "./event-bus.js";
 import { logger } from "../logger.js";
+import { computeNextFire } from "../utils/cron.js";
 
 // ── Workflow CRUD ────────────────────────────────────────────────────────────
 
@@ -558,11 +558,6 @@ export async function getWebhookTriggerByPath(webhookPath: string) {
 export async function getWorkflowTrigger(id: string) {
   const [trigger] = await db.select().from(workflowTriggers).where(eq(workflowTriggers.id, id));
   return trigger ?? null;
-}
-
-function computeNextFire(cronExpression: string): Date {
-  const interval = CronExpressionParser.parse(cronExpression);
-  return interval.next().toDate();
 }
 
 export async function createWorkflowTrigger(input: {

--- a/apps/api/src/services/workflow-trigger-service.test.ts
+++ b/apps/api/src/services/workflow-trigger-service.test.ts
@@ -141,31 +141,96 @@ describe("createTrigger", () => {
       }),
     ).rejects.toThrow("duplicate_type");
   });
-});
 
-describe("updateTrigger", () => {
-  beforeEach(() => vi.clearAllMocks());
-
-  it("updates a trigger", async () => {
-    const updated = makeDbRow({ enabled: false });
-
+  it("computes nextFireAt for an enabled schedule trigger", async () => {
     (db.select as any) = vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([]),
       }),
     });
 
-    (db.update as any) = vi.fn().mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([updated]),
-        }),
+    let capturedValues: Record<string, unknown> = {};
+    (db.insert as any) = vi.fn().mockReturnValue({
+      values: vi.fn().mockImplementation((values: Record<string, unknown>) => {
+        capturedValues = values;
+        return { returning: vi.fn().mockResolvedValue([makeDbRow({ type: "schedule" })]) };
       }),
     });
 
+    await createTrigger({
+      workflowId: "wf-1",
+      type: "schedule",
+      config: { cronExpression: "0 0 * * *" },
+    });
+
+    expect(capturedValues.nextFireAt).toBeInstanceOf(Date);
+    expect((capturedValues.nextFireAt as Date).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("leaves nextFireAt null for a disabled schedule trigger and for non-schedule types", async () => {
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const captured: Record<string, unknown>[] = [];
+    (db.insert as any) = vi.fn().mockReturnValue({
+      values: vi.fn().mockImplementation((values: Record<string, unknown>) => {
+        captured.push(values);
+        return { returning: vi.fn().mockResolvedValue([makeDbRow()]) };
+      }),
+    });
+
+    await createTrigger({
+      workflowId: "wf-1",
+      type: "schedule",
+      config: { cronExpression: "0 0 * * *" },
+      enabled: false,
+    });
+    await createTrigger({ workflowId: "wf-1", type: "manual", config: {} });
+
+    expect(captured[0].nextFireAt).toBeNull();
+    expect(captured[1].nextFireAt).toBeNull();
+  });
+});
+
+describe("updateTrigger", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /** Mock db.update capturing the `set(...)` payload. */
+  function mockUpdateCapture(returned: Record<string, unknown>) {
+    const captured: { set: Record<string, unknown> } = { set: {} };
+    (db.update as any) = vi.fn().mockReturnValue({
+      set: vi.fn().mockImplementation((set: Record<string, unknown>) => {
+        captured.set = set;
+        return {
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([returned]),
+          }),
+        };
+      }),
+    });
+    return captured;
+  }
+
+  it("updates a trigger", async () => {
+    const existing = makeDbRow();
+    const updated = makeDbRow({ enabled: false });
+
+    // getTrigger existence check resolves the current row.
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([existing]),
+      }),
+    });
+    const captured = mockUpdateCapture(updated);
+
     const result = await updateTrigger("trig-1", { enabled: false });
     expect(result).toEqual(updated);
-    expect(result.enabled).toBe(false);
+    expect(result!.enabled).toBe(false);
+    // Non-schedule triggers never get a nextFireAt stamped.
+    expect("nextFireAt" in captured.set).toBe(false);
   });
 
   it("returns null when trigger not found", async () => {
@@ -175,16 +240,69 @@ describe("updateTrigger", () => {
       }),
     });
 
-    (db.update as any) = vi.fn().mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([]),
-        }),
-      }),
-    });
+    (db.update as any) = vi.fn();
 
     const result = await updateTrigger("nonexistent", { enabled: false });
     expect(result).toBeNull();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it("recomputes nextFireAt when re-enabling a schedule trigger", async () => {
+    const existing = makeDbRow({
+      type: "schedule",
+      config: { cronExpression: "0 0 * * *" },
+      enabled: false,
+      nextFireAt: null,
+    });
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([existing]),
+      }),
+    });
+    const captured = mockUpdateCapture(makeDbRow({ type: "schedule", enabled: true }));
+
+    await updateTrigger("trig-1", { enabled: true });
+    expect(captured.set.nextFireAt).toBeInstanceOf(Date);
+    expect((captured.set.nextFireAt as Date).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("recomputes nextFireAt when the cron expression changes", async () => {
+    const existing = makeDbRow({
+      type: "schedule",
+      config: { cronExpression: "0 0 * * *" },
+      enabled: true,
+    });
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([existing]),
+      }),
+    });
+    const captured = mockUpdateCapture(makeDbRow({ type: "schedule" }));
+
+    // Every-minute cron → recomputed nextFireAt lands within the next minute.
+    await updateTrigger("trig-1", { config: { cronExpression: "* * * * *" } });
+    expect(captured.set.nextFireAt).toBeInstanceOf(Date);
+    const nextFireAt = (captured.set.nextFireAt as Date).getTime();
+    expect(nextFireAt).toBeGreaterThan(Date.now());
+    expect(nextFireAt).toBeLessThanOrEqual(Date.now() + 60_000);
+  });
+
+  it("clears nextFireAt when disabling a schedule trigger", async () => {
+    const existing = makeDbRow({
+      type: "schedule",
+      config: { cronExpression: "0 0 * * *" },
+      enabled: true,
+      nextFireAt: new Date(),
+    });
+    (db.select as any) = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([existing]),
+      }),
+    });
+    const captured = mockUpdateCapture(makeDbRow({ type: "schedule", enabled: false }));
+
+    await updateTrigger("trig-1", { enabled: false });
+    expect(captured.set.nextFireAt).toBeNull();
   });
 });
 

--- a/apps/api/src/services/workflow-trigger-service.ts
+++ b/apps/api/src/services/workflow-trigger-service.ts
@@ -1,6 +1,7 @@
 import { eq, and, desc } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { workflowTriggers } from "../db/schema.js";
+import { computeNextFire } from "../utils/cron.js";
 
 export async function listTriggers(workflowId: string) {
   return db
@@ -48,6 +49,14 @@ export async function createTrigger(input: {
     }
   }
 
+  // Schedule triggers are only picked up by the poller once next_fire_at is
+  // set — compute it here so triggers created through this service fire.
+  const enabled = input.enabled ?? true;
+  let nextFireAt: Date | null = null;
+  if (input.type === "schedule" && enabled && typeof input.config?.cronExpression === "string") {
+    nextFireAt = computeNextFire(input.config.cronExpression);
+  }
+
   const [trigger] = await db
     .insert(workflowTriggers)
     .values({
@@ -57,7 +66,8 @@ export async function createTrigger(input: {
       type: input.type,
       config: input.config ?? {},
       paramMapping: input.paramMapping,
-      enabled: input.enabled ?? true,
+      enabled,
+      nextFireAt,
     })
     .returning();
   return trigger;
@@ -71,6 +81,9 @@ export async function updateTrigger(
     enabled?: boolean;
   },
 ) {
+  const existing = await getTrigger(id);
+  if (!existing) return null;
+
   // Check webhook path uniqueness if updating config on a webhook trigger
   if (input.config && typeof input.config.path === "string") {
     const conflicts = await db
@@ -89,6 +102,19 @@ export async function updateTrigger(
   if (input.config !== undefined) updates.config = input.config;
   if (input.paramMapping !== undefined) updates.paramMapping = input.paramMapping;
   if (input.enabled !== undefined) updates.enabled = input.enabled;
+
+  // Recompute next_fire_at for schedule triggers: a cron change reschedules,
+  // re-enabling reschedules, disabling clears it.
+  if (existing.type === "schedule") {
+    const newConfig =
+      input.config !== undefined
+        ? input.config
+        : (existing.config as Record<string, unknown> | null);
+    const newEnabled = input.enabled ?? existing.enabled;
+    const cronExpression = newConfig?.cronExpression;
+    updates.nextFireAt =
+      newEnabled && typeof cronExpression === "string" ? computeNextFire(cronExpression) : null;
+  }
 
   const [updated] = await db
     .update(workflowTriggers)

--- a/apps/api/src/services/workflow-trigger.int.test.ts
+++ b/apps/api/src/services/workflow-trigger.int.test.ts
@@ -9,7 +9,9 @@
  *   - target_type="task_config" → instantiateTask → queued tasks row with
  *     rendered prompt/title
  *   - disabled / not-yet-due triggers are never selected
- * plus the workflow-trigger-service CRUD round-trip.
+ * plus the workflow-trigger-service CRUD round-trip — including that its
+ * create/update stamp nextFireAt for schedule triggers so they actually fire
+ * (regression: it used to leave nextFireAt null and they never fired).
  */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { eq } from "drizzle-orm";
@@ -364,20 +366,71 @@ describe("trigger CRUD (workflow-trigger-service)", () => {
     expect(await triggerService.getTrigger(ghost)).toBeNull();
   });
 
-  it("createTrigger does not compute nextFireAt for schedule triggers (actual behavior)", async () => {
-    // Unlike workflowService.createWorkflowTrigger, this service leaves
-    // nextFireAt null — a schedule trigger created through it (and through
-    // POST /api/jobs/:id/triggers, which calls it) is never selected by
-    // getDueScheduleTriggersAll until something else sets nextFireAt.
+  it("createTrigger computes nextFireAt for schedule triggers, and the trigger fires once due", async () => {
+    // Regression: this service used to leave nextFireAt null, so a schedule
+    // trigger created through it (and through POST /api/jobs/:id/triggers,
+    // which calls it) was never selected by getDueScheduleTriggersAll and
+    // never fired. It must behave like workflowService.createWorkflowTrigger.
+    const workflow = await insertWorkflow();
+    const beforeCreate = Date.now();
+    // Every-second cron (cron-parser 6-field): nextFireAt lands within ~1s,
+    // so the trigger becomes due without waiting out a minute boundary.
+    const trigger = await triggerService.createTrigger({
+      workflowId: workflow.id,
+      type: "schedule",
+      config: { cronExpression: "* * * * * *" },
+    });
+    expect(trigger.nextFireAt).not.toBeNull();
+    expect(trigger.nextFireAt!.getTime()).toBeGreaterThan(beforeCreate);
+    expect(trigger.nextFireAt!.getTime()).toBeLessThanOrEqual(Date.now() + 1_000);
+
+    // Once the computed nextFireAt passes, the worker check fires it.
+    await waitUntil(async () => Date.now() > trigger.nextFireAt!.getTime(), "trigger to be due");
+    await runTriggerCheck();
+
+    const runs = await runsFor(workflow.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].state).toBe("queued");
+    expect(runs[0].triggerId).toBe(trigger.id);
+
+    const after = await triggerService.getTrigger(trigger.id);
+    expect(after!.lastFiredAt).not.toBeNull();
+    expect(after!.nextFireAt!.getTime()).toBeGreaterThan(trigger.nextFireAt!.getTime());
+
+    // An every-second cron is perpetually due again — disable it so later
+    // checks can't re-fire it. Disabling a schedule trigger clears nextFireAt.
+    const disabled = await triggerService.updateTrigger(trigger.id, { enabled: false });
+    expect(disabled!.enabled).toBe(false);
+    expect(disabled!.nextFireAt).toBeNull();
+  });
+
+  it("updateTrigger recomputes nextFireAt on re-enable and cron change, clears it on disable", async () => {
     const workflow = await insertWorkflow();
     const trigger = await triggerService.createTrigger({
       workflowId: workflow.id,
       type: "schedule",
       config: { cronExpression: DAILY_CRON },
     });
-    expect(trigger.nextFireAt).toBeNull();
+    expect(trigger.nextFireAt).not.toBeNull();
 
-    await runTriggerCheck();
-    expect(await runsFor(workflow.id)).toHaveLength(0);
+    // Disabling clears nextFireAt → the poller can never select it.
+    const disabled = await triggerService.updateTrigger(trigger.id, { enabled: false });
+    expect(disabled!.nextFireAt).toBeNull();
+
+    // Re-enabling recomputes it from the stored cron config.
+    const reenabled = await triggerService.updateTrigger(trigger.id, { enabled: true });
+    expect(reenabled!.nextFireAt).not.toBeNull();
+    expect(reenabled!.nextFireAt!.getTime()).toBeGreaterThan(Date.now());
+
+    // Changing the cron reschedules: an hourly cron lands within the next
+    // hour, always sooner than the ~12h-out DAILY_CRON anchor.
+    const hourly = await triggerService.updateTrigger(trigger.id, {
+      config: { cronExpression: "0 * * * *" },
+    });
+    expect(hourly!.nextFireAt!.getTime()).toBeLessThanOrEqual(Date.now() + 60 * 60_000);
+    expect(hourly!.nextFireAt!.getTime()).toBeLessThan(reenabled!.nextFireAt!.getTime());
+
+    // Remove it so it can't become due for any later check in this file.
+    expect(await triggerService.deleteTrigger(trigger.id)).toBe(true);
   });
 });

--- a/apps/api/src/utils/cron.ts
+++ b/apps/api/src/utils/cron.ts
@@ -1,0 +1,17 @@
+import { CronExpressionParser } from "cron-parser";
+
+/**
+ * Next fire time for a cron expression — strictly after now.
+ *
+ * Shared by every service that stamps `workflow_triggers.next_fire_at`
+ * (workflow-service, task-config-service, workflow-trigger-service) so all
+ * trigger creation/update paths agree on scheduling semantics. The schedule
+ * poller (`getDueScheduleTriggersAll`) only selects rows with
+ * `next_fire_at <= now`, so a schedule trigger written without this value
+ * never fires.
+ *
+ * Throws if the expression is not valid cron (callers surface this as a 400).
+ */
+export function computeNextFire(cronExpression: string): Date {
+  return CronExpressionParser.parse(cronExpression).next().toDate();
+}


### PR DESCRIPTION
## Bug

Schedule triggers created through `workflow-trigger-service` **never fired**.

There are two creation paths for `workflow_triggers` rows:

- `workflowService.createWorkflowTrigger` / `taskConfigService.createTaskConfigTrigger` — used by the unified `POST /api/tasks/:id/triggers` route — compute `nextFireAt` from the cron expression at creation.
- `workflow-trigger-service.createTrigger` — used by the legacy **`POST /api/jobs/:id/triggers`** route — inserted the row **without** `nextFireAt`.

The schedule poller (`getDueScheduleTriggersAll`) only selects rows with `next_fire_at <= now`, so a schedule trigger created via `/api/jobs/:id/triggers` was perpetually invisible to the poller and never fired. `updateTrigger` (behind **`PATCH /api/jobs/:id/triggers/:triggerId`**) had the same gap: changing the cron expression or re-enabling a schedule trigger never (re)computed `nextFireAt`, so a trigger disabled-then-re-enabled through that route also went dead.

**Affected routes:** `POST /api/jobs/:id/triggers`, `PATCH /api/jobs/:id/triggers/:triggerId`.
**Unaffected:** unified `POST/PATCH /api/tasks/:id/triggers` (standalone + repo-blueprint) and `/api/task-configs/:id/triggers`.

## Fix

- Extracted `computeNextFire` into `apps/api/src/utils/cron.ts` and reuse it from `workflow-service.ts`, `task-config-service.ts`, and `workflow-trigger-service.ts` — the first two previously each had their own private copy, so this de-dupes the cron parsing rather than adding a third copy.
- `workflow-trigger-service.createTrigger` now stamps `nextFireAt` for enabled schedule triggers.
- `workflow-trigger-service.updateTrigger` now recomputes `nextFireAt` on cron change / re-enable and clears it on disable, mirroring the other two services (it now also short-circuits to `null` for a missing id before touching the DB, same as `updateTaskConfigTrigger`).

## Tests

- `apps/api/src/services/workflow-trigger.int.test.ts` — the test that explicitly pinned the buggy behavior ("createTrigger does not compute nextFireAt … never fires") is flipped into a positive one: a schedule trigger created via the service gets a computed `nextFireAt`, becomes due, and **the worker check fires it** (run created, `lastFiredAt` stamped, `nextFireAt` advanced). Added an `updateTrigger` test covering recompute-on-re-enable, recompute-on-cron-change, and clear-on-disable.
- `apps/api/e2e/scheduled-trigger.e2e.test.ts` — the legacy-route section pinned `nextFireAt = null`; it now asserts the legacy route computes `nextFireAt` like the unified route. The null-`nextFireAt` due-query case is preserved by nulling the column via direct SQL, since the API can no longer produce that state.
- `apps/api/src/services/workflow-trigger-service.test.ts` — unit coverage for the new create/update `nextFireAt` behavior; existing update mocks adjusted for the new existence check.

## Verification

- `cd apps/api && npx tsc --noEmit` — clean
- `npx vitest run` (apps/api unit) — 123 files, 2172 tests passed
- `npx vitest run --config vitest.integration.config.ts src/services/workflow-trigger.int.test.ts` — 12/12 passed, **twice**
- `npx vitest run --config vitest.e2e.config.ts e2e/scheduled-trigger.e2e.test.ts` — 4/4 passed, **twice**
- `pnpm format:check` — clean