### PR TITLE
fix(web): exclude e2e files from Next.js production build

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -19,5 +19,13 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "vitest.config.ts"]
+  "exclude": [
+    "node_modules",
+    "e2e",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "vitest.config.ts"
+  ]
 }


### PR DESCRIPTION
The web tsconfig includes all `*.ts` files, which causes files under `apps/web/e2e` to be type-checked during `next build`.

`apps/web/e2e/launch-stack.ts` imports API test utilities, which are not part of the production web build and causes the Docker web image build to fail.

Exclude the e2e directory from the web TypeScript config so E2E infrastructure is checked by the E2E/test tooling instead of Next.js production builds.