### PR TITLE
fix(security): enforce workspace scoping and role checks on job/connection/webhook routes

### DIFF
--- a/apps/api/src/routes/connections.test.ts
+++ b/apps/api/src/routes/connections.test.ts
@@ -15,6 +15,7 @@ const mockUpdateConnection = vi.fn();
 const mockDeleteConnection = vi.fn();
 const mockTestConnection = vi.fn();
 const mockListAssignments = vi.fn();
+const mockGetAssignment = vi.fn();
 const mockCreateAssignment = vi.fn();
 const mockUpdateAssignment = vi.fn();
 const mockDeleteAssignment = vi.fn();
@@ -32,6 +33,7 @@ vi.mock("../services/connection-service.js", () => ({
   deleteConnection: (...args: unknown[]) => mockDeleteConnection(...args),
   testConnection: (...args: unknown[]) => mockTestConnection(...args),
   listAssignments: (...args: unknown[]) => mockListAssignments(...args),
+  getAssignment: (...args: unknown[]) => mockGetAssignment(...args),
   createAssignment: (...args: unknown[]) => mockCreateAssignment(...args),
   updateAssignment: (...args: unknown[]) => mockUpdateAssignment(...args),
   deleteAssignment: (...args: unknown[]) => mockDeleteAssignment(...args),
@@ -363,6 +365,15 @@ describe("GET /api/connections/:id/assignments", () => {
 
     expect(res.statusCode).toBe(404);
   });
+
+  it("returns 404 for a connection in another workspace (no assignment read)", async () => {
+    mockGetConnection.mockResolvedValue({ id: "conn-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "GET", url: "/api/connections/conn-1/assignments" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockListAssignments).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /api/connections/:id/assignments", () => {
@@ -405,6 +416,34 @@ describe("POST /api/connections/:id/assignments", () => {
 
     expect(res.statusCode).toBe(404);
   });
+
+  it("returns 404 for a connection in another workspace (no assignment created)", async () => {
+    mockGetConnection.mockResolvedValue({ id: "conn-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/connections/conn-1/assignments",
+      payload: { repoId: "repo-1", permission: "read" },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockCreateAssignment).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a viewer", async () => {
+    const viewerApp = await buildRouteTestApp(connectionRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+
+    const res = await viewerApp.inject({
+      method: "POST",
+      url: "/api/connections/conn-1/assignments",
+      payload: { repoId: "repo-1", permission: "read" },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockCreateAssignment).not.toHaveBeenCalled();
+  });
 });
 
 describe("PATCH /api/connection-assignments/:id", () => {
@@ -412,6 +451,8 @@ describe("PATCH /api/connection-assignments/:id", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockGetAssignment.mockResolvedValue({ id: "asgn-1", connectionId: "conn-1" });
+    mockGetConnection.mockResolvedValue({ id: "conn-1", workspaceId: "ws-1" });
     app = await buildTestApp();
   });
 
@@ -427,6 +468,47 @@ describe("PATCH /api/connection-assignments/:id", () => {
     expect(res.statusCode).toBe(200);
     expect(mockUpdateAssignment).toHaveBeenCalledWith("asgn-1", { permission: "write" });
   });
+
+  it("returns 404 when the assignment does not exist (no update)", async () => {
+    mockGetAssignment.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/connection-assignments/nope",
+      payload: { permission: "write" },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockUpdateAssignment).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the owning connection is in another workspace (no update)", async () => {
+    mockGetConnection.mockResolvedValue({ id: "conn-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/connection-assignments/asgn-1",
+      payload: { permission: "write" },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockUpdateAssignment).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a viewer", async () => {
+    const viewerApp = await buildRouteTestApp(connectionRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+
+    const res = await viewerApp.inject({
+      method: "PATCH",
+      url: "/api/connection-assignments/asgn-1",
+      payload: { permission: "write" },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockUpdateAssignment).not.toHaveBeenCalled();
+  });
 });
 
 describe("DELETE /api/connection-assignments/:id", () => {
@@ -434,6 +516,8 @@ describe("DELETE /api/connection-assignments/:id", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockGetAssignment.mockResolvedValue({ id: "asgn-1", connectionId: "conn-1" });
+    mockGetConnection.mockResolvedValue({ id: "conn-1", workspaceId: "ws-1" });
     app = await buildTestApp();
   });
 
@@ -443,6 +527,38 @@ describe("DELETE /api/connection-assignments/:id", () => {
     const res = await app.inject({ method: "DELETE", url: "/api/connection-assignments/asgn-1" });
 
     expect(res.statusCode).toBe(204);
+  });
+
+  it("returns 404 when the assignment does not exist (no delete)", async () => {
+    mockGetAssignment.mockResolvedValue(null);
+
+    const res = await app.inject({ method: "DELETE", url: "/api/connection-assignments/nope" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockDeleteAssignment).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the owning connection is in another workspace (no delete)", async () => {
+    mockGetConnection.mockResolvedValue({ id: "conn-1", workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "DELETE", url: "/api/connection-assignments/asgn-1" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockDeleteAssignment).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a viewer", async () => {
+    const viewerApp = await buildRouteTestApp(connectionRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+
+    const res = await viewerApp.inject({
+      method: "DELETE",
+      url: "/api/connection-assignments/asgn-1",
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockDeleteAssignment).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -1,7 +1,8 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import * as connectionService from "../services/connection-service.js";
+import { requireRole } from "../plugins/auth.js";
 import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import {
@@ -95,6 +96,30 @@ const AssignmentsListResponse = z.object({ assignments: z.array(ConnectionAssign
 const AssignmentResponse = z.object({ assignment: ConnectionAssignmentSchema });
 
 // ── Routes ────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a connection by id, enforcing workspace ownership. On a missing or
+ * foreign connection it sends a 404 (foreign resources are indistinguishable
+ * from missing ones) and returns null; otherwise returns the connection.
+ * Callers must `return` when null is received.
+ */
+async function requireOwnedConnection(
+  req: FastifyRequest,
+  reply: FastifyReply,
+  connectionId: string,
+): Promise<Awaited<ReturnType<typeof connectionService.getConnection>>> {
+  const conn = await connectionService.getConnection(connectionId);
+  if (!conn) {
+    reply.status(404).send({ error: "Connection not found" });
+    return null;
+  }
+  const wsId = req.user?.workspaceId;
+  if (wsId && conn.workspaceId && conn.workspaceId !== wsId) {
+    reply.status(404).send({ error: "Connection not found" });
+    return null;
+  }
+  return conn;
+}
 
 export async function connectionRoutes(rawApp: FastifyInstance) {
   const app = rawApp.withTypeProvider<ZodTypeProvider>();
@@ -338,8 +363,8 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
       },
     },
     async (req, reply) => {
-      const conn = await connectionService.getConnection(req.params.id);
-      if (!conn) return reply.status(404).send({ error: "Connection not found" });
+      const conn = await requireOwnedConnection(req, reply, req.params.id);
+      if (!conn) return;
       const assignments = await connectionService.listAssignments(req.params.id);
       reply.send({ assignments });
     },
@@ -348,10 +373,11 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
   app.post(
     "/api/connections/:id/assignments",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "createConnectionAssignment",
         summary: "Create a connection assignment",
-        description: "Assign a connection to a repo/agent combination.",
+        description: "Assign a connection to a repo/agent combination. Requires `member` role.",
         tags: ["Repos & Integrations"],
         params: IdParamsSchema,
         body: createAssignmentSchema,
@@ -359,8 +385,8 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
       },
     },
     async (req, reply) => {
-      const conn = await connectionService.getConnection(req.params.id);
-      if (!conn) return reply.status(404).send({ error: "Connection not found" });
+      const conn = await requireOwnedConnection(req, reply, req.params.id);
+      if (!conn) return;
       const assignment = await connectionService.createAssignment(req.params.id, req.body);
       logAction({
         userId: req.user?.id,
@@ -376,17 +402,22 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
   app.patch(
     "/api/connection-assignments/:id",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "updateConnectionAssignment",
         summary: "Update a connection assignment",
-        description: "Partial update to a connection assignment.",
+        description: "Partial update to a connection assignment. Requires `member` role.",
         tags: ["Repos & Integrations"],
         params: IdParamsSchema,
         body: updateAssignmentSchema,
-        response: { 200: AssignmentResponse },
+        response: { 200: AssignmentResponse, 404: ErrorResponseSchema },
       },
     },
     async (req, reply) => {
+      const existing = await connectionService.getAssignment(req.params.id);
+      if (!existing) return reply.status(404).send({ error: "Assignment not found" });
+      const conn = await requireOwnedConnection(req, reply, existing.connectionId);
+      if (!conn) return;
       const assignment = await connectionService.updateAssignment(req.params.id, req.body);
       logAction({
         userId: req.user?.id,
@@ -402,16 +433,22 @@ export async function connectionRoutes(rawApp: FastifyInstance) {
   app.delete(
     "/api/connection-assignments/:id",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "deleteConnectionAssignment",
         summary: "Delete a connection assignment",
-        description: "Delete a connection assignment. Returns 204 on success.",
+        description:
+          "Delete a connection assignment. Returns 204 on success. Requires `member` role.",
         tags: ["Repos & Integrations"],
         params: IdParamsSchema,
-        response: { 204: z.null() },
+        response: { 204: z.null(), 404: ErrorResponseSchema },
       },
     },
     async (req, reply) => {
+      const existing = await connectionService.getAssignment(req.params.id);
+      if (!existing) return reply.status(404).send({ error: "Assignment not found" });
+      const conn = await requireOwnedConnection(req, reply, existing.connectionId);
+      if (!conn) return;
       await connectionService.deleteAssignment(req.params.id);
       logAction({
         userId: req.user?.id,

--- a/apps/api/src/routes/tasks-unified.test.ts
+++ b/apps/api/src/routes/tasks-unified.test.ts
@@ -289,3 +289,60 @@ describe("GET /api/tasks/:id/triggers", () => {
     expect(res.statusCode).toBe(405);
   });
 });
+
+describe("workspace scoping + role enforcement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function viewerApp(): Promise<FastifyInstance> {
+    return buildRouteTestApp(tasksUnifiedRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+  }
+
+  it("scopes the parent lookup to the caller's workspace (404 for foreign id)", async () => {
+    // Simulate the resolver rejecting a foreign id (it enforces workspace).
+    mockResolveAnyTaskById.mockResolvedValue(null);
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "POST", url: "/api/tasks/foreign/runs", payload: {} });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockResolveAnyTaskById).toHaveBeenCalledWith("foreign", "ws-1");
+  });
+
+  it("403s a viewer kicking off a run", async () => {
+    const app = await viewerApp();
+    const res = await app.inject({ method: "POST", url: "/api/tasks/wf-1/runs", payload: {} });
+    expect(res.statusCode).toBe(403);
+    expect(mockResolveAnyTaskById).not.toHaveBeenCalled();
+  });
+
+  it("403s a viewer creating a trigger", async () => {
+    const app = await viewerApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/tasks/wf-1/triggers",
+      payload: { type: "schedule", config: { cronExpression: "0 9 * * *" } },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(mockResolveAnyTaskById).not.toHaveBeenCalled();
+  });
+
+  it("403s a viewer updating a trigger", async () => {
+    const app = await viewerApp();
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/tasks/wf-1/triggers/trg-1",
+      payload: { enabled: false },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("403s a viewer deleting a trigger", async () => {
+    const app = await viewerApp();
+    const res = await app.inject({ method: "DELETE", url: "/api/tasks/wf-1/triggers/trg-1" });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/apps/api/src/routes/tasks-unified.ts
+++ b/apps/api/src/routes/tasks-unified.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import * as unifiedTaskService from "../services/unified-task-service.js";
 import * as workflowService from "../services/workflow-service.js";
 import * as taskConfigService from "../services/task-config-service.js";
+import { requireRole } from "../plugins/auth.js";
 import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 
@@ -120,6 +121,7 @@ export async function tasksUnifiedRoutes(rawApp: FastifyInstance) {
   app.post(
     "/api/tasks/:id/runs",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "createTaskRun",
         summary: "Kick off a run",
@@ -239,6 +241,7 @@ export async function tasksUnifiedRoutes(rawApp: FastifyInstance) {
   app.post(
     "/api/tasks/:id/triggers",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "createTaskTrigger",
         summary: "Attach a trigger to a Task",
@@ -307,6 +310,7 @@ export async function tasksUnifiedRoutes(rawApp: FastifyInstance) {
   app.patch(
     "/api/tasks/:id/triggers/:triggerId",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "updateTaskTrigger",
         summary: "Update a trigger",
@@ -362,6 +366,7 @@ export async function tasksUnifiedRoutes(rawApp: FastifyInstance) {
   app.delete(
     "/api/tasks/:id/triggers/:triggerId",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "deleteTaskTrigger",
         summary: "Delete a trigger",

--- a/apps/api/src/routes/webhooks.test.ts
+++ b/apps/api/src/routes/webhooks.test.ts
@@ -195,3 +195,52 @@ describe("GET /api/webhooks/:id/deliveries", () => {
     expect(res.statusCode).toBe(404);
   });
 });
+
+describe("webhook mutations require member role", () => {
+  async function viewerApp(): Promise<FastifyInstance> {
+    return buildRouteTestApp(webhookRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Seed getWebhook so a viewer that somehow reached the handler would still
+    // resolve a webhook — proving the 403 comes from the role gate, not a 404.
+    mockGetWebhook.mockResolvedValue({ id: "wh-1", workspaceId: "ws-1", secret: null, events: [] });
+  });
+
+  it("403s a viewer creating a webhook", async () => {
+    const app = await viewerApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/webhooks",
+      payload: { url: "https://example.com/hook", events: ["task.completed"] },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(mockCreateWebhook).not.toHaveBeenCalled();
+  });
+
+  it("403s a viewer updating a webhook", async () => {
+    const app = await viewerApp();
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/webhooks/wh-1",
+      payload: { events: ["task.failed"] },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("403s a viewer deleting a webhook", async () => {
+    const app = await viewerApp();
+    const res = await app.inject({ method: "DELETE", url: "/api/webhooks/wh-1" });
+    expect(res.statusCode).toBe(403);
+    expect(mockDeleteWebhook).not.toHaveBeenCalled();
+  });
+
+  it("403s a viewer firing a test delivery", async () => {
+    const app = await viewerApp();
+    const res = await app.inject({ method: "POST", url: "/api/webhooks/wh-1/test", payload: {} });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -3,6 +3,7 @@ import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { isSsrfSafeUrl } from "../utils/ssrf.js";
 import * as webhookService from "../services/webhook-service.js";
+import { requireRole } from "../plugins/auth.js";
 import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import { WebhookSchema, WebhookDeliverySchema } from "../schemas/integration.js";
@@ -127,12 +128,14 @@ export async function webhookRoutes(rawApp: FastifyInstance) {
   app.post(
     "/api/webhooks",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "createWebhook",
         summary: "Create an outbound webhook",
         description:
           "Register a new outbound webhook. The `url` is SSRF-guarded — " +
-          "URLs pointing at private/internal addresses are rejected.",
+          "URLs pointing at private/internal addresses are rejected. " +
+          "Requires `member` role.",
         tags: ["Repos & Integrations"],
         body: createWebhookSchema,
         response: { 201: WebhookResponseSchema },
@@ -157,12 +160,14 @@ export async function webhookRoutes(rawApp: FastifyInstance) {
   app.patch(
     "/api/webhooks/:id",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "updateWebhook",
         summary: "Update a webhook",
         description:
           "Partial update to a webhook. URL changes are SSRF-guarded; setting " +
-          "`active: false` pauses deliveries without deleting the record.",
+          "`active: false` pauses deliveries without deleting the record. " +
+          "Requires `member` role.",
         tags: ["Repos & Integrations"],
         params: IdParamsSchema,
         body: updateWebhookSchema,
@@ -195,10 +200,11 @@ export async function webhookRoutes(rawApp: FastifyInstance) {
   app.delete(
     "/api/webhooks/:id",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "deleteWebhook",
         summary: "Delete a webhook",
-        description: "Delete a webhook. Returns 204 on success.",
+        description: "Delete a webhook. Returns 204 on success. Requires `member` role.",
         tags: ["Repos & Integrations"],
         params: IdParamsSchema,
         response: { 204: z.null(), 404: ErrorResponseSchema },
@@ -228,13 +234,14 @@ export async function webhookRoutes(rawApp: FastifyInstance) {
   app.post(
     "/api/webhooks/:id/test",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "testWebhook",
         summary: "Fire a test delivery",
         description:
           "Deliver a synthetic sample payload for the specified event (or " +
           "the first subscribed event if omitted). Useful for verifying " +
-          "endpoint wiring without running a real task.",
+          "endpoint wiring without running a real task. Requires `member` role.",
         tags: ["Repos & Integrations"],
         params: IdParamsSchema,
         body: testWebhookBodySchema,

--- a/apps/api/src/routes/workflows.test.ts
+++ b/apps/api/src/routes/workflows.test.ts
@@ -10,6 +10,7 @@ const mockCreateWorkflow = vi.fn();
 const mockGetWorkflow = vi.fn();
 const mockGetWorkflowWithStats = vi.fn();
 const mockUpdateWorkflow = vi.fn();
+const mockCloneWorkflow = vi.fn();
 const mockDeleteWorkflow = vi.fn();
 const mockCreateWorkflowRun = vi.fn();
 const mockListWorkflowRuns = vi.fn();
@@ -29,6 +30,7 @@ vi.mock("../services/workflow-service.js", () => ({
   getWorkflow: (...args: unknown[]) => mockGetWorkflow(...args),
   getWorkflowWithStats: (...args: unknown[]) => mockGetWorkflowWithStats(...args),
   updateWorkflow: (...args: unknown[]) => mockUpdateWorkflow(...args),
+  cloneWorkflow: (...args: unknown[]) => mockCloneWorkflow(...args),
   deleteWorkflow: (...args: unknown[]) => mockDeleteWorkflow(...args),
   createWorkflowRun: (...args: unknown[]) => mockCreateWorkflowRun(...args),
   listWorkflowRuns: (...args: unknown[]) => mockListWorkflowRuns(...args),
@@ -133,6 +135,21 @@ describe("POST /api/jobs", () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  it("returns 403 for a viewer", async () => {
+    const viewerApp = await buildRouteTestApp(workflowRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+
+    const res = await viewerApp.inject({
+      method: "POST",
+      url: "/api/jobs",
+      payload: { name: "Deploy", promptTemplate: "Deploy the app" },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockCreateWorkflow).not.toHaveBeenCalled();
+  });
 });
 
 describe("GET /api/jobs/:id", () => {
@@ -172,6 +189,7 @@ describe("PATCH /api/jobs/:id", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow });
     app = await buildTestApp();
   });
 
@@ -189,6 +207,7 @@ describe("PATCH /api/jobs/:id", () => {
   });
 
   it("returns 404 when not found", async () => {
+    mockGetWorkflow.mockResolvedValue(null);
     mockUpdateWorkflow.mockResolvedValue(null);
 
     const res = await app.inject({
@@ -198,6 +217,36 @@ describe("PATCH /api/jobs/:id", () => {
     });
 
     expect(res.statusCode).toBe(404);
+    // Must not fall through to the mutation for a workflow that isn't resolved.
+    expect(mockUpdateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a workflow in another workspace (no mutation)", async () => {
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow, workspaceId: "ws-other" });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/jobs/w-1",
+      payload: { name: "Hijacked" },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockUpdateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a viewer", async () => {
+    const viewerApp = await buildRouteTestApp(workflowRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+
+    const res = await viewerApp.inject({
+      method: "PATCH",
+      url: "/api/jobs/w-1",
+      payload: { name: "Updated" },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockUpdateWorkflow).not.toHaveBeenCalled();
   });
 
   it("returns 400 on validation error", async () => {
@@ -213,11 +262,60 @@ describe("PATCH /api/jobs/:id", () => {
   });
 });
 
+describe("POST /api/jobs/:id/clone", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow });
+    app = await buildTestApp();
+  });
+
+  it("clones a workflow", async () => {
+    mockCloneWorkflow.mockResolvedValue({ ...mockWorkflow, id: "wf-2" });
+
+    const res = await app.inject({ method: "POST", url: "/api/jobs/wf-1/clone" });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().workflow.id).toBe("wf-2");
+  });
+
+  it("returns 404 when source not found (no clone)", async () => {
+    mockGetWorkflow.mockResolvedValue(null);
+
+    const res = await app.inject({ method: "POST", url: "/api/jobs/nope/clone" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockCloneWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a workflow in another workspace (no clone)", async () => {
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow, workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "POST", url: "/api/jobs/wf-1/clone" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockCloneWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a viewer", async () => {
+    const viewerApp = await buildRouteTestApp(workflowRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+
+    const res = await viewerApp.inject({ method: "POST", url: "/api/jobs/wf-1/clone" });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockCloneWorkflow).not.toHaveBeenCalled();
+  });
+});
+
 describe("DELETE /api/jobs/:id", () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow });
     app = await buildTestApp();
   });
 
@@ -230,11 +328,33 @@ describe("DELETE /api/jobs/:id", () => {
   });
 
   it("returns 404 when not found", async () => {
+    mockGetWorkflow.mockResolvedValue(null);
     mockDeleteWorkflow.mockResolvedValue(false);
 
     const res = await app.inject({ method: "DELETE", url: "/api/jobs/nonexistent" });
 
     expect(res.statusCode).toBe(404);
+    expect(mockDeleteWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a workflow in another workspace (no delete)", async () => {
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow, workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "DELETE", url: "/api/jobs/w-1" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockDeleteWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a viewer", async () => {
+    const viewerApp = await buildRouteTestApp(workflowRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+
+    const res = await viewerApp.inject({ method: "DELETE", url: "/api/jobs/w-1" });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockDeleteWorkflow).not.toHaveBeenCalled();
   });
 });
 
@@ -245,6 +365,7 @@ describe("POST /api/jobs/:id/runs", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow });
     app = await buildTestApp();
   });
 
@@ -262,15 +383,43 @@ describe("POST /api/jobs/:id/runs", () => {
   });
 
   it("returns 400 when run creation fails", async () => {
-    mockCreateWorkflowRun.mockRejectedValue(new Error("Workflow not found"));
+    mockCreateWorkflowRun.mockRejectedValue(new Error("disabled"));
 
     const res = await app.inject({
       method: "POST",
-      url: "/api/jobs/nonexistent/runs",
+      url: "/api/jobs/wf-1/runs",
       payload: {},
     });
 
     expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 404 for a workflow not in the workspace (no run created)", async () => {
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow, workspaceId: "ws-other" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/jobs/wf-1/runs",
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockCreateWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a viewer", async () => {
+    const viewerApp = await buildRouteTestApp(workflowRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+
+    const res = await viewerApp.inject({
+      method: "POST",
+      url: "/api/jobs/wf-1/runs",
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockCreateWorkflowRun).not.toHaveBeenCalled();
   });
 });
 
@@ -307,6 +456,7 @@ describe("GET /api/workflow-runs/:id", () => {
 
   it("returns a workflow run", async () => {
     mockGetWorkflowRun.mockResolvedValue({ ...mockWorkflowRun });
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow });
 
     const res = await app.inject({ method: "GET", url: "/api/workflow-runs/run-1" });
 
@@ -320,6 +470,15 @@ describe("GET /api/workflow-runs/:id", () => {
 
     expect(res.statusCode).toBe(404);
   });
+
+  it("returns 404 for a run whose workflow is in another workspace", async () => {
+    mockGetWorkflowRun.mockResolvedValue({ ...mockWorkflowRun });
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow, workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "GET", url: "/api/workflow-runs/run-1" });
+
+    expect(res.statusCode).toBe(404);
+  });
 });
 
 // ─── Workflow Run Operations ───
@@ -329,6 +488,8 @@ describe("POST /api/workflow-runs/:id/retry", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockGetWorkflowRun.mockResolvedValue({ ...mockWorkflowRun });
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow });
     app = await buildTestApp();
   });
 
@@ -350,6 +511,26 @@ describe("POST /api/workflow-runs/:id/retry", () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  it("returns 404 for a run whose workflow is in another workspace (no retry)", async () => {
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow, workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "POST", url: "/api/workflow-runs/run-1/retry" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockRetryWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a viewer", async () => {
+    const viewerApp = await buildRouteTestApp(workflowRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+
+    const res = await viewerApp.inject({ method: "POST", url: "/api/workflow-runs/run-1/retry" });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockRetryWorkflowRun).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /api/workflow-runs/:id/cancel", () => {
@@ -357,6 +538,8 @@ describe("POST /api/workflow-runs/:id/cancel", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockGetWorkflowRun.mockResolvedValue({ ...mockWorkflowRun });
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow });
     app = await buildTestApp();
   });
 
@@ -377,6 +560,26 @@ describe("POST /api/workflow-runs/:id/cancel", () => {
     const res = await app.inject({ method: "POST", url: "/api/workflow-runs/run-1/cancel" });
 
     expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 404 for a run whose workflow is in another workspace (no cancel)", async () => {
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow, workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "POST", url: "/api/workflow-runs/run-1/cancel" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a viewer", async () => {
+    const viewerApp = await buildRouteTestApp(workflowRoutes, {
+      user: { id: "user-1", workspaceId: "ws-1", workspaceRole: "viewer" },
+    });
+
+    const res = await viewerApp.inject({ method: "POST", url: "/api/workflow-runs/run-1/cancel" });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
   });
 });
 
@@ -439,5 +642,15 @@ describe("GET /api/workflow-runs/:id/logs", () => {
     const res = await app.inject({ method: "GET", url: "/api/workflow-runs/nonexistent/logs" });
 
     expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 for a run whose workflow is in another workspace", async () => {
+    mockGetWorkflowRun.mockResolvedValue({ ...mockWorkflowRun, state: "running" });
+    mockGetWorkflow.mockResolvedValue({ ...mockWorkflow, workspaceId: "ws-other" });
+
+    const res = await app.inject({ method: "GET", url: "/api/workflow-runs/run-1/logs" });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockGetWorkflowRunLogs).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/workflows.ts
+++ b/apps/api/src/routes/workflows.ts
@@ -1,8 +1,9 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import * as workflowService from "../services/workflow-service.js";
 import { workflowRunQueue } from "../workers/workflow-worker.js";
+import { requireRole } from "../plugins/auth.js";
 import { logAction } from "../services/optio-action-service.js";
 import { ErrorResponseSchema, IdParamsSchema } from "../schemas/common.js";
 import {
@@ -141,6 +142,41 @@ const WorkflowRunStatsResponseSchema = z
   })
   .describe("Aggregated workflow-run counts for the current workspace");
 
+/**
+ * Resolve a workflow by id, enforcing workspace ownership. Returns the
+ * workflow row when it exists and belongs to the caller's workspace (or is
+ * an unscoped legacy row), otherwise null. Callers translate null into a
+ * 404 so foreign resources are indistinguishable from missing ones.
+ */
+async function requireWorkflowInWorkspace(req: FastifyRequest, id: string) {
+  const workflow = await workflowService.getWorkflow(id);
+  if (!workflow) return null;
+  const wsId = req.user?.workspaceId;
+  if (wsId && workflow.workspaceId && workflow.workspaceId !== wsId) {
+    return null;
+  }
+  return workflow;
+}
+
+/**
+ * Resolve a workflow run by id, enforcing workspace ownership via its parent
+ * workflow. Runs carry no workspace column of their own, so ownership is
+ * derived from the workflow they belong to. Returns null (→ 404) for a
+ * missing run or one whose workflow lives in another workspace.
+ */
+async function requireWorkflowRunInWorkspace(req: FastifyRequest, runId: string) {
+  const run = await workflowService.getWorkflowRun(runId);
+  if (!run) return null;
+  const wsId = req.user?.workspaceId;
+  if (wsId) {
+    const parent = run.workflowId ? await workflowService.getWorkflow(run.workflowId) : null;
+    if (parent && parent.workspaceId && parent.workspaceId !== wsId) {
+      return null;
+    }
+  }
+  return run;
+}
+
 export async function workflowRoutes(rawApp: FastifyInstance) {
   const app = rawApp.withTypeProvider<ZodTypeProvider>();
 
@@ -192,10 +228,11 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
   app.post(
     "/api/jobs",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "createWorkflow",
         summary: "Create a workflow",
-        description: "Create a new workflow template.",
+        description: "Create a new workflow template. Requires `member` role.",
         tags: ["Workflows"],
         body: createWorkflowSchema,
         response: {
@@ -256,10 +293,11 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
   app.patch(
     "/api/jobs/:id",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "updateWorkflow",
         summary: "Update a workflow",
-        description: "Partial update to a workflow template.",
+        description: "Partial update to a workflow template. Requires `member` role.",
         tags: ["Workflows"],
         params: IdParamsSchema,
         body: updateWorkflowSchema,
@@ -273,6 +311,8 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
     async (req, reply) => {
       const { id } = req.params;
       const input = req.body;
+      const existing = await requireWorkflowInWorkspace(req, id);
+      if (!existing) return reply.status(404).send({ error: "Workflow not found" });
       try {
         const workflow = await workflowService.updateWorkflow(id, input);
         if (!workflow) return reply.status(404).send({ error: "Workflow not found" });
@@ -298,12 +338,14 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
   app.post(
     "/api/jobs/:id/clone",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "cloneWorkflow",
         summary: "Clone a workflow",
         description:
           "Clone an existing workflow and its non-webhook triggers. The " +
-          "clone has a new ID and is owned by the current workspace.",
+          "clone has a new ID and is owned by the current workspace. " +
+          "Requires `member` role.",
         tags: ["Workflows"],
         params: IdParamsSchema,
         response: {
@@ -314,6 +356,8 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
     },
     async (req, reply) => {
       const { id } = req.params;
+      const source = await requireWorkflowInWorkspace(req, id);
+      if (!source) return reply.status(404).send({ error: "Workflow not found" });
       const cloned = await workflowService.cloneWorkflow(id, {
         workspaceId: req.user?.workspaceId ?? undefined,
         createdBy: req.user?.id,
@@ -333,10 +377,13 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
   app.delete(
     "/api/jobs/:id",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "deleteWorkflow",
         summary: "Delete a workflow",
-        description: "Delete a workflow and all of its runs. Returns 204 on success.",
+        description:
+          "Delete a workflow and all of its runs. Returns 204 on success. " +
+          "Requires `member` role.",
         tags: ["Workflows"],
         params: IdParamsSchema,
         response: {
@@ -347,6 +394,8 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
     },
     async (req, reply) => {
       const { id } = req.params;
+      const existing = await requireWorkflowInWorkspace(req, id);
+      if (!existing) return reply.status(404).send({ error: "Workflow not found" });
       const deleted = await workflowService.deleteWorkflow(id);
       if (!deleted) return reply.status(404).send({ error: "Workflow not found" });
       logAction({
@@ -365,24 +414,29 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
   app.post(
     "/api/jobs/:id/runs",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "createWorkflowRun",
         summary: "Create a workflow run",
         description:
           "Create a new workflow run and enqueue it for the workflow worker. " +
           "The run is returned immediately in `queued` state — monitor its " +
-          "progress via `/api/workflow-runs/:id` or the WebSocket log stream.",
+          "progress via `/api/workflow-runs/:id` or the WebSocket log stream. " +
+          "Requires `member` role.",
         tags: ["Workflows"],
         params: IdParamsSchema,
         body: runWorkflowBodySchema,
         response: {
           201: WorkflowRunResponseSchema,
           400: ErrorResponseSchema,
+          404: ErrorResponseSchema,
         },
       },
     },
     async (req, reply) => {
       const { id } = req.params;
+      const workflow = await requireWorkflowInWorkspace(req, id);
+      if (!workflow) return reply.status(404).send({ error: "Workflow not found" });
       try {
         // createWorkflowRun enqueues on workflowRunQueue internally
         const run = await workflowService.createWorkflowRun(id, req.body);
@@ -448,7 +502,7 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
     },
     async (req, reply) => {
       const { id } = req.params;
-      const run = await workflowService.getWorkflowRun(id);
+      const run = await requireWorkflowRunInWorkspace(req, id);
       if (!run) return reply.status(404).send({ error: "Workflow run not found" });
       reply.send({ run });
     },
@@ -457,20 +511,26 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
   app.post(
     "/api/workflow-runs/:id/retry",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "retryWorkflowRun",
         summary: "Retry a workflow run",
-        description: "Re-queue a failed workflow run. Returns 400 if the run is not retryable.",
+        description:
+          "Re-queue a failed workflow run. Returns 400 if the run is not retryable. " +
+          "Requires `member` role.",
         tags: ["Workflows"],
         params: IdParamsSchema,
         response: {
           200: WorkflowRunResponseSchema,
           400: ErrorResponseSchema,
+          404: ErrorResponseSchema,
         },
       },
     },
     async (req, reply) => {
       const { id } = req.params;
+      const existing = await requireWorkflowRunInWorkspace(req, id);
+      if (!existing) return reply.status(404).send({ error: "Workflow run not found" });
       try {
         const run = await workflowService.retryWorkflowRun(id);
         logAction({
@@ -490,20 +550,26 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
   app.post(
     "/api/workflow-runs/:id/cancel",
     {
+      preHandler: [requireRole("member")],
       schema: {
         operationId: "cancelWorkflowRun",
         summary: "Cancel a workflow run",
-        description: "Cancel a running workflow run. Returns 400 if the run is not cancellable.",
+        description:
+          "Cancel a running workflow run. Returns 400 if the run is not cancellable. " +
+          "Requires `member` role.",
         tags: ["Workflows"],
         params: IdParamsSchema,
         response: {
           200: WorkflowRunResponseSchema,
           400: ErrorResponseSchema,
+          404: ErrorResponseSchema,
         },
       },
     },
     async (req, reply) => {
       const { id } = req.params;
+      const existing = await requireWorkflowRunInWorkspace(req, id);
+      if (!existing) return reply.status(404).send({ error: "Workflow run not found" });
       try {
         const run = await workflowService.cancelWorkflowRun(id);
         logAction({
@@ -538,7 +604,7 @@ export async function workflowRoutes(rawApp: FastifyInstance) {
     },
     async (req, reply) => {
       const { id } = req.params;
-      const run = await workflowService.getWorkflowRun(id);
+      const run = await requireWorkflowRunInWorkspace(req, id);
       if (!run) return reply.status(404).send({ error: "Workflow run not found" });
       const opts = req.query;
       const logs = await workflowService.getWorkflowRunLogs(id, opts);

--- a/apps/api/src/services/connection-service.ts
+++ b/apps/api/src/services/connection-service.ts
@@ -542,6 +542,20 @@ export async function listAssignments(connectionId: string): Promise<ConnectionA
   return rows.map(mapAssignmentRow);
 }
 
+/**
+ * Fetch a single assignment by id (read-only). Used by the routes layer to
+ * resolve the owning connection for workspace-scoping the flat
+ * `/api/connection-assignments/:id` routes, which otherwise take only the
+ * assignment id and would be an IDOR surface.
+ */
+export async function getAssignment(id: string): Promise<ConnectionAssignment | null> {
+  const [row] = await db
+    .select()
+    .from(connectionAssignments)
+    .where(eq(connectionAssignments.id, id));
+  return row ? mapAssignmentRow(row) : null;
+}
+
 export async function createAssignment(
   connectionId: string,
   input: {


### PR DESCRIPTION
## SECURITY

Fixes three linked cross-tenant authorization gaps confirmed by an internal security review. No working exploit payloads are included.

### A) CRITICAL — cross-tenant Job (workflow) hijack
The id-addressed handlers in `routes/workflows.ts` resolved the workflow/run **without any workspace check**, so any authenticated tenant could edit, clone, run, or delete another tenant's Job and read its runs/logs by guessing/enumerating a UUID:

- `PATCH /api/jobs/:id`, `POST /api/jobs/:id/clone`, `DELETE /api/jobs/:id`, `POST /api/jobs/:id/runs`
- `GET /api/workflow-runs/:id`, `POST /api/workflow-runs/:id/retry`, `POST /api/workflow-runs/:id/cancel`, `GET /api/workflow-runs/:id/logs`

**Fix:** added two resolver helpers mirroring the `routes/tasks.ts` pattern — `requireWorkflowInWorkspace()` and `requireWorkflowRunInWorkspace()` (runs carry no workspace column, so ownership is derived from the parent workflow). Every id handler now resolves through them and returns **404** (not 403) for missing or foreign resources, before any mutation runs.

### B) MEDIUM — missing RBAC on mutating routes
Mutating routes across `workflows.ts`, `tasks-unified.ts`, and `webhooks.ts` had **no `requireRole`**, so a `viewer` could create/run/delete. Matched the `tasks.ts` convention by adding `preHandler: [requireRole("member")]` to:

- workflows: `POST /api/jobs`, `PATCH/DELETE /api/jobs/:id`, `POST /api/jobs/:id/clone`, `POST /api/jobs/:id/runs`, `POST /api/workflow-runs/:id/retry|cancel`
- tasks-unified: `POST /api/tasks/:id/runs`, `POST/PATCH/DELETE /api/tasks/:id/triggers`
- webhooks: `POST /api/webhooks`, `PATCH/DELETE /api/webhooks/:id`, `POST /api/webhooks/:id/test`

(The unified task/trigger routes already scope the id via `resolveAnyTaskById(id, workspaceId)`; that stays intact — this only adds the role gate. A test locks in that the resolver is still called with the caller's workspace.)

### C) MEDIUM — connection-assignment IDOR
The connection-assignment routes in `routes/connections.ts` called `connectionService.getConnection(id)` (or nothing at all, for the flat routes) with **no workspace check**, allowing cross-tenant credential-binding tamper:

- `GET/POST /api/connections/:id/assignments`
- `PATCH/DELETE /api/connection-assignments/:id` (these took only the assignment id — a pure IDOR)

**Fix:** added a `requireOwnedConnection(req, reply, connectionId)` guard (404 on missing/foreign, mirroring the sibling connection routes) and a read-only `connectionService.getAssignment(id)` so the flat routes can resolve the owning connection before acting. Assignment mutations also now require `member`.

## Notes
- Foreign resources return **404** everywhere (indistinguishable from missing).
- Auth-disabled local dev is preserved — `requireRole` and the workspace checks already short-circuit via `isAuthDisabled()` / null workspaceId.
- Unscoped legacy rows (null `workspaceId`) remain accessible, consistent with the existing `tasks.ts`/`webhooks.ts` handlers.
- No changes to `workflow-service.ts` business logic (other open PRs touch it); only read-only getters are consumed. `persistent-agents.ts` / `persistent-agent-service.ts` untouched.

## Tests
Extended the existing route test files (`workflows.test.ts`, `connections.test.ts`, `webhooks.test.ts`, `tasks-unified.test.ts`): assert **404** for cross-workspace id access on the (A)/(C) routes and **403** for a `viewer` on the (B) mutations, verifying no service mutation is reached in either case.

- `apps/api` unit suite: **2202 passed**
- `apps/api` typecheck (`tsc --noEmit`): clean
- workspace `pnpm turbo typecheck`: 12/12 pass
- `pnpm format:check`: clean

Found via internal security review.
