### PR TITLE
fix(helm): allow setting a storage class for the built-in Postgres PVC

### DIFF
--- a/helm/optio/templates/postgres.yaml
+++ b/helm/optio/templates/postgres.yaml
@@ -22,6 +22,9 @@ spec:
   resources:
     requests:
       storage: {{ .Values.postgresql.storage.size }}
+  {{- if .Values.postgresql.storage.storageClass }}
+  storageClassName: {{ .Values.postgresql.storage.storageClass | quote }}
+  {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -225,6 +225,7 @@ postgresql:
   # Kubernetes nodeSelector for PostgreSQL pods (opt-in).
   nodeSelector: {}
   storage:
+    storageClass: ""  # Empty = cluster default storage class
     size: 5Gi
   auth:
     database: optio


### PR DESCRIPTION
## Summary

The postgres-data PVC omitted storageClassName entirely, so it always relied on the cluster providing a default StorageClass. On clusters without one — e.g. EKS, where neither gp2 nor gp3 is marked default — the PVC stays Pending indefinitely, Postgres never starts, and the API crash-loops with no obvious cause.

Add postgresql.storage.storageClass, mirroring the existing installedSkillsCache.storageClass and agent.pvc.storageClass pattern. Leaving it empty (the default) omits the field, preserving the current cluster-default behaviour.


## Testing

<!-- How was this tested? -->

- [ ] Tests pass (`pnpm turbo test`)
- [ ] Typechecks pass (`pnpm turbo typecheck`)

