### PR TITLE
fix(images): pin agent CLIs to work around Bun exec crash (#566)

### DIFF
--- a/images/base.Dockerfile
+++ b/images/base.Dockerfile
@@ -49,7 +49,16 @@ RUN node -e 'const [maj,min] = process.versions.openssl.split(".").map(Number); 
 RUN corepack enable && corepack prepare pnpm@10 --activate
 
 # Claude Code
-RUN npm install -g @anthropic-ai/claude-code
+# PINNED to work around a Bun regression, NOT for feature reasons.
+# 2.1.112 is the last release shipped as a plain Node.js bundle (bin/cli.js).
+# Starting at 2.1.113 the CLI ships as a Bun-compiled single-file binary
+# (bin/claude.exe), and every such build embeds Bun >= 1.3.13 — which segfaults
+# with "embedder failed to suspend thread ... for TLC" when the binary is launched
+# via `docker exec` / `kubectl exec` (i.e. NOT as PID 1) on Linux kernel >= 7.0.
+# Optio ALWAYS execs the agent inside the long-lived repo pod, so it always hits this.
+# Upstream regression: https://github.com/oven-sh/bun/issues/31832 (Bun 1.3.12-1.3.14).
+# TODO(#566): bump back to latest once upstream Bun ships a fix and claude-code adopts it.
+RUN npm install -g @anthropic-ai/claude-code@2.1.112
 
 # OpenAI Codex CLI
 RUN npm install -g @openai/codex
@@ -57,12 +66,22 @@ RUN npm install -g @openai/codex
 # GitHub Copilot CLI (pinned + best-effort — package may be temporarily unavailable)
 RUN npm install -g @github/copilot@1.0.20 || echo "WARN: @github/copilot install failed; copilot agent will not be available in this image"
 
-# OpenCode CLI (experimental — pinned version for stable JSON output).
+# OpenCode CLI (experimental).
+# PINNED to work around the same Bun regression as Claude Code above.
+# opencode ships as a Bun-compiled single-file binary. 1.14.20 is the last release
+# built with Bun 1.3.11; starting at 1.14.21 it is built with Bun >= 1.3.13, which
+# segfaults ("embedder failed to suspend thread ... for TLC") when launched via
+# `docker exec` / `kubectl exec` (not PID 1) on Linux kernel >= 7.0 — the config
+# Optio always runs agents in.
+# Upstream regression: https://github.com/oven-sh/bun/issues/31832 (Bun 1.3.12-1.3.14).
+# The install script pins via the VERSION env var; the OPENCODE_VERSION build-arg was
+# previously declared but never passed through, so `latest` was always installed.
+# TODO(#566): bump back to latest once upstream Bun ships a fix and opencode adopts it.
 # Best-effort: opencode.ai is a single point of failure for the install
 # script, so let the build succeed even when the upstream is briefly
 # unavailable (matches the @github/copilot and openclaw fallbacks).
-ARG OPENCODE_VERSION=latest
-RUN (curl -fsSL https://opencode.ai/install | bash \
+ARG OPENCODE_VERSION=1.14.20
+RUN (curl -fsSL https://opencode.ai/install | VERSION="${OPENCODE_VERSION}" bash \
   && mv /root/.opencode/bin/opencode /usr/local/bin/ \
   && rm -rf /root/.opencode) \
   || echo "WARN: opencode install failed; opencode agent will not be available in this image"


### PR DESCRIPTION
## Summary

Pins the two Bun-compiled agent CLIs in `images/base.Dockerfile` to their last-known-good, pre-regression versions to work around an upstream Bun crash that Optio's execution model always triggers.

Fixes #566.

## Root cause

Recent releases of `@anthropic-ai/claude-code` and `opencode` ship as **Bun-compiled single-file executables**. Bun 1.3.12–1.3.14 have a regression (oven-sh/bun#31832) where the binary **segfaults on startup with `embedder failed to suspend thread ... for TLC`** when it is launched via `docker exec` / `kubectl exec` — i.e. **not as PID 1** — on Linux kernel ≥ 7.0. The bisect in the upstream issue confirms 1.3.11 is the last working version.

Optio **always** execs the agent inside the long-lived pod-per-repo (`repo-pool-service.ts` `execTaskInRepoPod`), so this is exactly the failing configuration. We cannot make the agent PID 1 without abandoning pod-per-repo, so the fix is to pin the CLIs to versions that are **not** built with the broken Bun until upstream ships a fix.

## Versions chosen (and why)

### `@anthropic-ai/claude-code` → `2.1.112`
- `2.1.112` (published 2026-04-16) is the **last release shipped as a plain Node.js bundle** (`bin: cli.js`) — it does not use Bun at all, so it cannot hit this crash.
- `2.1.113` (2026-04-17) is the first Bun-compiled build (`bin: bin/claude.exe`, adds `@anthropic-ai/claude-code-<platform>` native optionalDependencies). I extracted the linux-x64 binary and confirmed it embeds **Bun `1.3.13+743d2a40e`** — already in the broken range. There is therefore **no** Bun-compiled claude-code build on a safe Bun; `2.1.112` is the newest safe version.
- Verification method: npm registry `time`/`versions` metadata for the `bin` + optionalDependency transition, plus `strings` on the extracted Linux binary for the embedded `bun-vX.Y.Z` / `X.Y.Z+<githash>` revision marker.

### `opencode` → `1.14.20`
- opencode always ships as a Bun-compiled binary. I binary-searched the GitHub release binaries by embedded Bun revision:
  - `1.14.20` (2026-04-21) → **Bun `1.3.11+af24e281e`** (safe)
  - `1.14.21` (2026-04-23) → **Bun `1.3.13+bf2e2cecf`** (broken)
  - every sampled release after that, up to and including latest `1.18.11`, is on Bun 1.3.13/1.3.14 (broken) — the transition is monotonic, no later revert.
- So `1.14.20` is the newest opencode built on a safe Bun.
- The install script (`https://opencode.ai/install`) pins via the `VERSION` env var. The `OPENCODE_VERSION` build-arg was previously **declared but never passed through** to the script, so `latest` was always installed regardless of the arg — this PR wires it through (`VERSION="${OPENCODE_VERSION}"`).

Other agent CLIs in the image are unaffected: `@openai/codex` (Rust), `@github/copilot` (already pinned), `@google/gemini-cli` (Node) are not Bun single-file executables.

## Verification
- `docker build -t optio-base-test:pr -f images/base.Dockerfile .` — succeeds.
- In the built image: `claude --version` → `2.1.112 (Claude Code)`, `opencode --version` → `1.14.20`.
- `pnpm format:check` — passes.

## Note
This is a **temporary pin**. Both pins have `TODO(#566)` comments referencing oven-sh/bun#31832; revert to `latest` (or an unpinned install) once upstream Bun ships a fix and the CLIs adopt it.
