### PR TITLE
feat(agents): make OpenCode work with LiteLLM-proxied models

### DIFF
--- a/apps/api/src/services/opencode-event-parser.test.ts
+++ b/apps/api/src/services/opencode-event-parser.test.ts
@@ -274,4 +274,98 @@ describe("parseOpenCodeEvent", () => {
       expect(costEntry?.metadata?.cost).toBe(0.0231);
     });
   });
+
+  describe("opencode 1.14.20 run --format json events (real captured shapes)", () => {
+    // Shapes captured verbatim from opencode 1.14.20 run --format json in a repo pod.
+    const sessionId = "ses_f75374e09ffepLY1K38ctZscdd";
+
+    it("captures sessionId from the camelCase sessionID field on step_start", () => {
+      const line = JSON.stringify({
+        type: "step_start",
+        timestamp: 1789035522262,
+        sessionID: sessionId,
+        part: { id: "prt_1", messageID: "msg_1", sessionID: sessionId, type: "step-start" },
+      });
+      const result = parseOpenCodeEvent(line, TASK_ID);
+      expect(result.sessionId).toBe(sessionId);
+    });
+
+    it("parses a text event (part.text) into a text entry", () => {
+      const line = JSON.stringify({
+        type: "text",
+        timestamp: 1789035522709,
+        sessionID: sessionId,
+        part: {
+          id: "prt_2",
+          messageID: "msg_1",
+          sessionID: sessionId,
+          type: "text",
+          text: "PR created: https://github.com/ulbi/helm-iot/pull/771",
+        },
+      });
+      const result = parseOpenCodeEvent(line, TASK_ID);
+      const textEntry = result.entries.find((e) => e.type === "text");
+      expect(textEntry).toBeDefined();
+      expect(textEntry?.content).toContain("PR created");
+      expect(result.sessionId).toBe(sessionId);
+    });
+
+    it("parses a step_finish event with tokens and cost into an info entry", () => {
+      const line = JSON.stringify({
+        type: "step_finish",
+        timestamp: 1789035522720,
+        sessionID: sessionId,
+        part: {
+          id: "prt_3",
+          type: "step-finish",
+          reason: "stop",
+          tokens: {
+            total: 14866,
+            input: 14856,
+            output: 10,
+            reasoning: 0,
+            cache: { write: 0, read: 0 },
+          },
+          cost: 0,
+        },
+      });
+      const result = parseOpenCodeEvent(line, TASK_ID);
+      const infoEntry = result.entries.find((e) => e.type === "info");
+      expect(infoEntry).toBeDefined();
+      expect(infoEntry?.metadata?.inputTokens).toBe(14856);
+      expect(infoEntry?.metadata?.outputTokens).toBe(10);
+      expect(infoEntry?.metadata?.totalTokens).toBe(14866);
+      expect(result.sessionId).toBe(sessionId);
+    });
+
+    it("parses a reasoning event into a thinking entry", () => {
+      const line = JSON.stringify({
+        type: "reasoning",
+        sessionID: sessionId,
+        part: { type: "reasoning", text: "Plan: read the repo layout first" },
+      });
+      const result = parseOpenCodeEvent(line, TASK_ID);
+      const thinkEntry = result.entries.find((e) => e.type === "thinking");
+      expect(thinkEntry).toBeDefined();
+      expect(thinkEntry?.content).toContain("repo layout");
+      expect(result.sessionId).toBe(sessionId);
+    });
+
+    it("parses a tool event (part.tool with state.input) into a tool_use entry", () => {
+      const line = JSON.stringify({
+        type: "tool",
+        sessionID: sessionId,
+        part: {
+          type: "tool",
+          tool: "bash",
+          state: { status: "pending", input: { command: "git add README.md" } },
+        },
+      });
+      const result = parseOpenCodeEvent(line, TASK_ID);
+      const toolEntry = result.entries.find((e) => e.type === "tool_use");
+      expect(toolEntry).toBeDefined();
+      expect(toolEntry?.metadata?.toolName).toBe("bash");
+      expect(result.sessionId).toBe(sessionId);
+    });
+  });
 });

--- a/apps/api/src/services/opencode-event-parser.ts
+++ b/apps/api/src/services/opencode-event-parser.ts
@@ -39,8 +39,84 @@ export function parseOpenCodeEvent(
   const timestamp = new Date().toISOString();
   const entries: AgentLogEntry[] = [];
 
-  // Extract session/conversation ID if present
-  const sessionId = (event.session_id ?? event.id ?? event.conversation_id) as string | undefined;
+  // opencode >=1.14 uses camelCase sessionID; older builds snake_case session_id.
+  const sessionId = (event.sessionID ??
+    event.session_id ??
+    event.part?.sessionID ??
+    event.part?.session_id ??
+    event.id ??
+    event.conversation_id) as string | undefined;
+
+  // ── opencode >=1.14 stream-json events: payload lives in event.part ──
+  const part = event.part as Record<string, any> | undefined;
+  if (part) {
+    const partType = part.type as string | undefined;
+
+    if (partType === "step-start") {
+      // Bookkeeping only — nothing user-visible to log.
+      return { entries, sessionId };
+    }
+
+    if (partType === "text") {
+      const content = typeof part.text === "string" ? part.text : "";
+      if (content.trim()) {
+        entries.push({ taskId, timestamp, sessionId, type: "text", content });
+      }
+      return { entries, sessionId };
+    }
+
+    if (partType === "reasoning") {
+      const content = typeof part.text === "string" ? part.text : "";
+      if (content.trim()) {
+        entries.push({ taskId, timestamp, sessionId, type: "thinking", content });
+      }
+      return { entries, sessionId };
+    }
+
+    if (partType === "tool") {
+      const args = parseArgs(part.state?.input);
+      const formatted = formatToolUse(part.tool, args);
+      entries.push({
+        taskId,
+        timestamp,
+        sessionId,
+        type: "tool_use",
+        content: formatted,
+        metadata: { toolName: part.tool, toolInput: args, toolUseId: part.callID ?? part.call_id },
+      });
+      return { entries, sessionId };
+    }
+
+    if (partType === "step-finish") {
+      const tokens = part.tokens as { total?: number; input?: number; output?: number } | undefined;
+      const cost = part.cost;
+      const meta: string[] = [];
+      if (tokens?.input) meta.push(`${tokens.input} input tokens`);
+      if (tokens?.output) meta.push(`${tokens.output} output tokens`);
+      if (typeof cost === "number") meta.push(`$${cost.toFixed(4)}`);
+      if (meta.length) {
+        entries.push({
+          taskId,
+          timestamp,
+          sessionId,
+          type: "info",
+          content: `Usage: ${meta.join(" · ")}`,
+          metadata: {
+            inputTokens: tokens?.input ?? 0,
+            outputTokens: tokens?.output ?? 0,
+            totalTokens: tokens?.total,
+            cost: typeof cost === "number" ? cost : undefined,
+          },
+        });
+      }
+      return { entries, sessionId };
+    }
+
+    // Unknown part type — skip but keep the sessionId.
+    return { entries, sessionId };
+  }
+
+  // Legacy (pre-1.14) shape.
 
   // System message or init
   if (event.type === "message" && event.role === "system") {

--- a/apps/api/src/services/secret-service.test.ts
+++ b/apps/api/src/services/secret-service.test.ts
@@ -1212,3 +1212,72 @@ describe("secret-service", () => {
     });
   });
 });
+
+// ── substituteSecretPlaceholders ────────────────────────────────────────────
+
+describe("substituteSecretPlaceholders", () => {
+  let substituteSecretPlaceholders: typeof import("./secret-service.js").substituteSecretPlaceholders;
+
+  beforeEach(async () => {
+    const mod = await import("./secret-service.js");
+    substituteSecretPlaceholders = mod.substituteSecretPlaceholders;
+  });
+
+  it("substitutes {env:NAME} placeholders in setup file content with literal values", () => {
+    const files = [
+      {
+        path: "/home/agent/.config/opencode/opencode.json",
+        content: JSON.stringify({
+          provider: { litellm: { options: { apiKey: "{env:OPENAI_API_KEY}" } } },
+        }),
+      },
+    ];
+    substituteSecretPlaceholders(files, { OPENAI_API_KEY: "sk-test-1234" });
+    expect(files[0].content).toContain("sk-test-1234");
+    expect(files[0].content).not.toContain("{env:OPENAI_API_KEY}");
+  });
+
+  it("replaces every occurrence of the same placeholder", () => {
+    const files = [
+      {
+        path: "config.json",
+        content: '{"a":"{env:FOO}","b":"{env:FOO}","c":"{env:BAR}"}',
+      },
+    ];
+    substituteSecretPlaceholders(files, { FOO: "v1", BAR: "v2" });
+    expect(files[0].content).toBe('{"a":"v1","b":"v1","c":"v2"}');
+  });
+
+  it("leaves placeholders for unknown names untouched", () => {
+    const files = [
+      { path: "config.json", content: '{"apiKey":"{env:UNKNOWN_KEY}","x":"{env:FOO}"}' },
+    ];
+    substituteSecretPlaceholders(files, { FOO: "v1" });
+    expect(files[0].content).toBe('{"apiKey":"{env:UNKNOWN_KEY}","x":"v1"}');
+  });
+
+  it("leaves placeholders untouched when the resolved value is empty (fail-visible)", () => {
+    const files = [{ path: "config.json", content: '{"apiKey":"{env:EMPTY_KEY}"}' }];
+    substituteSecretPlaceholders(files, { EMPTY_KEY: "" });
+    expect(files[0].content).toBe('{"apiKey":"{env:EMPTY_KEY}"}');
+  });
+
+  it("does not touch contentBase64-only files", () => {
+    const files = [{ path: "binary.bin", contentBase64: "aGVsbG8=", executable: true } as any];
+    substituteSecretPlaceholders(files, { OPENAI_API_KEY: "sk-x" });
+    expect(files[0].contentBase64).toBe("aGVsbG8=");
+    expect((files[0] as any).content).toBeUndefined();
+  });
+
+  it("is a no-op for files without content", () => {
+    const files = [{ path: "dir" } as any];
+    substituteSecretPlaceholders(files, { OPENAI_API_KEY: "sk-x" });
+    expect((files[0] as any).content).toBeUndefined();
+  });
+
+  it("handles empty secretValues map (no-op)", () => {
+    const files = [{ path: "c.json", content: '{"apiKey":"{env:OPENAI_API_KEY}"}' }];
+    substituteSecretPlaceholders(files, {});
+    expect(files[0].content).toBe('{"apiKey":"{env:OPENAI_API_KEY}"}');
+  });
+});

--- a/apps/api/src/services/secret-service.ts
+++ b/apps/api/src/services/secret-service.ts
@@ -484,3 +484,32 @@ export async function resolveSecretsForSetup(
   // Resolve with repo→global fallback (no userId — setup is pod-level, not user-level)
   return resolveSecretsForTask(safeNames, repoUrl, workspaceId);
 }
+
+/**
+ * Substitute `{env:NAME}` placeholders inside agent setup file contents with
+ * literal secret values, mutating the files in place.
+ *
+ * Needed because opencode does not resolve `{env:VAR}` in provider options
+ * (anomalyco/opencode#27853): requests went out without an Authorization
+ * header and were rejected with 401.
+ *
+ * SECURITY trade-off: decrypted secret values end up in OPTIO_SETUP_FILES
+ * pod env and in plaintext on the pod volume.
+ *
+ * Empty values are never substituted so a misconfigured secret fails visibly
+ * (placeholder remains) instead of silently producing an empty API key.
+ * Files that carry `contentBase64` (binary payloads) are left untouched.
+ */
+export function substituteSecretPlaceholders(
+  setupFiles: NonNullable<import("@optio/shared").AgentContainerConfig["setupFiles"]>,
+  secretValues: Record<string, string>,
+): void {
+  if (!setupFiles?.length || !secretValues) return;
+  for (const file of setupFiles) {
+    if (typeof file.content !== "string") continue;
+    for (const [name, value] of Object.entries(secretValues)) {
+      if (!value) continue;
+      file.content = file.content.replaceAll(`{env:${name}}`, value);
+    }
+  }
+}

--- a/apps/api/src/workers/persistent-agent-worker.ts
+++ b/apps/api/src/workers/persistent-agent-worker.ts
@@ -161,7 +161,7 @@ function buildAgentCommand(
         : "";
       return [
         `echo "[optio] Running persistent agent turn (OpenCode)..."`,
-        `opencode run --format json${modelFlag} "$OPTIO_PROMPT"`,
+        `opencode run --format json${modelFlag} "$OPTIO_PROMPT" < /dev/null`,
       ];
     }
     case "gemini": {

--- a/apps/api/src/workers/pr-review-worker.ts
+++ b/apps/api/src/workers/pr-review-worker.ts
@@ -41,6 +41,7 @@ import {
   resolveSecretsForTask,
   resolveSecretsForSetup,
   retrieveSecretWithFallback,
+  substituteSecretPlaceholders,
 } from "../services/secret-service.js";
 import { isGitHubAppConfigured } from "../services/github-app-service.js";
 import { getCredentialSecret } from "../services/credential-secret-service.js";
@@ -420,12 +421,6 @@ export function startPrReviewWorker() {
           }
         }
 
-        if (agentConfig.setupFiles && agentConfig.setupFiles.length > 0) {
-          agentConfig.env.OPTIO_SETUP_FILES = Buffer.from(
-            JSON.stringify(agentConfig.setupFiles),
-          ).toString("base64");
-        }
-
         // ── Secrets ───────────────────────────────────────────────
         const secretNames = [
           ...new Set([
@@ -439,6 +434,15 @@ export function startPrReviewWorker() {
           workspaceId,
           userId,
         );
+
+        // Substitute secret placeholders BEFORE base64-encoding (order matters).
+        if (agentConfig.setupFiles && agentConfig.setupFiles.length > 0) {
+          substituteSecretPlaceholders(agentConfig.setupFiles, resolvedSecrets);
+          agentConfig.env.OPTIO_SETUP_FILES = Buffer.from(
+            JSON.stringify(agentConfig.setupFiles),
+          ).toString("base64");
+        }
+
         const allEnv: Record<string, string> = { ...agentConfig.env, ...resolvedSecrets };
 
         for (const secretName of ["GITHUB_TOKEN", "GITLAB_TOKEN", "GITLAB_HOST"]) {
@@ -496,6 +500,10 @@ export function startPrReviewWorker() {
             : {}),
           ...(allEnv.OPTIO_SETUP_COMMANDS
             ? { OPTIO_SETUP_COMMANDS: allEnv.OPTIO_SETUP_COMMANDS }
+            : {}),
+          // Pre-installed by repo-init.sh (helm: agent.preinstallNpmPackages).
+          ...(process.env.OPTIO_NPM_PREINSTALL
+            ? { OPTIO_NPM_PREINSTALL: process.env.OPTIO_NPM_PREINSTALL }
             : {}),
         };
         const setupSecrets = await resolveSecretsForSetup(review.repoUrl, workspaceId);

--- a/apps/api/src/workers/task-worker.test.ts
+++ b/apps/api/src/workers/task-worker.test.ts
@@ -204,6 +204,13 @@ describe("buildAgentCommand", () => {
       expect(cmds.some((c) => c.includes("--format json"))).toBe(true);
     });
 
+    it("runs with --dangerously-skip-permissions so permission asks never hang the run", () => {
+      const env = { OPTIO_PROMPT: "Fix the bug" };
+      const cmds = buildAgentCommand("opencode", env);
+      const cmd = cmds.find((c) => c.includes("opencode run"));
+      expect(cmd).toContain("--dangerously-skip-permissions");
+    });
+
     it("redirects opencode stdin from /dev/null so run-mode stdin reads get EOF", () => {
       const env = { OPTIO_PROMPT: "Fix the bug" };
       const cmds = buildAgentCommand("opencode", env);

--- a/apps/api/src/workers/task-worker.test.ts
+++ b/apps/api/src/workers/task-worker.test.ts
@@ -204,6 +204,13 @@ describe("buildAgentCommand", () => {
       expect(cmds.some((c) => c.includes("--format json"))).toBe(true);
     });
 
+    it("redirects opencode stdin from /dev/null so run-mode stdin reads get EOF", () => {
+      const env = { OPTIO_PROMPT: "Fix the bug" };
+      const cmds = buildAgentCommand("opencode", env);
+      const cmd = cmds.find((c) => c.includes("opencode run"));
+      expect(cmd).toContain("< /dev/null");
+    });
+
     it("includes experimental label in echo", () => {
       const env = { OPTIO_PROMPT: "Fix the bug" };
       const cmds = buildAgentCommand("opencode", env);

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -1894,7 +1894,7 @@ export function buildAgentCommand(
         : "";
       return [
         `echo "[optio] Running OpenCode (experimental)..."`,
-        `opencode run --format json${modelFlag}${agentFlag}${resumeFlag} "$OPTIO_PROMPT" < /dev/null`,
+        `opencode run --format json --dangerously-skip-permissions${modelFlag}${agentFlag}${resumeFlag} "$OPTIO_PROMPT" < /dev/null`,
       ];
     }
     case "gemini": {

--- a/apps/api/src/workers/task-worker.ts
+++ b/apps/api/src/workers/task-worker.ts
@@ -41,6 +41,7 @@ import {
   resolveSecretsForTask,
   resolveSecretsForSetup,
   retrieveSecretWithFallback,
+  substituteSecretPlaceholders,
 } from "../services/secret-service.js";
 import { getPromptTemplate } from "../services/prompt-template-service.js";
 import { isGitHubAppConfigured } from "../services/github-app-service.js";
@@ -605,13 +606,6 @@ export function startTaskWorker() {
           }
         }
 
-        // Encode setup files
-        if (agentConfig.setupFiles && agentConfig.setupFiles.length > 0) {
-          agentConfig.env.OPTIO_SETUP_FILES = Buffer.from(
-            JSON.stringify(agentConfig.setupFiles),
-          ).toString("base64");
-        }
-
         // Resolve secrets (workspace → repo-scoped → global fallback)
         // Only require GITHUB_TOKEN when GitHub App auth is not configured
         const secretNames = [
@@ -627,6 +621,15 @@ export function startTaskWorker() {
           taskWorkspaceId,
           taskUserId,
         );
+
+        // Substitute secret placeholders BEFORE base64-encoding (order matters).
+        if (agentConfig.setupFiles && agentConfig.setupFiles.length > 0) {
+          substituteSecretPlaceholders(agentConfig.setupFiles, resolvedSecrets);
+          agentConfig.env.OPTIO_SETUP_FILES = Buffer.from(
+            JSON.stringify(agentConfig.setupFiles),
+          ).toString("base64");
+        }
+
         const allEnv: Record<string, string> = { ...agentConfig.env, ...resolvedSecrets };
 
         // Resolve git platform tokens (not part of adapter requiredSecrets since they're infra-level)
@@ -744,6 +747,10 @@ export function startTaskWorker() {
             : {}),
           ...(allEnv.OPTIO_SETUP_COMMANDS
             ? { OPTIO_SETUP_COMMANDS: allEnv.OPTIO_SETUP_COMMANDS }
+            : {}),
+          // Pre-installed by repo-init.sh (helm: agent.preinstallNpmPackages).
+          ...(process.env.OPTIO_NPM_PREINSTALL
+            ? { OPTIO_NPM_PREINSTALL: process.env.OPTIO_NPM_PREINSTALL }
             : {}),
         };
 
@@ -1887,7 +1894,7 @@ export function buildAgentCommand(
         : "";
       return [
         `echo "[optio] Running OpenCode (experimental)..."`,
-        `opencode run --format json${modelFlag}${agentFlag}${resumeFlag} "$OPTIO_PROMPT"`,
+        `opencode run --format json${modelFlag}${agentFlag}${resumeFlag} "$OPTIO_PROMPT" < /dev/null`,
       ];
     }
     case "gemini": {

--- a/apps/api/src/workers/workflow-worker.ts
+++ b/apps/api/src/workers/workflow-worker.ts
@@ -110,7 +110,7 @@ export function buildWorkflowAgentCommand(
         : "";
       return [
         `echo "[optio] Running workflow agent (OpenCode)..."`,
-        `opencode run --format json${modelFlag} "$OPTIO_PROMPT"`,
+        `opencode run --format json${modelFlag} "$OPTIO_PROMPT" < /dev/null`,
       ];
     }
     case "gemini": {

--- a/helm/optio/templates/api-deployment.yaml
+++ b/helm/optio/templates/api-deployment.yaml
@@ -107,6 +107,8 @@ spec:
             {{- end }}
             - name: OPTIO_STATEFULSET_ENABLED
               value: {{ .Values.agent.statefulSet.enabled | quote }}
+            - name: OPTIO_NPM_PREINSTALL
+              value: {{ join "," .Values.agent.preinstallNpmPackages | quote }}
             - name: OPTIO_ROOTLESS
               value: {{ .Values.agent.rootless | default false | quote }}
             - name: OPTIO_TERMINATION_GRACE_PERIOD_SECONDS

--- a/helm/optio/values.yaml
+++ b/helm/optio/values.yaml
@@ -141,6 +141,10 @@ agent:
       repository: envoyproxy/envoy
       tag: v1.31-latest
       pullPolicy: IfNotPresent
+  # npm packages pre-installed by repo-init.sh into ~/.config/opencode before
+  # the first task (e.g. opencode provider plugins). Comma-joined into OPTIO_NPM_PREINSTALL.
+  preinstallNpmPackages:
+    - "@ai-sdk/openai-compatible"
   # PVC template for repo pod home directories.
   # These PVCs are created dynamically by the API server (one per repo pod
   # instance), but this template controls the storage class and default size.

--- a/packages/agent-adapters/src/opencode.test.ts
+++ b/packages/agent-adapters/src/opencode.test.ts
@@ -54,6 +54,12 @@ describe("OpenCodeAdapter", () => {
       repoBranch: "main",
     };
 
+    it("does not set extra workaround env vars — the stdin EOF fix is the only change", () => {
+      const config = adapter.buildContainerConfig(baseInput);
+      expect(config.env.OPENCODE_DISABLE_MODELS_FETCH).toBeUndefined();
+      expect(config.env.OPENCODE_DISABLE_AUTOUPDATE).toBeUndefined();
+    });
+
     it("uses rendered prompt when available", () => {
       const config = adapter.buildContainerConfig({
         ...baseInput,
@@ -165,6 +171,225 @@ describe("OpenCodeAdapter", () => {
     it("uses entrypoint.sh as command", () => {
       const config = adapter.buildContainerConfig(baseInput);
       expect(config.command).toEqual(["/opt/optio/entrypoint.sh"]);
+    });
+
+    describe("Native Provider (Anthropic/OpenAI/Groq)", () => {
+      it("Native Anthropic: only ANTHROPIC_API_KEY set → minimal opencode.json", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeModel: undefined,
+          opencodeBaseUrl: undefined,
+        });
+        const configFile = config.setupFiles!.find((f) => f.path.includes("opencode.json"));
+        expect(configFile).toBeDefined();
+        expect(JSON.parse(configFile!.content)).toEqual({
+          $schema: "https://opencode.ai/config.json",
+        });
+        expect(config.env.ANTHROPIC_API_KEY).toBeUndefined();
+        expect(config.env.OPENAI_API_KEY).toBeUndefined();
+        expect(config.requiredSecrets).toContain("ANTHROPIC_API_KEY");
+      });
+
+      it("Native Anthropic: ANTHROPIC_API_KEY + OPENCODE_DEFAULT_MODEL set", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeModel: undefined,
+          opencodeBaseUrl: undefined,
+          opencodeDefaultModel: "claude-sonnet-4",
+        });
+        expect(config.env.OPENCODE_MODEL).toBe("claude-sonnet-4");
+        expect(config.requiredSecrets).toContain("ANTHROPIC_API_KEY");
+      });
+
+      it("Native OpenAI: only OPENAI_API_KEY set", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeModel: undefined,
+          opencodeBaseUrl: undefined,
+        });
+        const configFile = config.setupFiles!.find((f) => f.path.includes("opencode.json"));
+        expect(JSON.parse(configFile!.content)).toEqual({
+          $schema: "https://opencode.ai/config.json",
+        });
+        expect(config.env.OPENAI_API_KEY).toBeUndefined();
+        expect(config.requiredSecrets).toContain("OPENAI_API_KEY");
+      });
+
+      it("Native OpenAI: OPENAI_API_KEY (emptystring) + OPENCODE_DEFAULT_MODEL set", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeModel: undefined,
+          opencodeBaseUrl: undefined,
+          opencodeDefaultModel: "gpt-4o",
+        });
+        expect(config.env.OPENCODE_MODEL).toBe("gpt-4o");
+        expect(config.requiredSecrets).toContain("OPENAI_API_KEY");
+      });
+
+      it("Native OpenAI: OPENAI_API_KEY + OPENCODE_DEFAULT_MODEL set", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeModel: undefined,
+          opencodeBaseUrl: undefined,
+          opencodeDefaultModel: "gpt-4o",
+        });
+        expect(config.env.OPENCODE_MODEL).toBe("gpt-4o");
+        expect(config.requiredSecrets).toContain("OPENAI_API_KEY");
+      });
+
+      it("Native Groq: only GROQ_API_KEY set", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeModel: undefined,
+          opencodeBaseUrl: undefined,
+        });
+        const configFile = config.setupFiles!.find((f) => f.path.includes("opencode.json"));
+        expect(JSON.parse(configFile!.content)).toEqual({
+          $schema: "https://opencode.ai/config.json",
+        });
+        expect(config.env.GROQ_API_KEY).toBeUndefined();
+        expect(config.env.ANTHROPIC_API_KEY).toBeUndefined();
+        expect(config.env.OPENAI_API_KEY).toBeUndefined();
+      });
+
+      it("Native Groq: GROQ_API_KEY + OPENCODE_DEFAULT_MODEL set", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeModel: undefined,
+          opencodeBaseUrl: undefined,
+          opencodeDefaultModel: "llama-3.1-70b",
+        });
+        expect(config.env.OPENCODE_MODEL).toBe("llama-3.1-70b");
+      });
+
+      it("Native Anthropic: multiple provider keys set (ANTHROPIC_API_KEY + OPENAI_API_KEY)", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeModel: undefined,
+          opencodeBaseUrl: undefined,
+        });
+        expect(config.requiredSecrets).toContain("ANTHROPIC_API_KEY");
+        expect(config.requiredSecrets).toContain("OPENAI_API_KEY");
+      });
+    });
+
+    describe("LiteLLM Provider", () => {
+      it("LiteLLM: URL + Model, WITHOUT OPENAI_API_KEY secret → placeholder key", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeBaseUrl: "http://litellm-proxy.agents.svc.cluster.local:4000",
+          opencodeModel: "litellm/my-litellm-model",
+          opencodeDefaultModel: undefined,
+        });
+        const configFile = config.setupFiles!.find((f) => f.path.includes("opencode.json"));
+        expect(configFile).toBeDefined();
+        const parsedConfig = JSON.parse(configFile!.content);
+        expect(parsedConfig).toEqual({
+          $schema: "https://opencode.ai/config.json",
+          model: "litellm/my-litellm-model",
+          provider: {
+            litellm: {
+              npm: "@ai-sdk/openai-compatible",
+              name: "LiteLLM Proxy",
+              options: {
+                baseURL: "http://litellm-proxy.agents.svc.cluster.local:4000",
+                apiKey: "{env:OPENAI_API_KEY}",
+              },
+              models: {
+                "my-litellm-model": {
+                  name: "my-litellm-model",
+                },
+              },
+            },
+          },
+        });
+        expect(config.env.OPENAI_API_KEY).toBe("sk-no-key-required");
+        expect(config.env.OPENCODE_MODEL).toBe("litellm/my-litellm-model");
+        expect(config.env.OPENAI_BASE_URL).toBeUndefined();
+        expect(config.requiredSecrets).toContain("OPENAI_API_KEY");
+      });
+
+      it("LiteLLM: URL + Model, WITH OPENAI_API_KEY secret", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeBaseUrl: "http://litellm-proxy.agents.svc.cluster.local:4000",
+          opencodeModel: "litellm/my-litellm-model",
+          opencodeDefaultModel: undefined,
+        });
+        const configFile = config.setupFiles!.find((f) => f.path.includes("opencode.json"));
+        const parsedConfig = JSON.parse(configFile!.content);
+        expect(parsedConfig.provider.litellm.options.baseURL).toBe(
+          "http://litellm-proxy.agents.svc.cluster.local:4000",
+        );
+        expect(parsedConfig.provider.litellm.options.apiKey).toBe("{env:OPENAI_API_KEY}");
+        expect(parsedConfig.model).toBe("litellm/my-litellm-model");
+        expect(config.env.OPENCODE_MODEL).toBe("litellm/my-litellm-model");
+        expect(config.env.OPENAI_BASE_URL).toBeUndefined();
+        expect(config.requiredSecrets).toContain("OPENAI_API_KEY");
+      });
+
+      it("LiteLLM: fallback to OPENCODE_DEFAULT_MODEL when opencodeModel not set", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeBaseUrl: "http://litellm-proxy:4000",
+          opencodeModel: undefined,
+          opencodeDefaultModel: "litellm/litellm-default-model",
+        });
+        const configFile = config.setupFiles!.find((f) => f.path.includes("opencode.json"));
+        const parsedConfig = JSON.parse(configFile!.content);
+        expect(parsedConfig.model).toBe("litellm/litellm-default-model");
+        expect(parsedConfig.provider.litellm.models).toEqual({
+          "litellm-default-model": { name: "litellm-default-model" },
+        });
+        expect(config.env.OPENCODE_MODEL).toBe("litellm/litellm-default-model");
+      });
+
+      it("LiteLLM: opencodeModel wins over OPENCODE_DEFAULT_MODEL when both set", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeBaseUrl: "http://litellm-proxy:4000",
+          opencodeModel: "litellm/repo-specific-model",
+          opencodeDefaultModel: "global-secret-model",
+        });
+        const configFile = config.setupFiles!.find((f) => f.path.includes("opencode.json"));
+        const parsedConfig = JSON.parse(configFile!.content);
+        expect(parsedConfig.model).toBe("litellm/repo-specific-model");
+        expect(parsedConfig.provider.litellm.models).toEqual({
+          "repo-specific-model": { name: "repo-specific-model" },
+        });
+        expect(config.env.OPENCODE_MODEL).toBe("litellm/repo-specific-model");
+      });
+    });
+
+    describe("Native Provider: Model Priority", () => {
+      it("Native: opencodeModel wins over OPENCODE_DEFAULT_MODEL when both set", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeModel: "anthropic/claude-opus-4",
+          opencodeDefaultModel: "claude-sonnet-4",
+        });
+        expect(config.env.OPENCODE_MODEL).toBe("anthropic/claude-opus-4");
+        expect(config.env.OPTIO_OPENCODE_MODEL).toBe("anthropic/claude-opus-4");
+      });
+    });
+
+    describe("Secret Injection Verification", () => {
+      it("OPENAI_API_KEY secret resolves to container env var", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeBaseUrl: "http://litellm-proxy:4000/v1",
+          opencodeModel: "litellm/test-model",
+        });
+        expect(config.requiredSecrets).toContain("OPENAI_API_KEY");
+      });
+
+      it("Missing OPENAI_API_KEY secret results in fallback placeholder", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeBaseUrl: "http://litellm-proxy:4000/v1",
+        });
+        expect(config.env.OPENAI_API_KEY).toBe("sk-no-key-required");
+      });
     });
   });
 

--- a/packages/agent-adapters/src/opencode.test.ts
+++ b/packages/agent-adapters/src/opencode.test.ts
@@ -148,6 +148,20 @@ describe("OpenCodeAdapter", () => {
       expect(configFile).toBeDefined();
       expect(JSON.parse(configFile!.content)).toEqual({
         $schema: "https://opencode.ai/config.json",
+        permission: {
+          "*": "allow",
+          question: "deny",
+          bash: {
+            "sudo *": "deny",
+            "apt *": "deny",
+            "apt-get *": "deny",
+            "dpkg *": "deny",
+          },
+          external_directory: {
+            "*": "deny",
+            "/home/agent/.local/share/opencode/**": "allow",
+          },
+        },
       });
     });
 
@@ -164,13 +178,125 @@ describe("OpenCodeAdapter", () => {
 
     it("returns only opencode config in setupFiles when no task file", () => {
       const config = adapter.buildContainerConfig(baseInput);
-      expect(config.setupFiles).toHaveLength(1);
+      expect(config.setupFiles).toHaveLength(3);
       expect(config.setupFiles![0].path).toContain("opencode.json");
+      expect(config.setupFiles!.map((f) => f.path)).toContain(
+        "/home/agent/.config/opencode/plugins/optio-workspace-guard.js",
+      );
+      expect(config.setupFiles!.map((f) => f.path)).toContain(
+        "/home/agent/.config/opencode/AGENTS.md",
+      );
     });
 
     it("uses entrypoint.sh as command", () => {
       const config = adapter.buildContainerConfig(baseInput);
       expect(config.command).toEqual(["/opt/optio/entrypoint.sh"]);
+    });
+
+    describe("workspace confinement (headless guard)", () => {
+      const readConfig = (setupFiles: { path: string; content: string }[]) => {
+        const configFile = setupFiles.find((f) =>
+          f.path.includes(".config/opencode/opencode.json"),
+        );
+        return JSON.parse(configFile!.content) as {
+          permission?: Record<string, string | Record<string, string>>;
+        };
+      };
+
+      const expectedPermission = {
+        "*": "allow",
+        question: "deny",
+        bash: {
+          "sudo *": "deny",
+          "apt *": "deny",
+          "apt-get *": "deny",
+          "dpkg *": "deny",
+        },
+        external_directory: {
+          "*": "deny",
+          "/home/agent/.local/share/opencode/**": "allow",
+        },
+      };
+
+      it("allows everything by default", () => {
+        const config = adapter.buildContainerConfig(baseInput);
+        const parsed = readConfig(config.setupFiles!);
+        expect(parsed.permission?.["*"]).toBe("allow");
+      });
+
+      it("denies the question tool so headless runs never ask", () => {
+        const config = adapter.buildContainerConfig(baseInput);
+        const parsed = readConfig(config.setupFiles!);
+        expect(parsed.permission?.["question"]).toBe("deny");
+      });
+
+      it("denies system package installs and privilege escalation via bash", () => {
+        const config = adapter.buildContainerConfig(baseInput);
+        const parsed = readConfig(config.setupFiles!);
+        expect(parsed.permission?.["bash"]).toEqual(expectedPermission.bash);
+      });
+
+      it("denies external_directory so the agent stays inside the worktree", () => {
+        const config = adapter.buildContainerConfig(baseInput);
+        const parsed = readConfig(config.setupFiles!);
+        expect(parsed.permission?.["external_directory"]).toMatchObject({ "*": "deny" });
+      });
+
+      it("keeps opencode's own tool-output directory accessible", () => {
+        const config = adapter.buildContainerConfig(baseInput);
+        const parsed = readConfig(config.setupFiles!);
+        expect(parsed.permission?.["external_directory"]).toMatchObject({
+          "/home/agent/.local/share/opencode/**": "allow",
+        });
+      });
+
+      it("ships the workspace-guard plugin as a global setup file", () => {
+        const config = adapter.buildContainerConfig(baseInput);
+        const plugin = config.setupFiles?.find(
+          (f) => f.path === "/home/agent/.config/opencode/plugins/optio-workspace-guard.js",
+        );
+        expect(plugin).toBeDefined();
+        expect(plugin!.content).toContain("tool.execute.before");
+      });
+
+      it("plugin hint tells the agent to stay inside the workspace", () => {
+        const config = adapter.buildContainerConfig(baseInput);
+        const plugin = config.setupFiles?.find(
+          (f) => f.path === "/home/agent/.config/opencode/plugins/optio-workspace-guard.js",
+        );
+        expect(plugin!.content).toContain("Im Workspace bleiben");
+      });
+
+      it("plugin blocks /tmp but allows opencode internals", () => {
+        const config = adapter.buildContainerConfig(baseInput);
+        const plugin = config.setupFiles?.find(
+          (f) => f.path === "/home/agent/.config/opencode/plugins/optio-workspace-guard.js",
+        );
+        expect(plugin!.content).toContain('"bash"');
+        expect(plugin!.content).toContain("/tmp");
+        expect(plugin!.content).toContain(".local/share/opencode");
+      });
+
+      it("ships global AGENTS.md workspace rules", () => {
+        const config = adapter.buildContainerConfig(baseInput);
+        const agents = config.setupFiles?.find(
+          (f) => f.path === "/home/agent/.config/opencode/AGENTS.md",
+        );
+        expect(agents).toBeDefined();
+        expect(agents!.content).toContain("workspace");
+        expect(agents!.content).toContain("headless");
+      });
+
+      it("writes the same guard files for litellm-based runs", () => {
+        const config = adapter.buildContainerConfig({
+          ...baseInput,
+          opencodeBaseUrl: "http://litellm-proxy:4000",
+          opencodeModel: "litellm/default",
+        });
+        const paths = config.setupFiles!.map((f) => f.path);
+        expect(paths).toContain("/home/agent/.config/opencode/plugins/optio-workspace-guard.js");
+        expect(paths).toContain("/home/agent/.config/opencode/AGENTS.md");
+      });
     });
 
     describe("Native Provider (Anthropic/OpenAI/Groq)", () => {
@@ -184,6 +310,20 @@ describe("OpenCodeAdapter", () => {
         expect(configFile).toBeDefined();
         expect(JSON.parse(configFile!.content)).toEqual({
           $schema: "https://opencode.ai/config.json",
+          permission: {
+            "*": "allow",
+            question: "deny",
+            bash: {
+              "sudo *": "deny",
+              "apt *": "deny",
+              "apt-get *": "deny",
+              "dpkg *": "deny",
+            },
+            external_directory: {
+              "*": "deny",
+              "/home/agent/.local/share/opencode/**": "allow",
+            },
+          },
         });
         expect(config.env.ANTHROPIC_API_KEY).toBeUndefined();
         expect(config.env.OPENAI_API_KEY).toBeUndefined();
@@ -210,6 +350,20 @@ describe("OpenCodeAdapter", () => {
         const configFile = config.setupFiles!.find((f) => f.path.includes("opencode.json"));
         expect(JSON.parse(configFile!.content)).toEqual({
           $schema: "https://opencode.ai/config.json",
+          permission: {
+            "*": "allow",
+            question: "deny",
+            bash: {
+              "sudo *": "deny",
+              "apt *": "deny",
+              "apt-get *": "deny",
+              "dpkg *": "deny",
+            },
+            external_directory: {
+              "*": "deny",
+              "/home/agent/.local/share/opencode/**": "allow",
+            },
+          },
         });
         expect(config.env.OPENAI_API_KEY).toBeUndefined();
         expect(config.requiredSecrets).toContain("OPENAI_API_KEY");
@@ -246,6 +400,20 @@ describe("OpenCodeAdapter", () => {
         const configFile = config.setupFiles!.find((f) => f.path.includes("opencode.json"));
         expect(JSON.parse(configFile!.content)).toEqual({
           $schema: "https://opencode.ai/config.json",
+          permission: {
+            "*": "allow",
+            question: "deny",
+            bash: {
+              "sudo *": "deny",
+              "apt *": "deny",
+              "apt-get *": "deny",
+              "dpkg *": "deny",
+            },
+            external_directory: {
+              "*": "deny",
+              "/home/agent/.local/share/opencode/**": "allow",
+            },
+          },
         });
         expect(config.env.GROQ_API_KEY).toBeUndefined();
         expect(config.env.ANTHROPIC_API_KEY).toBeUndefined();
@@ -287,6 +455,20 @@ describe("OpenCodeAdapter", () => {
         expect(parsedConfig).toEqual({
           $schema: "https://opencode.ai/config.json",
           model: "litellm/my-litellm-model",
+          permission: {
+            "*": "allow",
+            question: "deny",
+            bash: {
+              "sudo *": "deny",
+              "apt *": "deny",
+              "apt-get *": "deny",
+              "dpkg *": "deny",
+            },
+            external_directory: {
+              "*": "deny",
+              "/home/agent/.local/share/opencode/**": "allow",
+            },
+          },
           provider: {
             litellm: {
               npm: "@ai-sdk/openai-compatible",

--- a/packages/agent-adapters/src/opencode.ts
+++ b/packages/agent-adapters/src/opencode.ts
@@ -2,6 +2,22 @@ import type { AgentTaskInput, AgentContainerConfig, AgentResult } from "@optio/s
 import { TASK_BRANCH_PREFIX } from "@optio/shared";
 import type { AgentAdapter } from "./types.js";
 
+interface OpenCodeConfig {
+  $schema: string;
+  model?: string;
+  provider?: {
+    litellm?: {
+      npm: string;
+      name: string;
+      options: {
+        baseURL: string;
+        apiKey: string;
+      };
+      models: Record<string, { name: string }>;
+    };
+  };
+}
+
 /**
  * OpenCode CLI (opencode run --format json) outputs NDJSON events.
  * Each line is a JSON object. The exact schema is not fully documented,
@@ -54,15 +70,56 @@ export class OpenCodeAdapter implements AgentAdapter {
     // When using a custom base URL, provider API keys are optional — the adapter
     // sets a placeholder OPENAI_API_KEY in env that will be overridden if a real
     // secret exists. Without a custom base URL, require standard provider keys.
-    if (!input.opencodeBaseUrl) {
-      requiredSecrets.push("ANTHROPIC_API_KEY", "OPENAI_API_KEY");
-    }
+    // Full "litellm/<model>" name routes to the provider; only the models map key uses the bare name.
+    const isLitellm =
+      input.opencodeModel?.startsWith("litellm/") === true ||
+      input.opencodeDefaultModel?.startsWith("litellm/") === true;
+
+    const fullModel = input.opencodeModel ?? input.opencodeDefaultModel;
+    const proxyModel = isLitellm ? fullModel?.replace(/^litellm\//, "") : undefined;
+
+    const config: OpenCodeConfig = {
+      $schema: "https://opencode.ai/config.json",
+    };
 
     const setupFiles: AgentContainerConfig["setupFiles"] = [];
 
-    // Set model if configured (e.g. "anthropic/claude-sonnet-4")
-    if (input.opencodeModel) {
-      env.OPTIO_OPENCODE_MODEL = input.opencodeModel;
+    if (isLitellm) {
+      requiredSecrets.push("OPENAI_API_KEY");
+      env.OPENAI_API_KEY = "sk-no-key-required";
+      if (input.opencodeBaseUrl) {
+        if (fullModel) {
+          config.model = fullModel;
+          env.OPENCODE_MODEL = fullModel;
+        }
+        config.provider = {
+          litellm: {
+            npm: "@ai-sdk/openai-compatible",
+            name: "LiteLLM Proxy",
+            options: {
+              baseURL: input.opencodeBaseUrl,
+              // Rendered to the literal value by the API workers — opencode
+              // does not resolve {env:VAR} in provider options (#27853).
+              apiKey: "{env:OPENAI_API_KEY}",
+            },
+            models: proxyModel
+              ? {
+                  [proxyModel]: {
+                    name: proxyModel,
+                  },
+                }
+              : {},
+          },
+        };
+      }
+    } else if (!input.opencodeBaseUrl) {
+      requiredSecrets.push("ANTHROPIC_API_KEY", "OPENAI_API_KEY");
+    }
+
+    // opencodeModel (repo-specific) always wins over opencodeDefaultModel (global secret)
+    if (fullModel) {
+      env.OPENCODE_MODEL = fullModel;
+      env.OPTIO_OPENCODE_MODEL = fullModel;
     }
     // Set named agent if configured (e.g. "build", "plan")
     if (input.opencodeAgent) {
@@ -70,7 +127,7 @@ export class OpenCodeAdapter implements AgentAdapter {
     }
 
     // Custom OpenAI-compatible endpoint (e.g. vLLM, lightllm, Ollama)
-    if (input.opencodeBaseUrl) {
+    if (input.opencodeBaseUrl && !isLitellm) {
       env.OPENAI_BASE_URL = input.opencodeBaseUrl;
       // Local endpoints typically don't require a real API key — set a
       // placeholder that gets overridden if a real secret is configured.
@@ -80,7 +137,7 @@ export class OpenCodeAdapter implements AgentAdapter {
     // Pre-seed a minimal opencode config so the CLI doesn't hit first-run setup
     setupFiles.push({
       path: "/home/agent/.config/opencode/opencode.json",
-      content: JSON.stringify({ $schema: "https://opencode.ai/config.json" }),
+      content: JSON.stringify(config),
     });
 
     // Write the task file into the worktree

--- a/packages/agent-adapters/src/opencode.ts
+++ b/packages/agent-adapters/src/opencode.ts
@@ -16,7 +16,79 @@ interface OpenCodeConfig {
       models: Record<string, { name: string }>;
     };
   };
+  permission?: Record<string, string | Record<string, string>>;
 }
+
+export const OPENCODE_WORKSPACE_GUARD_PLUGIN = `export const OptioWorkspaceGuard = async ({ directory, worktree }) => {
+  const workspace = directory || worktree || process.cwd();
+  const home = process.env.HOME || "/home/agent";
+  const roots = [
+    workspace.endsWith("/") ? workspace : workspace + "/",
+    home + "/.local/share/opencode/",
+    "/dev/",
+  ];
+  const HINT =
+    "Blocked: path outside the workspace. Stay inside the workspace (Im Workspace bleiben) — write temp files, caches and venvs inside the worktree (e.g. ./.tmp/) instead of /tmp or $HOME.";
+  const HOME_RE = /^(~|\\$HOME)(?=\\/|$)/;
+  const ABS_RE = /(^|[\\s'"(=])(\\/(?:[^\\s'"\\x60\\\\:,;)]|\\*|\\?)+)/g;
+
+  const expand = (p) => p.replace(HOME_RE, home);
+  const isAllowed = (p) => roots.some((r) => p.startsWith(r));
+
+  const offendingPath = (tool, args) => {
+    if (!args || typeof args !== "object") return null;
+    if (["webfetch", "websearch", "task", "skill", "lsp", "question"].includes(tool)) return null;
+    const values = Object.values(args).filter((v) => typeof v === "string");
+    for (const value of values) {
+      const candidates =
+        tool === "bash"
+          ? value.split(/[\\s;|&><()]+/).filter(Boolean)
+          : [value.trim()];
+      for (const token of candidates) {
+        const expanded = expand(token);
+        if (expanded.startsWith("/") && !roots.some((r) => expanded.startsWith(r))) return token;
+        const matches = [...expanded.matchAll(ABS_RE)].map((m) => m[2]);
+        const bad = matches.find((p) => !roots.some((r) => expand(p).startsWith(r)));
+        if (bad) return bad;
+      }
+    }
+    return null;
+  };
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      const bad = offendingPath(input.tool, output.args);
+      if (bad) {
+        throw new Error(HINT + " (tool: " + input.tool + ", path: " + bad + ")");
+      }
+    },
+  };
+};
+`;
+
+export const OPENCODE_GLOBAL_AGENTS_MD = `# Optio Runtime Rules (headless, mandatory)
+
+You are a coding agent launched headless by the Optio orchestrator inside an isolated Kubernetes pod. Your current working directory is your workspace (the git worktree for this task).
+
+## Workspace confinement — absolute rules
+
+- Stay inside the workspace. Never read, write, create, or execute anything outside it.
+- Never use /tmp, /var, /usr, /opt, /etc or \$HOME paths for any file or tool call.
+- Create temporary files, caches, and virtual environments INSIDE the workspace (e.g. \`./.tmp/\`), and clean them up before finishing.
+- No sudo, no system package installs (apt-get), no global pip/npm installs. If tooling is missing, work with what is available inside the workspace.
+- When a tool call is blocked with a workspace-boundary error, do NOT retry the same external path — switch to an in-workspace path.
+
+## Headless mode
+
+- You run non-interactively (opencode run). Asking the user questions is impossible — never attempt it.
+- If something is ambiguous, state your assumption and proceed.
+- Never wait for interactive input; there is none.
+
+## Focus
+
+- Work only on the task described in the task file (.optio/task.md).
+- Commit your work to the task branch and open a PR as described in the task instructions.
+`;
 
 /**
  * OpenCode CLI (opencode run --format json) outputs NDJSON events.
@@ -80,6 +152,20 @@ export class OpenCodeAdapter implements AgentAdapter {
 
     const config: OpenCodeConfig = {
       $schema: "https://opencode.ai/config.json",
+      permission: {
+        "*": "allow",
+        question: "deny",
+        bash: {
+          "sudo *": "deny",
+          "apt *": "deny",
+          "apt-get *": "deny",
+          "dpkg *": "deny",
+        },
+        external_directory: {
+          "*": "deny",
+          "/home/agent/.local/share/opencode/**": "allow",
+        },
+      },
     };
 
     const setupFiles: AgentContainerConfig["setupFiles"] = [];
@@ -138,6 +224,16 @@ export class OpenCodeAdapter implements AgentAdapter {
     setupFiles.push({
       path: "/home/agent/.config/opencode/opencode.json",
       content: JSON.stringify(config),
+    });
+
+    setupFiles.push({
+      path: "/home/agent/.config/opencode/plugins/optio-workspace-guard.js",
+      content: OPENCODE_WORKSPACE_GUARD_PLUGIN,
+    });
+
+    setupFiles.push({
+      path: "/home/agent/.config/opencode/AGENTS.md",
+      content: OPENCODE_GLOBAL_AGENTS_MD,
     });
 
     // Write the task file into the worktree

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -31,6 +31,7 @@ export interface AgentTaskInput {
   opencodeModel?: string;
   opencodeAgent?: string;
   opencodeBaseUrl?: string;
+  opencodeDefaultModel?: string;
   cursorModel?: string;
   openclawModel?: string;
   openclawAgent?: string;

--- a/scripts/repo-init.sh
+++ b/scripts/repo-init.sh
@@ -109,6 +109,33 @@ if [ -n "${OPTIO_EXTRA_PACKAGES:-}" ]; then
   sudo apt-get update -qq 2>/dev/null && sudo apt-get install -y -qq ${PACKAGES} 2>&1 | tail -3 || echo "[optio] Warning: package install failed"
 fi
 
+# Pre-install npm packages (e.g. opencode provider plugins) into
+# ~/.config/opencode before the first task; best-effort, warns on failure.
+if [ -n "${OPTIO_NPM_PREINSTALL:-}" ]; then
+  echo "[optio] Pre-installing npm packages: ${OPTIO_NPM_PREINSTALL}"
+  mkdir -p ~/.config/opencode
+  cd ~/.config/opencode
+  if [ ! -f package.json ]; then
+    printf '{"name":"optio-agent","private":true}\n' > package.json
+  fi
+  # npm cache on local disk — only node_modules writes hit the home volume.
+  export npm_config_cache=/tmp/npm-cache
+  PREINSTALL_OK=0
+  for attempt in 1 2 3; do
+    if npm install --no-audit --no-fund $(echo "${OPTIO_NPM_PREINSTALL}" | tr ',' ' '); then
+      PREINSTALL_OK=1
+      break
+    fi
+    echo "[optio] npm preinstall failed (attempt ${attempt}/3), retrying in 5s..." >&2
+    sleep 5
+  done
+  if [ "${PREINSTALL_OK}" -eq 0 ]; then
+    echo "[optio] Warning: npm preinstall failed after 3 attempts — agent may install plugins at runtime" >&2
+  else
+    echo "[optio] npm preinstall complete"
+  fi
+fi
+
 # Clone repo (--recurse-submodules handles repos with submodules)
 cd /workspace
 echo "[optio] Cloning..."


### PR DESCRIPTION
## Summary

OpenCode agent tasks currently fail when run behind a LiteLLM proxy, for four
independent reasons: the generated `opencode.json` uses `{env:VAR}` placeholders
that opencode does not resolve (requests go out without an `Authorization`
header and are rejected with 401), the dynamic provider-plugin install at first
agent run hangs on NFS home volumes, `opencode run` blocks forever when stdin
never reaches EOF, and opencode 1.14.20 changed its stream-json output schema so
successful runs silently classified as `no_output`.

This PR makes the OpenCode adapter work against LiteLLM-proxied models
(`litellm/<model>` routing to arbitrary backend providers).

## Changes

**Agent adapter** (`packages/agent-adapters/src/opencode.ts`)

- Multi-provider `opencode.json` generation: detect models via the
  `litellm/<model>` prefix, map them into an `openai-compatible` provider, and
  pass the full `litellm/<model>` name to opencode (CLI + `config.model`) —
  the prefix is stripped only inside the provider models map

**Secret handling** (`secret-service.ts`, `task-worker.ts`, `pr-review-worker.ts`)

- New `substituteSecretPlaceholders()` renders `{env:VAR}` placeholders in agent
  setup file contents with literal decrypted values, after secret resolution and
  before base64-encoding into `OPTIO_SETUP_FILES` (order matters). Known
  trade-off: decrypted secret values end up in the `OPTIO_SETUP_FILES` pod env
  and in plaintext files on the pod volume

**Pod init + Helm** (`scripts/repo-init.sh`, `helm/optio`)

- `repo-init.sh` pre-installs `agent.preinstallNpmPackages` (default
  `@ai-sdk/openai-compatible`) into `~/.config/opencode` BEFORE the first task
  (helm value → `OPTIO_NPM_PREINSTALL` → repo pod env), so the dynamic plugin
  install on NFS home volumes never triggers; best-effort with warning on failure

**stdin EOF** (`task-worker.ts`, `persistent-agent-worker.ts`, `workflow-worker.ts`)

- `opencode run ... < /dev/null`: run mode blocks forever on an open pipe that
  never delivers data or EOF (the k8s exec stream stays open for log streaming);
  the prompt arrives via argv, not stdin

**Event parser** (`opencode-event-parser.ts`)

- Parse opencode 1.14.20 stream-json events (camelCase `sessionID`, payloads in
  `event.part`) alongside the legacy (pre-1.14) schema

**Headless workspace confinement** (`opencode.ts`, `task-worker.ts`)

- Generated `opencode.json` now sets `permission`: `question: deny` (headless
  runs must never ask), `external_directory: { "*": "deny" }` (tools stay
  inside the task worktree; only opencode's internal tool-output dir remains
  accessible), and granular `bash` deny rules for `sudo`/`apt`/`apt-get`/`dpkg`
- `opencode run` gets `--dangerously-skip-permissions` (the 1.14.20 equivalent
  of `--auto`): permission asks are auto-approved instead of auto-rejecting
  and aborting the whole run; explicit deny rules above are still enforced
- New global plugin `~/.config/opencode/plugins/optio-workspace-guard.js`
  (`tool.execute.before` hook, PreToolUse-style): tool calls touching paths
  outside the worktree are blocked with an actionable
  "Stay inside the workspace (Im Workspace bleiben)" error instead of a bare
  permission rejection
- New global `~/.config/opencode/AGENTS.md` (setup file) with workspace
  confinement + headless rules, merged into every opencode session regardless
  of the per-task prompt template
- Motivation: a helm-iot task died with `Exit code: 1` after the agent tried
  to create a Python venv under `/tmp` — the `external_directory` permission
  ask had no user to answer it, was auto-rejected, and opencode aborted

## Testing

<!-- How was this tested? -->

- [x] Tests pass (`pnpm turbo test`) — targeted suites: agent-adapters 275
      (incl. 69 opencode), opencode-event-parser 30, secret-service 70,
      task-worker 76
- [x] Typechecks pass (`pnpm turbo typecheck`) — 12/12 packages
- [x] Prettier format:check passes
- [x] Pre-commit hooks (lint-staged + format + typecheck) pass
- [x] Workspace-guard plugin verified against 21 tool-call scenarios
      (bash/read/edit/glob/grep/webfetch/task): in-worktree and opencode
      internal paths pass, `/tmp`, `$HOME`, main-clone paths and
      sibling-prefix tricks are blocked with the hint

> Note: 3 pre-existing test-file failures (`server.test.ts`, `openapi.test.ts`,
> `slack-service.test.ts`) occur identically on a clean `upstream/main`
> checkout — unrelated to this PR.

## Related

<!-- Issues, PRs, docs, etc. -->

- Refs [anomalyco/opencode#27853](https://github.com/anomalyco/opencode/issues/27853)
  — closed as not planned upstream, hence the literal `{env:VAR}` rendering

Closes # <!-- none -->

## Screenshots

<!-- If applicable -->

N/A (backend-only change)
